### PR TITLE
Source TBB from oneAPI for activating CPU device

### DIFF
--- a/conda-recipe/run_test.sh
+++ b/conda-recipe/run_test.sh
@@ -4,6 +4,7 @@ set -e
 
 # Suppress error b/c it could fail on Ubuntu 18.04
 source ${ONEAPI_ROOT}/compiler/latest/env/vars.sh || true
+source ${ONEAPI_ROOT}/tbb/latest/env/vars.sh || true
 
 ${PYTHON} -c "import dpctl"
 ${PYTHON} -c "import dpctl.ocldrv"


### PR DESCRIPTION
In this PR I have tried to activate compute runtime for CPU. For some reason it is activated from oneAPI if activate TBB environment.
Finally activated TBB environment does not solve the problem because CPU device is visible in clinfo but it fails when I try to use it.