### PR TITLE
onaAPI beta10 compiler

### DIFF
--- a/conda-recipe/bld.bat
+++ b/conda-recipe/bld.bat
@@ -3,7 +3,7 @@ IF ERRORLEVEL 1 exit 1
 REM conda uses %ERRORLEVEL% but FPGA scripts can set it. So it should be reseted.
 set ERRORLEVEL=
 
-set "CC=dpcpp.exe"
+set "CC=clang.exe"
 set "CXX=dpcpp.exe"
 
 rmdir /S /Q build_cmake

--- a/conda-recipe/bld.bat
+++ b/conda-recipe/bld.bat
@@ -3,7 +3,7 @@ IF ERRORLEVEL 1 exit 1
 REM conda uses %ERRORLEVEL% but FPGA scripts can set it. So it should be reseted.
 set ERRORLEVEL=
 
-set "CC=clang.exe"
+set "CC=clang-cl.exe"
 set "CXX=dpcpp.exe"
 
 rmdir /S /Q build_cmake


### PR DESCRIPTION
With oneAPI beta10 compiler it is not working to use `CC=dpcpp.exe`. Use `CC=clang-cl.exe` instead.