### PR TITLE
Revert "Change default current device to None"

### DIFF
--- a/dpctl/ocldrv.py
+++ b/dpctl/ocldrv.py
@@ -532,7 +532,7 @@ class Runtime():
             else:
                 _logger.warning("No GPU device")
 
-            cls._curr_device = None
+            cls._curr_device = DeviceEnv(cls._runtime[0][0].curr_env)
 
         return obj
 
@@ -555,10 +555,6 @@ class Runtime():
 
         return Runtime._gpu_device is not None
 
-    def has_current_device(self):
-        ''' Returns True if GPU or CPU context manager is being used.'''
-
-        return Runtime._curr_device is not None
 
     def get_cpu_device(self):
         ''' Returns a cdata wrapper for the first available OpenCL
@@ -611,7 +607,6 @@ class Runtime():
 runtime = Runtime()
 has_cpu_device = runtime.has_cpu_device()
 has_gpu_device = runtime.has_gpu_device()
-has_current_device = runtime.has_current_device()
 
 #------- Global Functions
 


### PR DESCRIPTION
Reverts IntelPython/dpctl#39

This change causes crashes in Numba. There are places in Numba with following code `driver.runtime.get_current_device()` which returns None. And then it accesses to functions of None... crashes.

As I understand the original PR was intended to check if there is current device context or not. It could be achieved in another way without modification of `_curr_device`.