### PR TITLE
Feature/extra device info

### DIFF
--- a/backends/include/dppl_sycl_device_interface.h
+++ b/backends/include/dppl_sycl_device_interface.h
@@ -103,6 +103,56 @@ __dppl_give const char*
 DPPLDevice_GetDriverInfo (__dppl_keep const DPPLSyclDeviceRef DRef);
 
 /*!
+ * @brief Wrapper over device.get_info<info::device::max_compute_units>().
+ *
+ * @param    DRef           Opaque pointer to a sycl::device
+ * @return   Returns the valid result if device exists else returns 0.
+ */
+DPPL_API
+uint32_t
+DPPLDevice_GetMaxComputeUnites (__dppl_keep const DPPLSyclDeviceRef DRef);
+
+/*!
+ * @brief Wrapper for get_info<info::device::max_work_item_dimensions().
+ *
+ * @param    DRef           Opaque pointer to a sycl::device
+ * @return   Returns the valid result if device exists else returns 0.
+ */
+DPPL_API
+uint32_t
+DPPLDevice_GetMaxWorkItemDims (__dppl_keep const DPPLSyclDeviceRef DRef);
+
+/*!
+ * @brief Wrapper for get_info<info::device::max_work_item_sizes().
+ *
+ * @param    DRef           Opaque pointer to a sycl::device
+ * @return   Returns the valid result if device exists else returns Null.
+ */
+DPPL_API
+__dppl_keep size_t*
+DPPLDevice_GetMaxWorkItemSizes (__dppl_keep const DPPLSyclDeviceRef DRef);
+
+/*!
+ * @brief Wrapper for get_info<info::device::max_work_group_size().
+ *
+ * @param    DRef           Opaque pointer to a sycl::device
+ * @return   Returns the valid result if device exists else returns 0.
+ */
+DPPL_API
+size_t
+DPPLDevice_GetMaxWorkGroupSize (__dppl_keep const DPPLSyclDeviceRef DRef);
+
+/*!
+ * @brief Wrapper over device.get_info<info::device::max_num_sub_groups>.
+ *
+ * @param    DRef           Opaque pointer to a sycl::device
+ * @return   Returns the valid result if device exists else returns 0.
+ */
+DPPL_API
+uint32_t
+DPPLDevice_GetMaxNumSubGroups (__dppl_keep const DPPLSyclDeviceRef DRef);
+
+/*!
  * @brief Returns a C string for the device name.
  *
  * @param    DRef           Opaque pointer to a sycl::device

--- a/backends/include/dppl_utils.h
+++ b/backends/include/dppl_utils.h
@@ -24,6 +24,7 @@
 
 #pragma once
 
+#include "dppl_data_types.h"
 #include "Support/DllExport.h"
 #include "Support/ExternC.h"
 #include "Support/MemOwnershipAttrs.h"
@@ -31,11 +32,19 @@
 DPPL_C_EXTERN_C_BEGIN
 
 /*!
- * @brief Deletes the C String argument
+ * @brief Deletes the C String argument.
  *
  * @param    str            C string to be deleted
  */
 DPPL_API
 void DPPLCString_Delete (__dppl_take const char* str);
+
+/*!
+ * @brief Deletes an array of size_t elements.
+ *
+ * @param    arr            Array to be deleted.
+ */
+DPPL_API
+void DPPLSize_t_Array_Delete (__dppl_take size_t* arr);
 
 DPPL_C_EXTERN_C_END

--- a/backends/source/dppl_sycl_device_interface.cpp
+++ b/backends/source/dppl_sycl_device_interface.cpp
@@ -103,53 +103,143 @@ void DPPLDevice_Delete (__dppl_take DPPLSyclDeviceRef DRef)
 
 bool DPPLDevice_IsAccelerator (__dppl_keep const DPPLSyclDeviceRef DRef)
 {
-    return unwrap(DRef)->is_accelerator();
+    auto D = unwrap(DRef);
+    if(D) {
+        return unwrap(DRef)->is_accelerator();
+    }
+    return false;
 }
 
 bool DPPLDevice_IsCPU (__dppl_keep const DPPLSyclDeviceRef DRef)
 {
-    return unwrap(DRef)->is_cpu();
+    auto D = unwrap(DRef);
+    if(D) {
+        return unwrap(DRef)->is_cpu();
+    }
+    return false;
+
 }
 
 bool DPPLDevice_IsGPU (__dppl_keep const DPPLSyclDeviceRef DRef)
 {
-    return unwrap(DRef)->is_gpu();
+    auto D = unwrap(DRef);
+    if(D) {
+        return unwrap(DRef)->is_gpu();
+    }
+    return false;
 }
 
 
 bool DPPLDevice_IsHost (__dppl_keep const DPPLSyclDeviceRef DRef)
 {
-    return unwrap(DRef)->is_host();
+    auto D = unwrap(DRef);
+    if(D) {
+        return unwrap(DRef)->is_host();
+    }
+    return false;
+}
+
+
+uint32_t
+DPPLDevice_GetMaxComputeUnites (__dppl_keep const DPPLSyclDeviceRef DRef)
+{
+    auto D = unwrap(DRef);
+    if(D) {
+        return D->get_info<info::device::max_compute_units>();
+    }
+    return 0;
+
+}
+
+uint32_t
+DPPLDevice_GetMaxWorkItemDims (__dppl_keep const DPPLSyclDeviceRef DRef)
+{
+    auto D = unwrap(DRef);
+    if(D) {
+        return D->get_info<info::device::max_work_item_dimensions>();
+    }
+    return 0;
+}
+
+__dppl_keep size_t*
+DPPLDevice_GetMaxWorkItemSizes (__dppl_keep const DPPLSyclDeviceRef DRef)
+{
+    size_t *sizes = nullptr;
+    auto D = unwrap(DRef);
+    if(D) {
+        auto id_sizes = D->get_info<info::device::max_work_item_sizes>();
+        sizes = new size_t[3];
+        for(auto i = 0ul; i < 3; ++i) {
+            sizes[i] = id_sizes[i];
+        }
+    }
+    return sizes;
+}
+
+size_t
+DPPLDevice_GetMaxWorkGroupSize (__dppl_keep const DPPLSyclDeviceRef DRef)
+{
+    auto D = unwrap(DRef);
+    if(D) {
+        return D->get_info<info::device::max_work_group_size>();
+    }
+    return 0;
+}
+
+uint32_t
+DPPLDevice_GetMaxNumSubGroups (__dppl_keep const DPPLSyclDeviceRef DRef)
+{
+    auto D = unwrap(DRef);
+    if(D) {
+        return D->get_info<info::device::max_num_sub_groups>();
+    }
+    return 0;
 }
 
 __dppl_give const char*
 DPPLDevice_GetName (__dppl_keep const DPPLSyclDeviceRef DRef)
 {
-    auto name = unwrap(DRef)->get_info<info::device::name>();
-    auto cstr_name = new char [name.length()+1];
-    std::strcpy (cstr_name, name.c_str());
-    return cstr_name;
+    auto D = unwrap(DRef);
+    if(D) {
+        auto name = unwrap(DRef)->get_info<info::device::name>();
+        auto cstr_name = new char [name.length()+1];
+        std::strcpy (cstr_name, name.c_str());
+        return cstr_name;
+    }
+    return nullptr;
 }
 
 __dppl_give const char*
 DPPLDevice_GetVendorName (__dppl_keep const DPPLSyclDeviceRef DRef)
 {
-    auto vendor = unwrap(DRef)->get_info<info::device::name>();
-    auto cstr_vendor = new char [vendor.length()+1];
-    std::strcpy (cstr_vendor, vendor.c_str());
-    return cstr_vendor;
+    auto D = unwrap(DRef);
+    if(D) {
+        auto vendor = unwrap(DRef)->get_info<info::device::name>();
+        auto cstr_vendor = new char [vendor.length()+1];
+        std::strcpy (cstr_vendor, vendor.c_str());
+        return cstr_vendor;
+    }
+    return nullptr;
 }
 
 __dppl_give const char*
 DPPLDevice_GetDriverInfo (__dppl_keep const DPPLSyclDeviceRef DRef)
 {
-    auto driver = unwrap(DRef)->get_info<info::device::driver_version>();
-    auto cstr_driver = new char [driver.length()+1];
-    std::strcpy (cstr_driver, driver.c_str());
-    return cstr_driver;
+    auto D = unwrap(DRef);
+    if(D) {
+        auto driver = unwrap(DRef)->get_info<info::device::driver_version>();
+        auto cstr_driver = new char [driver.length()+1];
+        std::strcpy (cstr_driver, driver.c_str());
+        return cstr_driver;
+    }
+    return nullptr;
 }
 
 bool DPPLDevice_IsHostUnifiedMemory (__dppl_keep const DPPLSyclDeviceRef DRef)
 {
-    return unwrap(DRef)->get_info<info::device::host_unified_memory>();
+    auto D = unwrap(DRef);
+    if(D) {
+        return D->get_info<info::device::host_unified_memory>();
+    }
+    return false;
 }

--- a/backends/source/dppl_utils.cpp
+++ b/backends/source/dppl_utils.cpp
@@ -29,3 +29,8 @@ void DPPLCString_Delete (__dppl_take const char* str)
 {
     delete[] str;
 }
+
+void DPPLSize_t_Array_Delete (__dppl_take size_t* arr)
+{
+    delete[] arr;
+}

--- a/backends/tests/CMakeLists.txt
+++ b/backends/tests/CMakeLists.txt
@@ -23,6 +23,7 @@ else()
   link_directories(${GTEST_LIB_DIR})
 
   set(PYDPPL_BACKEND_TEST_CASES
+    test_sycl_device_interface
     test_sycl_kernel_interface
     test_sycl_platform_interface
     test_sycl_program_interface

--- a/backends/tests/test_sycl_device_interface.cpp
+++ b/backends/tests/test_sycl_device_interface.cpp
@@ -1,0 +1,230 @@
+//===----- test_sycl_device_interface.cpp - DPPL-SYCL interface -*- C++ -*-===//
+//
+//               Python Data Parallel Processing Library (PyDPPL)
+//
+// Copyright 2020 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// This file has unit test cases for functions defined in
+/// dppl_sycl_kernel_interface.h.
+///
+//===----------------------------------------------------------------------===//
+
+#include "dppl_sycl_device_interface.h"
+#include "dppl_sycl_queue_interface.h"
+#include "dppl_sycl_queue_manager.h"
+#include "dppl_utils.h"
+
+#include <gtest/gtest.h>
+#include <CL/sycl.hpp>
+
+using namespace cl::sycl;
+
+
+struct TestDPPLSyclDeviceInterface : public ::testing::Test
+{
+    DPPLSyclDeviceRef OpenCL_cpu = nullptr;
+    DPPLSyclDeviceRef OpenCL_gpu = nullptr;
+
+    TestDPPLSyclDeviceInterface ()
+    {
+        if(DPPLQueueMgr_GetNumQueues(DPPL_OPENCL, DPPL_CPU)) {
+            auto Q = DPPLQueueMgr_GetQueue(DPPL_OPENCL, DPPL_CPU, 0);
+            OpenCL_cpu = DPPLQueue_GetDevice(Q);
+            DPPLQueue_Delete(Q);
+        }
+
+        if(DPPLQueueMgr_GetNumQueues(DPPL_OPENCL, DPPL_GPU)) {
+            auto Q = DPPLQueueMgr_GetQueue(DPPL_OPENCL, DPPL_GPU, 0);
+            OpenCL_gpu = DPPLQueue_GetDevice(Q);
+            DPPLQueue_Delete(Q);
+        }
+    }
+
+    ~TestDPPLSyclDeviceInterface ()
+    {
+        DPPLDevice_Delete(OpenCL_cpu);
+        DPPLDevice_Delete(OpenCL_gpu);
+    }
+
+};
+
+TEST_F (TestDPPLSyclDeviceInterface, CheckOCLCPU_GetDriverInfo)
+{
+    if(!OpenCL_cpu)
+        GTEST_SKIP_("Skipping as no OpenCL CPU device found.");
+
+    auto DriverInfo = DPPLDevice_GetDriverInfo(OpenCL_cpu);
+    EXPECT_TRUE(DriverInfo != nullptr);
+    DPPLCString_Delete(DriverInfo);
+}
+
+TEST_F (TestDPPLSyclDeviceInterface, CheckOCLGPU_GetDriverInfo)
+{
+    if(!OpenCL_gpu)
+        GTEST_SKIP_("Skipping as no OpenCL CPU device found.");
+
+    auto DriverInfo = DPPLDevice_GetDriverInfo(OpenCL_gpu);
+    EXPECT_TRUE(DriverInfo != nullptr);
+    DPPLCString_Delete(DriverInfo);
+}
+
+TEST_F (TestDPPLSyclDeviceInterface, CheckOCLCPU_GetMaxComputeUnites)
+{
+    if(!OpenCL_cpu)
+        GTEST_SKIP_("Skipping as no OpenCL CPU device found.");
+
+    auto n = DPPLDevice_GetMaxComputeUnites(OpenCL_cpu);
+    EXPECT_TRUE(n != 0);
+}
+
+TEST_F (TestDPPLSyclDeviceInterface, CheckOCLGPU_GetMaxComputeUnites)
+{
+    if(!OpenCL_gpu)
+        GTEST_SKIP_("Skipping as no OpenCL GPU device found.");
+
+    auto n = DPPLDevice_GetMaxComputeUnites(OpenCL_gpu);
+    EXPECT_TRUE(n != 0);
+}
+
+TEST_F (TestDPPLSyclDeviceInterface, CheckOCLCPU_GetMaxWorkItemDims)
+{
+    if(!OpenCL_cpu)
+        GTEST_SKIP_("Skipping as no OpenCL CPU device found.");
+
+    auto n = DPPLDevice_GetMaxWorkItemDims(OpenCL_cpu);
+    EXPECT_TRUE(n != 0);
+}
+
+TEST_F (TestDPPLSyclDeviceInterface, CheckOCLGPU_GetMaxWorkItemDims)
+{
+    if(!OpenCL_gpu)
+        GTEST_SKIP_("Skipping as no OpenCL GPU device found.");
+
+    auto n = DPPLDevice_GetMaxWorkItemDims(OpenCL_gpu);
+    EXPECT_TRUE(n != 0);
+}
+
+TEST_F (TestDPPLSyclDeviceInterface, CheckOCLCPU_GetMaxWorkItemSizes)
+{
+    if(!OpenCL_cpu)
+        GTEST_SKIP_("Skipping as no OpenCL GPU device found.");
+
+    auto item_sizes = DPPLDevice_GetMaxWorkItemSizes(OpenCL_cpu);
+    EXPECT_TRUE(item_sizes != nullptr);
+    DPPLSize_t_Array_Delete(item_sizes);
+}
+
+TEST_F (TestDPPLSyclDeviceInterface, CheckOCLCPU_GetMaxWorkGroupSize)
+{
+    if(!OpenCL_cpu)
+        GTEST_SKIP_("Skipping as no OpenCL CPU device found.");
+
+    auto n = DPPLDevice_GetMaxWorkGroupSize(OpenCL_cpu);
+    EXPECT_TRUE(n != 0);
+}
+
+TEST_F (TestDPPLSyclDeviceInterface, CheckOCLGPU_GetMaxWorkGroupSize)
+{
+    if(!OpenCL_gpu)
+        GTEST_SKIP_("Skipping as no OpenCL GPU device found.");
+
+    auto n = DPPLDevice_GetMaxWorkGroupSize(OpenCL_gpu);
+    EXPECT_TRUE(n != 0);
+}
+
+TEST_F (TestDPPLSyclDeviceInterface, CheckOCLCPU_GetMaxNumSubGroups)
+{
+    if(!OpenCL_cpu)
+        GTEST_SKIP_("Skipping as no OpenCL CPU device found.");
+
+    auto n = DPPLDevice_GetMaxNumSubGroups(OpenCL_cpu);
+    EXPECT_TRUE(n != 0);
+}
+
+TEST_F (TestDPPLSyclDeviceInterface, CheckOCLGPU_GetMaxNumSubGroups)
+{
+    if(!OpenCL_gpu)
+        GTEST_SKIP_("Skipping as no OpenCL GPU device found.");
+
+    auto n = DPPLDevice_GetMaxNumSubGroups(OpenCL_gpu);
+    EXPECT_TRUE(n != 0);
+}
+
+TEST_F (TestDPPLSyclDeviceInterface, CheckOCLCPU_GetName)
+{
+    if(!OpenCL_cpu)
+        GTEST_SKIP_("Skipping as no OpenCL CPU device found.");
+
+    auto DevName = DPPLDevice_GetName(OpenCL_cpu);
+    EXPECT_TRUE(DevName != nullptr);
+    DPPLCString_Delete(DevName);
+}
+
+TEST_F (TestDPPLSyclDeviceInterface, CheckOCLGPU_GetName)
+{
+    if(!OpenCL_gpu)
+        GTEST_SKIP_("Skipping as no OpenCL CPU device found.");
+
+    auto DevName = DPPLDevice_GetName(OpenCL_gpu);
+    EXPECT_TRUE(DevName != nullptr);
+    DPPLCString_Delete(DevName);
+}
+
+TEST_F (TestDPPLSyclDeviceInterface, CheckOCLCPU_GetVendorName)
+{
+    if(!OpenCL_cpu)
+        GTEST_SKIP_("Skipping as no OpenCL CPU device found.");
+
+    auto VendorName = DPPLDevice_GetVendorName(OpenCL_cpu);
+    EXPECT_TRUE(VendorName != nullptr);
+    DPPLCString_Delete(VendorName);
+}
+
+TEST_F (TestDPPLSyclDeviceInterface, CheckOCLGPU_GetVendorName)
+{
+    if(!OpenCL_gpu)
+        GTEST_SKIP_("Skipping as no OpenCL CPU device found.");
+
+    auto VendorName = DPPLDevice_GetVendorName(OpenCL_gpu);
+    EXPECT_TRUE(VendorName != nullptr);
+    DPPLCString_Delete(VendorName);
+}
+
+TEST_F (TestDPPLSyclDeviceInterface, CheckOCLCPU_IsCPU)
+{
+    if(!OpenCL_cpu)
+        GTEST_SKIP_("Skipping as no OpenCL CPU device found.");
+
+    EXPECT_TRUE(DPPLDevice_IsCPU(OpenCL_cpu));
+}
+
+TEST_F (TestDPPLSyclDeviceInterface, CheckOCLGPU_IsGPU)
+{
+    if(!OpenCL_gpu)
+        GTEST_SKIP_("Skipping as no OpenCL CPU device found.");
+
+    EXPECT_TRUE(DPPLDevice_IsGPU(OpenCL_gpu));
+}
+
+int
+main (int argc, char** argv)
+{
+    ::testing::InitGoogleTest(&argc, argv);
+    int ret = RUN_ALL_TESTS();
+    return ret;
+}

--- a/backends/tests/test_sycl_kernel_interface.cpp
+++ b/backends/tests/test_sycl_kernel_interface.cpp
@@ -112,7 +112,7 @@ TEST_F (TestDPPLSyclKernelInterface, CheckGetNumArgs)
 int
 main (int argc, char** argv)
 {
-  ::testing::InitGoogleTest(&argc, argv);
-  int ret = RUN_ALL_TESTS();
-  return ret;
+    ::testing::InitGoogleTest(&argc, argv);
+    int ret = RUN_ALL_TESTS();
+    return ret;
 }


### PR DESCRIPTION
The PR closes issues #113 and #81.

Sycl `device` class provides several info device descriptors that can be extracted using `info::device`. This PR will expose several of the device descriptors inside dpctl C API (backends) and inside the dpctl.SyclDevice class. 

* info::device::max_compute_units
* info::device::max_work_item_dimensions
* info::device::max_work_item_sizes
* info::device::max_work_group_size
* info::device::max_num_sub_groups
* info::device::half_fp_config
* info::device::single_fp_config
* info::device::double_fp_config
* info::device::aspects 
    * int64_base_atomics
    * int64_extended_atomics

These attributes are needed inside Numba and possibly by other clients of dpctl to determine device capabilities.