### PR TITLE
Use INSTALL_PATH in cmake call

### DIFF
--- a/conda-recipe/bld.bat
+++ b/conda-recipe/bld.bat
@@ -17,7 +17,7 @@ rmdir /S /Q "%INSTALL_PREFIX%"
 
 cmake -G Ninja ^
     -DCMAKE_BUILD_TYPE=Release ^
-    "-DCMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX%" ^
+    "-DCMAKE_INSTALL_PREFIX=%INSTALL_PREFIX%" ^
     "-DCMAKE_PREFIX_PATH=%LIBRARY_PREFIX%" ^
     "-DDPCPP_ROOT=%DPCPP_ROOT%" ^
     "%SRC_DIR%/backends"
@@ -29,7 +29,7 @@ IF %ERRORLEVEL% NEQ 0 exit 1
 
 cd ..
 xcopy install\lib\*.lib dpctl /E /Y
-xcopy install\lib\*.dll dpctl /E /Y
+xcopy install\bin\*.dll dpctl /E /Y
 
 mkdir dpctl\include
 xcopy backends\include dpctl\include /E /Y


### PR DESCRIPTION
This ensures that backend libraries  are copied into dpctl
and included in the conda tar ball.

Also fixed copy statement to account for .lib files being
in %INSTALL_PREFIX%\lib and .dll files being in
%INSTALL_PREFIX%\bin on Windows.

@PokhodenkoSA @diptorupd @reazulhoque 