### PR TITLE
Add black formatter for Python code

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,4 @@
+# $ git config blame.ignoreRevsFile .git-blame-ignore-revs
+
+# Migrate code style to Black
+41ccd65e2e659aa0add0e5ab59f1a46e32cc4c46

--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -1,0 +1,28 @@
+# This is a workflow to format Python code with black formatter
+
+name: black
+
+# Controls when the action will run. Triggers the workflow on push or pull request
+# events but only for the master branch
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "black"
+  black:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v2
+      # Set up a Python environment for use in actions
+      - uses: actions/setup-python@v2
+
+      # Run black code formatter
+      - uses: psf/black@stable

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,1 +1,10 @@
-Coming soon
+# Python code style
+
+## black
+
+We use [black](https://black.readthedocs.io/en/stable/) code formatter.
+
+- Revision: `20.8b1` or branch `stable`.
+- See configuration in `pyproject.toml`.
+
+Run before each commit: `black .`

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
+
 What?
 ====
 A lightweight Python package exposing a subset of OpenCL and SYCL

--- a/dpctl/__init__.py
+++ b/dpctl/__init__.py
@@ -22,7 +22,7 @@
 ## This top-level dpctl module.
 ##
 ##===----------------------------------------------------------------------===##
-'''
+"""
     Data Parallel Control (dpCtl)
 
     dpCtl provides a lightweight Python abstraction over DPC++/SYCL and
@@ -43,11 +43,12 @@
 
     Please use `pydoc dpctl.ocldrv` to look at the current API for dpctl.ocldrv.
 
-'''
+"""
 __author__ = "Intel Corp."
 
 from ._sycl_core import *
 from ._version import get_versions
+
 
 def get_include():
     """
@@ -57,7 +58,9 @@ def get_include():
     this function to locate the appropriate include directory.
     """
     import os.path
-    return os.path.join(os.path.dirname(__file__), 'include')
 
-__version__ = get_versions()['version']
+    return os.path.join(os.path.dirname(__file__), "include")
+
+
+__version__ = get_versions()["version"]
 del get_versions

--- a/dpctl/_version.py
+++ b/dpctl/_version.py
@@ -1,4 +1,3 @@
-
 # This file helps to compute a version number in source trees obtained from
 # git-archive tarball (such as those provided by githubs download-from-tag
 # feature). Distribution tarballs (built by setup.py sdist) and build
@@ -58,17 +57,18 @@ HANDLERS = {}
 
 def register_vcs_handler(vcs, method):  # decorator
     """Decorator to mark a method as the handler for a particular VCS."""
+
     def decorate(f):
         """Store f in HANDLERS[vcs][method]."""
         if vcs not in HANDLERS:
             HANDLERS[vcs] = {}
         HANDLERS[vcs][method] = f
         return f
+
     return decorate
 
 
-def run_command(commands, args, cwd=None, verbose=False, hide_stderr=False,
-                env=None):
+def run_command(commands, args, cwd=None, verbose=False, hide_stderr=False, env=None):
     """Call the given command(s)."""
     assert isinstance(commands, list)
     p = None
@@ -76,10 +76,13 @@ def run_command(commands, args, cwd=None, verbose=False, hide_stderr=False,
         try:
             dispcmd = str([c] + args)
             # remember shell=False, so use git.cmd on windows, not just git
-            p = subprocess.Popen([c] + args, cwd=cwd, env=env,
-                                 stdout=subprocess.PIPE,
-                                 stderr=(subprocess.PIPE if hide_stderr
-                                         else None))
+            p = subprocess.Popen(
+                [c] + args,
+                cwd=cwd,
+                env=env,
+                stdout=subprocess.PIPE,
+                stderr=(subprocess.PIPE if hide_stderr else None),
+            )
             break
         except EnvironmentError:
             e = sys.exc_info()[1]
@@ -116,16 +119,22 @@ def versions_from_parentdir(parentdir_prefix, root, verbose):
     for i in range(3):
         dirname = os.path.basename(root)
         if dirname.startswith(parentdir_prefix):
-            return {"version": dirname[len(parentdir_prefix):],
-                    "full-revisionid": None,
-                    "dirty": False, "error": None, "date": None}
+            return {
+                "version": dirname[len(parentdir_prefix) :],
+                "full-revisionid": None,
+                "dirty": False,
+                "error": None,
+                "date": None,
+            }
         else:
             rootdirs.append(root)
             root = os.path.dirname(root)  # up a level
 
     if verbose:
-        print("Tried directories %s but none started with prefix %s" %
-              (str(rootdirs), parentdir_prefix))
+        print(
+            "Tried directories %s but none started with prefix %s"
+            % (str(rootdirs), parentdir_prefix)
+        )
     raise NotThisMethod("rootdir doesn't start with parentdir_prefix")
 
 
@@ -181,7 +190,7 @@ def git_versions_from_keywords(keywords, tag_prefix, verbose):
     # starting in git-1.8.3, tags are listed as "tag: foo-1.0" instead of
     # just "foo-1.0". If we see a "tag: " prefix, prefer those.
     TAG = "tag: "
-    tags = set([r[len(TAG):] for r in refs if r.startswith(TAG)])
+    tags = set([r[len(TAG) :] for r in refs if r.startswith(TAG)])
     if not tags:
         # Either we're using git < 1.8.3, or there really are no tags. We use
         # a heuristic: assume all version tags have a digit. The old git %d
@@ -190,7 +199,7 @@ def git_versions_from_keywords(keywords, tag_prefix, verbose):
         # between branches and tags. By ignoring refnames without digits, we
         # filter out many common branch names like "release" and
         # "stabilization", as well as "HEAD" and "master".
-        tags = set([r for r in refs if re.search(r'\d', r)])
+        tags = set([r for r in refs if re.search(r"\d", r)])
         if verbose:
             print("discarding '%s', no digits" % ",".join(refs - tags))
     if verbose:
@@ -198,19 +207,26 @@ def git_versions_from_keywords(keywords, tag_prefix, verbose):
     for ref in sorted(tags):
         # sorting will prefer e.g. "2.0" over "2.0rc1"
         if ref.startswith(tag_prefix):
-            r = ref[len(tag_prefix):]
+            r = ref[len(tag_prefix) :]
             if verbose:
                 print("picking %s" % r)
-            return {"version": r,
-                    "full-revisionid": keywords["full"].strip(),
-                    "dirty": False, "error": None,
-                    "date": date}
+            return {
+                "version": r,
+                "full-revisionid": keywords["full"].strip(),
+                "dirty": False,
+                "error": None,
+                "date": date,
+            }
     # no suitable tags, so version is "0+unknown", but full hex is still there
     if verbose:
         print("no suitable tags, using unknown + full revision id")
-    return {"version": "0+unknown",
-            "full-revisionid": keywords["full"].strip(),
-            "dirty": False, "error": "no suitable tags", "date": None}
+    return {
+        "version": "0+unknown",
+        "full-revisionid": keywords["full"].strip(),
+        "dirty": False,
+        "error": "no suitable tags",
+        "date": None,
+    }
 
 
 @register_vcs_handler("git", "pieces_from_vcs")
@@ -225,8 +241,7 @@ def git_pieces_from_vcs(tag_prefix, root, verbose, run_command=run_command):
     if sys.platform == "win32":
         GITS = ["git.cmd", "git.exe"]
 
-    out, rc = run_command(GITS, ["rev-parse", "--git-dir"], cwd=root,
-                          hide_stderr=True)
+    out, rc = run_command(GITS, ["rev-parse", "--git-dir"], cwd=root, hide_stderr=True)
     if rc != 0:
         if verbose:
             print("Directory %s not under git control" % root)
@@ -234,10 +249,19 @@ def git_pieces_from_vcs(tag_prefix, root, verbose, run_command=run_command):
 
     # if there is a tag matching tag_prefix, this yields TAG-NUM-gHEX[-dirty]
     # if there isn't one, this yields HEX[-dirty] (no NUM)
-    describe_out, rc = run_command(GITS, ["describe", "--tags", "--dirty",
-                                          "--always", "--long",
-                                          "--match", "%s*" % tag_prefix],
-                                   cwd=root)
+    describe_out, rc = run_command(
+        GITS,
+        [
+            "describe",
+            "--tags",
+            "--dirty",
+            "--always",
+            "--long",
+            "--match",
+            "%s*" % tag_prefix,
+        ],
+        cwd=root,
+    )
     # --long was added in git-1.5.5
     if describe_out is None:
         raise NotThisMethod("'git describe' failed")
@@ -260,17 +284,16 @@ def git_pieces_from_vcs(tag_prefix, root, verbose, run_command=run_command):
     dirty = git_describe.endswith("-dirty")
     pieces["dirty"] = dirty
     if dirty:
-        git_describe = git_describe[:git_describe.rindex("-dirty")]
+        git_describe = git_describe[: git_describe.rindex("-dirty")]
 
     # now we have TAG-NUM-gHEX or HEX
 
     if "-" in git_describe:
         # TAG-NUM-gHEX
-        mo = re.search(r'^(.+)-(\d+)-g([0-9a-f]+)$', git_describe)
+        mo = re.search(r"^(.+)-(\d+)-g([0-9a-f]+)$", git_describe)
         if not mo:
             # unparseable. Maybe git-describe is misbehaving?
-            pieces["error"] = ("unable to parse git-describe output: '%s'"
-                               % describe_out)
+            pieces["error"] = "unable to parse git-describe output: '%s'" % describe_out
             return pieces
 
         # tag
@@ -279,10 +302,12 @@ def git_pieces_from_vcs(tag_prefix, root, verbose, run_command=run_command):
             if verbose:
                 fmt = "tag '%s' doesn't start with prefix '%s'"
                 print(fmt % (full_tag, tag_prefix))
-            pieces["error"] = ("tag '%s' doesn't start with prefix '%s'"
-                               % (full_tag, tag_prefix))
+            pieces["error"] = "tag '%s' doesn't start with prefix '%s'" % (
+                full_tag,
+                tag_prefix,
+            )
             return pieces
-        pieces["closest-tag"] = full_tag[len(tag_prefix):]
+        pieces["closest-tag"] = full_tag[len(tag_prefix) :]
 
         # distance: number of commits since tag
         pieces["distance"] = int(mo.group(2))
@@ -293,13 +318,13 @@ def git_pieces_from_vcs(tag_prefix, root, verbose, run_command=run_command):
     else:
         # HEX: no tags
         pieces["closest-tag"] = None
-        count_out, rc = run_command(GITS, ["rev-list", "HEAD", "--count"],
-                                    cwd=root)
+        count_out, rc = run_command(GITS, ["rev-list", "HEAD", "--count"], cwd=root)
         pieces["distance"] = int(count_out)  # total number of commits
 
     # commit date: see ISO-8601 comment in git_versions_from_keywords()
-    date = run_command(GITS, ["show", "-s", "--format=%ci", "HEAD"],
-                       cwd=root)[0].strip()
+    date = run_command(GITS, ["show", "-s", "--format=%ci", "HEAD"], cwd=root)[
+        0
+    ].strip()
     pieces["date"] = date.strip().replace(" ", "T", 1).replace(" ", "", 1)
 
     return pieces
@@ -330,8 +355,7 @@ def render_pep440(pieces):
                 rendered += ".dirty"
     else:
         # exception #1
-        rendered = "0+untagged.%d.g%s" % (pieces["distance"],
-                                          pieces["short"])
+        rendered = "0+untagged.%d.g%s" % (pieces["distance"], pieces["short"])
         if pieces["dirty"]:
             rendered += ".dirty"
     return rendered
@@ -445,11 +469,13 @@ def render_git_describe_long(pieces):
 def render(pieces, style):
     """Render the given version pieces into the requested style."""
     if pieces["error"]:
-        return {"version": "unknown",
-                "full-revisionid": pieces.get("long"),
-                "dirty": None,
-                "error": pieces["error"],
-                "date": None}
+        return {
+            "version": "unknown",
+            "full-revisionid": pieces.get("long"),
+            "dirty": None,
+            "error": pieces["error"],
+            "date": None,
+        }
 
     if not style or style == "default":
         style = "pep440"  # the default
@@ -469,9 +495,13 @@ def render(pieces, style):
     else:
         raise ValueError("unknown style '%s'" % style)
 
-    return {"version": rendered, "full-revisionid": pieces["long"],
-            "dirty": pieces["dirty"], "error": None,
-            "date": pieces.get("date")}
+    return {
+        "version": rendered,
+        "full-revisionid": pieces["long"],
+        "dirty": pieces["dirty"],
+        "error": None,
+        "date": pieces.get("date"),
+    }
 
 
 def get_versions():
@@ -485,8 +515,7 @@ def get_versions():
     verbose = cfg.verbose
 
     try:
-        return git_versions_from_keywords(get_keywords(), cfg.tag_prefix,
-                                          verbose)
+        return git_versions_from_keywords(get_keywords(), cfg.tag_prefix, verbose)
     except NotThisMethod:
         pass
 
@@ -495,13 +524,16 @@ def get_versions():
         # versionfile_source is the relative path from the top of the source
         # tree (where the .git directory might live) to this file. Invert
         # this to find the root from __file__.
-        for i in cfg.versionfile_source.split('/'):
+        for i in cfg.versionfile_source.split("/"):
             root = os.path.dirname(root)
     except NameError:
-        return {"version": "0+unknown", "full-revisionid": None,
-                "dirty": None,
-                "error": "unable to find root of source tree",
-                "date": None}
+        return {
+            "version": "0+unknown",
+            "full-revisionid": None,
+            "dirty": None,
+            "error": "unable to find root of source tree",
+            "date": None,
+        }
 
     try:
         pieces = git_pieces_from_vcs(cfg.tag_prefix, root, verbose)
@@ -515,6 +547,10 @@ def get_versions():
     except NotThisMethod:
         pass
 
-    return {"version": "0+unknown", "full-revisionid": None,
-            "dirty": None,
-            "error": "unable to compute version", "date": None}
+    return {
+        "version": "0+unknown",
+        "full-revisionid": None,
+        "dirty": None,
+        "error": "unable to compute version",
+        "date": None,
+    }

--- a/dpctl/ocldrv.py
+++ b/dpctl/ocldrv.py
@@ -22,7 +22,7 @@
 ### This file exposes Python classes for different OpenCL classes that are
 ### exposed by the _opencl_core CFFI extension module.
 ##===----------------------------------------------------------------------===##
-''' The dpctl.ocldrv module contains a set of Python wrapper classes for
+""" The dpctl.ocldrv module contains a set of Python wrapper classes for
     OpenCL objects. The module has wrappers for cl_context, cl_device,
     cl_mem, cl_program, and cl_kernel objects.
 
@@ -37,7 +37,7 @@
         has_cpu_device - A flag set to True when an OpenCL GPU device is found
                          on the system.
 
-'''
+"""
 
 from __future__ import absolute_import, division, print_function
 
@@ -58,7 +58,7 @@ _logger = logging.getLogger(__name__)
 _ch = logging.StreamHandler()
 _ch.setLevel(logging.WARNING)
 # create formatter
-_formatter = logging.Formatter('DPPL-%(levelname)s - %(message)s')
+_formatter = logging.Formatter("DPPL-%(levelname)s - %(message)s")
 # add formatter to ch
 _ch.setFormatter(_formatter)
 # add ch to logger
@@ -71,23 +71,25 @@ _logger.addHandler(_ch)
 
 
 class DpplDriverError(Exception):
-    """ The exception is raised when dpctl.ocldrv cannot find an OpenCL Driver.
-    """
+    """The exception is raised when dpctl.ocldrv cannot find an OpenCL Driver."""
+
     pass
 
 
 class DeviceNotFoundError(Exception):
-    """ The exception is raised when the requested type of OpenCL device is
-        not available or not supported by dpctl.ocldrv.
+    """The exception is raised when the requested type of OpenCL device is
+    not available or not supported by dpctl.ocldrv.
     """
+
     pass
 
 
 class UnsupportedTypeError(Exception):
-    """ The exception is raised when an unsupported type is encountered when
-        creating an OpenCL KernelArg. Only DeviceArray or numpy.ndarray types
-        are supported.
+    """The exception is raised when an unsupported type is encountered when
+    creating an OpenCL KernelArg. Only DeviceArray or numpy.ndarray types
+    are supported.
     """
+
     pass
 
 
@@ -97,8 +99,10 @@ class UnsupportedTypeError(Exception):
 
 
 def _raise_driver_error(fname, errcode):
-    e = DpplDriverError("Could not find an OpenCL Driver. Ensure OpenCL \
-                         driver is installed.")
+    e = DpplDriverError(
+        "Could not find an OpenCL Driver. Ensure OpenCL \
+                         driver is installed."
+    )
     e.fname = fname
     e.code = errcode
     raise e
@@ -117,18 +121,25 @@ def _raise_unsupported_type_error(fname):
 
 
 def _raise_unsupported_kernel_arg_error(fname):
-    e = (UnsupportedTypeError("Type needs to be DeviceArray or a supported "
-                              "ctypes type."))
+    e = UnsupportedTypeError(
+        "Type needs to be DeviceArray or a supported " "ctypes type."
+    )
     e.fname = fname
     raise e
 
 
 def _is_supported_ctypes_raw_obj(obj):
-    return isinstance(obj, (ctypes.c_ssize_t,
-                            ctypes.c_double,
-                            ctypes.c_float,
-                            ctypes.c_uint8,
-                            ctypes.c_size_t))
+    return isinstance(
+        obj,
+        (
+            ctypes.c_ssize_t,
+            ctypes.c_double,
+            ctypes.c_float,
+            ctypes.c_uint8,
+            ctypes.c_size_t,
+        ),
+    )
+
 
 ##########################################################################
 # DeviceArray class
@@ -136,22 +147,23 @@ def _is_supported_ctypes_raw_obj(obj):
 
 
 class DeviceArray:
-    ''' A Python wrapper for an OpenCL cl_men buffer with read-write access. A
-        DeviceArray can only be created from a NumPy ndarray.
-    '''
-    _buffObj  = None
-    _ndarray  = None
+    """A Python wrapper for an OpenCL cl_men buffer with read-write access. A
+    DeviceArray can only be created from a NumPy ndarray.
+    """
+
+    _buffObj = None
+    _ndarray = None
     _buffSize = None
-    _dataPtr  = None
+    _dataPtr = None
 
     def __init__(self, env_ptr, arr):
-        ''' Creates a new DeviceArray from an ndarray.
+        """Creates a new DeviceArray from an ndarray.
 
-            Note that DeviceArray creation only allocates the cl_mem buffer
-            and does not actually move the data to the device. Data copy from
-            host to device is done when the DeviceArray instance is passed as
-            an argument to DeviceEnv.copy_array_to_device().
-        '''
+        Note that DeviceArray creation only allocates the cl_mem buffer
+        and does not actually move the data to the device. Data copy from
+        host to device is done when the DeviceArray instance is passed as
+        an argument to DeviceEnv.copy_array_to_device().
+        """
 
         # We only support device buffers for ndarray and ctypes (for basic
         # types like int, etc)
@@ -159,82 +171,73 @@ class DeviceArray:
             _raise_unsupported_type_error("DeviceArray constructor")
 
         # create a dp_buffer_t object
-        self._buffObj  = ffi.new("buffer_t *")
-        self._ndarray  = arr
+        self._buffObj = ffi.new("buffer_t *")
+        self._ndarray = arr
         self._buffSize = arr.itemsize * arr.size
-        self._dataPtr  = ffi.cast("void *", arr.ctypes.data)
-        retval = (lib.create_dp_rw_mem_buffer(env_ptr,
-                                              self._buffSize,
-                                              self._buffObj))
+        self._dataPtr = ffi.cast("void *", arr.ctypes.data)
+        retval = lib.create_dp_rw_mem_buffer(env_ptr, self._buffSize, self._buffObj)
         if retval == -1:
             _logger.warning("OpenCL Error Code  : %s", retval)
             _raise_driver_error("create_dp_rw_mem_buffer", -1)
 
     def __del__(self):
-        ''' Destroy the DeviceArray and release the OpenCL buffer.'''
+        """ Destroy the DeviceArray and release the OpenCL buffer."""
 
-        retval = (lib.destroy_dp_rw_mem_buffer(self._buffObj))
+        retval = lib.destroy_dp_rw_mem_buffer(self._buffObj)
         if retval == -1:
             _logger.warning("OpenCL Error Code  : %s", retval)
             _raise_driver_error("destroy_dp_rw_mem_buffer", -1)
 
     def get_buffer_obj(self):
-        ''' Returns a cdata wrapper object encapsulating an OpenCL buffer.
-        '''
+        """Returns a cdata wrapper object encapsulating an OpenCL buffer."""
 
         return self._buffObj
 
     def get_buffer_size(self):
-        ''' Returns the size of the OpenCL buffer in bytes.
-        '''
+        """Returns the size of the OpenCL buffer in bytes."""
 
         return self._buffSize
 
     def get_buffer_ptr(self):
-        ''' Returns a cdata wrapper over the actual OpenCL cl_mem pointer.
-        '''
+        """Returns a cdata wrapper over the actual OpenCL cl_mem pointer."""
 
         return self.get_buffer_obj()[0].buffer_ptr
 
     def get_data_ptr(self):
-        ''' Returns the data pointer for the NumPy ndarray used to create
-            the DeviceArray object.
-        '''
+        """Returns the data pointer for the NumPy ndarray used to create
+        the DeviceArray object.
+        """
 
         return self._dataPtr
 
     def get_ndarray(self):
-        ''' Returns the NumPy ndarray used to create the DeviceArray object.
-        '''
+        """Returns the NumPy ndarray used to create the DeviceArray object."""
 
         return self._ndarray
+
 
 ##########################################################################
 # Program class
 ##########################################################################
 
 
-class Program():
-
+class Program:
     def __init__(self, device_env, spirv_module):
         self._prog_t_obj = ffi.new("program_t *")
-        retval = (lib.create_dp_program_from_spirv(device_env.get_env_ptr(),
-                                                   spirv_module,
-                                                   len(spirv_module),
-                                                   self._prog_t_obj))
+        retval = lib.create_dp_program_from_spirv(
+            device_env.get_env_ptr(), spirv_module, len(spirv_module), self._prog_t_obj
+        )
         if retval == -1:
             _logger.warning("OpenCL Error Code  : %s", retval)
-            _raise_driver_error(
-                "create_dp_program_from_spirv", -1)
+            _raise_driver_error("create_dp_program_from_spirv", -1)
 
-        retval = (lib.build_dp_program(device_env.get_env_ptr(),
-                                       self._prog_t_obj[0]))
+        retval = lib.build_dp_program(device_env.get_env_ptr(), self._prog_t_obj[0])
         if retval == -1:
             _logger.warning("OpenCL Error Code  : %s", retval)
             _raise_driver_error("build_dp_program", -1)
 
     def __del__(self):
-        retval = (lib.destroy_dp_program(self._prog_t_obj))
+        retval = lib.destroy_dp_program(self._prog_t_obj)
         if retval == -1:
             _logger.warning("OpenCL Error Code  : %s", retval)
             _raise_driver_error("destroy_dp_program", -1)
@@ -248,20 +251,21 @@ class Program():
 ##########################################################################
 
 
-class Kernel():
-
+class Kernel:
     def __init__(self, device_env, prog_t_obj, kernel_name):
         self._kernel_t_obj = ffi.new("kernel_t *")
-        retval = (lib.create_dp_kernel(device_env.get_env_ptr(),
-                                       prog_t_obj.get_prog_t_obj(),
-                                       kernel_name.encode(),
-                                       self._kernel_t_obj))
+        retval = lib.create_dp_kernel(
+            device_env.get_env_ptr(),
+            prog_t_obj.get_prog_t_obj(),
+            kernel_name.encode(),
+            self._kernel_t_obj,
+        )
         if retval == -1:
             _logger.warning("OpenCL Error Code  : %s", retval)
             _raise_driver_error("create_dp_kernel", -1)
 
     def __del__(self):
-        retval = (lib.destroy_dp_kernel(self._kernel_t_obj))
+        retval = lib.destroy_dp_kernel(self._kernel_t_obj)
         if retval == -1:
             _logger.warning("OpenCL Error Code  : %s", retval)
             _raise_driver_error("destroy_dp_kernel", -1)
@@ -274,50 +278,50 @@ class Kernel():
         if retval == -1:
             _raise_driver_error("kernel dump_fn", -1)
 
+
 ##########################################################################
 # KernelArg class
 ##########################################################################
 
 
-class KernelArg():
-
+class KernelArg:
     def __init__(self, arg, void_p_arg=False):
         self.arg = arg
         self.kernel_arg_t = ffi.new("kernel_arg_t *")
         if void_p_arg is True:
             self.ptr_to_arg_p = ffi.new("void **")
             self.ptr_to_arg_p[0] = ffi.cast("void *", 0)
-            retval = (lib.create_dp_kernel_arg(self.ptr_to_arg_p,
-                                               ffi.sizeof(self.ptr_to_arg_p),
-                                               self.kernel_arg_t))
-            if(retval):
+            retval = lib.create_dp_kernel_arg(
+                self.ptr_to_arg_p, ffi.sizeof(self.ptr_to_arg_p), self.kernel_arg_t
+            )
+            if retval:
                 _raise_driver_error("create_dp_kernel_arg", -1)
         else:
             if isinstance(arg, DeviceArray):
                 self.ptr_to_arg_p = ffi.new("void **")
                 self.ptr_to_arg_p[0] = arg.get_buffer_obj()[0].buffer_ptr
-                retval = (lib.create_dp_kernel_arg(
-                                self.ptr_to_arg_p,
-                                arg.get_buffer_obj()[0].sizeof_buffer_ptr,
-                                self.kernel_arg_t))
-                if(retval):
+                retval = lib.create_dp_kernel_arg(
+                    self.ptr_to_arg_p,
+                    arg.get_buffer_obj()[0].sizeof_buffer_ptr,
+                    self.kernel_arg_t,
+                )
+                if retval:
                     _raise_driver_error("create_dp_kernel_arg", -1)
             else:
                 # it has to be of type ctypes
-                if getattr(arg, '__module__', None) == "ctypes":
-                    self.ptr_to_arg_p = ffi.cast("void *",
-                                                 ctypes.addressof(arg))
-                    retval = (lib.create_dp_kernel_arg(self.ptr_to_arg_p,
-                                                       ctypes.sizeof(arg),
-                                                       self.kernel_arg_t))
-                    if(retval):
+                if getattr(arg, "__module__", None) == "ctypes":
+                    self.ptr_to_arg_p = ffi.cast("void *", ctypes.addressof(arg))
+                    retval = lib.create_dp_kernel_arg(
+                        self.ptr_to_arg_p, ctypes.sizeof(arg), self.kernel_arg_t
+                    )
+                    if retval:
                         _raise_driver_error("create_dp_kernel_arg", -1)
                 else:
                     _logger.warning("Unsupported Type %s", type(arg))
                     _raise_unsupported_kernel_arg_error("KernelArg init")
 
     def __del__(self):
-        retval = (lib.destroy_dp_kernel_arg(self.kernel_arg_t))
+        retval = lib.destroy_dp_kernel_arg(self.kernel_arg_t)
         if retval == -1:
             _logger.warning("OpenCL Error Code  : %s", retval)
             _raise_driver_error("destroy_dp_kernel_arg", -1)
@@ -331,9 +335,8 @@ class KernelArg():
 ##########################################################################
 
 
-class DeviceEnv():
-    ''' A Python wrapper over an OpenCL cl_context object.
-    '''
+class DeviceEnv:
+    """A Python wrapper over an OpenCL cl_context object."""
 
     def __init__(self, env_t_obj):
         self._env_ptr = env_t_obj
@@ -342,59 +345,60 @@ class DeviceEnv():
         pass
 
     def retain_context(self):
-        ''' Increment the reference count of the OpenCL context object.
-        '''
+        """Increment the reference count of the OpenCL context object."""
 
-        retval = (lib.retain_dp_context(self._env_ptr.context))
-        if(retval == -1):
+        retval = lib.retain_dp_context(self._env_ptr.context)
+        if retval == -1:
             _raise_driver_error("retain_dp_context", -1)
 
-        return (self._env_ptr.context)
+        return self._env_ptr.context
 
     def release_context(self):
-        ''' Increment the reference count of the OpenCL context object.
-        '''
+        """Increment the reference count of the OpenCL context object."""
 
-        retval = (lib.release_dp_context(self._env_ptr.context))
+        retval = lib.release_dp_context(self._env_ptr.context)
         if retval == -1:
             _raise_driver_error("release_dp_context", -1)
 
     def copy_array_to_device(self, array):
-        ''' Accepts either a DeviceArray or a NumPy ndarray and copies the
-            data from host to an OpenCL device buffer. Returns either the
-            DeviceArray that was passed in as an argument, or for the case of
-            ndarrays returns a new DeviceArray.
+        """Accepts either a DeviceArray or a NumPy ndarray and copies the
+        data from host to an OpenCL device buffer. Returns either the
+        DeviceArray that was passed in as an argument, or for the case of
+        ndarrays returns a new DeviceArray.
 
-            If the function is called with a DeviceArray argument, the
-            function performs a blocking write of the data from the
-            DeviceArray's ndarray member into its OpenCL device buffer member.
-            When the function is called with an ndarray argument is, a new
-            DeviceArray is first created. The data copy operation is then
-            performed on the new DeviceArray.
-        '''
+        If the function is called with a DeviceArray argument, the
+        function performs a blocking write of the data from the
+        DeviceArray's ndarray member into its OpenCL device buffer member.
+        When the function is called with an ndarray argument is, a new
+        DeviceArray is first created. The data copy operation is then
+        performed on the new DeviceArray.
+        """
 
         if isinstance(array, DeviceArray):
-            retval = (lib.write_dp_mem_buffer_to_device(
-                              self._env_ptr,
-                              array.get_buffer_obj()[0],
-                              True,
-                              0,
-                              array.get_buffer_size(),
-                              array.get_data_ptr()))
+            retval = lib.write_dp_mem_buffer_to_device(
+                self._env_ptr,
+                array.get_buffer_obj()[0],
+                True,
+                0,
+                array.get_buffer_size(),
+                array.get_data_ptr(),
+            )
             if retval == -1:
                 _logger.warning("OpenCL Error Code  : %s", retval)
                 _raise_driver_error("write_dp_mem_buffer_to_device", -1)
             return array
-        elif (isinstance(array, ndarray) or getattr(array, '__module__', None)
-              == "ctypes"):
+        elif (
+            isinstance(array, ndarray) or getattr(array, "__module__", None) == "ctypes"
+        ):
             dArr = DeviceArray(self._env_ptr, array)
-            retval = (lib.write_dp_mem_buffer_to_device(
-                              self._env_ptr,
-                              dArr.get_buffer_obj()[0],
-                              True,
-                              0,
-                              dArr.get_buffer_size(),
-                              dArr.get_data_ptr()))
+            retval = lib.write_dp_mem_buffer_to_device(
+                self._env_ptr,
+                dArr.get_buffer_obj()[0],
+                True,
+                0,
+                dArr.get_buffer_size(),
+                dArr.get_data_ptr(),
+            )
             if retval == -1:
                 _logger.warning("OpenCL Error Code  : %s", retval)
                 _raise_driver_error("write_dp_mem_buffer_to_device", -1)
@@ -403,107 +407,104 @@ class DeviceEnv():
             _raise_unsupported_type_error("copy_array_to_device")
 
     def copy_array_from_device(self, array):
-        ''' Copies data from a cl_mem buffer into a DeviceArray's host memory
-            pointer. The function argument should be a DeviceArray object.
-        '''
+        """Copies data from a cl_mem buffer into a DeviceArray's host memory
+        pointer. The function argument should be a DeviceArray object.
+        """
 
         if not isinstance(array, DeviceArray):
             _raise_unsupported_type_error("copy_array_to_device")
-        retval = (lib.read_dp_mem_buffer_from_device(
-                          self._env_ptr,
-                          array.get_buffer_obj()[0],
-                          True,
-                          0,
-                          array.get_buffer_size(),
-                          array.get_data_ptr()))
+        retval = lib.read_dp_mem_buffer_from_device(
+            self._env_ptr,
+            array.get_buffer_obj()[0],
+            True,
+            0,
+            array.get_buffer_size(),
+            array.get_data_ptr(),
+        )
         if retval == -1:
             _logger.warning("OpenCL Error Code  : %s", retval)
             _raise_driver_error("read_dp_mem_buffer_from_device", -1)
 
     def create_device_array(self, array):
-        ''' Returns an new DeviceArray instance.
-        '''
+        """Returns an new DeviceArray instance."""
 
-        if not ((isinstance(array, ndarray) or
-                 getattr(array, '__module__', None)
-              == "ctypes")):
+        if not (
+            (
+                isinstance(array, ndarray)
+                or getattr(array, "__module__", None) == "ctypes"
+            )
+        ):
             _raise_unsupported_type_error("alloc_array_in_device")
 
         return DeviceArray(self._env_ptr, array)
 
     def device_support_int64_atomics(self):
-        ''' Returns True current device supports 64-bit int atomic operations
-        '''
+        """Returns True current device supports 64-bit int atomic operations"""
 
         return self._env_ptr.support_int64_atomics
 
     def device_support_float64_atomics(self):
-        ''' Returns True if current device supports 64-bit float atomic operations
-        '''
+        """Returns True if current device supports 64-bit float atomic operations"""
 
         return self._env_ptr.support_float64_atomics
 
     def get_context_ptr(self):
-        ''' Returns a cdata wrapper for the OpenCL cl_context object.
-        '''
+        """Returns a cdata wrapper for the OpenCL cl_context object."""
 
         return self._env_ptr.context
 
     def get_device_ptr(self):
-        ''' Returns a cdata wrapper for the OpenCL cl_device object.
-        '''
+        """Returns a cdata wrapper for the OpenCL cl_device object."""
 
         return self._env_ptr.device
 
     def get_queue_ptr(self):
-        ''' Returns a cdata wrapper for the OpenCL cl_command_queue object.
-        '''
+        """Returns a cdata wrapper for the OpenCL cl_command_queue object."""
 
         return self._env_ptr.queue
 
     def get_env_ptr(self):
-        ''' Returns a cdata wrapper for a C object encapsulating an OpenCL
-            cl_device object, a cl_command_queue object,
-            and a cl_context object.
-        '''
+        """Returns a cdata wrapper for a C object encapsulating an OpenCL
+        cl_device object, a cl_command_queue object,
+        and a cl_context object.
+        """
 
         return self._env_ptr
 
     def get_max_work_item_dims(self):
-        ''' Returns the maximum number of work items per work group for
-            the OpenCL device.
-        '''
+        """Returns the maximum number of work items per work group for
+        the OpenCL device.
+        """
 
         return self._env_ptr.max_work_item_dims
 
     def get_max_work_group_size(self):
-        ''' Returns the max work group size for the OpenCL device.
-        '''
+        """Returns the max work group size for the OpenCL device."""
 
         return self._env_ptr.max_work_group_size
 
     def dump(self):
-        ''' Prints metadata for the underlying OpenCL device.
-        '''
+        """Prints metadata for the underlying OpenCL device."""
 
         retval = self._env_ptr[0].dump_fn(self._env_ptr)
         if retval == -1:
             _raise_driver_error("env dump_fn", -1)
         return retval
 
+
 ##########################################################################
 # Runtime class
 ##########################################################################
 
 
-class Runtime():
-    '''Runtime is a singleton class that creates a C wrapper object storing
+class Runtime:
+    """Runtime is a singleton class that creates a C wrapper object storing
     available OpenCL contexts and corresponding OpenCL command queues. The
     context and the queue are stored only for the first available GPU and CPU
     OpenCL devices found on the system.
-    '''
+    """
 
-    _singleton    = None
+    _singleton = None
 
     def __new__(cls):
         obj = cls._singleton
@@ -516,8 +517,8 @@ class Runtime():
             cls._ffi = ffi
 
             ffiobj = ffi.new("runtime_t *")
-            retval = (lib.create_dp_runtime(ffiobj))
-            if(retval):
+            retval = lib.create_dp_runtime(ffiobj)
+            if retval:
                 _logger.warning("OpenCL Error Code  : %s", retval)
                 _raise_driver_error("create_dp_runtime", -1)
 
@@ -545,88 +546,85 @@ class Runtime():
 
     def __del__(self):
         if self._runtime:
-            retval = (self._lib.destroy_dp_runtime(self._runtime))
-            if(retval):
+            retval = self._lib.destroy_dp_runtime(self._runtime)
+            if retval:
                 _raise_driver_error("destroy_dp_runtime", -1)
 
     def has_cpu_device(self):
-        ''' Returns True is the system has an OpenCL driver for the CPU.'''
+        """ Returns True is the system has an OpenCL driver for the CPU."""
 
         return self._cpu_device is not None
 
     def has_gpu_device(self):
-        ''' Returns True is the system has an OpenCL driver for the GPU.'''
+        """ Returns True is the system has an OpenCL driver for the GPU."""
 
         return self._gpu_device is not None
 
-
     def get_cpu_device(self):
-        ''' Returns a cdata wrapper for the first available OpenCL
+        """Returns a cdata wrapper for the first available OpenCL
         CPU context.
-        '''
+        """
 
-        if(self._cpu_device is None):
+        if self._cpu_device is None:
             _raise_device_not_found_error("get_cpu_device")
 
         return self._cpu_device
 
     def get_gpu_device(self):
-        ''' Returns a cdata wrapper for the first available OpenCL
+        """Returns a cdata wrapper for the first available OpenCL
         GPU context.
-        '''
+        """
 
-        if(self._gpu_device is None):
+        if self._gpu_device is None:
             _raise_device_not_found_error("get_gpu_device")
 
         return self._gpu_device
 
     def get_current_device(self):
-        ''' Returns a cdata wrapper for the first available OpenCL
+        """Returns a cdata wrapper for the first available OpenCL
         CPU context.
-        '''
+        """
 
         return self._curr_device
 
     def get_runtime_ptr(self):
-        ''' Returns a reference to the runtime object.
-        '''
+        """Returns a reference to the runtime object."""
 
         return self._runtime[0]
 
     def dump(self):
-        ''' Prints OpenCL metadata about the available devices and contexts.
-        '''
+        """Prints OpenCL metadata about the available devices and contexts."""
 
         retval = self._runtime[0].dump_fn(Runtime._runtime[0])
         if retval == -1:
             _raise_driver_error("runtime dump_fn", -1)
         return retval
 
+
 ##########################################################################
 # Public API
 ##########################################################################
 
-#------- Global Data
+# ------- Global Data
 
 runtime = Runtime()
 has_cpu_device = runtime.has_cpu_device()
 has_gpu_device = runtime.has_gpu_device()
 
-#------- Global Functions
+# ------- Global Functions
 
-def enqueue_kernel (device_env, kernel, kernelargs, global_work_size,
-                    local_work_size):
-    ''' A single wrapper function over OpenCL clCreateKernelArgs and
-        clEnqueueNDRangeKernel. The function blocks till the enqueued kernel
-        finishes execution.
-    '''
+
+def enqueue_kernel(device_env, kernel, kernelargs, global_work_size, local_work_size):
+    """A single wrapper function over OpenCL clCreateKernelArgs and
+    clEnqueueNDRangeKernel. The function blocks till the enqueued kernel
+    finishes execution.
+    """
 
     l_work_size_array = None
     kernel_arg_array = ffi.new("kernel_arg_t [" + str(len(kernelargs)) + "]")
     g_work_size_array = ffi.new("size_t [" + str(len(global_work_size)) + "]")
     if local_work_size:
-        l_work_size_array = ffi.new(
-                              "size_t [" + str(len(local_work_size)) + "]")
+        l_work_size_array = ffi.new("size_t [" + str(len(local_work_size)) + "]")
     else:
         l_work_size_array = ffi.NULL
     for i in range(len(kernelargs)):
@@ -635,28 +633,28 @@ def enqueue_kernel (device_env, kernel, kernelargs, global_work_size,
         g_work_size_array[i] = global_work_size[i]
     for i in range(len(local_work_size)):
         l_work_size_array[i] = local_work_size[i]
-    retval = (lib.set_args_and_enqueue_dp_kernel(device_env.get_env_ptr(),
-                                                 kernel.get_kernel_t_obj(),
-                                                 len(kernelargs),
-                                                 kernel_arg_array,
-                                                 len(global_work_size),
-                                                 ffi.NULL,
-                                                 g_work_size_array,
-                                                 l_work_size_array))
-    if(retval):
+    retval = lib.set_args_and_enqueue_dp_kernel(
+        device_env.get_env_ptr(),
+        kernel.get_kernel_t_obj(),
+        len(kernelargs),
+        kernel_arg_array,
+        len(global_work_size),
+        ffi.NULL,
+        g_work_size_array,
+        l_work_size_array,
+    )
+    if retval:
         _raise_driver_error("set_args_and_enqueue_dp_kernel", -1)
 
 
 def is_available():
-    ''' Return a Boolean to indicate the availability of a DPPL device.
-    '''
+    """Return a Boolean to indicate the availability of a DPPL device."""
 
     return runtime.has_cpu_device() or runtime.has_gpu_device()
 
 
 def dppl_error():
-    ''' Raised a DpplDriverError exception.
-    '''
+    """Raised a DpplDriverError exception."""
 
     _raise_driver_error()
 
@@ -668,40 +666,38 @@ def dppl_error():
 
 @contextmanager
 def igpu_context(*args, **kwds):
-    ''' A context manager sets the current DeviceEnv inside the global
-        runtime object to the default GPU DeviceEnv. The GPU DeviceEnv is
-        yielded by the context manager.
-    '''
+    """A context manager sets the current DeviceEnv inside the global
+    runtime object to the default GPU DeviceEnv. The GPU DeviceEnv is
+    yielded by the context manager.
+    """
 
     device_id = 0
     # some validation code
-    if(args):
-        assert(len(args) == 1 and args[0] == 0)
+    if args:
+        assert len(args) == 1 and args[0] == 0
     _logger.debug("Set the current env to igpu device queue %s", device_id)
-    lib.set_curr_env(runtime.get_runtime_ptr(),
-                     runtime.get_gpu_device().get_env_ptr())
+    lib.set_curr_env(runtime.get_runtime_ptr(), runtime.get_gpu_device().get_env_ptr())
     device_env = runtime.get_current_device()
     yield device_env
 
     # After yield as the exit method
-    #TODO : one exit reset the current env to previous value
+    # TODO : one exit reset the current env to previous value
     _logger.debug("Exit method called")
 
 
 @contextmanager
 def cpu_context(*args, **kwds):
-    ''' A context manager sets the current DeviceEnv inside the global
-        runtime object to the default CPU DeviceEnv. The CPU DeviceEnv is
-        yielded by the context manager.
-    '''
+    """A context manager sets the current DeviceEnv inside the global
+    runtime object to the default CPU DeviceEnv. The CPU DeviceEnv is
+    yielded by the context manager.
+    """
 
     device_id = 0
     # some validation code
-    if(args):
-        assert(len(args) == 1 and args[0] == 0)
+    if args:
+        assert len(args) == 1 and args[0] == 0
     _logger.debug("Set the current env to cpu device queue %s", device_id)
-    lib.set_curr_env(runtime.get_runtime_ptr(),
-                     runtime.get_cpu_device().get_env_ptr())
+    lib.set_curr_env(runtime.get_runtime_ptr(), runtime.get_cpu_device().get_env_ptr())
     device_env = runtime.get_current_device()
     yield device_env
 

--- a/dpctl/opencl_core.py
+++ b/dpctl/opencl_core.py
@@ -30,28 +30,34 @@ from cffi import FFI
 
 ffi = FFI()
 
-dppl_opencl_interface_incldir = os.environ.get(
-                                    'DPPL_OPENCL_INTERFACE_INCLDIR', None)
-dppl_opencl_interface_libdir  = os.environ.get(
-                                    'DPPL_OPENCL_INTERFACE_LIBDIR', None)
-opencl_libdir  = os.environ.get('OpenCL_LIBDIR', None)
+dppl_opencl_interface_incldir = os.environ.get("DPPL_OPENCL_INTERFACE_INCLDIR", None)
+dppl_opencl_interface_libdir = os.environ.get("DPPL_OPENCL_INTERFACE_LIBDIR", None)
+opencl_libdir = os.environ.get("OpenCL_LIBDIR", None)
 
 if opencl_libdir is None:
-    raise ValueError("Abort! Set the OpenCL_LIBDIR envar to point to "
-                     "an OpenCL ICD")
+    raise ValueError("Abort! Set the OpenCL_LIBDIR envar to point to " "an OpenCL ICD")
 
 if dppl_opencl_interface_libdir is None:
-    raise ValueError("Abort! Set the DPPL_OPENCL_INTERFACE_LIBDIR envar to "
-                     "point to ibdplibdpglueglue.so")
+    raise ValueError(
+        "Abort! Set the DPPL_OPENCL_INTERFACE_LIBDIR envar to "
+        "point to ibdplibdpglueglue.so"
+    )
 
 if dppl_opencl_interface_incldir is None:
-    raise ValueError("Abort! Set the DP_GLUE_INCLDIR envar to point to "
-                     "dppl_opencl_interface.h")
+    raise ValueError(
+        "Abort! Set the DP_GLUE_INCLDIR envar to point to " "dppl_opencl_interface.h"
+    )
 
-glue_h = ''.join(list(filter(lambda x: len(x) > 0 and x[0] != "#",
-                             open(dppl_opencl_interface_incldir +
-                             '/dppl_opencl_interface.h', 'r')
-                             .readlines()))).replace('DPPL_API', '')
+glue_h = "".join(
+    list(
+        filter(
+            lambda x: len(x) > 0 and x[0] != "#",
+            open(
+                dppl_opencl_interface_incldir + "/dppl_opencl_interface.h", "r"
+            ).readlines(),
+        )
+    )
+).replace("DPPL_API", "")
 
 # cdef() expects a single string declaring the C types, functions and
 # globals needed to use the shared object. It must be in valid C syntax.
@@ -60,7 +66,8 @@ ffi.cdef(glue_h)
 ffi_lib_name = "dpctl._opencl_core"
 
 import sys
-IS_WIN = sys.platform in ['win32', 'cygwin']
+
+IS_WIN = sys.platform in ["win32", "cygwin"]
 del sys
 
 ffi.set_source(
@@ -70,9 +77,9 @@ ffi.set_source(
     """,
     include_dirs=[dppl_opencl_interface_incldir],
     library_dirs=[dppl_opencl_interface_libdir, opencl_libdir],
-    extra_link_args=[] if IS_WIN else ['-Wl,-rpath=$ORIGIN'],
+    extra_link_args=[] if IS_WIN else ["-Wl,-rpath=$ORIGIN"],
     libraries=["DPPLOpenCLInterface", "OpenCL"],
-)   # library name, for the linker
+)  # library name, for the linker
 del IS_WIN
 
 if __name__ == "__main__":

--- a/dpctl/tests/test_dump_functions.py
+++ b/dpctl/tests/test_dump_functions.py
@@ -28,16 +28,16 @@ import dpctl
 
 
 class TestDumpMethods(unittest.TestCase):
-
-    def test_dpctl_dump (self):
+    def test_dpctl_dump(self):
         try:
             dpctl.dump()
         except Exception:
             self.fail("Encountered an exception inside dump().")
 
-    @unittest.skipUnless(dpctl.has_sycl_platforms(),
-                         "No SYCL devices except the default host device.")
-    def test_dpctl_dump_device_info (self):
+    @unittest.skipUnless(
+        dpctl.has_sycl_platforms(), "No SYCL devices except the default host device."
+    )
+    def test_dpctl_dump_device_info(self):
         q = dpctl.get_current_queue()
         try:
             q.get_sycl_device().dump_device_info()
@@ -50,5 +50,6 @@ class TestDumpMethods(unittest.TestCase):
     #     except Exception:
     #         self.fail("Encountered an exception inside dump_device_info().")
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     unittest.main()

--- a/dpctl/tests/test_sycl_kernel_submit.py
+++ b/dpctl/tests/test_sycl_kernel_submit.py
@@ -28,10 +28,10 @@ import unittest
 import dpctl._memory as dpctl_mem
 import numpy as np
 
-@unittest.skipUnless(dpctl.has_gpu_queues(), "No OpenCL GPU queues available")
-class Test1DKernelSubmit (unittest.TestCase):
 
-    def test_create_program_from_source (self):
+@unittest.skipUnless(dpctl.has_gpu_queues(), "No OpenCL GPU queues available")
+class Test1DKernelSubmit(unittest.TestCase):
+    def test_create_program_from_source(self):
         oclSrc = "                                                             \
         kernel void axpy(global int* a, global int* b, global int* c, int d) { \
             size_t index = get_global_id(0);                                   \
@@ -40,14 +40,14 @@ class Test1DKernelSubmit (unittest.TestCase):
         with dpctl.device_context("opencl:gpu:0"):
             q = dpctl.get_current_queue()
             prog = dpctl.create_program_from_source(q, oclSrc)
-            axpyKernel = prog.get_sycl_kernel('axpy')
+            axpyKernel = prog.get_sycl_kernel("axpy")
 
-            abuf = dpctl_mem.MemoryUSMShared(1024*np.dtype('i').itemsize)
-            bbuf = dpctl_mem.MemoryUSMShared(1024*np.dtype('i').itemsize)
-            cbuf = dpctl_mem.MemoryUSMShared(1024*np.dtype('i').itemsize)
-            a = np.ndarray((1024), buffer=abuf, dtype='i')
-            b = np.ndarray((1024), buffer=bbuf, dtype='i')
-            c = np.ndarray((1024), buffer=cbuf, dtype='i')
+            abuf = dpctl_mem.MemoryUSMShared(1024 * np.dtype("i").itemsize)
+            bbuf = dpctl_mem.MemoryUSMShared(1024 * np.dtype("i").itemsize)
+            cbuf = dpctl_mem.MemoryUSMShared(1024 * np.dtype("i").itemsize)
+            a = np.ndarray((1024), buffer=abuf, dtype="i")
+            b = np.ndarray((1024), buffer=bbuf, dtype="i")
+            c = np.ndarray((1024), buffer=cbuf, dtype="i")
             a[:] = np.arange(1024)
             b[:] = np.arange(1024, 0, -1)
             c[:] = 0
@@ -62,8 +62,8 @@ class Test1DKernelSubmit (unittest.TestCase):
             r = [1024]
 
             q.submit(axpyKernel, args, r)
-            self.assertTrue(np.allclose(c, a*d + b))
+            self.assertTrue(np.allclose(c, a * d + b))
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/dpctl/tests/test_sycl_program.py
+++ b/dpctl/tests/test_sycl_program.py
@@ -27,10 +27,10 @@ import dpctl
 import unittest
 import os
 
-@unittest.skipUnless(dpctl.has_gpu_queues(), "No OpenCL GPU queues available")
-class TestProgramFromOCLSource (unittest.TestCase):
 
-    def test_create_program_from_source (self):
+@unittest.skipUnless(dpctl.has_gpu_queues(), "No OpenCL GPU queues available")
+class TestProgramFromOCLSource(unittest.TestCase):
+    def test_create_program_from_source(self):
         oclSrc = "                                                             \
         kernel void add(global int* a, global int* b, global int* c) {         \
             size_t index = get_global_id(0);                                   \
@@ -48,62 +48,59 @@ class TestProgramFromOCLSource (unittest.TestCase):
             self.assertTrue(prog.has_sycl_kernel("add"))
             self.assertTrue(prog.has_sycl_kernel("axpy"))
 
-            addKernel = prog.get_sycl_kernel('add')
-            axpyKernel = prog.get_sycl_kernel('axpy')
+            addKernel = prog.get_sycl_kernel("add")
+            axpyKernel = prog.get_sycl_kernel("axpy")
 
-            self.assertEqual(addKernel.get_function_name(),"add")
-            self.assertEqual(axpyKernel.get_function_name(),"axpy")
+            self.assertEqual(addKernel.get_function_name(), "add")
+            self.assertEqual(axpyKernel.get_function_name(), "axpy")
             self.assertEqual(addKernel.get_num_args(), 3)
             self.assertEqual(axpyKernel.get_num_args(), 4)
 
 
 @unittest.skipUnless(dpctl.has_gpu_queues(), "No OpenCL GPU queues available")
-class TestProgramFromSPRIV (unittest.TestCase):
-
+class TestProgramFromSPRIV(unittest.TestCase):
     def test_create_program_from_spirv(self):
 
         CURR_DIR = os.path.dirname(os.path.abspath(__file__))
-        spirv_file = os.path.join(CURR_DIR, 'input_files/multi_kernel.spv')
-        with open(spirv_file, 'rb') as fin:
+        spirv_file = os.path.join(CURR_DIR, "input_files/multi_kernel.spv")
+        with open(spirv_file, "rb") as fin:
             spirv = fin.read()
             with dpctl.device_context("opencl:gpu:0"):
                 q = dpctl.get_current_queue()
-                prog = dpctl.create_program_from_spirv(q,spirv)
+                prog = dpctl.create_program_from_spirv(q, spirv)
                 self.assertIsNotNone(prog)
                 self.assertTrue(prog.has_sycl_kernel("add"))
                 self.assertTrue(prog.has_sycl_kernel("axpy"))
 
-                addKernel = prog.get_sycl_kernel('add')
-                axpyKernel = prog.get_sycl_kernel('axpy')
+                addKernel = prog.get_sycl_kernel("add")
+                axpyKernel = prog.get_sycl_kernel("axpy")
 
-                self.assertEqual(addKernel.get_function_name(),"add")
-                self.assertEqual(axpyKernel.get_function_name(),"axpy")
+                self.assertEqual(addKernel.get_function_name(), "add")
+                self.assertEqual(axpyKernel.get_function_name(), "axpy")
                 self.assertEqual(addKernel.get_num_args(), 3)
                 self.assertEqual(axpyKernel.get_num_args(), 4)
 
+
 @unittest.skipUnless(
     dpctl.has_gpu_queues(backend_ty=dpctl.backend_type.level_zero),
-    "No Level0 GPU queues available"
+    "No Level0 GPU queues available",
 )
-class TestProgramForLevel0GPU (unittest.TestCase):
-
+class TestProgramForLevel0GPU(unittest.TestCase):
     def test_create_program_from_spirv(self):
 
         CURR_DIR = os.path.dirname(os.path.abspath(__file__))
-        spirv_file = os.path.join(CURR_DIR, 'input_files/multi_kernel.spv')
-        with open(spirv_file, 'rb') as fin:
+        spirv_file = os.path.join(CURR_DIR, "input_files/multi_kernel.spv")
+        with open(spirv_file, "rb") as fin:
             spirv = fin.read()
             with dpctl.device_context("level0:gpu:0"):
                 q = dpctl.get_current_queue()
                 try:
-                    prog = dpctl.create_program_from_spirv(q,spirv)
-                    self.fail(
-                        "Tried to create program for an unsupported Level0 GPU."
-                    )
+                    prog = dpctl.create_program_from_spirv(q, spirv)
+                    self.fail("Tried to create program for an unsupported Level0 GPU.")
                 except ValueError:
                     pass
 
-    def test_create_program_from_source (self):
+    def test_create_program_from_source(self):
         oclSrc = "                                                             \
         kernel void add(global int* a, global int* b, global int* c) {         \
             size_t index = get_global_id(0);                                   \
@@ -117,12 +114,10 @@ class TestProgramForLevel0GPU (unittest.TestCase):
             q = dpctl.get_current_queue()
             try:
                 prog = dpctl.create_program_from_source(q, oclSrc)
-                self.fail(
-                    "Tried to create program for an unsupported Level0 GPU."
-                )
+                self.fail("Tried to create program for an unsupported Level0 GPU.")
             except ValueError:
                 pass
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/dpctl/tests/test_sycl_queue.py
+++ b/dpctl/tests/test_sycl_queue.py
@@ -25,25 +25,21 @@
 import dpctl
 import unittest
 
-class TestSyclQueue (unittest.TestCase):
-    @unittest.skipUnless(
-        dpctl.has_gpu_queues(), "No OpenCL GPU queues available"
-    )
-    @unittest.skipUnless(
-        dpctl.has_cpu_queues(), "No OpenCL CPU queues available"
-    )
-    def test_queue_not_equals (self):
+
+class TestSyclQueue(unittest.TestCase):
+    @unittest.skipUnless(dpctl.has_gpu_queues(), "No OpenCL GPU queues available")
+    @unittest.skipUnless(dpctl.has_cpu_queues(), "No OpenCL CPU queues available")
+    def test_queue_not_equals(self):
         with dpctl.device_context("opencl:gpu") as gpuQ0:
             with dpctl.device_context("opencl:cpu") as cpuQ:
                 self.assertFalse(cpuQ.equals(gpuQ0))
 
-    @unittest.skipUnless(
-        dpctl.has_gpu_queues(), "No OpenCL GPU queues available"
-    )
-    def test_queue_equals (self):
+    @unittest.skipUnless(dpctl.has_gpu_queues(), "No OpenCL GPU queues available")
+    def test_queue_equals(self):
         with dpctl.device_context("opencl:gpu") as gpuQ0:
             with dpctl.device_context("opencl:gpu") as gpuQ1:
                 self.assertTrue(gpuQ0.equals(gpuQ1))
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     unittest.main()

--- a/dpctl/tests/test_sycl_queue_manager.py
+++ b/dpctl/tests/test_sycl_queue_manager.py
@@ -26,23 +26,22 @@ import dpctl
 import unittest
 
 
-class TestGetNumPlatforms (unittest.TestCase):
-    @unittest.skipIf(not dpctl.has_sycl_platforms(),
-                     "No SYCL platforms available")
-    def test_dpctl_get_num_platforms (self):
-        if(dpctl.has_sycl_platforms):
+class TestGetNumPlatforms(unittest.TestCase):
+    @unittest.skipIf(not dpctl.has_sycl_platforms(), "No SYCL platforms available")
+    def test_dpctl_get_num_platforms(self):
+        if dpctl.has_sycl_platforms:
             self.assertGreaterEqual(dpctl.get_num_platforms(), 1)
 
 
 @unittest.skipIf(not dpctl.has_sycl_platforms(), "No SYCL platforms available")
-class TestDumpMethods (unittest.TestCase):
-    def test_dpctl_dump (self):
+class TestDumpMethods(unittest.TestCase):
+    def test_dpctl_dump(self):
         try:
             dpctl.dump()
         except Exception:
             self.fail("Encountered an exception inside dump().")
 
-    def test_dpctl_dump_device_info (self):
+    def test_dpctl_dump_device_info(self):
         q = dpctl.get_current_queue()
         try:
             q.get_sycl_device().dump_device_info()
@@ -51,25 +50,18 @@ class TestDumpMethods (unittest.TestCase):
 
 
 @unittest.skipIf(not dpctl.has_sycl_platforms(), "No SYCL platforms available")
-class TestIsInDeviceContext (unittest.TestCase):
-
-    def test_is_in_device_context_outside_device_ctxt (self):
+class TestIsInDeviceContext(unittest.TestCase):
+    def test_is_in_device_context_outside_device_ctxt(self):
         self.assertFalse(dpctl.is_in_device_context())
 
-    @unittest.skipUnless(
-        dpctl.has_gpu_queues(), "No OpenCL GPU queues available"
-    )
-    def test_is_in_device_context_inside_device_ctxt (self):
+    @unittest.skipUnless(dpctl.has_gpu_queues(), "No OpenCL GPU queues available")
+    def test_is_in_device_context_inside_device_ctxt(self):
         with dpctl.device_context("opencl:gpu:0"):
             self.assertTrue(dpctl.is_in_device_context())
 
-    @unittest.skipUnless(
-        dpctl.has_gpu_queues(), "No OpenCL GPU queues available"
-    )
-    @unittest.skipUnless(
-        dpctl.has_cpu_queues(), "No OpenCL CPU queues available"
-    )
-    def test_is_in_device_context_inside_nested_device_ctxt (self):
+    @unittest.skipUnless(dpctl.has_gpu_queues(), "No OpenCL GPU queues available")
+    @unittest.skipUnless(dpctl.has_cpu_queues(), "No OpenCL CPU queues available")
+    def test_is_in_device_context_inside_nested_device_ctxt(self):
         with dpctl.device_context("opencl:cpu:0"):
             with dpctl.device_context("opencl:gpu:0"):
                 self.assertTrue(dpctl.is_in_device_context())
@@ -78,72 +70,52 @@ class TestIsInDeviceContext (unittest.TestCase):
 
 
 @unittest.skipIf(not dpctl.has_sycl_platforms(), "No SYCL platforms available")
-class TestGetCurrentDevice (unittest.TestCase):
-
-    def test_get_current_device_type_outside_device_ctxt (self):
+class TestGetCurrentDevice(unittest.TestCase):
+    def test_get_current_device_type_outside_device_ctxt(self):
         self.assertNotEqual(dpctl.get_current_device_type(), None)
 
-    def test_get_current_device_type_inside_device_ctxt (self):
+    def test_get_current_device_type_inside_device_ctxt(self):
         self.assertNotEqual(dpctl.get_current_device_type(), None)
 
         with dpctl.device_context("opencl:gpu:0"):
-            self.assertEqual(
-                dpctl.get_current_device_type(), dpctl.device_type.gpu
-            )
+            self.assertEqual(dpctl.get_current_device_type(), dpctl.device_type.gpu)
 
         self.assertNotEqual(dpctl.get_current_device_type(), None)
 
-    @unittest.skipUnless(
-        dpctl.has_cpu_queues(), "No OpenCL CPU queues available"
-    )
-    def test_get_current_device_type_inside_nested_device_ctxt (self):
+    @unittest.skipUnless(dpctl.has_cpu_queues(), "No OpenCL CPU queues available")
+    def test_get_current_device_type_inside_nested_device_ctxt(self):
         self.assertNotEqual(dpctl.get_current_device_type(), None)
 
         with dpctl.device_context("opencl:cpu:0"):
-            self.assertEqual(
-                dpctl.get_current_device_type(), dpctl.device_type.cpu
-            )
+            self.assertEqual(dpctl.get_current_device_type(), dpctl.device_type.cpu)
 
             with dpctl.device_context("opencl:gpu:0"):
-                self.assertEqual(
-                    dpctl.get_current_device_type(), dpctl.device_type.gpu
-                )
-            self.assertEqual(
-                dpctl.get_current_device_type(), dpctl.device_type.cpu
-            )
+                self.assertEqual(dpctl.get_current_device_type(), dpctl.device_type.gpu)
+            self.assertEqual(dpctl.get_current_device_type(), dpctl.device_type.cpu)
 
         self.assertNotEqual(dpctl.get_current_device_type(), None)
 
 
 @unittest.skipIf(not dpctl.has_sycl_platforms(), "No SYCL platforms available")
-class TestGetCurrentQueueInMultipleThreads (unittest.TestCase):
-
-    def test_num_current_queues_outside_with_clause (self):
+class TestGetCurrentQueueInMultipleThreads(unittest.TestCase):
+    def test_num_current_queues_outside_with_clause(self):
         self.assertEqual(dpctl.get_num_activated_queues(), 0)
 
-    @unittest.skipUnless(
-        dpctl.has_gpu_queues(), "No OpenCL GPU queues available"
-    )
-    @unittest.skipUnless(
-        dpctl.has_cpu_queues(), "No OpenCL CPU queues available"
-    )
-    def test_num_current_queues_inside_with_clause (self):
+    @unittest.skipUnless(dpctl.has_gpu_queues(), "No OpenCL GPU queues available")
+    @unittest.skipUnless(dpctl.has_cpu_queues(), "No OpenCL CPU queues available")
+    def test_num_current_queues_inside_with_clause(self):
         with dpctl.device_context("opencl:cpu:0"):
             self.assertEqual(dpctl.get_num_activated_queues(), 1)
             with dpctl.device_context("opencl:gpu:0"):
                 self.assertEqual(dpctl.get_num_activated_queues(), 2)
         self.assertEqual(dpctl.get_num_activated_queues(), 0)
 
-
-    @unittest.skipUnless(
-        dpctl.has_gpu_queues(), "No OpenCL GPU queues available"
-    )
-    @unittest.skipUnless(
-        dpctl.has_cpu_queues(), "No OpenCL CPU queues available"
-    )
-    def test_num_current_queues_inside_threads (self):
+    @unittest.skipUnless(dpctl.has_gpu_queues(), "No OpenCL GPU queues available")
+    @unittest.skipUnless(dpctl.has_cpu_queues(), "No OpenCL CPU queues available")
+    def test_num_current_queues_inside_threads(self):
         from threading import Thread
-        def SessionThread (self):
+
+        def SessionThread(self):
             self.assertEqual(dpctl.get_num_activated_queues(), 0)
             with dpctl.device_context("opencl:gpu:0"):
                 self.assertEqual(dpctl.get_num_activated_queues(), 1)
@@ -156,5 +128,5 @@ class TestGetCurrentQueueInMultipleThreads (unittest.TestCase):
             Session2.start()
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/dpctl/tests/test_sycl_queue_memcpy.py
+++ b/dpctl/tests/test_sycl_queue_memcpy.py
@@ -26,17 +26,17 @@ import dpctl
 import unittest
 
 
-class TestQueueMemcpy (unittest.TestCase):
-
-    def _create_memory (self):
+class TestQueueMemcpy(unittest.TestCase):
+    def _create_memory(self):
         nbytes = 1024
         queue = dpctl.get_current_queue()
         mobj = dpctl._memory.MemoryUSMShared(nbytes, queue)
         return mobj
 
-    @unittest.skipUnless(dpctl.has_sycl_platforms(),
-                         "No SYCL devices except the default host device.")
-    def test_memcpy_copy_usm_to_usm (self):
+    @unittest.skipUnless(
+        dpctl.has_sycl_platforms(), "No SYCL devices except the default host device."
+    )
+    def test_memcpy_copy_usm_to_usm(self):
         mobj1 = self._create_memory()
         mobj2 = self._create_memory()
         q = dpctl.get_current_queue()
@@ -44,15 +44,16 @@ class TestQueueMemcpy (unittest.TestCase):
         mv1 = memoryview(mobj1)
         mv2 = memoryview(mobj2)
 
-        mv1[:3] = b'123'
+        mv1[:3] = b"123"
 
         q.memcpy(mobj2, mobj1, 3)
 
-        self.assertEqual(mv2[:3], b'123')
+        self.assertEqual(mv2[:3], b"123")
 
-    @unittest.skipUnless(dpctl.has_sycl_platforms(),
-                         "No SYCL devices except the default host device.")
-    def test_memcpy_type_error (self):
+    @unittest.skipUnless(
+        dpctl.has_sycl_platforms(), "No SYCL devices except the default host device."
+    )
+    def test_memcpy_type_error(self):
         mobj = self._create_memory()
         q = dpctl.get_current_queue()
 
@@ -69,5 +70,5 @@ class TestQueueMemcpy (unittest.TestCase):
         self.assertEqual(str(cm.exception), "Parameter src should be Memory.")
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/dpctl/tests/test_sycl_usm.py
+++ b/dpctl/tests/test_sycl_usm.py
@@ -27,34 +27,33 @@ import dpctl
 from dpctl._memory import MemoryUSMShared, MemoryUSMHost, MemoryUSMDevice
 
 
-class TestMemory (unittest.TestCase):
-
-    @unittest.skipUnless(dpctl.has_sycl_platforms(),
-                         "No SYCL devices except the default host device.")
-    def test_memory_create (self):
+class TestMemory(unittest.TestCase):
+    @unittest.skipUnless(
+        dpctl.has_sycl_platforms(), "No SYCL devices except the default host device."
+    )
+    def test_memory_create(self):
         nbytes = 1024
         queue = dpctl.get_current_queue()
         mobj = MemoryUSMShared(nbytes, queue)
         self.assertEqual(mobj.nbytes, nbytes)
 
-    def _create_memory (self):
+    def _create_memory(self):
         nbytes = 1024
         queue = dpctl.get_current_queue()
         mobj = MemoryUSMShared(nbytes, queue)
         return mobj
 
-    @unittest.skipUnless(dpctl.has_sycl_platforms(),
-                         "No SYCL devices except the default host device.")
-    def test_memory_without_context (self):
+    @unittest.skipUnless(
+        dpctl.has_sycl_platforms(), "No SYCL devices except the default host device."
+    )
+    def test_memory_without_context(self):
         mobj = self._create_memory()
 
         # Without context
-        self.assertEqual(mobj._usm_type(), 'shared')
+        self.assertEqual(mobj._usm_type(), "shared")
 
-    @unittest.skipUnless(
-        dpctl.has_cpu_queues(), "No OpenCL CPU queues available"
-    )
-    def test_memory_cpu_context (self):
+    @unittest.skipUnless(dpctl.has_cpu_queues(), "No OpenCL CPU queues available")
+    def test_memory_cpu_context(self):
         mobj = self._create_memory()
 
         # CPU context
@@ -62,32 +61,31 @@ class TestMemory (unittest.TestCase):
             # type respective to the context in which
             # memory was created
             usm_type = mobj._usm_type()
-            self.assertEqual(usm_type, 'shared')
+            self.assertEqual(usm_type, "shared")
 
             current_queue = dpctl.get_current_queue()
             # type as view from current queue
             usm_type = mobj._usm_type(current_queue)
             # type can be unknown if current queue is
             # not in the same SYCL context
-            self.assertTrue(usm_type in ['unknown', 'shared'])
+            self.assertTrue(usm_type in ["unknown", "shared"])
 
-    @unittest.skipUnless(
-        dpctl.has_gpu_queues(), "No OpenCL GPU queues available"
-    )
-    def test_memory_gpu_context (self):
+    @unittest.skipUnless(dpctl.has_gpu_queues(), "No OpenCL GPU queues available")
+    def test_memory_gpu_context(self):
         mobj = self._create_memory()
 
         # GPU context
         with dpctl.device_context("opencl:gpu:0"):
             usm_type = mobj._usm_type()
-            self.assertEqual(usm_type, 'shared')
+            self.assertEqual(usm_type, "shared")
             current_queue = dpctl.get_current_queue()
             usm_type = mobj._usm_type(current_queue)
-            self.assertTrue(usm_type in ['unknown', 'shared'])
+            self.assertTrue(usm_type in ["unknown", "shared"])
 
-    @unittest.skipUnless(dpctl.has_sycl_platforms(),
-                         "No SYCL devices except the default host device.")
-    def test_buffer_protocol (self):
+    @unittest.skipUnless(
+        dpctl.has_sycl_platforms(), "No SYCL devices except the default host device."
+    )
+    def test_buffer_protocol(self):
         mobj = self._create_memory()
         mv1 = memoryview(mobj)
         mv2 = memoryview(mobj)
@@ -100,17 +98,19 @@ class TestMemoryUSMBase:
     MemoryUSMClass = None
     usm_type = None
 
-    @unittest.skipUnless(dpctl.has_sycl_platforms(),
-                         "No SYCL devices except the default host device.")
-    def test_create_with_queue (self):
+    @unittest.skipUnless(
+        dpctl.has_sycl_platforms(), "No SYCL devices except the default host device."
+    )
+    def test_create_with_queue(self):
         q = dpctl.get_current_queue()
         m = self.MemoryUSMClass(1024, q)
         self.assertEqual(m.nbytes, 1024)
         self.assertEqual(m._usm_type(), self.usm_type)
 
-    @unittest.skipUnless(dpctl.has_sycl_platforms(),
-                         "No SYCL devices except the default host device.")
-    def test_create_without_queue (self):
+    @unittest.skipUnless(
+        dpctl.has_sycl_platforms(), "No SYCL devices except the default host device."
+    )
+    def test_create_without_queue(self):
         m = self.MemoryUSMClass(1024)
         self.assertEqual(m.nbytes, 1024)
         self.assertEqual(m._usm_type(), self.usm_type)
@@ -120,22 +120,22 @@ class TestMemoryUSMShared(TestMemoryUSMBase, unittest.TestCase):
     """ Tests for MemoryUSMShared """
 
     MemoryUSMClass = MemoryUSMShared
-    usm_type = 'shared'
+    usm_type = "shared"
 
 
 class TestMemoryUSMHost(TestMemoryUSMBase, unittest.TestCase):
     """ Tests for MemoryUSMHost """
 
     MemoryUSMClass = MemoryUSMHost
-    usm_type = 'host'
+    usm_type = "host"
 
 
 class TestMemoryUSMDevice(TestMemoryUSMBase, unittest.TestCase):
     """ Tests for MemoryUSMDevice """
 
     MemoryUSMClass = MemoryUSMDevice
-    usm_type = 'device'
+    usm_type = "device"
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[tool.black]
+exclude = 'versioneer.py'

--- a/setup.py
+++ b/setup.py
@@ -32,51 +32,62 @@ from Cython.Build import cythonize
 import numpy as np
 
 requirements = [
-    'cffi>=1.0.0',
-    'cython',
+    "cffi>=1.0.0",
+    "cython",
 ]
 
 IS_WIN = False
 IS_MAC = False
 IS_LIN = False
 
-if 'linux' in sys.platform:
+if "linux" in sys.platform:
     IS_LIN = True
-elif sys.platform == 'darwin':
+elif sys.platform == "darwin":
     IS_MAC = True
-elif sys.platform in ['win32', 'cygwin']:
+elif sys.platform in ["win32", "cygwin"]:
     IS_WIN = True
 else:
-    assert False, sys.platform + ' not supported'
+    assert False, sys.platform + " not supported"
 
-dppl_sycl_interface_lib     = os.environ['DPPL_SYCL_INTERFACE_LIBDIR']
-dppl_sycl_interface_include = os.environ['DPPL_SYCL_INTERFACE_INCLDIR']
-sycl_lib = os.environ['ONEAPI_ROOT']+"\compiler\latest\windows\lib"
+dppl_sycl_interface_lib = os.environ["DPPL_SYCL_INTERFACE_LIBDIR"]
+dppl_sycl_interface_include = os.environ["DPPL_SYCL_INTERFACE_INCLDIR"]
+sycl_lib = os.environ["ONEAPI_ROOT"] + "\compiler\latest\windows\lib"
+
 
 def get_sdl_cflags():
     if IS_LIN or IS_MAC:
-        return ['-fstack-protector', '-fPIC',
-                '-D_FORTIFY_SOURCE=2', '-Wformat', '-Wformat-security',]
+        return [
+            "-fstack-protector",
+            "-fPIC",
+            "-D_FORTIFY_SOURCE=2",
+            "-Wformat",
+            "-Wformat-security",
+        ]
     elif IS_WIN:
         return []
+
 
 def get_sdl_ldflags():
     if IS_LIN:
-        return ['-Wl,-z,noexecstack,-z,relro,-z,now',]
+        return [
+            "-Wl,-z,noexecstack,-z,relro,-z,now",
+        ]
     elif IS_MAC:
         return []
     elif IS_WIN:
-        return ['/NXCompat', '/DynamicBase']
+        return ["/NXCompat", "/DynamicBase"]
+
 
 def get_other_cxxflags():
     if IS_LIN:
-        return ['-O3', '-fsycl', '-std=c++17']
+        return ["-O3", "-fsycl", "-std=c++17"]
     elif IS_MAC:
         return []
     elif IS_WIN:
         # FIXME: These are specific to MSVC and we should first make sure
         # what compiler we are using.
-        return ['/Ox', '/std:c++17']
+        return ["/Ox", "/std:c++17"]
+
 
 def extensions():
     # Security flags
@@ -86,11 +97,11 @@ def extensions():
     librarys = []
 
     if IS_LIN:
-        libs += ['rt', 'DPPLSyclInterface']
+        libs += ["rt", "DPPLSyclInterface"]
     elif IS_MAC:
         pass
     elif IS_WIN:
-        libs += ['DPPLSyclInterface', 'sycl']
+        libs += ["DPPLSyclInterface", "sycl"]
 
     if IS_LIN:
         librarys = [dppl_sycl_interface_lib]
@@ -105,47 +116,58 @@ def extensions():
         runtime_library_dirs = []
 
     extension_args = {
-        "depends": [dppl_sycl_interface_include,],
+        "depends": [
+            dppl_sycl_interface_include,
+        ],
         "include_dirs": [np.get_include(), dppl_sycl_interface_include],
         "extra_compile_args": eca + get_other_cxxflags(),
         "extra_link_args": ela,
         "libraries": libs,
         "library_dirs": librarys,
         "runtime_library_dirs": runtime_library_dirs,
-        "language": 'c++',
+        "language": "c++",
     }
 
     extensions = [
-        Extension('dpctl._sycl_core', [os.path.join('dpctl', 'sycl_core.pyx'),],
-            **extension_args),
-        Extension('dpctl._memory', [os.path.join('dpctl', '_memory.pyx'),],
-            **extension_args),
+        Extension(
+            "dpctl._sycl_core",
+            [
+                os.path.join("dpctl", "sycl_core.pyx"),
+            ],
+            **extension_args
+        ),
+        Extension(
+            "dpctl._memory",
+            [
+                os.path.join("dpctl", "_memory.pyx"),
+            ],
+            **extension_args
+        ),
     ]
 
     exts = cythonize(extensions)
     return exts
 
+
 setup(
-    name='dpctl',
+    name="dpctl",
     version=versioneer.get_version(),
     cmdclass=versioneer.get_cmdclass(),
     description="A lightweight Python wrapper for a subset of OpenCL and SYCL.",
     license="Apache 2.0",
     author="Intel Corporation",
-    url='https://github.com/IntelPython/dpCtl',
+    url="https://github.com/IntelPython/dpCtl",
     packages=find_packages(include=["*"]),
     include_package_data=True,
-    ext_modules = extensions(),
+    ext_modules=extensions(),
     setup_requires=requirements,
-    cffi_modules=[
-       "./dpctl/opencl_core.py:ffi"
-    ],
+    cffi_modules=["./dpctl/opencl_core.py:ffi"],
     install_requires=requirements,
-    keywords='dpctl',
+    keywords="dpctl",
     classifiers=[
         "Development Status :: 3 - Alpha",
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
-        'Programming Language :: Python :: 3.8',
-    ]
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+    ],
 )


### PR DESCRIPTION
[black](https://github.com/psf/black) is "The Uncompromising Code Formatter".

- [x] Use the black badge in project's README.md for indicating the code style
- [x] Add GitHub Actions for black for check code style
- [x] Ignore versioneer.py because it is 3rd party file (see `pyproject.toml`)
- [x] Format all Python code with black (just `black .`)
- [x] Add ignoring revisions in blame so you can see meaningful blame info after global formatting commit
- [x] Update CONTRIBUTING.md for all developers to use black in everyday work

Usage is simple: `black .`

This PR should be merged, not squashed.