### PR TITLE
Add clang-format for C/C++ code

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,127 @@
+---
+Language:        Cpp
+# BasedOnStyle:  LLVM
+AccessModifierOffset: -2
+AlignAfterOpenBracket: Align
+AlignConsecutiveMacros: false
+AlignConsecutiveAssignments: false
+AlignConsecutiveDeclarations: false
+AlignEscapedNewlines: Right
+AlignOperands:   true
+AlignTrailingComments: true
+AllowAllArgumentsOnNextLine: true
+AllowAllConstructorInitializersOnNextLine: true
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortBlocksOnASingleLine: false
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: All
+AllowShortLambdasOnASingleLine: All
+AllowShortIfStatementsOnASingleLine: Never
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: false
+AlwaysBreakTemplateDeclarations: MultiLine
+BinPackArguments: true
+BinPackParameters: true
+BraceWrapping:
+  AfterCaseLabel:  false
+  AfterClass:      false
+  AfterControlStatement: false
+  AfterEnum:       false
+  AfterFunction:   false
+  AfterNamespace:  false
+  AfterObjCDeclaration: false
+  AfterStruct:     false
+  AfterUnion:      false
+  AfterExternBlock: false
+  BeforeCatch:     false
+  BeforeElse:      false
+  IndentBraces:    false
+  SplitEmptyFunction: true
+  SplitEmptyRecord: true
+  SplitEmptyNamespace: true
+BreakBeforeBinaryOperators: None
+BreakBeforeBraces: Attach
+BreakBeforeInheritanceComma: false
+BreakInheritanceList: BeforeColon
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializersBeforeComma: false
+BreakConstructorInitializers: BeforeColon
+BreakAfterJavaFieldAnnotations: false
+BreakStringLiterals: true
+ColumnLimit:     80
+CommentPragmas:  '^ IWYU pragma:'
+CompactNamespaces: false
+ConstructorInitializerAllOnOneLineOrOnePerLine: false
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: true
+DerivePointerAlignment: false
+DisableFormat:   false
+ExperimentalAutoDetectBinPacking: false
+FixNamespaceComments: true
+ForEachMacros:
+  - foreach
+  - Q_FOREACH
+  - BOOST_FOREACH
+IncludeBlocks:   Preserve
+IncludeCategories:
+  - Regex:           '^"(llvm|llvm-c|clang|clang-c)/'
+    Priority:        2
+  - Regex:           '^(<|"(gtest|gmock|isl|json)/)'
+    Priority:        3
+  - Regex:           '.*'
+    Priority:        1
+IncludeIsMainRegex: '(Test)?$'
+IndentCaseLabels: false
+IndentPPDirectives: None
+IndentWidth:     2
+IndentWrappedFunctionNames: false
+JavaScriptQuotes: Leave
+JavaScriptWrapImports: true
+KeepEmptyLinesAtTheStartOfBlocks: true
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: None
+ObjCBinPackProtocolList: Auto
+ObjCBlockIndentWidth: 2
+ObjCSpaceAfterProperty: false
+ObjCSpaceBeforeProtocolList: true
+PenaltyBreakAssignment: 2
+PenaltyBreakBeforeFirstCallParameter: 19
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakString: 1000
+PenaltyBreakTemplateDeclaration: 10
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 60
+PointerAlignment: Right
+ReflowComments:  true
+SortIncludes:    true
+SortUsingDeclarations: true
+SpaceAfterCStyleCast: false
+SpaceAfterLogicalNot: false
+SpaceAfterTemplateKeyword: true
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeCpp11BracedList: false
+SpaceBeforeCtorInitializerColon: true
+SpaceBeforeInheritanceColon: true
+SpaceBeforeParens: ControlStatements
+SpaceBeforeRangeBasedForLoopColon: true
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 1
+SpacesInAngles:  false
+SpacesInContainerLiterals: true
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+Standard:        Cpp11
+StatementMacros:
+  - Q_UNUSED
+  - QT_REQUIRE_VERSION
+TabWidth:        8
+UseTab:          Never
+...
+

--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -2,3 +2,6 @@
 
 # Migrate code style to Black
 41ccd65e2e659aa0add0e5ab59f1a46e32cc4c46
+
+# Migrate code style to clang-format
+44bb346d721b17ebfbeadc3134997cad0ea36b41

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,3 +8,16 @@ We use [black](https://black.readthedocs.io/en/stable/) code formatter.
 - See configuration in `pyproject.toml`.
 
 Run before each commit: `black .`
+
+# C/C++ code style
+
+## clang-format
+
+We use [clang-format](https://clang.llvm.org/docs/ClangFormat.html) code formatter.
+
+Install: `pip install clang`
+
+- Revision: `9.0.1`
+- See configuration in `.clang-format`. Created by: `$ clang-format -style=llvm -dump-config > .clang-format`
+
+Run before each commit: `clang-format -style=file -i backends/include/*.h backends/include/Support/*.h backends/source/*.c backends/source/*.cpp backends/tests/*.cpp`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,6 +4,8 @@
 
 We use [black](https://black.readthedocs.io/en/stable/) code formatter.
 
+Install: `pip install black`
+
 - Revision: `20.8b1` or branch `stable`.
 - See configuration in `pyproject.toml`.
 

--- a/backends/include/Support/CBindingWrapping.h
+++ b/backends/include/Support/CBindingWrapping.h
@@ -23,23 +23,20 @@
 ///
 //===----------------------------------------------------------------------===//
 
- #pragma once
+#pragma once
 
- #define DEFINE_SIMPLE_CONVERSION_FUNCTIONS(ty, ref)     \
-   inline ty *unwrap(ref P) {                            \
-     return reinterpret_cast<ty*>(P);                    \
-   }                                                     \
-                                                         \
-   inline ref wrap(const ty *P) {                        \
-     return reinterpret_cast<ref>(const_cast<ty*>(P));   \
-   }
+#define DEFINE_SIMPLE_CONVERSION_FUNCTIONS(ty, ref)                            \
+  inline ty *unwrap(ref P) { return reinterpret_cast<ty *>(P); }               \
+                                                                               \
+  inline ref wrap(const ty *P) {                                               \
+    return reinterpret_cast<ref>(const_cast<ty *>(P));                         \
+  }
 
- #define DEFINE_STDCXX_CONVERSION_FUNCTIONS(ty, ref)     \
-   DEFINE_SIMPLE_CONVERSION_FUNCTIONS(ty, ref)           \
-                                                         \
-   template<typename T>                                  \
-   inline T *unwrap(ref P) {                             \
-     T *Q = (T*)unwrap(P);                               \
-     assert(Q && "Invalid cast!");                       \
-     return Q;                                           \
-   }
+#define DEFINE_STDCXX_CONVERSION_FUNCTIONS(ty, ref)                            \
+  DEFINE_SIMPLE_CONVERSION_FUNCTIONS(ty, ref)                                  \
+                                                                               \
+  template <typename T> inline T *unwrap(ref P) {                              \
+    T *Q = (T *)unwrap(P);                                                     \
+    assert(Q && "Invalid cast!");                                              \
+    return Q;                                                                  \
+  }

--- a/backends/include/Support/DllExport.h
+++ b/backends/include/Support/DllExport.h
@@ -26,11 +26,11 @@
 #pragma once
 
 #ifdef _WIN32
-#    ifdef DPPLSyclInterface_EXPORTS
-#        define DPPL_API __declspec(dllexport)
-#    else
-#        define DPPL_API __declspec(dllimport)
-#    endif
+#ifdef DPPLSyclInterface_EXPORTS
+#define DPPL_API __declspec(dllexport)
 #else
-#    define DPPL_API
+#define DPPL_API __declspec(dllimport)
+#endif
+#else
+#define DPPL_API
 #endif

--- a/backends/include/Support/ExternC.h
+++ b/backends/include/Support/ExternC.h
@@ -26,8 +26,8 @@
 #pragma once
 
 #ifdef __cplusplus
-#define DPPL_C_EXTERN_C_BEGIN  extern "C" {
-#define DPPL_C_EXTERN_C_END    }
+#define DPPL_C_EXTERN_C_BEGIN extern "C" {
+#define DPPL_C_EXTERN_C_END }
 #else
 #define DPPL_C_EXTERN_C_BEGIN
 #define DPPL_C_EXTERN_C_END

--- a/backends/include/dppl_data_types.h
+++ b/backends/include/dppl_data_types.h
@@ -40,12 +40,12 @@
 #ifndef _MSC_VER
 
 #if !defined(UINT32_MAX)
-# error "The standard header <cstdint> is not C++11 compliant. Must #define "\
+#error "The standard header <cstdint> is not C++11 compliant. Must #define "\
         "__STDC_LIMIT_MACROS before #including llvm-c/DataTypes.h"
 #endif
 
 #if !defined(UINT32_C)
-# error "The standard header <cstdint> is not C++11 compliant. Must #define "\
+#error "The standard header <cstdint> is not C++11 compliant. Must #define "\
         "__STDC_CONSTANT_MACROS before #including llvm-c/DataTypes.h"
 #endif
 
@@ -78,13 +78,13 @@ typedef signed int ssize_t;
 
 /* Set defaults for constants which we cannot find. */
 #if !defined(INT64_MAX)
-# define INT64_MAX 9223372036854775807LL
+#define INT64_MAX 9223372036854775807LL
 #endif
 #if !defined(INT64_MIN)
-# define INT64_MIN ((-INT64_MAX)-1)
+#define INT64_MIN ((-INT64_MAX) - 1)
 #endif
 #if !defined(UINT64_MAX)
-# define UINT64_MAX 0xffffffffffffffffULL
+#define UINT64_MAX 0xffffffffffffffffULL
 #endif
 
 #ifndef HUGE_VALF

--- a/backends/include/dppl_opencl_interface.h
+++ b/backends/include/dppl_opencl_interface.h
@@ -29,85 +29,68 @@
 #include <stdbool.h>
 #include <stdlib.h>
 
-
 #ifdef _WIN32
-#    ifdef DPPLOpenCLInterface_EXPORTS
-#        define DPPL_API __declspec(dllexport)
-#    else
-#        define DPPL_API __declspec(dllimport)
-#    endif
+#ifdef DPPLOpenCLInterface_EXPORTS
+#define DPPL_API __declspec(dllexport)
 #else
-#    define DPPL_API
+#define DPPL_API __declspec(dllimport)
+#endif
+#else
+#define DPPL_API
 #endif
 
-
-enum DP_GLUE_ERROR_CODES
-{
-    DP_GLUE_SUCCESS = 0,
-    DP_GLUE_FAILURE = -1
-};
-
+enum DP_GLUE_ERROR_CODES { DP_GLUE_SUCCESS = 0, DP_GLUE_FAILURE = -1 };
 
 /*!
  *
  */
-struct dp_env
-{
-    unsigned id_;
-    // TODO : Add members to store more device related information such as name
-    void *context;
-    void *device;
-    void *queue;
-    unsigned int max_work_item_dims;
-    size_t max_work_group_size;
-    int support_int64_atomics;
-    int support_float64_atomics;
-    int (*dump_fn) (void *);
+struct dp_env {
+  unsigned id_;
+  // TODO : Add members to store more device related information such as name
+  void *context;
+  void *device;
+  void *queue;
+  unsigned int max_work_item_dims;
+  size_t max_work_group_size;
+  int support_int64_atomics;
+  int support_float64_atomics;
+  int (*dump_fn)(void *);
 };
 
-typedef struct dp_env* env_t;
+typedef struct dp_env *env_t;
 
-
-struct dp_buffer
-{
-    unsigned id_;
-    // This may, for example, be a cl_mem pointer
-    void *buffer_ptr;
-    // Stores the size of the buffer_ptr (e.g sizeof(cl_mem))
-    size_t sizeof_buffer_ptr;
+struct dp_buffer {
+  unsigned id_;
+  // This may, for example, be a cl_mem pointer
+  void *buffer_ptr;
+  // Stores the size of the buffer_ptr (e.g sizeof(cl_mem))
+  size_t sizeof_buffer_ptr;
 };
 
-typedef struct dp_buffer* buffer_t;
+typedef struct dp_buffer *buffer_t;
 
-
-struct dp_kernel
-{
-    unsigned id_;
-    void *kernel;
-    int (*dump_fn) (void *);
+struct dp_kernel {
+  unsigned id_;
+  void *kernel;
+  int (*dump_fn)(void *);
 };
 
-typedef struct dp_kernel* kernel_t;
+typedef struct dp_kernel *kernel_t;
 
-
-struct dp_program
-{
-    unsigned id_;
-    void *program;
+struct dp_program {
+  unsigned id_;
+  void *program;
 };
 
-typedef struct dp_program* program_t;
+typedef struct dp_program *program_t;
 
-
-struct dp_kernel_arg
-{
-    unsigned id_;
-    const void *arg_value;
-    size_t arg_size;
+struct dp_kernel_arg {
+  unsigned id_;
+  const void *arg_value;
+  size_t arg_size;
 };
 
-typedef struct dp_kernel_arg* kernel_arg_t;
-
+typedef struct dp_kernel_arg *kernel_arg_t;
 
 /*! @struct dp_runtime_t
  *  @brief Stores an array of the available OpenCL or Level-0 platform/drivers.
@@ -119,23 +102,22 @@ typedef struct dp_kernel_arg* kernel_arg_t;
  *  An array of OpenCL platforms.
  *
  */
-struct dp_runtime
-{
-    unsigned id_;
-    unsigned num_platforms;
-    void *platform_ids;
-    bool has_cpu;
-    bool has_gpu;
-    env_t first_cpu_env;
-    env_t first_gpu_env;
-    env_t curr_env;
-    int (*dump_fn) (void *);
+struct dp_runtime {
+  unsigned id_;
+  unsigned num_platforms;
+  void *platform_ids;
+  bool has_cpu;
+  bool has_gpu;
+  env_t first_cpu_env;
+  env_t first_gpu_env;
+  env_t curr_env;
+  int (*dump_fn)(void *);
 };
 
-typedef struct dp_runtime* runtime_t;
+typedef struct dp_runtime *runtime_t;
 
 DPPL_API
-int set_curr_env (runtime_t rt, env_t env);
+int set_curr_env(runtime_t rt, env_t env);
 
 /*!
  * @brief Initializes a new dp_runtime_t object
@@ -147,8 +129,7 @@ int set_curr_env (runtime_t rt, env_t env);
  *         initialized.
  */
 DPPL_API
-int create_dp_runtime (runtime_t *rt);
-
+int create_dp_runtime(runtime_t *rt);
 
 /*!
  * @brief Free the runtime and all its resources.
@@ -158,152 +139,118 @@ int create_dp_runtime (runtime_t *rt);
  * @return An error code indicating if resource freeing was successful.
  */
 DPPL_API
-int destroy_dp_runtime (runtime_t *rt);
-
-
-/*!
- *
- */
-DPPL_API
-int create_dp_rw_mem_buffer (env_t env_t_ptr, size_t buffsize, buffer_t *buff);
-
-
-DPPL_API
-int destroy_dp_rw_mem_buffer (buffer_t *buff);
-
+int destroy_dp_runtime(runtime_t *rt);
 
 /*!
  *
  */
 DPPL_API
-int write_dp_mem_buffer_to_device (env_t env_t_ptr,
-                                   buffer_t buff,
-                                   bool blocking_copy,
-                                   size_t offset,
-                                   size_t buffersize,
-                                   const void *data_ptr);
+int create_dp_rw_mem_buffer(env_t env_t_ptr, size_t buffsize, buffer_t *buff);
 
+DPPL_API
+int destroy_dp_rw_mem_buffer(buffer_t *buff);
 
 /*!
  *
  */
 DPPL_API
-int read_dp_mem_buffer_from_device (env_t env_t_ptr,
-                                    buffer_t buff,
-                                    bool blocking_copy,
-                                    size_t offset,
-                                    size_t buffersize,
-                                    void *data_ptr);
-
+int write_dp_mem_buffer_to_device(env_t env_t_ptr, buffer_t buff,
+                                  bool blocking_copy, size_t offset,
+                                  size_t buffersize, const void *data_ptr);
 
 /*!
  *
  */
 DPPL_API
-int create_dp_program_from_spirv (env_t env_t_ptr,
-                                  const void *il,
-                                  size_t length,
+int read_dp_mem_buffer_from_device(env_t env_t_ptr, buffer_t buff,
+                                   bool blocking_copy, size_t offset,
+                                   size_t buffersize, void *data_ptr);
+
+/*!
+ *
+ */
+DPPL_API
+int create_dp_program_from_spirv(env_t env_t_ptr, const void *il, size_t length,
+                                 program_t *program_t_ptr);
+
+/*!
+ *
+ */
+DPPL_API
+int create_dp_program_from_source(env_t env_t_ptr, unsigned int count,
+                                  const char **strings, const size_t *lengths,
                                   program_t *program_t_ptr);
 
+/*!
+ *
+ */
+DPPL_API
+int destroy_dp_program(program_t *program_t_ptr);
+
+DPPL_API
+int build_dp_program(env_t env_t_ptr, program_t program_t_ptr);
 
 /*!
  *
  */
 DPPL_API
-int create_dp_program_from_source (env_t env_t_ptr,
-                                   unsigned int count,
-                                   const char **strings,
-                                   const size_t *lengths,
-                                   program_t *program_t_ptr);
+int create_dp_kernel(env_t env_t_ptr, program_t program_ptr,
+                     const char *kernel_name, kernel_t *kernel_ptr);
+
+DPPL_API
+int destroy_dp_kernel(kernel_t *kernel_ptr);
 
 /*!
  *
  */
 DPPL_API
-int destroy_dp_program (program_t *program_t_ptr);
-
-
-DPPL_API
-int build_dp_program (env_t env_t_ptr, program_t program_t_ptr);
+int create_dp_kernel_arg(const void *arg_value, size_t arg_size,
+                         kernel_arg_t *kernel_arg_t_ptr);
 
 /*!
  *
  */
 DPPL_API
-int create_dp_kernel (env_t env_t_ptr,
-                      program_t program_ptr,
-                      const char *kernel_name,
-                      kernel_t *kernel_ptr);
-
-
-DPPL_API
-int destroy_dp_kernel (kernel_t *kernel_ptr);
-
+int create_dp_kernel_arg_from_buffer(buffer_t *buffer_t_ptr,
+                                     kernel_arg_t *kernel_arg_t_ptr);
 
 /*!
  *
  */
 DPPL_API
-int create_dp_kernel_arg (const void *arg_value,
-                          size_t arg_size,
-                          kernel_arg_t *kernel_arg_t_ptr);
-
+int destroy_dp_kernel_arg(kernel_arg_t *kernel_arg_t_ptr);
 
 /*!
  *
  */
 DPPL_API
-int create_dp_kernel_arg_from_buffer (buffer_t *buffer_t_ptr,
-                                      kernel_arg_t *kernel_arg_t_ptr);
-
-
-/*!
- *
- */
-DPPL_API
-int destroy_dp_kernel_arg (kernel_arg_t *kernel_arg_t_ptr);
-
+int set_args_and_enqueue_dp_kernel(env_t env_t_ptr, kernel_t kernel_t_ptr,
+                                   size_t nargs, const kernel_arg_t *args,
+                                   unsigned int work_dim,
+                                   const size_t *global_work_offset,
+                                   const size_t *global_work_size,
+                                   const size_t *local_work_size);
 
 /*!
  *
  */
 DPPL_API
-int set_args_and_enqueue_dp_kernel (env_t env_t_ptr,
-                                    kernel_t kernel_t_ptr,
-                                    size_t nargs,
-                                    const kernel_arg_t *args,
-                                    unsigned int work_dim,
-                                    const size_t *global_work_offset,
-                                    const size_t *global_work_size,
-                                    const size_t *local_work_size);
-
+int set_args_and_enqueue_dp_kernel_auto_blocking(
+    env_t env_t_ptr, kernel_t kernel_t_ptr, size_t nargs,
+    const kernel_arg_t *args, unsigned int num_dims, size_t *dim_starts,
+    size_t *dim_stops);
 
 /*!
  *
  */
 DPPL_API
-int set_args_and_enqueue_dp_kernel_auto_blocking (env_t env_t_ptr,
-                                                  kernel_t kernel_t_ptr,
-                                                  size_t nargs,
-                                                  const kernel_arg_t *args,
-                                                  unsigned int num_dims,
-                                                  size_t *dim_starts,
-                                                  size_t *dim_stops);
-
+int retain_dp_context(env_t env_t_ptr);
 
 /*!
  *
  */
 DPPL_API
-int retain_dp_context (env_t env_t_ptr);
-
-
-/*!
- *
- */
-DPPL_API
-int release_dp_context (env_t env_t_ptr);
-
+int release_dp_context(env_t env_t_ptr);
 
 //---- TODO:
 

--- a/backends/include/dppl_sycl_context_interface.h
+++ b/backends/include/dppl_sycl_context_interface.h
@@ -25,12 +25,12 @@
 
 #pragma once
 
-#include "dppl_data_types.h"
-#include "dppl_sycl_types.h"
-#include "dppl_sycl_platform_interface.h"
 #include "Support/DllExport.h"
 #include "Support/ExternC.h"
 #include "Support/MemOwnershipAttrs.h"
+#include "dppl_data_types.h"
+#include "dppl_sycl_platform_interface.h"
+#include "dppl_sycl_types.h"
 #include <stdbool.h>
 
 DPPL_C_EXTERN_C_BEGIN
@@ -44,8 +44,8 @@ DPPL_C_EXTERN_C_BEGIN
  * @return   True if the underlying sycl::context are same, false otherwise.
  */
 DPPL_API
-bool DPPLContext_AreEq (__dppl_keep const DPPLSyclContextRef CtxRef1,
-                        __dppl_keep const DPPLSyclContextRef CtxRef2);
+bool DPPLContext_AreEq(__dppl_keep const DPPLSyclContextRef CtxRef1,
+                       __dppl_keep const DPPLSyclContextRef CtxRef2);
 
 /*!
  * @brief Returns true if this SYCL context is a host context.
@@ -54,18 +54,18 @@ bool DPPLContext_AreEq (__dppl_keep const DPPLSyclContextRef CtxRef1,
  * @return   True if the SYCL context is a host context, else False.
  */
 DPPL_API
-bool DPPLContext_IsHost (__dppl_keep const DPPLSyclContextRef CtxRef);
+bool DPPLContext_IsHost(__dppl_keep const DPPLSyclContextRef CtxRef);
 
 /*!
  * @brief Returns the sycl backend for the DPPLSyclContextRef pointer.
  *
  * @param    CtxRef         An opaque pointer to a sycl::context.
- * @return   The sycl backend for the DPPLSyclContextRef returned as 
+ * @return   The sycl backend for the DPPLSyclContextRef returned as
  * a DPPLSyclBackendType enum type.
  */
 DPPL_API
 DPPLSyclBackendType
-DPPLContext_GetBackend (__dppl_keep const DPPLSyclContextRef CtxRef);
+DPPLContext_GetBackend(__dppl_keep const DPPLSyclContextRef CtxRef);
 
 /*!
  * @brief Delete the pointer after casting it to sycl::context
@@ -73,6 +73,6 @@ DPPLContext_GetBackend (__dppl_keep const DPPLSyclContextRef CtxRef);
  * @param    CtxRef        The DPPLSyclContextRef pointer to be deleted.
  */
 DPPL_API
-void DPPLContext_Delete (__dppl_take DPPLSyclContextRef CtxRef);
+void DPPLContext_Delete(__dppl_take DPPLSyclContextRef CtxRef);
 
 DPPL_C_EXTERN_C_END

--- a/backends/include/dppl_sycl_device_interface.h
+++ b/backends/include/dppl_sycl_device_interface.h
@@ -27,12 +27,12 @@
 
 #pragma once
 
-#include "dppl_data_types.h"
-#include "dppl_sycl_enum_types.h"
-#include "dppl_sycl_types.h"
 #include "Support/DllExport.h"
 #include "Support/ExternC.h"
 #include "Support/MemOwnershipAttrs.h"
+#include "dppl_data_types.h"
+#include "dppl_sycl_enum_types.h"
+#include "dppl_sycl_types.h"
 
 DPPL_C_EXTERN_C_BEGIN
 
@@ -42,7 +42,7 @@ DPPL_C_EXTERN_C_BEGIN
  * @param    DRef           A DPPLSyclDeviceRef pointer.
  */
 DPPL_API
-void DPPLDevice_DumpInfo (__dppl_keep const DPPLSyclDeviceRef DRef);
+void DPPLDevice_DumpInfo(__dppl_keep const DPPLSyclDeviceRef DRef);
 
 /*!
  * @brief Deletes a DPPLSyclDeviceRef pointer after casting to to sycl::device.
@@ -50,7 +50,7 @@ void DPPLDevice_DumpInfo (__dppl_keep const DPPLSyclDeviceRef DRef);
  * @param    DRef           The DPPLSyclDeviceRef pointer to be freed.
  */
 DPPL_API
-void DPPLDevice_Delete (__dppl_take DPPLSyclDeviceRef DRef);
+void DPPLDevice_Delete(__dppl_take DPPLSyclDeviceRef DRef);
 
 /*!
  * @brief Returns true if this SYCL device is an OpenCL device and the device
@@ -60,7 +60,7 @@ void DPPLDevice_Delete (__dppl_take DPPLSyclDeviceRef DRef);
  * @return   True if the device type is an accelerator, else False.
  */
 DPPL_API
-bool DPPLDevice_IsAccelerator (__dppl_keep const DPPLSyclDeviceRef DRef);
+bool DPPLDevice_IsAccelerator(__dppl_keep const DPPLSyclDeviceRef DRef);
 
 /*!
  * @brief Returns true if this SYCL device is an OpenCL device and the device
@@ -70,7 +70,7 @@ bool DPPLDevice_IsAccelerator (__dppl_keep const DPPLSyclDeviceRef DRef);
  * @return   True if the device type is a cpu, else False.
  */
 DPPL_API
-bool DPPLDevice_IsCPU (__dppl_keep const DPPLSyclDeviceRef DRef);
+bool DPPLDevice_IsCPU(__dppl_keep const DPPLSyclDeviceRef DRef);
 
 /*!
  * @brief Returns true if this SYCL device is an OpenCL device and the device
@@ -80,7 +80,7 @@ bool DPPLDevice_IsCPU (__dppl_keep const DPPLSyclDeviceRef DRef);
  * @return    True if the device type is a gpu, else False.
  */
 DPPL_API
-bool DPPLDevice_IsGPU (__dppl_keep const DPPLSyclDeviceRef DRef);
+bool DPPLDevice_IsGPU(__dppl_keep const DPPLSyclDeviceRef DRef);
 
 /*!
  * @brief Returns true if this SYCL device is a host device.
@@ -89,7 +89,7 @@ bool DPPLDevice_IsGPU (__dppl_keep const DPPLSyclDeviceRef DRef);
  * @return   True if the device is a host device, else False.
  */
 DPPL_API
-bool DPPLDevice_IsHost (__dppl_keep const DPPLSyclDeviceRef DRef);
+bool DPPLDevice_IsHost(__dppl_keep const DPPLSyclDeviceRef DRef);
 
 /*!
  * @brief Returns the OpenCL software driver version as a C string.
@@ -99,8 +99,8 @@ bool DPPLDevice_IsHost (__dppl_keep const DPPLSyclDeviceRef DRef);
  *           to the OpenCL driver version if this is a OpenCL device.
  */
 DPPL_API
-__dppl_give const char*
-DPPLDevice_GetDriverInfo (__dppl_keep const DPPLSyclDeviceRef DRef);
+__dppl_give const char *
+DPPLDevice_GetDriverInfo(__dppl_keep const DPPLSyclDeviceRef DRef);
 
 /*!
  * @brief Returns a C string for the device name.
@@ -109,8 +109,8 @@ DPPLDevice_GetDriverInfo (__dppl_keep const DPPLSyclDeviceRef DRef);
  * @return   A C string containing the OpenCL device name.
  */
 DPPL_API
-__dppl_give const char*
-DPPLDevice_GetName (__dppl_keep const DPPLSyclDeviceRef DRef);
+__dppl_give const char *
+DPPLDevice_GetName(__dppl_keep const DPPLSyclDeviceRef DRef);
 
 /*!
  * @brief Returns a C string corresponding to the vendor name.
@@ -119,8 +119,8 @@ DPPLDevice_GetName (__dppl_keep const DPPLSyclDeviceRef DRef);
  * @return    A C string containing the OpenCL device vendor name.
  */
 DPPL_API
-__dppl_give const char*
-DPPLDevice_GetVendorName (__dppl_keep const DPPLSyclDeviceRef DRef);
+__dppl_give const char *
+DPPLDevice_GetVendorName(__dppl_keep const DPPLSyclDeviceRef DRef);
 
 /*!
  * @brief Returns True if the device and the host share a unified memory
@@ -131,6 +131,6 @@ DPPLDevice_GetVendorName (__dppl_keep const DPPLSyclDeviceRef DRef);
  * with the host.
  */
 DPPL_API
-bool DPPLDevice_IsHostUnifiedMemory (__dppl_keep const DPPLSyclDeviceRef DRef);
+bool DPPLDevice_IsHostUnifiedMemory(__dppl_keep const DPPLSyclDeviceRef DRef);
 
 DPPL_C_EXTERN_C_END

--- a/backends/include/dppl_sycl_enum_types.h
+++ b/backends/include/dppl_sycl_enum_types.h
@@ -35,30 +35,28 @@ DPPL_C_EXTERN_C_BEGIN
  * @brief Redefinition of DPC++-specific Sycl backend types.
  *
  */
-enum DPPLSyclBackendType
-{
-    DPPL_UNKNOWN_BACKEND = 0x0,
-    DPPL_OPENCL          = 1 << 16,
-    DPPL_HOST            = 1 << 15,
-    DPPL_LEVEL_ZERO      = 1 << 14,
-    DPPL_CUDA            = 1 << 13
+enum DPPLSyclBackendType {
+  DPPL_UNKNOWN_BACKEND = 0x0,
+  DPPL_OPENCL = 1 << 16,
+  DPPL_HOST = 1 << 15,
+  DPPL_LEVEL_ZERO = 1 << 14,
+  DPPL_CUDA = 1 << 13
 };
 
 /*!
  * @brief DPPL device types that are equivalent to Sycl's device_type.
  *
  */
-enum DPPLSyclDeviceType
-{
-    DPPL_CPU         = 1 << 0,
-    DPPL_GPU         = 1 << 1,
-    DPPL_ACCELERATOR = 1 << 2,
-    DPPL_CUSTOM      = 1 << 3,
-    DPPL_AUTOMATIC   = 1 << 4,
-    DPPL_HOST_DEVICE = 1 << 5,
-    DPPL_ALL         = 1 << 6
-    // IMP: before adding new values here look at DPPLSyclBackendType enum. The
-    // values should not overlap.
+enum DPPLSyclDeviceType {
+  DPPL_CPU = 1 << 0,
+  DPPL_GPU = 1 << 1,
+  DPPL_ACCELERATOR = 1 << 2,
+  DPPL_CUSTOM = 1 << 3,
+  DPPL_AUTOMATIC = 1 << 4,
+  DPPL_HOST_DEVICE = 1 << 5,
+  DPPL_ALL = 1 << 6
+  // IMP: before adding new values here look at DPPLSyclBackendType enum. The
+  // values should not overlap.
 };
 
 /*!
@@ -68,24 +66,23 @@ enum DPPLSyclDeviceType
  * \todo Add support for sycl::buffer
  *
  */
-typedef enum
-{
-    DPPL_CHAR,
-    DPPL_SIGNED_CHAR,
-    DPPL_UNSIGNED_CHAR,
-    DPPL_SHORT,
-    DPPL_INT,
-    DPPL_UNSIGNED_INT,
-    DPPL_UNSIGNED_INT8,
-    DPPL_LONG,
-    DPPL_UNSIGNED_LONG,
-    DPPL_LONG_LONG,
-    DPPL_UNSIGNED_LONG_LONG,
-    DPPL_SIZE_T,
-    DPPL_FLOAT,
-    DPPL_DOUBLE,
-    DPPL_LONG_DOUBLE,
-    DPPL_VOID_PTR
+typedef enum {
+  DPPL_CHAR,
+  DPPL_SIGNED_CHAR,
+  DPPL_UNSIGNED_CHAR,
+  DPPL_SHORT,
+  DPPL_INT,
+  DPPL_UNSIGNED_INT,
+  DPPL_UNSIGNED_INT8,
+  DPPL_LONG,
+  DPPL_UNSIGNED_LONG,
+  DPPL_LONG_LONG,
+  DPPL_UNSIGNED_LONG_LONG,
+  DPPL_SIZE_T,
+  DPPL_FLOAT,
+  DPPL_DOUBLE,
+  DPPL_LONG_DOUBLE,
+  DPPL_VOID_PTR
 } DPPLKernelArgType;
 
 DPPL_C_EXTERN_C_END

--- a/backends/include/dppl_sycl_event_interface.h
+++ b/backends/include/dppl_sycl_event_interface.h
@@ -25,12 +25,11 @@
 
 #pragma once
 
-#include "dppl_data_types.h"
-#include "dppl_sycl_types.h"
 #include "Support/DllExport.h"
 #include "Support/ExternC.h"
 #include "Support/MemOwnershipAttrs.h"
-
+#include "dppl_data_types.h"
+#include "dppl_sycl_types.h"
 
 DPPL_C_EXTERN_C_BEGIN
 
@@ -40,7 +39,7 @@ DPPL_C_EXTERN_C_BEGIN
  * @param    ERef           An opaque DPPLSyclEventRef pointer on which to wait.
  */
 DPPL_API
-void DPPLEvent_Wait (__dppl_keep DPPLSyclEventRef ERef);
+void DPPLEvent_Wait(__dppl_keep DPPLSyclEventRef ERef);
 
 /*!
  * @brief Deletes the DPPLSyclEventRef after casting it to a sycl::event.
@@ -49,7 +48,6 @@ void DPPLEvent_Wait (__dppl_keep DPPLSyclEventRef ERef);
  *                          freed.
  */
 DPPL_API
-void
-DPPLEvent_Delete (__dppl_take DPPLSyclEventRef ERef);
+void DPPLEvent_Delete(__dppl_take DPPLSyclEventRef ERef);
 
 DPPL_C_EXTERN_C_END

--- a/backends/include/dppl_sycl_kernel_interface.h
+++ b/backends/include/dppl_sycl_kernel_interface.h
@@ -29,11 +29,11 @@
 
 #pragma once
 
-#include "dppl_data_types.h"
-#include "dppl_sycl_types.h"
 #include "Support/DllExport.h"
 #include "Support/ExternC.h"
 #include "Support/MemOwnershipAttrs.h"
+#include "dppl_data_types.h"
+#include "dppl_sycl_types.h"
 
 DPPL_C_EXTERN_C_BEGIN
 
@@ -46,8 +46,8 @@ DPPL_C_EXTERN_C_BEGIN
  *           returns a nullptr.
  */
 DPPL_API
-__dppl_give const char*
-DPPLKernel_GetFunctionName (__dppl_keep const DPPLSyclKernelRef KRef);
+__dppl_give const char *
+DPPLKernel_GetFunctionName(__dppl_keep const DPPLSyclKernelRef KRef);
 
 /*!
  * @brief Returns the number of arguments for the OpenCL kernel.
@@ -58,8 +58,7 @@ DPPLKernel_GetFunctionName (__dppl_keep const DPPLSyclKernelRef KRef);
  *           kernel.
  */
 DPPL_API
-size_t
-DPPLKernel_GetNumArgs (__dppl_keep const DPPLSyclKernelRef KRef);
+size_t DPPLKernel_GetNumArgs(__dppl_keep const DPPLSyclKernelRef KRef);
 
 /*!
  * @brief Deletes the DPPLSyclKernelRef after casting it to a sycl::kernel.
@@ -68,7 +67,6 @@ DPPLKernel_GetNumArgs (__dppl_keep const DPPLSyclKernelRef KRef);
  *                          interoperability kernel.
  */
 DPPL_API
-void
-DPPLKernel_Delete (__dppl_take DPPLSyclKernelRef KRef);
+void DPPLKernel_Delete(__dppl_take DPPLSyclKernelRef KRef);
 
 DPPL_C_EXTERN_C_END

--- a/backends/include/dppl_sycl_platform_interface.h
+++ b/backends/include/dppl_sycl_platform_interface.h
@@ -25,11 +25,11 @@
 
 #pragma once
 
-#include "dppl_data_types.h"
-#include "dppl_sycl_enum_types.h"
 #include "Support/DllExport.h"
 #include "Support/ExternC.h"
 #include "Support/MemOwnershipAttrs.h"
+#include "dppl_data_types.h"
+#include "dppl_sycl_enum_types.h"
 
 DPPL_C_EXTERN_C_BEGIN
 
@@ -40,7 +40,7 @@ DPPL_C_EXTERN_C_BEGIN
  * @return The number of available sycl::platforms.
  */
 DPPL_API
-size_t DPPLPlatform_GetNumNonHostPlatforms ();
+size_t DPPLPlatform_GetNumNonHostPlatforms();
 
 /*!
  * @brief Returns the number of unique non-host sycl backends on the system.
@@ -48,7 +48,7 @@ size_t DPPLPlatform_GetNumNonHostPlatforms ();
  * @return   The number of unique sycl backends.
  */
 DPPL_API
-size_t DPPLPlatform_GetNumNonHostBackends ();
+size_t DPPLPlatform_GetNumNonHostBackends();
 
 /*!
  * @brief Returns an array of the unique non-host DPPLSyclBackendType values on
@@ -57,7 +57,7 @@ size_t DPPLPlatform_GetNumNonHostBackends ();
  * @return   An array of DPPLSyclBackendType enum values.
  */
 DPPL_API
-__dppl_give DPPLSyclBackendType* DPPLPlatform_GetListOfNonHostBackends ();
+__dppl_give DPPLSyclBackendType *DPPLPlatform_GetListOfNonHostBackends();
 
 /*!
  * @brief Frees an array of DPPLSyclBackendType enum values.
@@ -65,13 +65,13 @@ __dppl_give DPPLSyclBackendType* DPPLPlatform_GetListOfNonHostBackends ();
  * @param    BEArr      An array of DPPLSyclBackendType enum values to be freed.
  */
 DPPL_API
-void DPPLPlatform_DeleteListOfBackends (__dppl_take DPPLSyclBackendType* BEArr);
+void DPPLPlatform_DeleteListOfBackends(__dppl_take DPPLSyclBackendType *BEArr);
 
 /*!
  * @brief Prints out some selected info about all sycl::platform on the system.
  *
  */
 DPPL_API
-void DPPLPlatform_DumpInfo ();
+void DPPLPlatform_DumpInfo();
 
 DPPL_C_EXTERN_C_END

--- a/backends/include/dppl_sycl_program_interface.h
+++ b/backends/include/dppl_sycl_program_interface.h
@@ -29,11 +29,11 @@
 
 #pragma once
 
-#include "dppl_data_types.h"
-#include "dppl_sycl_types.h"
 #include "Support/DllExport.h"
 #include "Support/ExternC.h"
 #include "Support/MemOwnershipAttrs.h"
+#include "dppl_data_types.h"
+#include "dppl_sycl_types.h"
 
 DPPL_C_EXTERN_C_BEGIN
 
@@ -57,9 +57,8 @@ DPPL_C_EXTERN_C_BEGIN
  */
 DPPL_API
 __dppl_give DPPLSyclProgramRef
-DPPLProgram_CreateFromOCLSpirv (__dppl_keep const DPPLSyclContextRef Ctx,
-                                __dppl_keep const void *IL,
-                                size_t Length);
+DPPLProgram_CreateFromOCLSpirv(__dppl_keep const DPPLSyclContextRef Ctx,
+                               __dppl_keep const void *IL, size_t Length);
 
 /*!
  * @brief Create a Sycl program from an OpenCL kernel source string.
@@ -71,10 +70,9 @@ DPPLProgram_CreateFromOCLSpirv (__dppl_keep const DPPLSyclContextRef Ctx,
  *           else returns NULL.
  */
 DPPL_API
-__dppl_give DPPLSyclProgramRef
-DPPLProgram_CreateFromOCLSource (__dppl_keep const DPPLSyclContextRef Ctx,
-                                 __dppl_keep const char *Source,
-                                 __dppl_keep const char *CompileOpts);
+__dppl_give DPPLSyclProgramRef DPPLProgram_CreateFromOCLSource(
+    __dppl_keep const DPPLSyclContextRef Ctx, __dppl_keep const char *Source,
+    __dppl_keep const char *CompileOpts);
 
 /*!
  * @brief Returns the SyclKernel with given name from the program, if not found
@@ -85,9 +83,8 @@ DPPLProgram_CreateFromOCLSource (__dppl_keep const DPPLSyclContextRef Ctx,
  * @return   A SyclKernel reference if the kernel exists, else NULL
  */
 DPPL_API
-__dppl_give DPPLSyclKernelRef
-DPPLProgram_GetKernel (__dppl_keep DPPLSyclProgramRef PRef,
-                       __dppl_keep const char *KernelName);
+__dppl_give DPPLSyclKernelRef DPPLProgram_GetKernel(
+    __dppl_keep DPPLSyclProgramRef PRef, __dppl_keep const char *KernelName);
 
 /*!
  * @brief Return True if a SyclKernel with given name exists in the program, if
@@ -98,9 +95,8 @@ DPPLProgram_GetKernel (__dppl_keep DPPLSyclProgramRef PRef,
  * @return   True if the kernel exists, else False
  */
 DPPL_API
-bool
-DPPLProgram_HasKernel (__dppl_keep DPPLSyclProgramRef PRef,
-                       __dppl_keep const char *KernelName);
+bool DPPLProgram_HasKernel(__dppl_keep DPPLSyclProgramRef PRef,
+                           __dppl_keep const char *KernelName);
 
 /*!
  * @brief Frees the DPPLSyclProgramRef pointer.
@@ -108,7 +104,6 @@ DPPLProgram_HasKernel (__dppl_keep DPPLSyclProgramRef PRef,
  * @param    PRef           Opaque pointer to a sycl::program
  */
 DPPL_API
-void
-DPPLProgram_Delete (__dppl_take DPPLSyclProgramRef PRef);
+void DPPLProgram_Delete(__dppl_take DPPLSyclProgramRef PRef);
 
 DPPL_C_EXTERN_C_END

--- a/backends/include/dppl_sycl_queue_interface.h
+++ b/backends/include/dppl_sycl_queue_interface.h
@@ -27,12 +27,12 @@
 
 #pragma once
 
-#include "dppl_data_types.h"
-#include "dppl_sycl_enum_types.h"
-#include "dppl_sycl_types.h"
 #include "Support/DllExport.h"
 #include "Support/ExternC.h"
 #include "Support/MemOwnershipAttrs.h"
+#include "dppl_data_types.h"
+#include "dppl_sycl_enum_types.h"
+#include "dppl_sycl_types.h"
 
 DPPL_C_EXTERN_C_BEGIN
 
@@ -42,7 +42,7 @@ DPPL_C_EXTERN_C_BEGIN
  * @param    QRef           A DPPLSyclQueueRef pointer that gets deleted.
  */
 DPPL_API
-void DPPLQueue_Delete (__dppl_take DPPLSyclQueueRef QRef);
+void DPPLQueue_Delete(__dppl_take DPPLSyclQueueRef QRef);
 
 /*!
  * @brief Checks if two DPPLSyclQueueRef objects point to the same sycl::queue.
@@ -52,8 +52,8 @@ void DPPLQueue_Delete (__dppl_take DPPLSyclQueueRef QRef);
  * @return   True if the underlying sycl::queue are same, false otherwise.
  */
 DPPL_API
-bool DPPLQueue_AreEq (__dppl_keep const DPPLSyclQueueRef QRef1,
-                      __dppl_keep const DPPLSyclQueueRef QRef2);
+bool DPPLQueue_AreEq(__dppl_keep const DPPLSyclQueueRef QRef1,
+                     __dppl_keep const DPPLSyclQueueRef QRef2);
 
 /*!
  * @brief Returns the Sycl backend for the provided sycl::queue.
@@ -63,7 +63,7 @@ bool DPPLQueue_AreEq (__dppl_keep const DPPLSyclQueueRef QRef1,
  * queue.
  */
 DPPL_API
-DPPLSyclBackendType DPPLQueue_GetBackend (__dppl_keep DPPLSyclQueueRef QRef);
+DPPLSyclBackendType DPPLQueue_GetBackend(__dppl_keep DPPLSyclQueueRef QRef);
 
 /*!
  * @brief Returns the Sycl context for the queue.
@@ -73,7 +73,7 @@ DPPLSyclBackendType DPPLQueue_GetBackend (__dppl_keep DPPLSyclQueueRef QRef);
  */
 DPPL_API
 __dppl_give DPPLSyclContextRef
-DPPLQueue_GetContext (__dppl_keep const DPPLSyclQueueRef QRef);
+DPPLQueue_GetContext(__dppl_keep const DPPLSyclQueueRef QRef);
 
 /*!
  * @brief returns the Sycl device for the queue.
@@ -83,7 +83,7 @@ DPPLQueue_GetContext (__dppl_keep const DPPLSyclQueueRef QRef);
  */
 DPPL_API
 __dppl_give DPPLSyclDeviceRef
-DPPLQueue_GetDevice (__dppl_keep const DPPLSyclQueueRef QRef);
+DPPLQueue_GetDevice(__dppl_keep const DPPLSyclQueueRef QRef);
 
 /*!
  * @brief Submits the kernel to the specified queue with the provided range
@@ -117,16 +117,12 @@ DPPLQueue_GetDevice (__dppl_keep const DPPLSyclQueueRef QRef);
  *           sycl::queue.submit() function.
  */
 DPPL_API
-DPPLSyclEventRef
-DPPLQueue_SubmitRange (__dppl_keep const DPPLSyclKernelRef KRef,
-                       __dppl_keep const DPPLSyclQueueRef QRef,
-                       __dppl_keep void **Args,
-                       __dppl_keep const DPPLKernelArgType *ArgTypes,
-                       size_t NArgs,
-                       __dppl_keep const size_t Range[3],
-                       size_t NRange,
-                       __dppl_keep const DPPLSyclEventRef *DepEvents,
-                       size_t NDepEvents);
+DPPLSyclEventRef DPPLQueue_SubmitRange(
+    __dppl_keep const DPPLSyclKernelRef KRef,
+    __dppl_keep const DPPLSyclQueueRef QRef, __dppl_keep void **Args,
+    __dppl_keep const DPPLKernelArgType *ArgTypes, size_t NArgs,
+    __dppl_keep const size_t Range[3], size_t NRange,
+    __dppl_keep const DPPLSyclEventRef *DepEvents, size_t NDepEvents);
 
 /*!
  * @brief Submits the kernel to the specified queue with the provided nd_range
@@ -164,17 +160,13 @@ DPPLQueue_SubmitRange (__dppl_keep const DPPLSyclKernelRef KRef,
  *           sycl::queue.submit() function.
  */
 DPPL_API
-DPPLSyclEventRef
-DPPLQueue_SubmitNDRange(__dppl_keep const DPPLSyclKernelRef KRef,
-                        __dppl_keep const DPPLSyclQueueRef QRef,
-                        __dppl_keep void **Args,
-                        __dppl_keep const DPPLKernelArgType *ArgTypes,
-                        size_t NArgs,
-                        __dppl_keep const size_t gRange[3],
-                        __dppl_keep const size_t lRange[3],
-                        size_t NDims,
-                        __dppl_keep const DPPLSyclEventRef *DepEvents,
-                        size_t NDepEvents);
+DPPLSyclEventRef DPPLQueue_SubmitNDRange(
+    __dppl_keep const DPPLSyclKernelRef KRef,
+    __dppl_keep const DPPLSyclQueueRef QRef, __dppl_keep void **Args,
+    __dppl_keep const DPPLKernelArgType *ArgTypes, size_t NArgs,
+    __dppl_keep const size_t gRange[3], __dppl_keep const size_t lRange[3],
+    size_t NDims, __dppl_keep const DPPLSyclEventRef *DepEvents,
+    size_t NDepEvents);
 
 /*!
  * @brief Calls the sycl::queue.submit function to do a blocking wait on all
@@ -183,8 +175,7 @@ DPPLQueue_SubmitNDRange(__dppl_keep const DPPLSyclKernelRef KRef,
  * @param    QRef           Opaque pointer to a sycl::queue.
  */
 DPPL_API
-void
-DPPLQueue_Wait (__dppl_keep const DPPLSyclQueueRef QRef);
+void DPPLQueue_Wait(__dppl_keep const DPPLSyclQueueRef QRef);
 
 /*!
  * @brief C-API wrapper for sycl::queue::memcpy, the function waits on an event
@@ -196,7 +187,7 @@ DPPLQueue_Wait (__dppl_keep const DPPLSyclQueueRef QRef);
  * @param    Count          A number of bytes to copy.
  */
 DPPL_API
-void DPPLQueue_Memcpy (__dppl_keep const DPPLSyclQueueRef QRef,
-                       void *Dest, const void *Src, size_t Count);
+void DPPLQueue_Memcpy(__dppl_keep const DPPLSyclQueueRef QRef, void *Dest,
+                      const void *Src, size_t Count);
 
 DPPL_C_EXTERN_C_END

--- a/backends/include/dppl_sycl_queue_manager.h
+++ b/backends/include/dppl_sycl_queue_manager.h
@@ -33,13 +33,13 @@
 
 #pragma once
 
-#include "dppl_data_types.h"
-#include "dppl_sycl_types.h"
-#include "dppl_sycl_context_interface.h"
-#include "dppl_sycl_device_interface.h"
 #include "Support/DllExport.h"
 #include "Support/ExternC.h"
 #include "Support/MemOwnershipAttrs.h"
+#include "dppl_data_types.h"
+#include "dppl_sycl_context_interface.h"
+#include "dppl_sycl_device_interface.h"
+#include "dppl_sycl_types.h"
 
 DPPL_C_EXTERN_C_BEGIN
 
@@ -51,7 +51,7 @@ DPPL_C_EXTERN_C_BEGIN
  * wrapped inside an opaque DPPLSyclQueueRef pointer.
  */
 DPPL_API
-__dppl_give DPPLSyclQueueRef DPPLQueueMgr_GetCurrentQueue ();
+__dppl_give DPPLSyclQueueRef DPPLQueueMgr_GetCurrentQueue();
 
 /*!
  * @brief Get a sycl::queue object of the specified type and device id.
@@ -64,10 +64,9 @@ __dppl_give DPPLSyclQueueRef DPPLQueueMgr_GetCurrentQueue ();
  * raised if no such device exists.
  */
 DPPL_API
-__dppl_give DPPLSyclQueueRef
-DPPLQueueMgr_GetQueue (DPPLSyclBackendType BETy,
-                       DPPLSyclDeviceType DeviceTy,
-                       size_t DNum);
+__dppl_give DPPLSyclQueueRef DPPLQueueMgr_GetQueue(DPPLSyclBackendType BETy,
+                                                   DPPLSyclDeviceType DeviceTy,
+                                                   size_t DNum);
 
 /*!
  * @brief Get the number of activated queues not including the global or
@@ -76,7 +75,7 @@ DPPLQueueMgr_GetQueue (DPPLSyclBackendType BETy,
  * @return The number of activated queues.
  */
 DPPL_API
-size_t DPPLQueueMgr_GetNumActivatedQueues ();
+size_t DPPLQueueMgr_GetNumActivatedQueues();
 
 /*!
  * @brief Get the number of available queues for given backend and device type
@@ -87,8 +86,8 @@ size_t DPPLQueueMgr_GetNumActivatedQueues ();
  * @return   The number of available queues.
  */
 DPPL_API
-size_t DPPLQueueMgr_GetNumQueues (DPPLSyclBackendType BETy,
-                                  DPPLSyclDeviceType DeviceTy);
+size_t DPPLQueueMgr_GetNumQueues(DPPLSyclBackendType BETy,
+                                 DPPLSyclDeviceType DeviceTy);
 
 /*!
  * @brief Returns True if the passed in queue and the current queue are the
@@ -99,24 +98,22 @@ size_t DPPLQueueMgr_GetNumQueues (DPPLSyclBackendType BETy,
  * the currently activated queue.
  */
 DPPL_API
-bool DPPLQueueMgr_IsCurrentQueue (__dppl_keep const DPPLSyclQueueRef QRef);
+bool DPPLQueueMgr_IsCurrentQueue(__dppl_keep const DPPLSyclQueueRef QRef);
 
 /*!
-* @brief Set the default DPPL queue to the sycl::queue for the given backend
-* and device type combination and return a DPPLSyclQueueRef for that queue.
-* If no queue was created Null is returned to caller.
-*
-* @param    BETy           Type of Sycl backend.
-* @param    DeviceTy       The type of Sycl device (sycl_device_type)
-* @param    DNum           Device id for the device
-* @return A copy of the sycl::queue that was set as the new default queue. If no
-* queue could be created then returns Null.
-*/
+ * @brief Set the default DPPL queue to the sycl::queue for the given backend
+ * and device type combination and return a DPPLSyclQueueRef for that queue.
+ * If no queue was created Null is returned to caller.
+ *
+ * @param    BETy           Type of Sycl backend.
+ * @param    DeviceTy       The type of Sycl device (sycl_device_type)
+ * @param    DNum           Device id for the device
+ * @return A copy of the sycl::queue that was set as the new default queue. If
+ * no queue could be created then returns Null.
+ */
 DPPL_API
-__dppl_give DPPLSyclQueueRef
-DPPLQueueMgr_SetAsDefaultQueue (DPPLSyclBackendType BETy,
-                                DPPLSyclDeviceType DeviceTy,
-                                size_t DNum);
+__dppl_give DPPLSyclQueueRef DPPLQueueMgr_SetAsDefaultQueue(
+    DPPLSyclBackendType BETy, DPPLSyclDeviceType DeviceTy, size_t DNum);
 
 /*!
  * @brief Pushes a new sycl::queue object to the top of DPPL's thread-local
@@ -139,10 +136,9 @@ DPPLQueueMgr_SetAsDefaultQueue (DPPLSyclBackendType BETy,
  * stack of sycl::queue objects. Nullptr is returned if no such device exists.
  */
 DPPL_API
-__dppl_give DPPLSyclQueueRef
-DPPLQueueMgr_PushQueue (DPPLSyclBackendType BETy,
-                        DPPLSyclDeviceType DeviceTy,
-                        size_t DNum);
+__dppl_give DPPLSyclQueueRef DPPLQueueMgr_PushQueue(DPPLSyclBackendType BETy,
+                                                    DPPLSyclDeviceType DeviceTy,
+                                                    size_t DNum);
 
 /*!
  * @brief Pops the top of stack element from DPPL's stack of activated
@@ -156,6 +152,6 @@ DPPLQueueMgr_PushQueue (DPPLSyclBackendType BETy,
  *
  */
 DPPL_API
-void DPPLQueueMgr_PopQueue ();
+void DPPLQueueMgr_PopQueue();
 
 DPPL_C_EXTERN_C_END

--- a/backends/include/dppl_sycl_types.h
+++ b/backends/include/dppl_sycl_types.h
@@ -65,11 +65,11 @@ typedef struct DPPLOpaqueSyclPlatform *DPPLSyclPlatformRef;
  */
 typedef struct DPPLOpaqueSyclProgram *DPPLSyclProgramRef;
 
- /*!
-  * @brief Opaque pointer to a sycl::queue
-  *
-  * @see sycl::queue
-  */
+/*!
+ * @brief Opaque pointer to a sycl::queue
+ *
+ * @see sycl::queue
+ */
 typedef struct DPPLOpaqueSyclQueue *DPPLSyclQueueRef;
 
 /*!

--- a/backends/include/dppl_sycl_usm_interface.h
+++ b/backends/include/dppl_sycl_usm_interface.h
@@ -25,11 +25,11 @@
 
 #pragma once
 
-#include "dppl_data_types.h"
-#include "dppl_sycl_types.h"
 #include "Support/DllExport.h"
 #include "Support/ExternC.h"
 #include "Support/MemOwnershipAttrs.h"
+#include "dppl_data_types.h"
+#include "dppl_sycl_types.h"
 
 DPPL_C_EXTERN_C_BEGIN
 
@@ -40,7 +40,7 @@ DPPL_C_EXTERN_C_BEGIN
  */
 DPPL_API
 __dppl_give DPPLSyclUSMRef
-DPPLmalloc_shared (size_t size, __dppl_keep const DPPLSyclQueueRef QRef);
+DPPLmalloc_shared(size_t size, __dppl_keep const DPPLSyclQueueRef QRef);
 
 /*!
  * @brief Crete USM host memory.
@@ -49,7 +49,7 @@ DPPLmalloc_shared (size_t size, __dppl_keep const DPPLSyclQueueRef QRef);
  */
 DPPL_API
 __dppl_give DPPLSyclUSMRef
-DPPLmalloc_host (size_t size, __dppl_keep const DPPLSyclQueueRef QRef);
+DPPLmalloc_host(size_t size, __dppl_keep const DPPLSyclQueueRef QRef);
 
 /*!
  * @brief Crete USM device memory.
@@ -58,23 +58,23 @@ DPPLmalloc_host (size_t size, __dppl_keep const DPPLSyclQueueRef QRef);
  */
 DPPL_API
 __dppl_give DPPLSyclUSMRef
-DPPLmalloc_device (size_t size, __dppl_keep const DPPLSyclQueueRef QRef);
+DPPLmalloc_device(size_t size, __dppl_keep const DPPLSyclQueueRef QRef);
 
 /*!
  * @brief Free USM memory.
  *
  */
 DPPL_API
-void DPPLfree_with_queue (__dppl_take DPPLSyclUSMRef MRef,
-                          __dppl_keep const DPPLSyclQueueRef QRef);
+void DPPLfree_with_queue(__dppl_take DPPLSyclUSMRef MRef,
+                         __dppl_keep const DPPLSyclQueueRef QRef);
 
 /*!
  * @brief Free USM memory.
  *
  */
 DPPL_API
-void DPPLfree_with_context (__dppl_take DPPLSyclUSMRef MRef,
-                            __dppl_keep const DPPLSyclContextRef CRef);
+void DPPLfree_with_context(__dppl_take DPPLSyclUSMRef MRef,
+                           __dppl_keep const DPPLSyclContextRef CRef);
 
 /*!
  * @brief Get pointer type.
@@ -82,8 +82,7 @@ void DPPLfree_with_context (__dppl_take DPPLSyclUSMRef MRef,
  * @return "host", "device", "shared" or "unknown"
  */
 DPPL_API
-const char *
-DPPLUSM_GetPointerType (__dppl_keep const DPPLSyclUSMRef MRef,
-                        __dppl_keep const DPPLSyclContextRef CRef);
+const char *DPPLUSM_GetPointerType(__dppl_keep const DPPLSyclUSMRef MRef,
+                                   __dppl_keep const DPPLSyclContextRef CRef);
 
 DPPL_C_EXTERN_C_END

--- a/backends/include/dppl_utils.h
+++ b/backends/include/dppl_utils.h
@@ -36,6 +36,6 @@ DPPL_C_EXTERN_C_BEGIN
  * @param    str            C string to be deleted
  */
 DPPL_API
-void DPPLCString_Delete (__dppl_take const char* str);
+void DPPLCString_Delete(__dppl_take const char *str);
 
 DPPL_C_EXTERN_C_END

--- a/backends/include/error_check_macros.h
+++ b/backends/include/error_check_macros.h
@@ -43,69 +43,73 @@
 // FIXME : memory allocated in a function should be released in the error
 // section
 
-#define CHECK_OPEN_CL_ERROR(x, M) do {                                         \
+#define CHECK_OPEN_CL_ERROR(x, M)                                              \
+  do {                                                                         \
     int retval = (x);                                                          \
-    switch(retval) {                                                           \
+    switch (retval) {                                                          \
     case 0:                                                                    \
-        break;                                                                 \
+      break;                                                                   \
     case -36:                                                                  \
-        fprintf(stderr, "Open CL Runtime Error: %d (%s) on Line %d in %s\n",   \
-                retval, "[CL_INVALID_COMMAND_QUEUE]command_queue is not a "    \
-                        "valid command-queue.",                                \
-                __LINE__, __FILE__);                                           \
-        goto error;                                                            \
+      fprintf(stderr, "Open CL Runtime Error: %d (%s) on Line %d in %s\n",     \
+              retval,                                                          \
+              "[CL_INVALID_COMMAND_QUEUE]command_queue is not a "              \
+              "valid command-queue.",                                          \
+              __LINE__, __FILE__);                                             \
+      goto error;                                                              \
     case -38:                                                                  \
-        fprintf(stderr, "Open CL Runtime Error: %d (%s) on Line %d in %s\n"    \
-                        "%s\n",                                                \
-                retval, "[CL_INVALID_MEM_OBJECT] memory object is not a "      \
-                        "valid OpenCL memory object.",                         \
-                __LINE__, __FILE__,M);                                         \
-        goto error;                                                            \
+      fprintf(stderr,                                                          \
+              "Open CL Runtime Error: %d (%s) on Line %d in %s\n"              \
+              "%s\n",                                                          \
+              retval,                                                          \
+              "[CL_INVALID_MEM_OBJECT] memory object is not a "                \
+              "valid OpenCL memory object.",                                   \
+              __LINE__, __FILE__, M);                                          \
+      goto error;                                                              \
     case -45:                                                                  \
-        fprintf(stderr, "Open CL Runtime Error: %d (%s) on Line %d in %s\n",   \
-                retval, "[CL_INVALID_PROGRAM_EXECUTABLE] no successfully "     \
-                        "built program executable available for device "       \
-                        "associated with command_queue.",                      \
-                __LINE__, __FILE__);                                           \
-        goto error;                                                            \
+      fprintf(stderr, "Open CL Runtime Error: %d (%s) on Line %d in %s\n",     \
+              retval,                                                          \
+              "[CL_INVALID_PROGRAM_EXECUTABLE] no successfully "               \
+              "built program executable available for device "                 \
+              "associated with command_queue.",                                \
+              __LINE__, __FILE__);                                             \
+      goto error;                                                              \
     case -54:                                                                  \
-        fprintf(stderr, "Open CL Runtime Error: %d (%s) on Line %d in %s\n",   \
-                retval, "[CL_INVALID_WORK_GROUP_SIZE]",                        \
-                __LINE__, __FILE__);                                           \
-        goto error;                                                            \
+      fprintf(stderr, "Open CL Runtime Error: %d (%s) on Line %d in %s\n",     \
+              retval, "[CL_INVALID_WORK_GROUP_SIZE]", __LINE__, __FILE__);     \
+      goto error;                                                              \
     default:                                                                   \
-        fprintf(stderr, "Open CL Runtime Error: %d (%s) on Line %d in %s\n",   \
-                retval, M, __LINE__, __FILE__);                                \
-        goto error;                                                            \
+      fprintf(stderr, "Open CL Runtime Error: %d (%s) on Line %d in %s\n",     \
+              retval, M, __LINE__, __FILE__);                                  \
+      goto error;                                                              \
     }                                                                          \
-} while(0)
+  } while (0)
 
-
-#define CHECK_MALLOC_ERROR(type, x) do {                                       \
-    type * ptr = (type*)(x);                                                   \
-    if(ptr == NULL) {                                                          \
-        fprintf(stderr, "Malloc Error for type %s on Line %d in %s",           \
-                #type, __LINE__, __FILE__);                                    \
-        perror(" ");                                                           \
-        free(ptr);                                                             \
-        ptr = NULL;                                                            \
-        goto malloc_error;                                                     \
+#define CHECK_MALLOC_ERROR(type, x)                                            \
+  do {                                                                         \
+    type *ptr = (type *)(x);                                                   \
+    if (ptr == NULL) {                                                         \
+      fprintf(stderr, "Malloc Error for type %s on Line %d in %s", #type,      \
+              __LINE__, __FILE__);                                             \
+      perror(" ");                                                             \
+      free(ptr);                                                               \
+      ptr = NULL;                                                              \
+      goto malloc_error;                                                       \
     }                                                                          \
-} while(0)
+  } while (0)
 
-
-#define CHECK_DPGLUE_ERROR(x, M) do {                                          \
+#define CHECK_DPGLUE_ERROR(x, M)                                               \
+  do {                                                                         \
     int retval = (x);                                                          \
-    switch(retval) {                                                           \
+    switch (retval) {                                                          \
     case 0:                                                                    \
-        break;                                                                 \
+      break;                                                                   \
     case -1:                                                                   \
-        fprintf(stderr, "DP_Glue Error: %d (%s) on Line %d in %s\n",           \
-                retval, M, __LINE__, __FILE__);                                \
-        goto error;                                                            \
+      fprintf(stderr, "DP_Glue Error: %d (%s) on Line %d in %s\n", retval, M,  \
+              __LINE__, __FILE__);                                             \
+      goto error;                                                              \
     default:                                                                   \
-        fprintf(stderr, "DP_Glue Error: %d (%s) on Line %d in %s\n",           \
-                retval, M, __LINE__, __FILE__);                                \
-        goto error;                                                            \
+      fprintf(stderr, "DP_Glue Error: %d (%s) on Line %d in %s\n", retval, M,  \
+              __LINE__, __FILE__);                                             \
+      goto error;                                                              \
     }                                                                          \
-} while(0)
+  } while (0)

--- a/backends/source/dppl_opencl_interface.c
+++ b/backends/source/dppl_opencl_interface.c
@@ -25,1142 +25,1047 @@
 //===----------------------------------------------------------------------===//
 #include "dppl_opencl_interface.h"
 #include "error_check_macros.h"
-#include <string.h>
+#include <CL/cl.h> /* OpenCL headers */
 #include <assert.h>
-#include <CL/cl.h>  /* OpenCL headers */
+#include <string.h>
 
 /*------------------------------- Magic numbers ------------------------------*/
 
-#define RUNTIME_ID   0x6dd5e8c8
-#define ENV_ID       0x6c78fd87
-#define BUFFER_ID    0xc55c47b1
-#define KERNEL_ID    0x032dc08e
-#define PROGRAM_ID   0xc3842d12
+#define RUNTIME_ID 0x6dd5e8c8
+#define ENV_ID 0x6c78fd87
+#define BUFFER_ID 0xc55c47b1
+#define KERNEL_ID 0x032dc08e
+#define PROGRAM_ID 0xc3842d12
 #define KERNELARG_ID 0xd42f630f
 
 #if DEBUG
 
-static void check_runtime_id (runtime_t x)
-{
-    assert(x->id_ == RUNTIME_ID);
-}
+static void check_runtime_id(runtime_t x) { assert(x->id_ == RUNTIME_ID); }
 
-static void check_env_id (env_t x)
-{
-    assert(x->id_ == ENV_ID);
-}
+static void check_env_id(env_t x) { assert(x->id_ == ENV_ID); }
 
-static void check_buffer_id (buffer_t x)
-{
-    assert(x->id_ == BUFFER_ID);
-}
+static void check_buffer_id(buffer_t x) { assert(x->id_ == BUFFER_ID); }
 
-static void check_kernel_id (kernel_t x)
-{
-    assert(x->id_ == KERNEL_ID);
-}
+static void check_kernel_id(kernel_t x) { assert(x->id_ == KERNEL_ID); }
 
-static void check_program_id (program_t x)
-{
-    assert(x->id_ == PROGRAM_ID);
-}
+static void check_program_id(program_t x) { assert(x->id_ == PROGRAM_ID); }
 
-static void check_kernelarg_id (kernel_arg_t x)
-{
-    assert(x->id_ == KERNELARG_ID);
+static void check_kernelarg_id(kernel_arg_t x) {
+  assert(x->id_ == KERNELARG_ID);
 }
 
 #endif
 
 /*------------------------------- Private helpers ----------------------------*/
 
+static int get_platform_name(cl_platform_id platform, char **platform_name) {
+  cl_int err;
+  size_t n;
 
-static int get_platform_name (cl_platform_id platform, char **platform_name)
-{
-    cl_int err;
-    size_t n;
+  err = clGetPlatformInfo(platform, CL_PLATFORM_NAME, 0, *platform_name, &n);
+  CHECK_OPEN_CL_ERROR(err, "Could not get platform name length.");
 
-    err = clGetPlatformInfo(platform, CL_PLATFORM_NAME, 0, *platform_name, &n);
-    CHECK_OPEN_CL_ERROR(err, "Could not get platform name length.");
+  // Allocate memory for the platform name string
+  *platform_name = (char *)malloc(sizeof(char) * n);
+  CHECK_MALLOC_ERROR(char *, *platform_name);
 
-    // Allocate memory for the platform name string
-    *platform_name = (char*)malloc(sizeof(char)*n);
-    CHECK_MALLOC_ERROR(char*, *platform_name);
+  err = clGetPlatformInfo(platform, CL_PLATFORM_NAME, n, *platform_name, NULL);
+  CHECK_OPEN_CL_ERROR(err, "Could not get platform name.");
 
-    err = clGetPlatformInfo(platform, CL_PLATFORM_NAME, n, *platform_name,
-            NULL);
-    CHECK_OPEN_CL_ERROR(err, "Could not get platform name.");
-
-    return DP_GLUE_SUCCESS;
+  return DP_GLUE_SUCCESS;
 
 malloc_error:
-    return DP_GLUE_FAILURE;
+  return DP_GLUE_FAILURE;
 error:
-    free(*platform_name);
-    return DP_GLUE_FAILURE;
+  free(*platform_name);
+  return DP_GLUE_FAILURE;
 }
-
 
 /*!
  *
  */
-static int dump_device_info (void *obj)
-{
-    cl_int err;
-    char *value;
-    size_t size;
-    cl_uint maxComputeUnits;
-    env_t env_t_ptr;
+static int dump_device_info(void *obj) {
+  cl_int err;
+  char *value;
+  size_t size;
+  cl_uint maxComputeUnits;
+  env_t env_t_ptr;
 
-    value = NULL;
-    env_t_ptr = (env_t)obj;
-    cl_device_id device = (cl_device_id)(env_t_ptr->device);
+  value = NULL;
+  env_t_ptr = (env_t)obj;
+  cl_device_id device = (cl_device_id)(env_t_ptr->device);
 
-    err = clRetainDevice(device);
-    CHECK_OPEN_CL_ERROR(err, "Could not retain device.");
+  err = clRetainDevice(device);
+  CHECK_OPEN_CL_ERROR(err, "Could not retain device.");
 
-    // print device name
-    err = clGetDeviceInfo(device, CL_DEVICE_NAME, 0, NULL, &size);
-    CHECK_OPEN_CL_ERROR(err, "Could not get device name.");
-    value = (char*)malloc(size);
-    err = clGetDeviceInfo(device, CL_DEVICE_NAME, size, value, NULL);
-    CHECK_OPEN_CL_ERROR(err, "Could not get device name.");
-    printf("Device: %s\n", value);
-    free(value);
+  // print device name
+  err = clGetDeviceInfo(device, CL_DEVICE_NAME, 0, NULL, &size);
+  CHECK_OPEN_CL_ERROR(err, "Could not get device name.");
+  value = (char *)malloc(size);
+  err = clGetDeviceInfo(device, CL_DEVICE_NAME, size, value, NULL);
+  CHECK_OPEN_CL_ERROR(err, "Could not get device name.");
+  printf("Device: %s\n", value);
+  free(value);
 
-    // print hardware device version
-    err = clGetDeviceInfo(device, CL_DEVICE_VERSION, 0, NULL, &size);
-    CHECK_OPEN_CL_ERROR(err, "Could not get device version.");
-    value = (char*) malloc(size);
-    err = clGetDeviceInfo(device, CL_DEVICE_VERSION, size, value, NULL);
-    CHECK_OPEN_CL_ERROR(err, "Could not get device version.");
-    printf("Hardware version: %s\n", value);
-    free(value);
+  // print hardware device version
+  err = clGetDeviceInfo(device, CL_DEVICE_VERSION, 0, NULL, &size);
+  CHECK_OPEN_CL_ERROR(err, "Could not get device version.");
+  value = (char *)malloc(size);
+  err = clGetDeviceInfo(device, CL_DEVICE_VERSION, size, value, NULL);
+  CHECK_OPEN_CL_ERROR(err, "Could not get device version.");
+  printf("Hardware version: %s\n", value);
+  free(value);
 
-    // print software driver version
-    clGetDeviceInfo(device, CL_DRIVER_VERSION, 0, NULL, &size);
-    CHECK_OPEN_CL_ERROR(err, "Could not get driver version.");
-    value = (char*) malloc(size);
-    clGetDeviceInfo(device, CL_DRIVER_VERSION, size, value, NULL);
-    CHECK_OPEN_CL_ERROR(err, "Could not get driver version.");
-    printf("Software version: %s\n", value);
-    free(value);
+  // print software driver version
+  clGetDeviceInfo(device, CL_DRIVER_VERSION, 0, NULL, &size);
+  CHECK_OPEN_CL_ERROR(err, "Could not get driver version.");
+  value = (char *)malloc(size);
+  clGetDeviceInfo(device, CL_DRIVER_VERSION, size, value, NULL);
+  CHECK_OPEN_CL_ERROR(err, "Could not get driver version.");
+  printf("Software version: %s\n", value);
+  free(value);
 
-    // print c version supported by compiler for device
-    clGetDeviceInfo(device, CL_DEVICE_OPENCL_C_VERSION, 0, NULL, &size);
-    CHECK_OPEN_CL_ERROR(err, "Could not get open cl version.");
-    value = (char*) malloc(size);
-    clGetDeviceInfo(device, CL_DEVICE_OPENCL_C_VERSION, size, value, NULL);
-    CHECK_OPEN_CL_ERROR(err, "Could not get open cl version.");
-    printf("OpenCL C version: %s\n", value);
-    free(value);
+  // print c version supported by compiler for device
+  clGetDeviceInfo(device, CL_DEVICE_OPENCL_C_VERSION, 0, NULL, &size);
+  CHECK_OPEN_CL_ERROR(err, "Could not get open cl version.");
+  value = (char *)malloc(size);
+  clGetDeviceInfo(device, CL_DEVICE_OPENCL_C_VERSION, size, value, NULL);
+  CHECK_OPEN_CL_ERROR(err, "Could not get open cl version.");
+  printf("OpenCL C version: %s\n", value);
+  free(value);
 
-    // print parallel compute units
-    clGetDeviceInfo(device, CL_DEVICE_MAX_COMPUTE_UNITS,
-                    sizeof(maxComputeUnits), &maxComputeUnits, NULL);
-    CHECK_OPEN_CL_ERROR(err, "Could not get number of compute units.");
-    printf("Parallel compute units: %d\n", maxComputeUnits);
+  // print parallel compute units
+  clGetDeviceInfo(device, CL_DEVICE_MAX_COMPUTE_UNITS, sizeof(maxComputeUnits),
+                  &maxComputeUnits, NULL);
+  CHECK_OPEN_CL_ERROR(err, "Could not get number of compute units.");
+  printf("Parallel compute units: %d\n", maxComputeUnits);
 
-    err = clReleaseDevice(device);
-    CHECK_OPEN_CL_ERROR(err, "Could not release device.");
+  err = clReleaseDevice(device);
+  CHECK_OPEN_CL_ERROR(err, "Could not release device.");
 
-    return DP_GLUE_SUCCESS;
+  return DP_GLUE_SUCCESS;
 
 error:
-    free(value);
-    return DP_GLUE_FAILURE;
+  free(value);
+  return DP_GLUE_FAILURE;
 }
-
 
 /*!
  * @brief Helper function to print out information about the platform and
  * devices available to this runtime.
  *
  */
-static int dump_dp_runtime_info (void *obj)
-{
-    size_t i;
-    runtime_t rt;
+static int dump_dp_runtime_info(void *obj) {
+  size_t i;
+  runtime_t rt;
 
-    rt = (runtime_t)obj;
+  rt = (runtime_t)obj;
 #if DEBUG
-    check_runtime_id(rt);
+  check_runtime_id(rt);
 #endif
-    if(rt) {
-        printf("Number of platforms : %d\n", rt->num_platforms);
-        cl_platform_id *platforms = rt->platform_ids;
-        for(i = 0; i < rt->num_platforms; ++i) {
-            char *platform_name = NULL;
-            get_platform_name(platforms[i], &platform_name);
-            printf("Platform #%zu: %s\n", i, platform_name);
-            free(platform_name);
-        }
+  if (rt) {
+    printf("Number of platforms : %d\n", rt->num_platforms);
+    cl_platform_id *platforms = rt->platform_ids;
+    for (i = 0; i < rt->num_platforms; ++i) {
+      char *platform_name = NULL;
+      get_platform_name(platforms[i], &platform_name);
+      printf("Platform #%zu: %s\n", i, platform_name);
+      free(platform_name);
     }
+  }
 
-    return DP_GLUE_SUCCESS;
+  return DP_GLUE_SUCCESS;
 }
-
 
 /*!
  *
  */
-static int dump_dp_kernel_info (void *obj)
-{
-    cl_int err;
-    char *value;
-    size_t size;
-    cl_uint numKernelArgs;
-    cl_kernel kernel;
-    kernel_t kernel_t_ptr;
+static int dump_dp_kernel_info(void *obj) {
+  cl_int err;
+  char *value;
+  size_t size;
+  cl_uint numKernelArgs;
+  cl_kernel kernel;
+  kernel_t kernel_t_ptr;
 
-    value = NULL;
-    kernel_t_ptr = (kernel_t)obj;
+  value = NULL;
+  kernel_t_ptr = (kernel_t)obj;
 #if DEBUG
-    check_kernel_id(kernel_t_ptr);
+  check_kernel_id(kernel_t_ptr);
 #endif
-    kernel = (cl_kernel)(kernel_t_ptr->kernel);
+  kernel = (cl_kernel)(kernel_t_ptr->kernel);
 
-    // print kernel function name
-    err = clGetKernelInfo(kernel, CL_KERNEL_FUNCTION_NAME, 0, NULL, &size);
-    CHECK_OPEN_CL_ERROR(err, "Could not get kernel function name size.");
-    value = (char*)malloc(size);
-    err = clGetKernelInfo(kernel, CL_KERNEL_FUNCTION_NAME, size, value, NULL);
-    CHECK_OPEN_CL_ERROR(err, "Could not get kernel function name.");
-    printf("Kernel Function name: %s\n", value);
-    free(value);
+  // print kernel function name
+  err = clGetKernelInfo(kernel, CL_KERNEL_FUNCTION_NAME, 0, NULL, &size);
+  CHECK_OPEN_CL_ERROR(err, "Could not get kernel function name size.");
+  value = (char *)malloc(size);
+  err = clGetKernelInfo(kernel, CL_KERNEL_FUNCTION_NAME, size, value, NULL);
+  CHECK_OPEN_CL_ERROR(err, "Could not get kernel function name.");
+  printf("Kernel Function name: %s\n", value);
+  free(value);
 
-    // print the number of kernel args
-    err = clGetKernelInfo(kernel, CL_KERNEL_NUM_ARGS, sizeof(numKernelArgs),
-            &numKernelArgs, NULL);
-    CHECK_OPEN_CL_ERROR(err, "Could not get kernel num args.");
-    printf("Number of kernel arguments : %d\n", numKernelArgs);
+  // print the number of kernel args
+  err = clGetKernelInfo(kernel, CL_KERNEL_NUM_ARGS, sizeof(numKernelArgs),
+                        &numKernelArgs, NULL);
+  CHECK_OPEN_CL_ERROR(err, "Could not get kernel num args.");
+  printf("Number of kernel arguments : %d\n", numKernelArgs);
 
-    return DP_GLUE_SUCCESS;
+  return DP_GLUE_SUCCESS;
 
 error:
-    free(value);
-    return DP_GLUE_FAILURE;
+  free(value);
+  return DP_GLUE_FAILURE;
 }
-
 
 /*!
  *
  */
-static int get_first_device (cl_platform_id* platforms,
-                             cl_uint platformCount,
-                             cl_device_id *device,
-                             cl_device_type device_ty)
-{
-    cl_int status;
-    cl_uint ndevices = 0;
-    unsigned int i;
+static int get_first_device(cl_platform_id *platforms, cl_uint platformCount,
+                            cl_device_id *device, cl_device_type device_ty) {
+  cl_int status;
+  cl_uint ndevices = 0;
+  unsigned int i;
 
-    for (i = 0; i < platformCount; ++i) {
-        // get all devices of env_ty
-        status = clGetDeviceIDs(platforms[i], device_ty, 0, NULL, &ndevices);
-        // If this platform has no devices of this type then continue
-        if(!ndevices) continue;
+  for (i = 0; i < platformCount; ++i) {
+    // get all devices of env_ty
+    status = clGetDeviceIDs(platforms[i], device_ty, 0, NULL, &ndevices);
+    // If this platform has no devices of this type then continue
+    if (!ndevices)
+      continue;
 
-        // get the first device
-        status = clGetDeviceIDs(platforms[i], device_ty, 1, device, NULL);
-        CHECK_OPEN_CL_ERROR(status, "Could not get first cl_device_id.");
+    // get the first device
+    status = clGetDeviceIDs(platforms[i], device_ty, 1, device, NULL);
+    CHECK_OPEN_CL_ERROR(status, "Could not get first cl_device_id.");
 
-        // If the first device of this type was discovered, no need to look more
-        if(ndevices) break;
-    }
+    // If the first device of this type was discovered, no need to look more
+    if (ndevices)
+      break;
+  }
 
-    if(ndevices)
-        return DP_GLUE_SUCCESS;
-    else
-        return DP_GLUE_FAILURE;
+  if (ndevices)
+    return DP_GLUE_SUCCESS;
+  else
+    return DP_GLUE_FAILURE;
 
 error:
+  return DP_GLUE_FAILURE;
+}
+
+static int support_int64_atomics(cl_device_id *device) {
+
+  cl_int err;
+  size_t size;
+  char *value;
+
+  err = clGetDeviceInfo(*device, CL_DEVICE_EXTENSIONS, 0, NULL, &size);
+  if (err != CL_SUCCESS) {
+    printf("Unable to obtain device info for param\n");
     return DP_GLUE_FAILURE;
+  }
+  value = (char *)malloc(size);
+  clGetDeviceInfo(*device, CL_DEVICE_EXTENSIONS, size, value, NULL);
+
+  if (strstr(value, "cl_khr_int64_base_atomics") != NULL) {
+    return DP_GLUE_SUCCESS;
+  } else {
+    return DP_GLUE_FAILURE;
+  }
 }
 
-static int support_int64_atomics(cl_device_id *device)
-{
+static int support_float64_atomics(cl_device_id *device) {
 
-    cl_int err;
-    size_t size;
-    char *value;
+  cl_int err;
+  size_t size;
+  char *value;
 
-    err = clGetDeviceInfo(*device, CL_DEVICE_EXTENSIONS, 0, NULL, &size);
-    if (err != CL_SUCCESS ) {
-        printf("Unable to obtain device info for param\n");
-        return DP_GLUE_FAILURE;
-    }
-    value = (char*) malloc(size);
-    clGetDeviceInfo(*device, CL_DEVICE_EXTENSIONS, size, value, NULL);
+  err = clGetDeviceInfo(*device, CL_DEVICE_EXTENSIONS, 0, NULL, &size);
+  if (err != CL_SUCCESS) {
+    printf("Unable to obtain device info for param\n");
+    return DP_GLUE_FAILURE;
+  }
+  value = (char *)malloc(size);
+  clGetDeviceInfo(*device, CL_DEVICE_EXTENSIONS, size, value, NULL);
 
-    if(strstr(value, "cl_khr_int64_base_atomics") != NULL) {
-        return DP_GLUE_SUCCESS;
-    } else {
-        return DP_GLUE_FAILURE;
-    }
-}
-
-static int support_float64_atomics(cl_device_id *device)
-{
-
-    cl_int err;
-    size_t size;
-    char *value;
-
-    err = clGetDeviceInfo(*device, CL_DEVICE_EXTENSIONS, 0, NULL, &size);
-    if (err != CL_SUCCESS ) {
-        printf("Unable to obtain device info for param\n");
-        return DP_GLUE_FAILURE;
-    }
-    value = (char*) malloc(size);
-    clGetDeviceInfo(*device, CL_DEVICE_EXTENSIONS, size, value, NULL);
-
-    if(strstr(value, "cl_khr_fp64") != NULL) {
-        return DP_GLUE_SUCCESS;
-    } else {
-        return DP_GLUE_FAILURE;
-    }
+  if (strstr(value, "cl_khr_fp64") != NULL) {
+    return DP_GLUE_SUCCESS;
+  } else {
+    return DP_GLUE_FAILURE;
+  }
 }
 
 /*!
  *
  */
-static int create_dp_env_t (cl_platform_id* platforms,
-                            size_t nplatforms,
-                            cl_device_type device_ty,
-                            env_t *env_t_ptr)
-{
-    cl_int err;
-    int err1;
-    env_t env;
-    cl_device_id *device;
+static int create_dp_env_t(cl_platform_id *platforms, size_t nplatforms,
+                           cl_device_type device_ty, env_t *env_t_ptr) {
+  cl_int err;
+  int err1;
+  env_t env;
+  cl_device_id *device;
 
-    env = NULL;
-    device = NULL;
+  env = NULL;
+  device = NULL;
 
-    // Allocate the env_t object
-    env = (env_t)malloc(sizeof(struct dp_env));
-    CHECK_MALLOC_ERROR(env_t, env);
-    env->id_ = ENV_ID;
+  // Allocate the env_t object
+  env = (env_t)malloc(sizeof(struct dp_env));
+  CHECK_MALLOC_ERROR(env_t, env);
+  env->id_ = ENV_ID;
 
-    env->context = NULL;
-    env->device = NULL;
-    env->queue = NULL;
-    env->max_work_item_dims = 0;
-    env->max_work_group_size = 0;
-    env->dump_fn = NULL;
+  env->context = NULL;
+  env->device = NULL;
+  env->queue = NULL;
+  env->max_work_item_dims = 0;
+  env->max_work_group_size = 0;
+  env->dump_fn = NULL;
 
-    device = (cl_device_id*)malloc(sizeof(cl_device_id));
+  device = (cl_device_id *)malloc(sizeof(cl_device_id));
 
-    err1 = get_first_device(platforms, nplatforms, device, device_ty);
-    CHECK_DPGLUE_ERROR(err1, "Failed inside get_first_device");
+  err1 = get_first_device(platforms, nplatforms, device, device_ty);
+  CHECK_DPGLUE_ERROR(err1, "Failed inside get_first_device");
 
-    // get the CL_DEVICE_MAX_WORK_ITEM_DIMENSIONS for this device
-    err = clGetDeviceInfo(*device, CL_DEVICE_MAX_WORK_ITEM_DIMENSIONS,
-            sizeof(env->max_work_item_dims), &env->max_work_item_dims, NULL);
-    CHECK_OPEN_CL_ERROR(err, "Could not get max work item dims");
+  // get the CL_DEVICE_MAX_WORK_ITEM_DIMENSIONS for this device
+  err = clGetDeviceInfo(*device, CL_DEVICE_MAX_WORK_ITEM_DIMENSIONS,
+                        sizeof(env->max_work_item_dims),
+                        &env->max_work_item_dims, NULL);
+  CHECK_OPEN_CL_ERROR(err, "Could not get max work item dims");
 
-    // get the CL_DEVICE_MAX_WORK_GROUP_SIZE for this device
-    err = clGetDeviceInfo(*device, CL_DEVICE_MAX_WORK_GROUP_SIZE,
-            sizeof(env->max_work_group_size), &env->max_work_group_size, NULL);
-    CHECK_OPEN_CL_ERROR(err, "Could not get max work group size");
+  // get the CL_DEVICE_MAX_WORK_GROUP_SIZE for this device
+  err = clGetDeviceInfo(*device, CL_DEVICE_MAX_WORK_GROUP_SIZE,
+                        sizeof(env->max_work_group_size),
+                        &env->max_work_group_size, NULL);
+  CHECK_OPEN_CL_ERROR(err, "Could not get max work group size");
 
-    // Create a context and associate it with device
-    env->context = clCreateContext(NULL, 1, device, NULL, NULL, &err);
-    CHECK_OPEN_CL_ERROR(err, "Could not create device context.");
-    // Create a queue and associate it with the context
-    env->queue = clCreateCommandQueueWithProperties((cl_context)env->context,
-            *device, 0, &err);
+  // Create a context and associate it with device
+  env->context = clCreateContext(NULL, 1, device, NULL, NULL, &err);
+  CHECK_OPEN_CL_ERROR(err, "Could not create device context.");
+  // Create a queue and associate it with the context
+  env->queue = clCreateCommandQueueWithProperties((cl_context)env->context,
+                                                  *device, 0, &err);
 
-    CHECK_OPEN_CL_ERROR(err, "Could not create command queue.");
+  CHECK_OPEN_CL_ERROR(err, "Could not create command queue.");
 
-    env->device = *device;
-    env ->dump_fn = dump_device_info;
+  env->device = *device;
+  env->dump_fn = dump_device_info;
 
-    if (DP_GLUE_SUCCESS == support_int64_atomics(device)) {
-        env->support_int64_atomics = 1;
-    } else {
-        env->support_int64_atomics = 0;
-    }
+  if (DP_GLUE_SUCCESS == support_int64_atomics(device)) {
+    env->support_int64_atomics = 1;
+  } else {
+    env->support_int64_atomics = 0;
+  }
 
-    if (DP_GLUE_SUCCESS == support_float64_atomics(device)) {
-        env->support_float64_atomics = 1;
-    } else {
-        env->support_float64_atomics = 0;
-    }
+  if (DP_GLUE_SUCCESS == support_float64_atomics(device)) {
+    env->support_float64_atomics = 1;
+  } else {
+    env->support_float64_atomics = 0;
+  }
 
-    free(device);
-    *env_t_ptr = env;
+  free(device);
+  *env_t_ptr = env;
 
-    return DP_GLUE_SUCCESS;
+  return DP_GLUE_SUCCESS;
 
 malloc_error:
-    return DP_GLUE_FAILURE;
+  return DP_GLUE_FAILURE;
 error:
-    free(env);
-    *env_t_ptr = NULL;
-    return DP_GLUE_FAILURE;
+  free(env);
+  *env_t_ptr = NULL;
+  return DP_GLUE_FAILURE;
 }
 
-
-static int destroy_dp_env_t (env_t *env_t_ptr)
-{
-    cl_int err;
+static int destroy_dp_env_t(env_t *env_t_ptr) {
+  cl_int err;
 #if DEBUG
-    check_env_id(*env_t_ptr);
+  check_env_id(*env_t_ptr);
 #endif
-    err = clReleaseCommandQueue((cl_command_queue)(*env_t_ptr)->queue);
-    CHECK_OPEN_CL_ERROR(err, "Could not release command queue.");
-    err = clReleaseDevice((cl_device_id)(*env_t_ptr)->device);
-    CHECK_OPEN_CL_ERROR(err, "Could not release device.");
-    err = clReleaseContext((cl_context)(*env_t_ptr)->context);
-    CHECK_OPEN_CL_ERROR(err, "Could not release context.");
+  err = clReleaseCommandQueue((cl_command_queue)(*env_t_ptr)->queue);
+  CHECK_OPEN_CL_ERROR(err, "Could not release command queue.");
+  err = clReleaseDevice((cl_device_id)(*env_t_ptr)->device);
+  CHECK_OPEN_CL_ERROR(err, "Could not release device.");
+  err = clReleaseContext((cl_context)(*env_t_ptr)->context);
+  CHECK_OPEN_CL_ERROR(err, "Could not release context.");
 
-    free(*env_t_ptr);
+  free(*env_t_ptr);
 
-    return DP_GLUE_SUCCESS;
+  return DP_GLUE_SUCCESS;
 
 error:
-    return DP_GLUE_FAILURE;
+  return DP_GLUE_FAILURE;
 }
-
 
 /*!
  * @brief Initialize the runtime object.
  */
-static int init_runtime_t_obj (runtime_t rt)
-{
-    cl_int status;
-    int ret;
-    cl_platform_id *platforms;
+static int init_runtime_t_obj(runtime_t rt) {
+  cl_int status;
+  int ret;
+  cl_platform_id *platforms;
 #if DEBUG
-    check_runtime_id(rt);
+  check_runtime_id(rt);
 #endif
-    // get count of available platforms
-    status = clGetPlatformIDs(0, NULL, &(rt->num_platforms));
-    CHECK_OPEN_CL_ERROR(status, "Could not get platform count.");
+  // get count of available platforms
+  status = clGetPlatformIDs(0, NULL, &(rt->num_platforms));
+  CHECK_OPEN_CL_ERROR(status, "Could not get platform count.");
 
-    if(!rt->num_platforms) {
-        fprintf(stderr, "No OpenCL platforms found.\n");
-        goto error;
-    }
+  if (!rt->num_platforms) {
+    fprintf(stderr, "No OpenCL platforms found.\n");
+    goto error;
+  }
 
-    // Allocate memory for the platforms array
-    rt->platform_ids = (cl_platform_id*)malloc(
-                           sizeof(cl_platform_id)*rt->num_platforms
-                       );
-    CHECK_MALLOC_ERROR(cl_platform_id, rt->platform_ids);
+  // Allocate memory for the platforms array
+  rt->platform_ids =
+      (cl_platform_id *)malloc(sizeof(cl_platform_id) * rt->num_platforms);
+  CHECK_MALLOC_ERROR(cl_platform_id, rt->platform_ids);
 
-    // Get the platforms
-    status = clGetPlatformIDs(rt->num_platforms, rt->platform_ids, NULL);
-    CHECK_OPEN_CL_ERROR(status, "Could not get platform ids");
-    // Cast rt->platforms to a pointer of type cl_platform_id, as we cannot do
-    // pointer arithmetic on void*.
-    platforms = (cl_platform_id*)rt->platform_ids;
-    // Get the first cpu device on this platform
-    ret = create_dp_env_t(platforms, rt->num_platforms,
-                          CL_DEVICE_TYPE_CPU, &rt->first_cpu_env);
-    rt->has_cpu = !ret;
+  // Get the platforms
+  status = clGetPlatformIDs(rt->num_platforms, rt->platform_ids, NULL);
+  CHECK_OPEN_CL_ERROR(status, "Could not get platform ids");
+  // Cast rt->platforms to a pointer of type cl_platform_id, as we cannot do
+  // pointer arithmetic on void*.
+  platforms = (cl_platform_id *)rt->platform_ids;
+  // Get the first cpu device on this platform
+  ret = create_dp_env_t(platforms, rt->num_platforms, CL_DEVICE_TYPE_CPU,
+                        &rt->first_cpu_env);
+  rt->has_cpu = !ret;
 
 #if DEBUG
-    if(rt->has_cpu)
-        printf("DEBUG: CPU device acquired...\n");
-    else
-        printf("DEBUG: No CPU available on the system\n");
+  if (rt->has_cpu)
+    printf("DEBUG: CPU device acquired...\n");
+  else
+    printf("DEBUG: No CPU available on the system\n");
 #endif
 
-    // Get the first gpu device on this platform
-    ret = create_dp_env_t(platforms, rt->num_platforms,
-                          CL_DEVICE_TYPE_GPU, &rt->first_gpu_env);
-    rt->has_gpu = !ret;
+  // Get the first gpu device on this platform
+  ret = create_dp_env_t(platforms, rt->num_platforms, CL_DEVICE_TYPE_GPU,
+                        &rt->first_gpu_env);
+  rt->has_gpu = !ret;
 
 #if DEBUG
-    if(rt->has_gpu)
-        printf("DEBUG: GPU device acquired...\n");
-    else
-        printf("DEBUG: No GPU available on the system.\n");
+  if (rt->has_gpu)
+    printf("DEBUG: GPU device acquired...\n");
+  else
+    printf("DEBUG: No GPU available on the system.\n");
 #endif
 
-    if(rt->has_gpu)
-        rt->curr_env = rt->first_gpu_env;
-    else if(rt->has_cpu)
-        rt->curr_env = rt->first_cpu_env;
-    else
-        goto error;
+  if (rt->has_gpu)
+    rt->curr_env = rt->first_gpu_env;
+  else if (rt->has_cpu)
+    rt->curr_env = rt->first_cpu_env;
+  else
+    goto error;
 
-    return DP_GLUE_SUCCESS;
+  return DP_GLUE_SUCCESS;
 
 malloc_error:
 
-    return DP_GLUE_FAILURE;
+  return DP_GLUE_FAILURE;
 error:
-    free(rt->platform_ids);
+  free(rt->platform_ids);
 
-    return DP_GLUE_FAILURE;
+  return DP_GLUE_FAILURE;
 }
 
 /*-------------------------- End of private helpers --------------------------*/
 
-int set_curr_env (runtime_t rt, env_t env)
-{
-    if(env && rt) {
-        rt->curr_env = env;
-        return DP_GLUE_SUCCESS;
-    }
-    return DP_GLUE_FAILURE;
+int set_curr_env(runtime_t rt, env_t env) {
+  if (env && rt) {
+    rt->curr_env = env;
+    return DP_GLUE_SUCCESS;
+  }
+  return DP_GLUE_FAILURE;
 }
 
 /*!
  * @brief Initializes a new dp_runtime_t object
  *
  */
-int create_dp_runtime (runtime_t *rt)
-{
-    int err;
-    runtime_t rtobj;
+int create_dp_runtime(runtime_t *rt) {
+  int err;
+  runtime_t rtobj;
 
-    rtobj = NULL;
-    // Allocate a new struct dp_runtime object
-    rtobj = (runtime_t)malloc(sizeof(struct dp_runtime));
-    CHECK_MALLOC_ERROR(runtime_t, rt);
+  rtobj = NULL;
+  // Allocate a new struct dp_runtime object
+  rtobj = (runtime_t)malloc(sizeof(struct dp_runtime));
+  CHECK_MALLOC_ERROR(runtime_t, rt);
 
-    rtobj->id_ = RUNTIME_ID;
-    rtobj->num_platforms = 0;
-    rtobj->platform_ids  = NULL;
-    err = init_runtime_t_obj(rtobj);
-    CHECK_DPGLUE_ERROR(err, "Could not initialize runtime object.");
-    rtobj->dump_fn = dump_dp_runtime_info;
+  rtobj->id_ = RUNTIME_ID;
+  rtobj->num_platforms = 0;
+  rtobj->platform_ids = NULL;
+  err = init_runtime_t_obj(rtobj);
+  CHECK_DPGLUE_ERROR(err, "Could not initialize runtime object.");
+  rtobj->dump_fn = dump_dp_runtime_info;
 
-    *rt = rtobj;
+  *rt = rtobj;
 #if DEBUG
-    printf("DEBUG: Created an new dp_runtime object\n");
+  printf("DEBUG: Created an new dp_runtime object\n");
 #endif
-    return DP_GLUE_SUCCESS;
+  return DP_GLUE_SUCCESS;
 
 malloc_error:
-    return DP_GLUE_FAILURE;
+  return DP_GLUE_FAILURE;
 error:
-    free(rtobj);
-    return DP_GLUE_FAILURE;
+  free(rtobj);
+  return DP_GLUE_FAILURE;
 }
-
 
 /*!
  * @brief Free the runtime and all its resources.
  *
  */
-int destroy_dp_runtime (runtime_t *rt)
-{
-    int err;
+int destroy_dp_runtime(runtime_t *rt) {
+  int err;
 #if DEBUG
-    check_runtime_id(*rt);
+  check_runtime_id(*rt);
 #endif
 
 #if DEBUG
-    printf("DEBUG: Going to destroy the dp_runtime object\n");
+  printf("DEBUG: Going to destroy the dp_runtime object\n");
 #endif
-    // free the first_cpu_device
-    if((*rt)->first_cpu_env) {
-        err = destroy_dp_env_t(&(*rt)->first_cpu_env);
-        CHECK_DPGLUE_ERROR(err, "Could not destroy first_cpu_device.");
-    }
+  // free the first_cpu_device
+  if ((*rt)->first_cpu_env) {
+    err = destroy_dp_env_t(&(*rt)->first_cpu_env);
+    CHECK_DPGLUE_ERROR(err, "Could not destroy first_cpu_device.");
+  }
 
-    // free the first_gpu_device
-    if((*rt)->first_gpu_env) {
-        err = destroy_dp_env_t(&(*rt)->first_gpu_env);
-        CHECK_DPGLUE_ERROR(err, "Could not destroy first_gpu_device.");
-    }
+  // free the first_gpu_device
+  if ((*rt)->first_gpu_env) {
+    err = destroy_dp_env_t(&(*rt)->first_gpu_env);
+    CHECK_DPGLUE_ERROR(err, "Could not destroy first_gpu_device.");
+  }
 
-    // free the platforms
-    free((cl_platform_id*)(*rt)->platform_ids);
-    // free the runtime_t object
-    free(*rt);
+  // free the platforms
+  free((cl_platform_id *)(*rt)->platform_ids);
+  // free the runtime_t object
+  free(*rt);
 
 #if DEBUG
-    printf("DEBUG: Destroyed the new dp_runtime object\n");
+  printf("DEBUG: Destroyed the new dp_runtime object\n");
 #endif
-    return DP_GLUE_SUCCESS;
+  return DP_GLUE_SUCCESS;
 
 error:
-    return DP_GLUE_FAILURE;
+  return DP_GLUE_FAILURE;
 }
-
 
 /*!
  *
  */
-int retain_dp_context (env_t env_t_ptr)
-{
-    cl_int err;
-    cl_context context;
+int retain_dp_context(env_t env_t_ptr) {
+  cl_int err;
+  cl_context context;
 #if DEBUG
-    check_env_id(env_t_ptr);
+  check_env_id(env_t_ptr);
 #endif
-    context = (cl_context)(env_t_ptr->context);
-    err = clRetainContext(context);
-    CHECK_OPEN_CL_ERROR(err, "Failed when calling clRetainContext.");
+  context = (cl_context)(env_t_ptr->context);
+  err = clRetainContext(context);
+  CHECK_OPEN_CL_ERROR(err, "Failed when calling clRetainContext.");
 
-    return DP_GLUE_SUCCESS;
+  return DP_GLUE_SUCCESS;
 error:
-    return DP_GLUE_FAILURE;
+  return DP_GLUE_FAILURE;
 }
-
 
 /*!
  *
  */
-int release_dp_context (env_t env_t_ptr)
-{
-    cl_int err;
-    cl_context context;
+int release_dp_context(env_t env_t_ptr) {
+  cl_int err;
+  cl_context context;
 #if DEBUG
-    check_env_id(env_t_ptr);
+  check_env_id(env_t_ptr);
 #endif
-    context = (cl_context)(env_t_ptr->context);
-    err = clReleaseContext(context);
-    CHECK_OPEN_CL_ERROR(err, "Failed when calling clRetainContext.");
+  context = (cl_context)(env_t_ptr->context);
+  err = clReleaseContext(context);
+  CHECK_OPEN_CL_ERROR(err, "Failed when calling clRetainContext.");
 
-    return DP_GLUE_SUCCESS;
+  return DP_GLUE_SUCCESS;
 error:
-    return DP_GLUE_FAILURE;
+  return DP_GLUE_FAILURE;
 }
 
-
-int create_dp_rw_mem_buffer (env_t env_t_ptr,
-                             size_t buffsize,
-                             buffer_t *buffer_t_ptr)
-{
-    cl_int err;
-    buffer_t buff;
-    cl_context context;
+int create_dp_rw_mem_buffer(env_t env_t_ptr, size_t buffsize,
+                            buffer_t *buffer_t_ptr) {
+  cl_int err;
+  buffer_t buff;
+  cl_context context;
 #if DEBUG
-    check_env_id(env_t_ptr);
+  check_env_id(env_t_ptr);
 #endif
-    buff = NULL;
+  buff = NULL;
 
-    // Get the context from the device
-    context = (cl_context)(env_t_ptr->context);
-    err = clRetainContext(context);
-    CHECK_OPEN_CL_ERROR(err, "Failed to retain context.");
+  // Get the context from the device
+  context = (cl_context)(env_t_ptr->context);
+  err = clRetainContext(context);
+  CHECK_OPEN_CL_ERROR(err, "Failed to retain context.");
 
-    // Allocate a dp_buffer object
-    buff = (buffer_t)malloc(sizeof(struct dp_buffer));
-    CHECK_MALLOC_ERROR(buffer_t, buffer_t_ptr);
+  // Allocate a dp_buffer object
+  buff = (buffer_t)malloc(sizeof(struct dp_buffer));
+  CHECK_MALLOC_ERROR(buffer_t, buffer_t_ptr);
 
-    buff->id_ = BUFFER_ID;
+  buff->id_ = BUFFER_ID;
 
-    // Create the OpenCL buffer.
-    // NOTE : Copying of data from host to device needs to happen explicitly
-    // using clEnqueue[Write|Read]Buffer. This would change in the future.
-    buff->buffer_ptr = clCreateBuffer(context, CL_MEM_READ_WRITE, buffsize,
-                                      NULL, &err);
-    CHECK_OPEN_CL_ERROR(err, "Failed to create CL buffer.");
+  // Create the OpenCL buffer.
+  // NOTE : Copying of data from host to device needs to happen explicitly
+  // using clEnqueue[Write|Read]Buffer. This would change in the future.
+  buff->buffer_ptr =
+      clCreateBuffer(context, CL_MEM_READ_WRITE, buffsize, NULL, &err);
+  CHECK_OPEN_CL_ERROR(err, "Failed to create CL buffer.");
 
-    buff->sizeof_buffer_ptr = sizeof(cl_mem);
+  buff->sizeof_buffer_ptr = sizeof(cl_mem);
 #if DEBUG
-    printf("DEBUG: CL RW buffer created...\n");
+  printf("DEBUG: CL RW buffer created...\n");
 #endif
-    *buffer_t_ptr = buff;
-    err = clReleaseContext(context);
-    CHECK_OPEN_CL_ERROR(err, "Failed to release context.");
+  *buffer_t_ptr = buff;
+  err = clReleaseContext(context);
+  CHECK_OPEN_CL_ERROR(err, "Failed to release context.");
 
-    return DP_GLUE_SUCCESS;
+  return DP_GLUE_SUCCESS;
 
 malloc_error:
-    return DP_GLUE_FAILURE;
+  return DP_GLUE_FAILURE;
 error:
-    free(buff);
-    return DP_GLUE_FAILURE;
+  free(buff);
+  return DP_GLUE_FAILURE;
 }
 
-
-int destroy_dp_rw_mem_buffer (buffer_t *buff)
-{
-    cl_int err;
+int destroy_dp_rw_mem_buffer(buffer_t *buff) {
+  cl_int err;
 #if DEBUG
-    check_buffer_id(*buff);
+  check_buffer_id(*buff);
 #endif
-    err = clReleaseMemObject((cl_mem)(*buff)->buffer_ptr);
-    CHECK_OPEN_CL_ERROR(err, "Failed to release CL buffer.");
-    free(*buff);
+  err = clReleaseMemObject((cl_mem)(*buff)->buffer_ptr);
+  CHECK_OPEN_CL_ERROR(err, "Failed to release CL buffer.");
+  free(*buff);
 
 #if DEBUG
-    printf("DEBUG: CL buffer destroyed...\n");
+  printf("DEBUG: CL buffer destroyed...\n");
 #endif
 
-    return DP_GLUE_SUCCESS;
+  return DP_GLUE_SUCCESS;
 
 error:
-    return DP_GLUE_FAILURE;
+  return DP_GLUE_FAILURE;
 }
 
-
-int write_dp_mem_buffer_to_device (env_t env_t_ptr,
-                                   buffer_t buffer_t_ptr,
-                                   bool blocking,
-                                   size_t offset,
-                                   size_t buffersize,
-                                   const void *data_ptr)
-{
-    cl_int err;
-    cl_command_queue queue;
-    cl_mem mem;
+int write_dp_mem_buffer_to_device(env_t env_t_ptr, buffer_t buffer_t_ptr,
+                                  bool blocking, size_t offset,
+                                  size_t buffersize, const void *data_ptr) {
+  cl_int err;
+  cl_command_queue queue;
+  cl_mem mem;
 #if DEBUG
-    check_env_id(env_t_ptr);
-    check_buffer_id(buffer_t_ptr);
+  check_env_id(env_t_ptr);
+  check_buffer_id(buffer_t_ptr);
 #endif
-    queue = (cl_command_queue)env_t_ptr->queue;
-    mem = (cl_mem)buffer_t_ptr->buffer_ptr;
+  queue = (cl_command_queue)env_t_ptr->queue;
+  mem = (cl_mem)buffer_t_ptr->buffer_ptr;
 
 #if DEBUG
-    assert(mem && "buffer memory is NULL");
+  assert(mem && "buffer memory is NULL");
 #endif
 
-    err = clRetainMemObject(mem);
-    CHECK_OPEN_CL_ERROR(err, "Failed to retain the command queue.");
-    err = clRetainCommandQueue(queue);
-    CHECK_OPEN_CL_ERROR(err, "Failed to retain the buffer memory object.");
+  err = clRetainMemObject(mem);
+  CHECK_OPEN_CL_ERROR(err, "Failed to retain the command queue.");
+  err = clRetainCommandQueue(queue);
+  CHECK_OPEN_CL_ERROR(err, "Failed to retain the buffer memory object.");
 
-    // Not using any events for the time being. Eventually we want to figure
-    // out the event dependencies using parfor analysis.
-    err = clEnqueueWriteBuffer(queue, mem, blocking?CL_TRUE:CL_FALSE,
-            offset, buffersize, data_ptr, 0, NULL, NULL);
-    CHECK_OPEN_CL_ERROR(err, "Failed to write to CL buffer.");
+  // Not using any events for the time being. Eventually we want to figure
+  // out the event dependencies using parfor analysis.
+  err = clEnqueueWriteBuffer(queue, mem, blocking ? CL_TRUE : CL_FALSE, offset,
+                             buffersize, data_ptr, 0, NULL, NULL);
+  CHECK_OPEN_CL_ERROR(err, "Failed to write to CL buffer.");
 
-    err = clReleaseCommandQueue(queue);
-    CHECK_OPEN_CL_ERROR(err, "Failed to release the command queue.");
-    err = clReleaseMemObject(mem);
-    CHECK_OPEN_CL_ERROR(err, "Failed to release the buffer memory object.");
+  err = clReleaseCommandQueue(queue);
+  CHECK_OPEN_CL_ERROR(err, "Failed to release the command queue.");
+  err = clReleaseMemObject(mem);
+  CHECK_OPEN_CL_ERROR(err, "Failed to release the buffer memory object.");
 
 #if DEBUG
-    printf("DEBUG: CL buffer written to device...\n");
+  printf("DEBUG: CL buffer written to device...\n");
 #endif
-    //--- TODO: Implement a version that uses clEnqueueMapBuffer
+  //--- TODO: Implement a version that uses clEnqueueMapBuffer
 
-    return DP_GLUE_SUCCESS;
+  return DP_GLUE_SUCCESS;
 error:
-    return DP_GLUE_FAILURE;
+  return DP_GLUE_FAILURE;
 }
 
-
-int read_dp_mem_buffer_from_device (env_t env_t_ptr,
-                                    buffer_t buffer_t_ptr,
-                                    bool blocking,
-                                    size_t offset,
-                                    size_t buffersize,
-                                    void *data_ptr)
-{
-    cl_int err;
-    cl_command_queue queue;
-    cl_mem mem;
+int read_dp_mem_buffer_from_device(env_t env_t_ptr, buffer_t buffer_t_ptr,
+                                   bool blocking, size_t offset,
+                                   size_t buffersize, void *data_ptr) {
+  cl_int err;
+  cl_command_queue queue;
+  cl_mem mem;
 #if DEBUG
-    check_env_id(env_t_ptr);
-    check_buffer_id(buffer_t_ptr);
+  check_env_id(env_t_ptr);
+  check_buffer_id(buffer_t_ptr);
 #endif
-    queue = (cl_command_queue)env_t_ptr->queue;
-    mem = (cl_mem)buffer_t_ptr->buffer_ptr;
+  queue = (cl_command_queue)env_t_ptr->queue;
+  mem = (cl_mem)buffer_t_ptr->buffer_ptr;
 
-    err = clRetainMemObject(mem);
-    CHECK_OPEN_CL_ERROR(err, "Failed to retain the command queue.");
-    err = clRetainCommandQueue(queue);
-    CHECK_OPEN_CL_ERROR(err, "Failed to retain the command queue.");
+  err = clRetainMemObject(mem);
+  CHECK_OPEN_CL_ERROR(err, "Failed to retain the command queue.");
+  err = clRetainCommandQueue(queue);
+  CHECK_OPEN_CL_ERROR(err, "Failed to retain the command queue.");
 
-    // Not using any events for the time being. Eventually we want to figure
-    // out the event dependencies using parfor analysis.
-    err = clEnqueueReadBuffer(queue, mem, blocking?CL_TRUE:CL_FALSE,
-            offset, buffersize, data_ptr, 0, NULL, NULL);
-    CHECK_OPEN_CL_ERROR(err, "Failed to read from CL buffer.");
+  // Not using any events for the time being. Eventually we want to figure
+  // out the event dependencies using parfor analysis.
+  err = clEnqueueReadBuffer(queue, mem, blocking ? CL_TRUE : CL_FALSE, offset,
+                            buffersize, data_ptr, 0, NULL, NULL);
+  CHECK_OPEN_CL_ERROR(err, "Failed to read from CL buffer.");
 
-    err = clReleaseCommandQueue(queue);
-    CHECK_OPEN_CL_ERROR(err, "Failed to release the command queue.");
-    err = clReleaseMemObject(mem);
-    CHECK_OPEN_CL_ERROR(err, "Failed to release the buffer memory object.");
+  err = clReleaseCommandQueue(queue);
+  CHECK_OPEN_CL_ERROR(err, "Failed to release the command queue.");
+  err = clReleaseMemObject(mem);
+  CHECK_OPEN_CL_ERROR(err, "Failed to release the buffer memory object.");
 
 #if DEBUG
-    printf("DEBUG: CL buffer read from device...\n");
+  printf("DEBUG: CL buffer read from device...\n");
 #endif
-    fflush(stdout);
-    //--- TODO: Implement a version that uses clEnqueueMapBuffer
+  fflush(stdout);
+  //--- TODO: Implement a version that uses clEnqueueMapBuffer
 
-    return DP_GLUE_SUCCESS;
+  return DP_GLUE_SUCCESS;
 error:
-    return DP_GLUE_FAILURE;
+  return DP_GLUE_FAILURE;
 }
 
-
-int create_dp_program_from_spirv (env_t env_t_ptr,
-                                  const void *il,
-                                  size_t length,
-                                  program_t *program_t_ptr)
-{
-    cl_int err;
-    cl_context context;
-    program_t prog;
+int create_dp_program_from_spirv(env_t env_t_ptr, const void *il, size_t length,
+                                 program_t *program_t_ptr) {
+  cl_int err;
+  cl_context context;
+  program_t prog;
 #if DUMP_SPIRV
-    FILE *write_file;
+  FILE *write_file;
 #endif
 #if DEBUG
-    check_env_id(env_t_ptr);
+  check_env_id(env_t_ptr);
 #endif
-    prog = NULL;
+  prog = NULL;
 
 #if DUMP_SPIRV
-    write_file = fopen("latest.spirv","wb");
-    fwrite(il,length,1,write_file);
-    fclose(write_file);
+  write_file = fopen("latest.spirv", "wb");
+  fwrite(il, length, 1, write_file);
+  fclose(write_file);
 #endif
 
-    prog = (program_t)malloc(sizeof(struct dp_program));
-    CHECK_MALLOC_ERROR(program_t, program_t_ptr);
+  prog = (program_t)malloc(sizeof(struct dp_program));
+  CHECK_MALLOC_ERROR(program_t, program_t_ptr);
 
-    prog->id_ = PROGRAM_ID;
+  prog->id_ = PROGRAM_ID;
 
-    context = (cl_context)env_t_ptr->context;
+  context = (cl_context)env_t_ptr->context;
 
-    err = clRetainContext(context);
-    CHECK_OPEN_CL_ERROR(err, "Could not retain context");
-    // Create a program with a SPIR-V file
-    prog->program = clCreateProgramWithIL(context, il, length, &err);
-    CHECK_OPEN_CL_ERROR(err, "Could not create program with IL");
+  err = clRetainContext(context);
+  CHECK_OPEN_CL_ERROR(err, "Could not retain context");
+  // Create a program with a SPIR-V file
+  prog->program = clCreateProgramWithIL(context, il, length, &err);
+  CHECK_OPEN_CL_ERROR(err, "Could not create program with IL");
 #if DEBUG
-    printf("DEBUG: CL program created from spirv of length %zu...\n", length);
+  printf("DEBUG: CL program created from spirv of length %zu...\n", length);
 #endif
 
-    *program_t_ptr = prog;
+  *program_t_ptr = prog;
 
-    err = clReleaseContext(context);
-    CHECK_OPEN_CL_ERROR(err, "Could not release context");
+  err = clReleaseContext(context);
+  CHECK_OPEN_CL_ERROR(err, "Could not release context");
 
-    return DP_GLUE_SUCCESS;
+  return DP_GLUE_SUCCESS;
 
 malloc_error:
-    return DP_GLUE_FAILURE;
+  return DP_GLUE_FAILURE;
 error:
-    free(prog);
-    return DP_GLUE_FAILURE;
+  free(prog);
+  return DP_GLUE_FAILURE;
 }
 
-
-int create_dp_program_from_source (env_t env_t_ptr,
-                                   unsigned int count,
-                                   const char **strings,
-                                   const size_t *lengths,
-                                   program_t *program_t_ptr)
-{
-    cl_int err;
-    cl_context context;
-    program_t prog;
+int create_dp_program_from_source(env_t env_t_ptr, unsigned int count,
+                                  const char **strings, const size_t *lengths,
+                                  program_t *program_t_ptr) {
+  cl_int err;
+  cl_context context;
+  program_t prog;
 #if DEBUG
-    check_env_id(env_t_ptr);
+  check_env_id(env_t_ptr);
 #endif
-    prog = NULL;
-    prog = (program_t)malloc(sizeof(struct dp_program));
-    CHECK_MALLOC_ERROR(program_t, program_t_ptr);
+  prog = NULL;
+  prog = (program_t)malloc(sizeof(struct dp_program));
+  CHECK_MALLOC_ERROR(program_t, program_t_ptr);
 
-    prog->id_ = PROGRAM_ID;
+  prog->id_ = PROGRAM_ID;
 
-    context = (cl_context)env_t_ptr->context;
+  context = (cl_context)env_t_ptr->context;
 
-    err = clRetainContext(context);
-    CHECK_OPEN_CL_ERROR(err, "Could not retain context");
-    // Create a program with string source files
-    prog->program = clCreateProgramWithSource(context, count, strings,
-            lengths, &err);
-    CHECK_OPEN_CL_ERROR(err, "Could not create program with source");
+  err = clRetainContext(context);
+  CHECK_OPEN_CL_ERROR(err, "Could not retain context");
+  // Create a program with string source files
+  prog->program =
+      clCreateProgramWithSource(context, count, strings, lengths, &err);
+  CHECK_OPEN_CL_ERROR(err, "Could not create program with source");
 #if DEBUG
-    printf("DEBUG: CL program created from source...\n");
+  printf("DEBUG: CL program created from source...\n");
 #endif
 
-    *program_t_ptr = prog;
+  *program_t_ptr = prog;
 
-    err = clReleaseContext(context);
-    CHECK_OPEN_CL_ERROR(err, "Could not release context");
+  err = clReleaseContext(context);
+  CHECK_OPEN_CL_ERROR(err, "Could not release context");
 
-    return DP_GLUE_SUCCESS;
+  return DP_GLUE_SUCCESS;
 
 malloc_error:
-    return DP_GLUE_FAILURE;
+  return DP_GLUE_FAILURE;
 error:
-    free(prog);
-    return DP_GLUE_FAILURE;
+  free(prog);
+  return DP_GLUE_FAILURE;
 }
 
-
-int destroy_dp_program (program_t *program_ptr)
-{
-    cl_int err;
+int destroy_dp_program(program_t *program_ptr) {
+  cl_int err;
 #if DEBUG
-    check_program_id(*program_ptr);
+  check_program_id(*program_ptr);
 #endif
-    err = clReleaseProgram((cl_program)(*program_ptr)->program);
-    CHECK_OPEN_CL_ERROR(err, "Failed to release CL program.");
-    free(*program_ptr);
+  err = clReleaseProgram((cl_program)(*program_ptr)->program);
+  CHECK_OPEN_CL_ERROR(err, "Failed to release CL program.");
+  free(*program_ptr);
 
 #if DEBUG
-    printf("DEBUG: CL program destroyed...\n");
+  printf("DEBUG: CL program destroyed...\n");
 #endif
 
-    return DP_GLUE_SUCCESS;
+  return DP_GLUE_SUCCESS;
 
 error:
-    return DP_GLUE_FAILURE;
+  return DP_GLUE_FAILURE;
 }
 
-
-int build_dp_program (env_t env_t_ptr, program_t program_t_ptr)
-{
-    cl_int err;
-    cl_device_id device;
+int build_dp_program(env_t env_t_ptr, program_t program_t_ptr) {
+  cl_int err;
+  cl_device_id device;
 #if DEBUG
-    check_env_id(env_t_ptr);
-    check_program_id(program_t_ptr);
+  check_env_id(env_t_ptr);
+  check_program_id(program_t_ptr);
 #endif
-    device = (cl_device_id)env_t_ptr->device;
-    err = clRetainDevice(device);
-    CHECK_OPEN_CL_ERROR(err, "Could not retain device");
-    // Build (compile) the program for the device
-    err = clBuildProgram((cl_program)program_t_ptr->program, 1, &device, NULL,
-            NULL, NULL);
-    CHECK_OPEN_CL_ERROR(err, "Could not build program");
+  device = (cl_device_id)env_t_ptr->device;
+  err = clRetainDevice(device);
+  CHECK_OPEN_CL_ERROR(err, "Could not retain device");
+  // Build (compile) the program for the device
+  err = clBuildProgram((cl_program)program_t_ptr->program, 1, &device, NULL,
+                       NULL, NULL);
+  CHECK_OPEN_CL_ERROR(err, "Could not build program");
 #if DEBUG
-    printf("DEBUG: CL program successfully built.\n");
+  printf("DEBUG: CL program successfully built.\n");
 #endif
-    err = clReleaseDevice(device);
-    CHECK_OPEN_CL_ERROR(err, "Could not release device");
+  err = clReleaseDevice(device);
+  CHECK_OPEN_CL_ERROR(err, "Could not release device");
 
-    return DP_GLUE_SUCCESS;
+  return DP_GLUE_SUCCESS;
 
 error:
-    return DP_GLUE_FAILURE;
+  return DP_GLUE_FAILURE;
 }
-
 
 /*!
  *
  */
-int create_dp_kernel (env_t env_t_ptr,
-                      program_t program_t_ptr,
-                      const char *kernel_name,
-                      kernel_t *kernel_ptr)
-{
-    cl_int err;
-    cl_context context;
-    kernel_t ker;
+int create_dp_kernel(env_t env_t_ptr, program_t program_t_ptr,
+                     const char *kernel_name, kernel_t *kernel_ptr) {
+  cl_int err;
+  cl_context context;
+  kernel_t ker;
 #if DEBUG
-    check_env_id(env_t_ptr);
+  check_env_id(env_t_ptr);
 #endif
-    ker = NULL;
-    ker = (kernel_t)malloc(sizeof(struct dp_kernel));
-    CHECK_MALLOC_ERROR(kernel_t, kernel_ptr);
+  ker = NULL;
+  ker = (kernel_t)malloc(sizeof(struct dp_kernel));
+  CHECK_MALLOC_ERROR(kernel_t, kernel_ptr);
 
-    ker->id_ = KERNEL_ID;
+  ker->id_ = KERNEL_ID;
 
-    context = (cl_context)(env_t_ptr->context);
-    err = clRetainContext(context);
-    CHECK_OPEN_CL_ERROR(err, "Could not retain context");
-    ker->kernel = clCreateKernel((cl_program)(program_t_ptr->program),
-            kernel_name, &err);
-    CHECK_OPEN_CL_ERROR(err, "Could not create kernel");
-    err = clReleaseContext(context);
-    CHECK_OPEN_CL_ERROR(err, "Could not release context");
+  context = (cl_context)(env_t_ptr->context);
+  err = clRetainContext(context);
+  CHECK_OPEN_CL_ERROR(err, "Could not retain context");
+  ker->kernel =
+      clCreateKernel((cl_program)(program_t_ptr->program), kernel_name, &err);
+  CHECK_OPEN_CL_ERROR(err, "Could not create kernel");
+  err = clReleaseContext(context);
+  CHECK_OPEN_CL_ERROR(err, "Could not release context");
 #if DEBUG
-    printf("DEBUG: CL kernel created\n");
+  printf("DEBUG: CL kernel created\n");
 #endif
-    ker->dump_fn = dump_dp_kernel_info;
-    *kernel_ptr = ker;
-    return DP_GLUE_SUCCESS;
+  ker->dump_fn = dump_dp_kernel_info;
+  *kernel_ptr = ker;
+  return DP_GLUE_SUCCESS;
 
 malloc_error:
-    return DP_GLUE_FAILURE;
+  return DP_GLUE_FAILURE;
 error:
-    free(ker);
-    return DP_GLUE_FAILURE;
+  free(ker);
+  return DP_GLUE_FAILURE;
 }
 
-
-int destroy_dp_kernel (kernel_t *kernel_ptr)
-{
-    cl_int err;
+int destroy_dp_kernel(kernel_t *kernel_ptr) {
+  cl_int err;
 #if DEBUG
-    check_kernel_id(*kernel_ptr);
+  check_kernel_id(*kernel_ptr);
 #endif
-    err = clReleaseKernel((cl_kernel)(*kernel_ptr)->kernel);
-    CHECK_OPEN_CL_ERROR(err, "Failed to release CL kernel.");
-    free(*kernel_ptr);
+  err = clReleaseKernel((cl_kernel)(*kernel_ptr)->kernel);
+  CHECK_OPEN_CL_ERROR(err, "Failed to release CL kernel.");
+  free(*kernel_ptr);
 
 #if DEBUG
-    printf("DEBUG: CL kernel destroyed...\n");
+  printf("DEBUG: CL kernel destroyed...\n");
 #endif
 
-    return DP_GLUE_SUCCESS;
+  return DP_GLUE_SUCCESS;
 
 error:
-    return DP_GLUE_FAILURE;
+  return DP_GLUE_FAILURE;
 }
-
 
 /*!
  *
  */
-int create_dp_kernel_arg (const void *arg_value,
-                          size_t arg_size,
-                          kernel_arg_t *kernel_arg_t_ptr)
-{
-    kernel_arg_t kernel_arg;
+int create_dp_kernel_arg(const void *arg_value, size_t arg_size,
+                         kernel_arg_t *kernel_arg_t_ptr) {
+  kernel_arg_t kernel_arg;
 
-    kernel_arg = NULL;
-    kernel_arg = (kernel_arg_t)malloc(sizeof(struct dp_kernel_arg));
-    CHECK_MALLOC_ERROR(kernel_arg_t, kernel_arg);
+  kernel_arg = NULL;
+  kernel_arg = (kernel_arg_t)malloc(sizeof(struct dp_kernel_arg));
+  CHECK_MALLOC_ERROR(kernel_arg_t, kernel_arg);
 
-    kernel_arg->id_ = KERNELARG_ID;
-    kernel_arg->arg_size = arg_size;
-    kernel_arg->arg_value = arg_value;
+  kernel_arg->id_ = KERNELARG_ID;
+  kernel_arg->arg_size = arg_size;
+  kernel_arg->arg_value = arg_value;
 
 #if DEBUG
-    printf("DEBUG: Kernel arg created\n");
+  printf("DEBUG: Kernel arg created\n");
 //    void **tp = (void**)kernel_arg->arg_value;
 //    printf("DEBUG: create_kernel_arg %p (size %ld, addr %p)\n",
 //            kernel_arg, kernel_arg->arg_size, *tp);
 #endif
 
-    *kernel_arg_t_ptr = kernel_arg;
+  *kernel_arg_t_ptr = kernel_arg;
 
-    return DP_GLUE_SUCCESS;
+  return DP_GLUE_SUCCESS;
 
 malloc_error:
-    return DP_GLUE_FAILURE;
+  return DP_GLUE_FAILURE;
 }
 
 /*!
  *
  */
-int create_dp_kernel_arg_from_buffer (buffer_t *buffer_t_ptr,
-                                      kernel_arg_t *kernel_arg_t_ptr)
-{
+int create_dp_kernel_arg_from_buffer(buffer_t *buffer_t_ptr,
+                                     kernel_arg_t *kernel_arg_t_ptr) {
 #if DEBUG
-    check_buffer_id(*buffer_t_ptr);
+  check_buffer_id(*buffer_t_ptr);
 #endif
-    return create_dp_kernel_arg(&((*buffer_t_ptr)->buffer_ptr),
-                                (*buffer_t_ptr)->sizeof_buffer_ptr,
-                                kernel_arg_t_ptr);
+  return create_dp_kernel_arg(&((*buffer_t_ptr)->buffer_ptr),
+                              (*buffer_t_ptr)->sizeof_buffer_ptr,
+                              kernel_arg_t_ptr);
 }
 
 /*!
  *
  */
-int destroy_dp_kernel_arg (kernel_arg_t *kernel_arg_t_ptr)
-{
-    free(*kernel_arg_t_ptr);
+int destroy_dp_kernel_arg(kernel_arg_t *kernel_arg_t_ptr) {
+  free(*kernel_arg_t_ptr);
 
 #if DEBUG
-    printf("DEBUG: Kernel arg destroyed...\n");
+  printf("DEBUG: Kernel arg destroyed...\n");
 #endif
 
-    return DP_GLUE_SUCCESS;
+  return DP_GLUE_SUCCESS;
 }
-
 
 /*!
  *
  */
-int set_args_and_enqueue_dp_kernel (env_t env_t_ptr,
-                                    kernel_t kernel_t_ptr,
-                                    size_t nargs,
-                                    const kernel_arg_t *array_of_args,
-                                    unsigned int work_dim,
-                                    const size_t *global_work_offset,
-                                    const size_t *global_work_size,
-                                    const size_t *local_work_size)
-{
-    size_t i;
-    cl_int err;
-    cl_kernel kernel;
-    cl_command_queue queue;
+int set_args_and_enqueue_dp_kernel(env_t env_t_ptr, kernel_t kernel_t_ptr,
+                                   size_t nargs,
+                                   const kernel_arg_t *array_of_args,
+                                   unsigned int work_dim,
+                                   const size_t *global_work_offset,
+                                   const size_t *global_work_size,
+                                   const size_t *local_work_size) {
+  size_t i;
+  cl_int err;
+  cl_kernel kernel;
+  cl_command_queue queue;
 
-    err = 0;
+  err = 0;
 #if DEBUG
-    check_env_id(env_t_ptr);
-    check_kernel_id(kernel_t_ptr);
+  check_env_id(env_t_ptr);
+  check_kernel_id(kernel_t_ptr);
 #endif
-    kernel = (cl_kernel)kernel_t_ptr->kernel;
-    queue = (cl_command_queue)env_t_ptr->queue;
+  kernel = (cl_kernel)kernel_t_ptr->kernel;
+  queue = (cl_command_queue)env_t_ptr->queue;
 #if DEBUG
-    kernel_t_ptr->dump_fn(kernel_t_ptr);
+  kernel_t_ptr->dump_fn(kernel_t_ptr);
 #endif
-    // Set the kernel arguments
-    for(i = 0; i < nargs; ++i) {
+  // Set the kernel arguments
+  for (i = 0; i < nargs; ++i) {
 #if DEBUG
-        printf("DEBUG: clSetKernelArgs for arg # %zu\n", i);
+    printf("DEBUG: clSetKernelArgs for arg # %zu\n", i);
 #endif
-        kernel_arg_t this_arg = array_of_args[i];
+    kernel_arg_t this_arg = array_of_args[i];
 #if DEBUG
-        check_kernelarg_id(this_arg);
-        void **tp = (void**)this_arg->arg_value;
-        printf("DEBUG: clSetKernelArgs for arg # %zu (size %zu, addr %p)\n", i,
-                this_arg->arg_size, *tp);
+    check_kernelarg_id(this_arg);
+    void **tp = (void **)this_arg->arg_value;
+    printf("DEBUG: clSetKernelArgs for arg # %zu (size %zu, addr %p)\n", i,
+           this_arg->arg_size, *tp);
 #endif
-        err = clSetKernelArg(kernel, i, this_arg->arg_size,
-                             this_arg->arg_value);
-        CHECK_OPEN_CL_ERROR(err, "Could not set arguments to the kernel");
-    }
+    err = clSetKernelArg(kernel, i, this_arg->arg_size, this_arg->arg_value);
+    CHECK_OPEN_CL_ERROR(err, "Could not set arguments to the kernel");
+  }
 
-    // Execute the kernel. Not using events for the time being.
-    err = clEnqueueNDRangeKernel(queue, kernel, work_dim, global_work_offset,
-            global_work_size, local_work_size, 0, NULL, NULL);
-    CHECK_OPEN_CL_ERROR(err, "Could not enqueue the kernel");
+  // Execute the kernel. Not using events for the time being.
+  err =
+      clEnqueueNDRangeKernel(queue, kernel, work_dim, global_work_offset,
+                             global_work_size, local_work_size, 0, NULL, NULL);
+  CHECK_OPEN_CL_ERROR(err, "Could not enqueue the kernel");
 
-    err = clFinish(queue);
-    CHECK_OPEN_CL_ERROR(err, "Failed while waiting for queue to finish");
+  err = clFinish(queue);
+  CHECK_OPEN_CL_ERROR(err, "Failed while waiting for queue to finish");
 #if DEBUG
-    printf("DEBUG: CL Kernel Finish...\n");
+  printf("DEBUG: CL Kernel Finish...\n");
 #endif
-    return DP_GLUE_SUCCESS;
+  return DP_GLUE_SUCCESS;
 
 error:
-    return DP_GLUE_FAILURE;
+  return DP_GLUE_FAILURE;
 }
-
 
 /*!
  *
  */
-int set_args_and_enqueue_dp_kernel_auto_blocking (env_t env_t_ptr,
-                                                  kernel_t kernel_t_ptr,
-                                                  size_t nargs,
-                                                  const kernel_arg_t *args,
-                                                  unsigned int num_dims,
-                                                  size_t *dim_starts,
-                                                  size_t *dim_stops)
-{
-    size_t *global_work_size;
-//    size_t *local_work_size;
-    int err;
-    unsigned i;
+int set_args_and_enqueue_dp_kernel_auto_blocking(
+    env_t env_t_ptr, kernel_t kernel_t_ptr, size_t nargs,
+    const kernel_arg_t *args, unsigned int num_dims, size_t *dim_starts,
+    size_t *dim_stops) {
+  size_t *global_work_size;
+  //    size_t *local_work_size;
+  int err;
+  unsigned i;
 
-    global_work_size = (size_t*)malloc(sizeof(size_t) * num_dims);
-//    local_work_size  = (size_t*)malloc(sizeof(size_t) * num_dims);
-    CHECK_MALLOC_ERROR(size_t, global_work_size);
-//    CHECK_MALLOC_ERROR(size_t, local_work_size);
+  global_work_size = (size_t *)malloc(sizeof(size_t) * num_dims);
+  //    local_work_size  = (size_t*)malloc(sizeof(size_t) * num_dims);
+  CHECK_MALLOC_ERROR(size_t, global_work_size);
+  //    CHECK_MALLOC_ERROR(size_t, local_work_size);
 
-    assert(num_dims > 0 && num_dims < 4);
-    for (i = 0; i < num_dims; ++i) {
-        global_work_size[i] = dim_stops[i] - dim_starts[i] + 1;
-    }
+  assert(num_dims > 0 && num_dims < 4);
+  for (i = 0; i < num_dims; ++i) {
+    global_work_size[i] = dim_stops[i] - dim_starts[i] + 1;
+  }
 
-    err = set_args_and_enqueue_dp_kernel(env_t_ptr,
-                                         kernel_t_ptr,
-                                         nargs,
-                                         args,
-                                         num_dims,
-                                         NULL,
-                                         global_work_size,
-                                         NULL);
-    free(global_work_size);
-//    free(local_work_size);
-    return err;
+  err = set_args_and_enqueue_dp_kernel(env_t_ptr, kernel_t_ptr, nargs, args,
+                                       num_dims, NULL, global_work_size, NULL);
+  free(global_work_size);
+  //    free(local_work_size);
+  return err;
 
 malloc_error:
-    free(global_work_size);
-//    free(local_work_size);
-    return DP_GLUE_FAILURE;
+  free(global_work_size);
+  //    free(local_work_size);
+  return DP_GLUE_FAILURE;
 }

--- a/backends/source/dppl_sycl_context_interface.cpp
+++ b/backends/source/dppl_sycl_context_interface.cpp
@@ -30,47 +30,41 @@
 
 using namespace cl::sycl;
 
-namespace
-{
+namespace {
 // Create wrappers for C Binding types (see CBindingWrapping.h).
 DEFINE_SIMPLE_CONVERSION_FUNCTIONS(context, DPPLSyclContextRef)
 } /* end of anonymous namespace */
 
-bool DPPLContext_AreEq (__dppl_keep const DPPLSyclContextRef CtxRef1,
-                        __dppl_keep const DPPLSyclContextRef CtxRef2)
-{
-    if(!(CtxRef1 && CtxRef2))
-        // \todo handle error
-        return false;
-    return (*unwrap(CtxRef1) == *unwrap(CtxRef2));
+bool DPPLContext_AreEq(__dppl_keep const DPPLSyclContextRef CtxRef1,
+                       __dppl_keep const DPPLSyclContextRef CtxRef2) {
+  if (!(CtxRef1 && CtxRef2))
+    // \todo handle error
+    return false;
+  return (*unwrap(CtxRef1) == *unwrap(CtxRef2));
 }
 
-bool DPPLContext_IsHost (__dppl_keep const DPPLSyclContextRef CtxRef)
-{
-    return unwrap(CtxRef)->is_host();
+bool DPPLContext_IsHost(__dppl_keep const DPPLSyclContextRef CtxRef) {
+  return unwrap(CtxRef)->is_host();
 }
 
-void DPPLContext_Delete (__dppl_take DPPLSyclContextRef CtxRef)
-{
-    delete unwrap(CtxRef);
+void DPPLContext_Delete(__dppl_take DPPLSyclContextRef CtxRef) {
+  delete unwrap(CtxRef);
 }
 
 DPPLSyclBackendType
-DPPLContext_GetBackend (__dppl_keep const DPPLSyclContextRef CtxRef)
-{
-    auto BE = unwrap(CtxRef)->get_platform().get_backend();
+DPPLContext_GetBackend(__dppl_keep const DPPLSyclContextRef CtxRef) {
+  auto BE = unwrap(CtxRef)->get_platform().get_backend();
 
-    switch(BE)
-    {
-        case backend::host:
-            return DPPL_HOST;
-        case backend::opencl:
-            return DPPL_OPENCL;
-        case backend::level_zero:
-            return DPPL_LEVEL_ZERO;
-        case backend::cuda:
-            return DPPL_CUDA;
-        default:
-            return DPPL_UNKNOWN_BACKEND;
-    }
+  switch (BE) {
+  case backend::host:
+    return DPPL_HOST;
+  case backend::opencl:
+    return DPPL_OPENCL;
+  case backend::level_zero:
+    return DPPL_LEVEL_ZERO;
+  case backend::cuda:
+    return DPPL_CUDA;
+  default:
+    return DPPL_UNKNOWN_BACKEND;
+  }
 }

--- a/backends/source/dppl_sycl_device_interface.cpp
+++ b/backends/source/dppl_sycl_device_interface.cpp
@@ -26,59 +26,56 @@
 
 #include "dppl_sycl_device_interface.h"
 #include "Support/CBindingWrapping.h"
+#include <CL/sycl.hpp> /* SYCL headers   */
 #include <iomanip>
 #include <iostream>
-#include <CL/sycl.hpp>                /* SYCL headers   */
 
 using namespace cl::sycl;
 
-namespace
-{
+namespace {
 // Create wrappers for C Binding types (see CBindingWrapping.h).
 DEFINE_SIMPLE_CONVERSION_FUNCTIONS(device, DPPLSyclDeviceRef)
 
- /*!
+/*!
  * @brief Helper function to print the metadata for a sycl::device.
  *
  * @param    Device         My Param doc
  */
-void dump_device_info (const device & Device)
-{
-    std::stringstream ss;
+void dump_device_info(const device &Device) {
+  std::stringstream ss;
 
-    ss << std::setw(4) << " " << std::left << std::setw(16) << "Name"
-       << Device.get_info<info::device::name>() << '\n';
-    ss << std::setw(4) << " " << std::left << std::setw(16) << "Driver version"
-       << Device.get_info<info::device::driver_version>() << '\n';
-    ss << std::setw(4) << " " << std::left << std::setw(16) << "Vendor"
-       << Device.get_info<info::device::vendor>() << '\n';
-    ss << std::setw(4) << " " << std::left << std::setw(16) << "Profile"
-       << Device.get_info<info::device::profile>() << '\n';
-    ss << std::setw(4) << " " << std::left << std::setw(16) << "Device type";
+  ss << std::setw(4) << " " << std::left << std::setw(16) << "Name"
+     << Device.get_info<info::device::name>() << '\n';
+  ss << std::setw(4) << " " << std::left << std::setw(16) << "Driver version"
+     << Device.get_info<info::device::driver_version>() << '\n';
+  ss << std::setw(4) << " " << std::left << std::setw(16) << "Vendor"
+     << Device.get_info<info::device::vendor>() << '\n';
+  ss << std::setw(4) << " " << std::left << std::setw(16) << "Profile"
+     << Device.get_info<info::device::profile>() << '\n';
+  ss << std::setw(4) << " " << std::left << std::setw(16) << "Device type";
 
-    auto devTy = Device.get_info<info::device::device_type>();
-    switch(devTy)
-    {
-    case info::device_type::cpu:
-        ss << "cpu" << '\n';
-        break;
-    case info::device_type::gpu:
-        ss << "gpu" << '\n';
-        break;
-    case info::device_type::accelerator:
-        ss << "accelerator" << '\n';
-        break;
-    case info::device_type::custom:
-        ss << "custom" << '\n';
-        break;
-    case info::device_type::host:
-        ss << "host" << '\n';
-        break;
-    default:
-        ss << "unknown" << '\n';
-    }
+  auto devTy = Device.get_info<info::device::device_type>();
+  switch (devTy) {
+  case info::device_type::cpu:
+    ss << "cpu" << '\n';
+    break;
+  case info::device_type::gpu:
+    ss << "gpu" << '\n';
+    break;
+  case info::device_type::accelerator:
+    ss << "accelerator" << '\n';
+    break;
+  case info::device_type::custom:
+    ss << "custom" << '\n';
+    break;
+  case info::device_type::host:
+    ss << "host" << '\n';
+    break;
+  default:
+    ss << "unknown" << '\n';
+  }
 
-    std::cout << ss.str();
+  std::cout << ss.str();
 }
 
 } /* end of anonymous namespace */
@@ -89,67 +86,55 @@ void dump_device_info (const device & Device)
  * vendor, and device profile are printed out. More attributed may be added
  * later.
  */
-void DPPLDevice_DumpInfo (__dppl_keep const DPPLSyclDeviceRef DRef)
-{
-    auto Device = unwrap(DRef);
-    dump_device_info(*Device);
+void DPPLDevice_DumpInfo(__dppl_keep const DPPLSyclDeviceRef DRef) {
+  auto Device = unwrap(DRef);
+  dump_device_info(*Device);
 }
 
-
-void DPPLDevice_Delete (__dppl_take DPPLSyclDeviceRef DRef)
-{
-    delete unwrap(DRef);
+void DPPLDevice_Delete(__dppl_take DPPLSyclDeviceRef DRef) {
+  delete unwrap(DRef);
 }
 
-bool DPPLDevice_IsAccelerator (__dppl_keep const DPPLSyclDeviceRef DRef)
-{
-    return unwrap(DRef)->is_accelerator();
+bool DPPLDevice_IsAccelerator(__dppl_keep const DPPLSyclDeviceRef DRef) {
+  return unwrap(DRef)->is_accelerator();
 }
 
-bool DPPLDevice_IsCPU (__dppl_keep const DPPLSyclDeviceRef DRef)
-{
-    return unwrap(DRef)->is_cpu();
+bool DPPLDevice_IsCPU(__dppl_keep const DPPLSyclDeviceRef DRef) {
+  return unwrap(DRef)->is_cpu();
 }
 
-bool DPPLDevice_IsGPU (__dppl_keep const DPPLSyclDeviceRef DRef)
-{
-    return unwrap(DRef)->is_gpu();
+bool DPPLDevice_IsGPU(__dppl_keep const DPPLSyclDeviceRef DRef) {
+  return unwrap(DRef)->is_gpu();
 }
 
-
-bool DPPLDevice_IsHost (__dppl_keep const DPPLSyclDeviceRef DRef)
-{
-    return unwrap(DRef)->is_host();
+bool DPPLDevice_IsHost(__dppl_keep const DPPLSyclDeviceRef DRef) {
+  return unwrap(DRef)->is_host();
 }
 
-__dppl_give const char*
-DPPLDevice_GetName (__dppl_keep const DPPLSyclDeviceRef DRef)
-{
-    auto name = unwrap(DRef)->get_info<info::device::name>();
-    auto cstr_name = new char [name.length()+1];
-    std::strcpy (cstr_name, name.c_str());
-    return cstr_name;
+__dppl_give const char *
+DPPLDevice_GetName(__dppl_keep const DPPLSyclDeviceRef DRef) {
+  auto name = unwrap(DRef)->get_info<info::device::name>();
+  auto cstr_name = new char[name.length() + 1];
+  std::strcpy(cstr_name, name.c_str());
+  return cstr_name;
 }
 
-__dppl_give const char*
-DPPLDevice_GetVendorName (__dppl_keep const DPPLSyclDeviceRef DRef)
-{
-    auto vendor = unwrap(DRef)->get_info<info::device::name>();
-    auto cstr_vendor = new char [vendor.length()+1];
-    std::strcpy (cstr_vendor, vendor.c_str());
-    return cstr_vendor;
+__dppl_give const char *
+DPPLDevice_GetVendorName(__dppl_keep const DPPLSyclDeviceRef DRef) {
+  auto vendor = unwrap(DRef)->get_info<info::device::name>();
+  auto cstr_vendor = new char[vendor.length() + 1];
+  std::strcpy(cstr_vendor, vendor.c_str());
+  return cstr_vendor;
 }
 
-__dppl_give const char*
-DPPLDevice_GetDriverInfo (__dppl_keep const DPPLSyclDeviceRef DRef)
-{
-    auto driver = unwrap(DRef)->get_info<info::device::driver_version>();
-    auto cstr_driver = new char [driver.length()+1];
-    std::strcpy (cstr_driver, driver.c_str());
-    return cstr_driver;
+__dppl_give const char *
+DPPLDevice_GetDriverInfo(__dppl_keep const DPPLSyclDeviceRef DRef) {
+  auto driver = unwrap(DRef)->get_info<info::device::driver_version>();
+  auto cstr_driver = new char[driver.length() + 1];
+  std::strcpy(cstr_driver, driver.c_str());
+  return cstr_driver;
 }
 
-bool DPPLDevice_IsHostUnifiedMemory (__dppl_keep const DPPLSyclDeviceRef DRef)
-{
-    return unwrap(DRef)->get_info<info::device::host_unified_memory>();
+bool DPPLDevice_IsHostUnifiedMemory(__dppl_keep const DPPLSyclDeviceRef DRef) {
+  return unwrap(DRef)->get_info<info::device::host_unified_memory>();
 }

--- a/backends/source/dppl_sycl_event_interface.cpp
+++ b/backends/source/dppl_sycl_event_interface.cpp
@@ -27,26 +27,21 @@
 #include "dppl_sycl_event_interface.h"
 #include "Support/CBindingWrapping.h"
 
-#include <CL/sycl.hpp>                /* SYCL headers   */
+#include <CL/sycl.hpp> /* SYCL headers   */
 
 using namespace cl::sycl;
 
-namespace
-{
+namespace {
 // Create wrappers for C Binding types (see CBindingWrapping.h)
 DEFINE_SIMPLE_CONVERSION_FUNCTIONS(event, DPPLSyclEventRef)
 } /* end of anonymous namespace */
 
-
-void DPPLEvent_Wait (__dppl_keep DPPLSyclEventRef ERef)
-{
-    // \todo How to handle errors? E.g. when ERef is null or not a valid event.
-    auto SyclEvent = unwrap(ERef);
-    SyclEvent->wait();
+void DPPLEvent_Wait(__dppl_keep DPPLSyclEventRef ERef) {
+  // \todo How to handle errors? E.g. when ERef is null or not a valid event.
+  auto SyclEvent = unwrap(ERef);
+  SyclEvent->wait();
 }
 
-void
-DPPLEvent_Delete (__dppl_take DPPLSyclEventRef ERef)
-{
-    delete unwrap(ERef);
+void DPPLEvent_Delete(__dppl_take DPPLSyclEventRef ERef) {
+  delete unwrap(ERef);
 }

--- a/backends/source/dppl_sycl_kernel_interface.cpp
+++ b/backends/source/dppl_sycl_kernel_interface.cpp
@@ -31,45 +31,39 @@
 
 using namespace cl::sycl;
 
-namespace
-{
+namespace {
 
 DEFINE_SIMPLE_CONVERSION_FUNCTIONS(kernel, DPPLSyclKernelRef)
 
 } /* end of anonymous namespace */
 
-__dppl_give const char*
-DPPLKernel_GetFunctionName (__dppl_keep const DPPLSyclKernelRef Kernel)
-{
-    if(!Kernel) {
-        // \todo record error
-        return nullptr;
-    }
+__dppl_give const char *
+DPPLKernel_GetFunctionName(__dppl_keep const DPPLSyclKernelRef Kernel) {
+  if (!Kernel) {
+    // \todo record error
+    return nullptr;
+  }
 
-    auto SyclKernel = unwrap(Kernel);
-    auto kernel_name = SyclKernel->get_info<info::kernel::function_name>();
-    if(kernel_name.empty())
-        return nullptr;
-    auto cstr_name = new char [kernel_name.length()+1];
-    std::strcpy (cstr_name, kernel_name.c_str());
-    return cstr_name;
+  auto SyclKernel = unwrap(Kernel);
+  auto kernel_name = SyclKernel->get_info<info::kernel::function_name>();
+  if (kernel_name.empty())
+    return nullptr;
+  auto cstr_name = new char[kernel_name.length() + 1];
+  std::strcpy(cstr_name, kernel_name.c_str());
+  return cstr_name;
 }
 
-size_t
-DPPLKernel_GetNumArgs (__dppl_keep const DPPLSyclKernelRef Kernel)
-{
-    if(!Kernel) {
-        // \todo record error
-        return -1;
-    }
+size_t DPPLKernel_GetNumArgs(__dppl_keep const DPPLSyclKernelRef Kernel) {
+  if (!Kernel) {
+    // \todo record error
+    return -1;
+  }
 
-    auto SyclKernel = unwrap(Kernel);
-    auto num_args = SyclKernel->get_info<info::kernel::num_args>();
-    return (size_t)num_args;
+  auto SyclKernel = unwrap(Kernel);
+  auto num_args = SyclKernel->get_info<info::kernel::num_args>();
+  return (size_t)num_args;
 }
 
-void
-DPPLKernel_Delete (__dppl_take DPPLSyclKernelRef Kernel)
-{
-    delete unwrap(Kernel);
+void DPPLKernel_Delete(__dppl_take DPPLSyclKernelRef Kernel) {
+  delete unwrap(Kernel);
 }

--- a/backends/source/dppl_sycl_platform_interface.cpp
+++ b/backends/source/dppl_sycl_platform_interface.cpp
@@ -34,160 +34,149 @@
 
 using namespace cl::sycl;
 
-namespace
-{
-std::set<DPPLSyclBackendType>
-get_set_of_non_hostbackends ()
-{
-    std::set<DPPLSyclBackendType> be_set;
-    for (auto p : platform::get_platforms()) {
-		if(p.is_host())
-            continue;
-        auto be = p.get_backend();
-        switch (be)
-        {
-        case backend::host:
-            break;
-        case backend::cuda:
-            be_set.insert(DPPLSyclBackendType::DPPL_CUDA);
-            break;
-        case backend::level_zero:
-            be_set.insert(DPPLSyclBackendType::DPPL_LEVEL_ZERO);
-            break;
-        case backend::opencl:
-            be_set.insert(DPPLSyclBackendType::DPPL_OPENCL);
-            break;
-        default:
-            break;
-        }
+namespace {
+std::set<DPPLSyclBackendType> get_set_of_non_hostbackends() {
+  std::set<DPPLSyclBackendType> be_set;
+  for (auto p : platform::get_platforms()) {
+    if (p.is_host())
+      continue;
+    auto be = p.get_backend();
+    switch (be) {
+    case backend::host:
+      break;
+    case backend::cuda:
+      be_set.insert(DPPLSyclBackendType::DPPL_CUDA);
+      break;
+    case backend::level_zero:
+      be_set.insert(DPPLSyclBackendType::DPPL_LEVEL_ZERO);
+      break;
+    case backend::opencl:
+      be_set.insert(DPPLSyclBackendType::DPPL_OPENCL);
+      break;
+    default:
+      break;
     }
-    return be_set;
+  }
+  return be_set;
 }
 
 } // namespace
 
 /*!
-* Prints out the following sycl::info::platform attributes for each platform
-* found on the system:
-*      - info::platform::name
-*      - info::platform::version
-*      - info::platform::vendor
-*      - info::platform::profile
-*      - backend (opencl, cuda, level-zero, host)
-*      - number of devices on the platform
-*
-* Additionally, for each device we print out:
-*      - info::device::name
-*      - info::device::driver_version
-*      - type of the device based on the aspects cpu, gpu, accelerator.
-*/
-void DPPLPlatform_DumpInfo ()
-{
-    size_t i = 0;
+ * Prints out the following sycl::info::platform attributes for each platform
+ * found on the system:
+ *      - info::platform::name
+ *      - info::platform::version
+ *      - info::platform::vendor
+ *      - info::platform::profile
+ *      - backend (opencl, cuda, level-zero, host)
+ *      - number of devices on the platform
+ *
+ * Additionally, for each device we print out:
+ *      - info::device::name
+ *      - info::device::driver_version
+ *      - type of the device based on the aspects cpu, gpu, accelerator.
+ */
+void DPPLPlatform_DumpInfo() {
+  size_t i = 0;
 
-    // Print out the info for each platform
-    auto platforms = platform::get_platforms();
-    for (auto &p : platforms) {
-        std::cout << "---Platform " << i << '\n';
-        std::stringstream ss;
+  // Print out the info for each platform
+  auto platforms = platform::get_platforms();
+  for (auto &p : platforms) {
+    std::cout << "---Platform " << i << '\n';
+    std::stringstream ss;
 
-        auto vendor = p.get_info<info::platform::vendor>();
-        if (vendor.empty())
-            vendor = "unknown";
+    auto vendor = p.get_info<info::platform::vendor>();
+    if (vendor.empty())
+      vendor = "unknown";
 
-        ss << std::setw(4) << " " << std::left << std::setw(12) << "Name"
-           << p.get_info<info::platform::name>() << '\n';
-        ss << std::setw(4) << " " << std::left << std::setw(12) << "Version"
-           << p.get_info<info::platform::version>() << '\n';
-        ss << std::setw(4) << " " << std::left << std::setw(12) << "Vendor"
-           << vendor << '\n';
-        ss << std::setw(4) << " " << std::left << std::setw(12) << "Profile"
-           << p.get_info<info::platform::profile>() << '\n';
-        ss << std::setw(4) << " " << std::left << std::setw(12) << "Backend";
-        p.is_host() ? (ss << "unknown") : (ss << p.get_backend());
-        ss << '\n';
+    ss << std::setw(4) << " " << std::left << std::setw(12) << "Name"
+       << p.get_info<info::platform::name>() << '\n';
+    ss << std::setw(4) << " " << std::left << std::setw(12) << "Version"
+       << p.get_info<info::platform::version>() << '\n';
+    ss << std::setw(4) << " " << std::left << std::setw(12) << "Vendor"
+       << vendor << '\n';
+    ss << std::setw(4) << " " << std::left << std::setw(12) << "Profile"
+       << p.get_info<info::platform::profile>() << '\n';
+    ss << std::setw(4) << " " << std::left << std::setw(12) << "Backend";
+    p.is_host() ? (ss << "unknown") : (ss << p.get_backend());
+    ss << '\n';
 
-        // Get number of devices on the platform
-        auto devices = p.get_devices();
+    // Get number of devices on the platform
+    auto devices = p.get_devices();
 
-        ss << std::setw(4) << " " << std::left << std::setw(12) << "Devices"
-           << devices.size() << '\n';
-        // Print some of the device information
-        for (auto dn = 0ul; dn < devices.size(); ++dn) {
-            ss << std::setw(4) << "---Device " << dn << '\n';
-            ss << std::setw(8) << " " << std::left << std::setw(20)
-               << "Name" << devices[dn].get_info<info::device::name>() << '\n';
-            ss << std::setw(8) << " " << std::left << std::setw(20)
-               << "Driver version"
-               << devices[dn].get_info<info::device::driver_version>() << '\n';
-            ss << std::setw(8) << " " << std::left << std::setw(20)
-               << "Device type";
+    ss << std::setw(4) << " " << std::left << std::setw(12) << "Devices"
+       << devices.size() << '\n';
+    // Print some of the device information
+    for (auto dn = 0ul; dn < devices.size(); ++dn) {
+      ss << std::setw(4) << "---Device " << dn << '\n';
+      ss << std::setw(8) << " " << std::left << std::setw(20) << "Name"
+         << devices[dn].get_info<info::device::name>() << '\n';
+      ss << std::setw(8) << " " << std::left << std::setw(20)
+         << "Driver version"
+         << devices[dn].get_info<info::device::driver_version>() << '\n';
+      ss << std::setw(8) << " " << std::left << std::setw(20) << "Device type";
 
-            auto devTy = devices[dn].get_info<info::device::device_type>();
-            switch (devTy)
-            {
-            case info::device_type::cpu:
-                ss << "cpu" << '\n';
-                break;
-            case info::device_type::gpu:
-                ss << "gpu" << '\n';
-                break;
-            case info::device_type::accelerator:
-                ss << "accelerator" << '\n';
-                break;
-            case info::device_type::custom:
-                ss << "custom" << '\n';
-                break;
-            case info::device_type::host:
-                ss << "host" << '\n';
-                break;
-            default:
-                ss << "unknown" << '\n';
-            }
-        }
-        std::cout << ss.str();
-        ++i;
+      auto devTy = devices[dn].get_info<info::device::device_type>();
+      switch (devTy) {
+      case info::device_type::cpu:
+        ss << "cpu" << '\n';
+        break;
+      case info::device_type::gpu:
+        ss << "gpu" << '\n';
+        break;
+      case info::device_type::accelerator:
+        ss << "accelerator" << '\n';
+        break;
+      case info::device_type::custom:
+        ss << "custom" << '\n';
+        break;
+      case info::device_type::host:
+        ss << "host" << '\n';
+        break;
+      default:
+        ss << "unknown" << '\n';
+      }
     }
+    std::cout << ss.str();
+    ++i;
+  }
 }
 
 /*!
-* Returns the number of sycl::platform on the system.
-*/
-size_t DPPLPlatform_GetNumNonHostPlatforms ()
-{
-	auto nNonHostPlatforms = 0ul;
-	for (auto &p : platform::get_platforms()) {
-		if (p.is_host())
-			continue;
-		++nNonHostPlatforms;
-	}
-    return nNonHostPlatforms;
+ * Returns the number of sycl::platform on the system.
+ */
+size_t DPPLPlatform_GetNumNonHostPlatforms() {
+  auto nNonHostPlatforms = 0ul;
+  for (auto &p : platform::get_platforms()) {
+    if (p.is_host())
+      continue;
+    ++nNonHostPlatforms;
+  }
+  return nNonHostPlatforms;
 }
 
-size_t DPPLPlatform_GetNumNonHostBackends ()
-{
-    return get_set_of_non_hostbackends().size();
+size_t DPPLPlatform_GetNumNonHostBackends() {
+  return get_set_of_non_hostbackends().size();
 }
 
-__dppl_give DPPLSyclBackendType *DPPLPlatform_GetListOfNonHostBackends ()
-{
-    auto be_set = get_set_of_non_hostbackends();
+__dppl_give DPPLSyclBackendType *DPPLPlatform_GetListOfNonHostBackends() {
+  auto be_set = get_set_of_non_hostbackends();
 
-    if (be_set.empty())
-        return nullptr;
+  if (be_set.empty())
+    return nullptr;
 
-    DPPLSyclBackendType *BEArr = new DPPLSyclBackendType[be_set.size()];
+  DPPLSyclBackendType *BEArr = new DPPLSyclBackendType[be_set.size()];
 
-    auto i = 0ul;
-    for (auto be : be_set) {
-        BEArr[i] = be;
-        ++i;
-    }
+  auto i = 0ul;
+  for (auto be : be_set) {
+    BEArr[i] = be;
+    ++i;
+  }
 
-    return BEArr;
+  return BEArr;
 }
 
-void DPPLPlatform_DeleteListOfBackends (__dppl_take DPPLSyclBackendType *BEArr)
-{
-    delete[] BEArr;
+void DPPLPlatform_DeleteListOfBackends(__dppl_take DPPLSyclBackendType *BEArr) {
+  delete[] BEArr;
 }

--- a/backends/source/dppl_sycl_program_interface.cpp
+++ b/backends/source/dppl_sycl_program_interface.cpp
@@ -27,13 +27,12 @@
 #include "dppl_sycl_program_interface.h"
 #include "Support/CBindingWrapping.h"
 
-#include <CL/sycl.hpp> /* Sycl headers */
 #include <CL/cl.h>     /* OpenCL headers */
+#include <CL/sycl.hpp> /* Sycl headers */
 
 using namespace cl::sycl;
 
-namespace
-{
+namespace {
 DEFINE_SIMPLE_CONVERSION_FUNCTIONS(context, DPPLSyclContextRef)
 DEFINE_SIMPLE_CONVERSION_FUNCTIONS(program, DPPLSyclProgramRef)
 DEFINE_SIMPLE_CONVERSION_FUNCTIONS(kernel, DPPLSyclKernelRef)
@@ -41,140 +40,131 @@ DEFINE_SIMPLE_CONVERSION_FUNCTIONS(kernel, DPPLSyclKernelRef)
 } /* end of anonymous namespace */
 
 __dppl_give DPPLSyclProgramRef
-DPPLProgram_CreateFromOCLSpirv (__dppl_keep const DPPLSyclContextRef CtxRef,
-                                __dppl_keep const void *IL,
-                                size_t length)
-{
-    cl_int err;
-    context *SyclCtx;
-    if(!CtxRef) {
-        // \todo handle error
-        return nullptr;
-    }
+DPPLProgram_CreateFromOCLSpirv(__dppl_keep const DPPLSyclContextRef CtxRef,
+                               __dppl_keep const void *IL, size_t length) {
+  cl_int err;
+  context *SyclCtx;
+  if (!CtxRef) {
+    // \todo handle error
+    return nullptr;
+  }
 
-    SyclCtx = unwrap(CtxRef);
-    auto CLCtx   = SyclCtx->get();
-    auto CLProgram = clCreateProgramWithIL(CLCtx, IL, length, &err);
-    if (err) {
-        // \todo: record the error string and any other information.
-        std::cerr << "OpenCL program could not be created from the SPIR-V "
-                     "binary. OpenCL Error " << err << ".\n";
-        return nullptr;
-    }
-    auto SyclDevices = SyclCtx->get_devices();
+  SyclCtx = unwrap(CtxRef);
+  auto CLCtx = SyclCtx->get();
+  auto CLProgram = clCreateProgramWithIL(CLCtx, IL, length, &err);
+  if (err) {
+    // \todo: record the error string and any other information.
+    std::cerr << "OpenCL program could not be created from the SPIR-V "
+                 "binary. OpenCL Error "
+              << err << ".\n";
+    return nullptr;
+  }
+  auto SyclDevices = SyclCtx->get_devices();
 
-    // Get a list of CL Devices from the Sycl devices
-    auto CLDevices = new cl_device_id[SyclDevices.size()];
-    for (auto i = 0ul; i < SyclDevices.size(); ++i)
-        CLDevices[i] = SyclDevices[i].get();
+  // Get a list of CL Devices from the Sycl devices
+  auto CLDevices = new cl_device_id[SyclDevices.size()];
+  for (auto i = 0ul; i < SyclDevices.size(); ++i)
+    CLDevices[i] = SyclDevices[i].get();
 
-    // Build the OpenCL interoperability program
-    err = clBuildProgram(CLProgram, (cl_uint)(SyclDevices.size()), CLDevices,
-                         nullptr, nullptr, nullptr);
-    // free the CLDevices array
-    delete[] CLDevices;
+  // Build the OpenCL interoperability program
+  err = clBuildProgram(CLProgram, (cl_uint)(SyclDevices.size()), CLDevices,
+                       nullptr, nullptr, nullptr);
+  // free the CLDevices array
+  delete[] CLDevices;
 
-    if (err) {
-        // \todo: record the error string and any other information.
-        std::cerr << "OpenCL program could not be built. OpenCL Error "
-                  << err << ".\n";
-        return nullptr;
-    }
+  if (err) {
+    // \todo: record the error string and any other information.
+    std::cerr << "OpenCL program could not be built. OpenCL Error " << err
+              << ".\n";
+    return nullptr;
+  }
 
-    // Create the Sycl program from OpenCL program
-    try {
-        auto SyclProgram = new program(*SyclCtx, CLProgram);
-        return wrap(SyclProgram);
-    } catch (invalid_object_error) {
-        // \todo record error
-        return nullptr;
-    }
+  // Create the Sycl program from OpenCL program
+  try {
+    auto SyclProgram = new program(*SyclCtx, CLProgram);
+    return wrap(SyclProgram);
+  } catch (invalid_object_error) {
+    // \todo record error
+    return nullptr;
+  }
 }
 
-__dppl_give DPPLSyclProgramRef
-DPPLProgram_CreateFromOCLSource (__dppl_keep const DPPLSyclContextRef Ctx,
-                                 __dppl_keep const char *Source,
-                                 __dppl_keep const char *CompileOpts)
-{
-    cl_int err;
-    std::string compileOpts;
-    context *SyclCtx = nullptr;
-    program *SyclProgram = nullptr;
+__dppl_give DPPLSyclProgramRef DPPLProgram_CreateFromOCLSource(
+    __dppl_keep const DPPLSyclContextRef Ctx, __dppl_keep const char *Source,
+    __dppl_keep const char *CompileOpts) {
+  cl_int err;
+  std::string compileOpts;
+  context *SyclCtx = nullptr;
+  program *SyclProgram = nullptr;
 
-    if(!Ctx) {
-        // \todo handle error
-        return nullptr;
-    }
+  if (!Ctx) {
+    // \todo handle error
+    return nullptr;
+  }
 
-    if(!Source) {
-        // \todo handle error message
-        return nullptr;
-    }
+  if (!Source) {
+    // \todo handle error message
+    return nullptr;
+  }
 
-    SyclCtx = unwrap(Ctx);
-    SyclProgram = new program(*SyclCtx);
-    std::string source = Source;
+  SyclCtx = unwrap(Ctx);
+  SyclProgram = new program(*SyclCtx);
+  std::string source = Source;
 
-    if(CompileOpts) {
-        compileOpts = CompileOpts;
-    }
+  if (CompileOpts) {
+    compileOpts = CompileOpts;
+  }
 
-    try{
-        SyclProgram->build_with_source(source, compileOpts);
-        return wrap(SyclProgram);
-    } catch (compile_program_error) {
-        delete SyclProgram;
-        // \todo record error
-        return nullptr;
-    } catch (feature_not_supported) {
-        delete SyclProgram;
-        // \todo record error
-        return nullptr;
-    }
+  try {
+    SyclProgram->build_with_source(source, compileOpts);
+    return wrap(SyclProgram);
+  } catch (compile_program_error) {
+    delete SyclProgram;
+    // \todo record error
+    return nullptr;
+  } catch (feature_not_supported) {
+    delete SyclProgram;
+    // \todo record error
+    return nullptr;
+  }
 }
 
-__dppl_give DPPLSyclKernelRef
-DPPLProgram_GetKernel (__dppl_keep DPPLSyclProgramRef PRef,
-                       __dppl_keep const char *KernelName)
-{
-    if(!PRef) {
-        // \todo record error
-        return nullptr;
-    }
-    auto SyclProgram = unwrap(PRef);
-    if(!KernelName) {
-        // \todo record error
-        return nullptr;
-    }
-    std::string name = KernelName;
-    try {
-        auto SyclKernel = new kernel(SyclProgram->get_kernel(name));
-        return wrap(SyclKernel);
-    } catch (invalid_object_error) {
-        // \todo record error
-        return nullptr;
-    }
+__dppl_give DPPLSyclKernelRef DPPLProgram_GetKernel(
+    __dppl_keep DPPLSyclProgramRef PRef, __dppl_keep const char *KernelName) {
+  if (!PRef) {
+    // \todo record error
+    return nullptr;
+  }
+  auto SyclProgram = unwrap(PRef);
+  if (!KernelName) {
+    // \todo record error
+    return nullptr;
+  }
+  std::string name = KernelName;
+  try {
+    auto SyclKernel = new kernel(SyclProgram->get_kernel(name));
+    return wrap(SyclKernel);
+  } catch (invalid_object_error) {
+    // \todo record error
+    return nullptr;
+  }
 }
 
-bool
-DPPLProgram_HasKernel (__dppl_keep DPPLSyclProgramRef PRef,
-                       __dppl_keep const char *KernelName)
-{
-    if(!PRef) {
-        // \todo handle error
-        return false;
-    }
+bool DPPLProgram_HasKernel(__dppl_keep DPPLSyclProgramRef PRef,
+                           __dppl_keep const char *KernelName) {
+  if (!PRef) {
+    // \todo handle error
+    return false;
+  }
 
-    auto SyclProgram = unwrap(PRef);
-    try {
-        return SyclProgram->has_kernel(KernelName);
-    } catch (invalid_object_error) {
-        return false;
-    }
+  auto SyclProgram = unwrap(PRef);
+  try {
+    return SyclProgram->has_kernel(KernelName);
+  } catch (invalid_object_error) {
+    return false;
+  }
 }
 
-void
-DPPLProgram_Delete (__dppl_take DPPLSyclProgramRef PRef)
-{
-    delete unwrap(PRef);
+void DPPLProgram_Delete(__dppl_take DPPLSyclProgramRef PRef) {
+  delete unwrap(PRef);
 }

--- a/backends/source/dppl_sycl_queue_interface.cpp
+++ b/backends/source/dppl_sycl_queue_interface.cpp
@@ -25,17 +25,16 @@
 //===----------------------------------------------------------------------===//
 
 #include "dppl_sycl_queue_interface.h"
-#include "dppl_sycl_context_interface.h"
 #include "Support/CBindingWrapping.h"
+#include "dppl_sycl_context_interface.h"
 #include <exception>
 #include <stdexcept>
 
-#include <CL/sycl.hpp>                /* SYCL headers   */
+#include <CL/sycl.hpp> /* SYCL headers   */
 
 using namespace cl::sycl;
 
-namespace
-{
+namespace {
 // Create wrappers for C Binding types (see CBindingWrapping.h).
 DEFINE_SIMPLE_CONVERSION_FUNCTIONS(context, DPPLSyclContextRef)
 DEFINE_SIMPLE_CONVERSION_FUNCTIONS(device, DPPLSyclDeviceRef)
@@ -49,68 +48,66 @@ DEFINE_SIMPLE_CONVERSION_FUNCTIONS(queue, DPPLSyclQueueRef)
  * @param    cgh            My Param doc
  * @param    Arg            My Param doc
  */
-bool set_kernel_arg (handler &cgh, size_t idx, __dppl_keep void *Arg,
-                     DPPLKernelArgType ArgTy)
-{
-    bool arg_set = true;
+bool set_kernel_arg(handler &cgh, size_t idx, __dppl_keep void *Arg,
+                    DPPLKernelArgType ArgTy) {
+  bool arg_set = true;
 
-    switch (ArgTy)
-    {
-    case DPPL_CHAR:
-        cgh.set_arg(idx, *(char*)Arg);
-        break;
-    case DPPL_SIGNED_CHAR:
-        cgh.set_arg(idx, *(signed char*)Arg);
-        break;
-    case DPPL_UNSIGNED_CHAR:
-        cgh.set_arg(idx, *(unsigned char*)Arg);
-        break;
-    case DPPL_SHORT:
-        cgh.set_arg(idx, *(short*)Arg);
-        break;
-    case DPPL_INT:
-        cgh.set_arg(idx, *(int*)Arg);
-        break;
-    case DPPL_UNSIGNED_INT:
-        cgh.set_arg(idx, *(unsigned int*)Arg);
-        break;
-    case DPPL_UNSIGNED_INT8:
-        cgh.set_arg(idx, *(uint8_t*)Arg);
-        break;
-    case DPPL_LONG:
-        cgh.set_arg(idx, *(long*)Arg);
-        break;
-    case DPPL_UNSIGNED_LONG:
-        cgh.set_arg(idx, *(unsigned long*)Arg);
-        break;
-    case DPPL_LONG_LONG:
-        cgh.set_arg(idx, *(long long*)Arg);
-        break;
-    case DPPL_UNSIGNED_LONG_LONG:
-        cgh.set_arg(idx, *(unsigned long long*)Arg);
-        break;
-    case DPPL_SIZE_T:
-        cgh.set_arg(idx, *(size_t*)Arg);
-        break;
-    case DPPL_FLOAT:
-        cgh.set_arg(idx, *(float*)Arg);
-        break;
-    case DPPL_DOUBLE:
-        cgh.set_arg(idx, *(double*)Arg);
-        break;
-    case DPPL_LONG_DOUBLE:
-        cgh.set_arg(idx, *(long double*)Arg);
-        break;
-    case DPPL_VOID_PTR:
-        cgh.set_arg(idx, Arg);
-        break;
-    default:
-        // \todo handle errors
-        arg_set = false;
-        std::cerr << "Kernel argument could not be created.\n";
-        break;
-    }
-    return arg_set;
+  switch (ArgTy) {
+  case DPPL_CHAR:
+    cgh.set_arg(idx, *(char *)Arg);
+    break;
+  case DPPL_SIGNED_CHAR:
+    cgh.set_arg(idx, *(signed char *)Arg);
+    break;
+  case DPPL_UNSIGNED_CHAR:
+    cgh.set_arg(idx, *(unsigned char *)Arg);
+    break;
+  case DPPL_SHORT:
+    cgh.set_arg(idx, *(short *)Arg);
+    break;
+  case DPPL_INT:
+    cgh.set_arg(idx, *(int *)Arg);
+    break;
+  case DPPL_UNSIGNED_INT:
+    cgh.set_arg(idx, *(unsigned int *)Arg);
+    break;
+  case DPPL_UNSIGNED_INT8:
+    cgh.set_arg(idx, *(uint8_t *)Arg);
+    break;
+  case DPPL_LONG:
+    cgh.set_arg(idx, *(long *)Arg);
+    break;
+  case DPPL_UNSIGNED_LONG:
+    cgh.set_arg(idx, *(unsigned long *)Arg);
+    break;
+  case DPPL_LONG_LONG:
+    cgh.set_arg(idx, *(long long *)Arg);
+    break;
+  case DPPL_UNSIGNED_LONG_LONG:
+    cgh.set_arg(idx, *(unsigned long long *)Arg);
+    break;
+  case DPPL_SIZE_T:
+    cgh.set_arg(idx, *(size_t *)Arg);
+    break;
+  case DPPL_FLOAT:
+    cgh.set_arg(idx, *(float *)Arg);
+    break;
+  case DPPL_DOUBLE:
+    cgh.set_arg(idx, *(double *)Arg);
+    break;
+  case DPPL_LONG_DOUBLE:
+    cgh.set_arg(idx, *(long double *)Arg);
+    break;
+  case DPPL_VOID_PTR:
+    cgh.set_arg(idx, Arg);
+    break;
+  default:
+    // \todo handle errors
+    arg_set = false;
+    std::cerr << "Kernel argument could not be created.\n";
+    break;
+  }
+  return arg_set;
 }
 
 } /* end of anonymous namespace */
@@ -118,182 +115,160 @@ bool set_kernel_arg (handler &cgh, size_t idx, __dppl_keep void *Arg,
 /*!
  * Delete the passed in pointer after verifying it points to a sycl::queue.
  */
-void DPPLQueue_Delete (__dppl_take DPPLSyclQueueRef QRef)
-{
-    delete unwrap(QRef);
+void DPPLQueue_Delete(__dppl_take DPPLSyclQueueRef QRef) {
+  delete unwrap(QRef);
 }
 
-
-bool DPPLQueue_AreEq (__dppl_keep const DPPLSyclQueueRef QRef1,
-                      __dppl_keep const DPPLSyclQueueRef QRef2)
-{
-    if(!(QRef1 && QRef2))
-        // \todo handle error
-        return false;
-    return (*unwrap(QRef1) == *unwrap(QRef2));
+bool DPPLQueue_AreEq(__dppl_keep const DPPLSyclQueueRef QRef1,
+                     __dppl_keep const DPPLSyclQueueRef QRef2) {
+  if (!(QRef1 && QRef2))
+    // \todo handle error
+    return false;
+  return (*unwrap(QRef1) == *unwrap(QRef2));
 }
 
-DPPLSyclBackendType DPPLQueue_GetBackend (__dppl_keep DPPLSyclQueueRef QRef)
-{
-    auto Q = unwrap(QRef);
-    try {
-        auto C = Q->get_context();
-        return DPPLContext_GetBackend(wrap(&C));
-    }
-    catch (runtime_error &re) {
-        std::cerr << re.what() << '\n';
-        // store error message
-        return DPPL_UNKNOWN_BACKEND;
-    }
+DPPLSyclBackendType DPPLQueue_GetBackend(__dppl_keep DPPLSyclQueueRef QRef) {
+  auto Q = unwrap(QRef);
+  try {
+    auto C = Q->get_context();
+    return DPPLContext_GetBackend(wrap(&C));
+  } catch (runtime_error &re) {
+    std::cerr << re.what() << '\n';
+    // store error message
+    return DPPL_UNKNOWN_BACKEND;
+  }
 }
 
 __dppl_give DPPLSyclDeviceRef
-DPPLQueue_GetDevice (__dppl_keep const DPPLSyclQueueRef QRef)
-{
-    auto Q = unwrap(QRef);
-    auto Device = new device(Q->get_device());
-    return wrap(Device);
+DPPLQueue_GetDevice(__dppl_keep const DPPLSyclQueueRef QRef) {
+  auto Q = unwrap(QRef);
+  auto Device = new device(Q->get_device());
+  return wrap(Device);
 }
 
 __dppl_give DPPLSyclContextRef
-DPPLQueue_GetContext (__dppl_keep const DPPLSyclQueueRef QRef)
-{
-    auto Q = unwrap(QRef);
-    auto Context = new context(Q->get_context());
-    return wrap(Context);
+DPPLQueue_GetContext(__dppl_keep const DPPLSyclQueueRef QRef) {
+  auto Q = unwrap(QRef);
+  auto Context = new context(Q->get_context());
+  return wrap(Context);
 }
 
-__dppl_give DPPLSyclEventRef
-DPPLQueue_SubmitRange (__dppl_keep const DPPLSyclKernelRef KRef,
-                       __dppl_keep const DPPLSyclQueueRef QRef,
-                       __dppl_keep void **Args,
-                       __dppl_keep const DPPLKernelArgType *ArgTypes,
-                       size_t NArgs,
-                       __dppl_keep const size_t Range[3],
-                       size_t NDims,
-                       __dppl_keep const DPPLSyclEventRef *DepEvents,
-                       size_t NDepEvents)
-{
-    auto Kernel = unwrap(KRef);
-    auto Queue  = unwrap(QRef);
-    event e;
+__dppl_give DPPLSyclEventRef DPPLQueue_SubmitRange(
+    __dppl_keep const DPPLSyclKernelRef KRef,
+    __dppl_keep const DPPLSyclQueueRef QRef, __dppl_keep void **Args,
+    __dppl_keep const DPPLKernelArgType *ArgTypes, size_t NArgs,
+    __dppl_keep const size_t Range[3], size_t NDims,
+    __dppl_keep const DPPLSyclEventRef *DepEvents, size_t NDepEvents) {
+  auto Kernel = unwrap(KRef);
+  auto Queue = unwrap(QRef);
+  event e;
 
-    try {
-        e = Queue->submit([&](handler& cgh) {
-            // Depend on any event that was specified by the caller.
-            if(NDepEvents)
-                for(auto i = 0ul; i < NDepEvents; ++i)
-                    cgh.depends_on(*unwrap(DepEvents[i]));
+  try {
+    e = Queue->submit([&](handler &cgh) {
+      // Depend on any event that was specified by the caller.
+      if (NDepEvents)
+        for (auto i = 0ul; i < NDepEvents; ++i)
+          cgh.depends_on(*unwrap(DepEvents[i]));
 
-            for (auto i = 0ul; i < NArgs; ++i) {
-                // \todo add support for Sycl buffers
-                // \todo handle errors properly
-                if(!set_kernel_arg(cgh, i, Args[i], ArgTypes[i]))
-                    exit(1);
-            }
-            switch(NDims)
-            {
-            case 1:
-                cgh.parallel_for(range<1>{Range[0]}, *Kernel);
-                break;
-            case 2:
-                cgh.parallel_for(range<2>{Range[0], Range[1]}, *Kernel);
-                break;
-            case 3:
-                cgh.parallel_for(range<3>{Range[0], Range[1], Range[2]},
-                                 *Kernel);
-                break;
-            default:
-                // \todo handle the error
-                throw std::runtime_error("Range cannot be greater than three "
-                                         "dimensions.");
-            }
-        });
-    } catch (runtime_error &re) {
-        // \todo fix error handling
-        std::cerr << re.what() << '\n';
-        return nullptr;
-    } catch (std::runtime_error &sre) {
-        std::cerr << sre.what() << '\n';
-        return nullptr;
-    }
+      for (auto i = 0ul; i < NArgs; ++i) {
+        // \todo add support for Sycl buffers
+        // \todo handle errors properly
+        if (!set_kernel_arg(cgh, i, Args[i], ArgTypes[i]))
+          exit(1);
+      }
+      switch (NDims) {
+      case 1:
+        cgh.parallel_for(range<1>{Range[0]}, *Kernel);
+        break;
+      case 2:
+        cgh.parallel_for(range<2>{Range[0], Range[1]}, *Kernel);
+        break;
+      case 3:
+        cgh.parallel_for(range<3>{Range[0], Range[1], Range[2]}, *Kernel);
+        break;
+      default:
+        // \todo handle the error
+        throw std::runtime_error("Range cannot be greater than three "
+                                 "dimensions.");
+      }
+    });
+  } catch (runtime_error &re) {
+    // \todo fix error handling
+    std::cerr << re.what() << '\n';
+    return nullptr;
+  } catch (std::runtime_error &sre) {
+    std::cerr << sre.what() << '\n';
+    return nullptr;
+  }
 
-    return wrap(new event(e));
+  return wrap(new event(e));
 }
 
-DPPLSyclEventRef
-DPPLQueue_SubmitNDRange(__dppl_keep const DPPLSyclKernelRef KRef,
-                        __dppl_keep const DPPLSyclQueueRef QRef,
-                        __dppl_keep void **Args,
-                        __dppl_keep const DPPLKernelArgType *ArgTypes,
-                        size_t NArgs,
-                        __dppl_keep const size_t gRange[3],
-                        __dppl_keep const size_t lRange[3],
-                        size_t NDims,
-                        __dppl_keep const DPPLSyclEventRef *DepEvents,
-                        size_t NDepEvents)
-{
-    auto Kernel = unwrap(KRef);
-    auto Queue  = unwrap(QRef);
-    event e;
+DPPLSyclEventRef DPPLQueue_SubmitNDRange(
+    __dppl_keep const DPPLSyclKernelRef KRef,
+    __dppl_keep const DPPLSyclQueueRef QRef, __dppl_keep void **Args,
+    __dppl_keep const DPPLKernelArgType *ArgTypes, size_t NArgs,
+    __dppl_keep const size_t gRange[3], __dppl_keep const size_t lRange[3],
+    size_t NDims, __dppl_keep const DPPLSyclEventRef *DepEvents,
+    size_t NDepEvents) {
+  auto Kernel = unwrap(KRef);
+  auto Queue = unwrap(QRef);
+  event e;
 
-    try {
-        e = Queue->submit([&](handler& cgh) {
-            // Depend on any event that was specified by the caller.
-            if(NDepEvents)
-                for(auto i = 0ul; i < NDepEvents; ++i)
-                    cgh.depends_on(*unwrap(DepEvents[i]));
+  try {
+    e = Queue->submit([&](handler &cgh) {
+      // Depend on any event that was specified by the caller.
+      if (NDepEvents)
+        for (auto i = 0ul; i < NDepEvents; ++i)
+          cgh.depends_on(*unwrap(DepEvents[i]));
 
-            for (auto i = 0ul; i < NArgs; ++i) {
-                // \todo add support for Sycl buffers
-                // \todo handle errors properly
-                if(!set_kernel_arg(cgh, i, Args[i], ArgTypes[i]))
-                    exit(1);
-            }
-            switch(NDims)
-            {
-            case 1:
-                cgh.parallel_for(nd_range<1>{{gRange[0]},{lRange[0]}}, *Kernel);
-                break;
-            case 2:
-                cgh.parallel_for(nd_range<2>{{gRange[0], gRange[1]},
-                                             {lRange[0], lRange[1]}}, *Kernel);
-                break;
-            case 3:
-                cgh.parallel_for(nd_range<3>{{gRange[0], gRange[1], gRange[2]},
-                                             {lRange[0], lRange[1], lRange[2]}},
-                                             *Kernel);
-                break;
-            default:
-                // \todo handle the error
-                throw std::runtime_error("Range cannot be greater than three "
-                                         "dimensions.");
-            }
-        });
-    } catch (runtime_error &re) {
-        // \todo fix error handling
-        std::cerr << re.what() << '\n';
-        return nullptr;
-    } catch (std::runtime_error &sre) {
-        std::cerr << sre.what() << '\n';
-        return nullptr;
-    }
+      for (auto i = 0ul; i < NArgs; ++i) {
+        // \todo add support for Sycl buffers
+        // \todo handle errors properly
+        if (!set_kernel_arg(cgh, i, Args[i], ArgTypes[i]))
+          exit(1);
+      }
+      switch (NDims) {
+      case 1:
+        cgh.parallel_for(nd_range<1>{{gRange[0]}, {lRange[0]}}, *Kernel);
+        break;
+      case 2:
+        cgh.parallel_for(
+            nd_range<2>{{gRange[0], gRange[1]}, {lRange[0], lRange[1]}},
+            *Kernel);
+        break;
+      case 3:
+        cgh.parallel_for(nd_range<3>{{gRange[0], gRange[1], gRange[2]},
+                                     {lRange[0], lRange[1], lRange[2]}},
+                         *Kernel);
+        break;
+      default:
+        // \todo handle the error
+        throw std::runtime_error("Range cannot be greater than three "
+                                 "dimensions.");
+      }
+    });
+  } catch (runtime_error &re) {
+    // \todo fix error handling
+    std::cerr << re.what() << '\n';
+    return nullptr;
+  } catch (std::runtime_error &sre) {
+    std::cerr << sre.what() << '\n';
+    return nullptr;
+  }
 
-    return wrap(new event(e));
+  return wrap(new event(e));
 }
 
-void
-DPPLQueue_Wait (__dppl_keep DPPLSyclQueueRef QRef)
-{
-    // \todo what happens if the QRef is null or a pointer to a valid sycl queue
-    auto SyclQueue = unwrap(QRef);
-    SyclQueue->wait();
+void DPPLQueue_Wait(__dppl_keep DPPLSyclQueueRef QRef) {
+  // \todo what happens if the QRef is null or a pointer to a valid sycl queue
+  auto SyclQueue = unwrap(QRef);
+  SyclQueue->wait();
 }
 
-void DPPLQueue_Memcpy (__dppl_take const DPPLSyclQueueRef QRef,
-                       void *Dest, const void *Src, size_t Count)
-{
-    auto Q = unwrap(QRef);
-    auto event = Q->memcpy(Dest, Src, Count);
-    event.wait();
+void DPPLQueue_Memcpy(__dppl_take const DPPLSyclQueueRef QRef, void *Dest,
+                      const void *Src, size_t Count) {
+  auto Q = unwrap(QRef);
+  auto event = Q->memcpy(Dest, Src, Count);
+  event.wait();
 }

--- a/backends/source/dppl_sycl_usm_interface.cpp
+++ b/backends/source/dppl_sycl_usm_interface.cpp
@@ -27,12 +27,11 @@
 #include "dppl_sycl_usm_interface.h"
 #include "Support/CBindingWrapping.h"
 
-#include <CL/sycl.hpp>                /* SYCL headers   */
+#include <CL/sycl.hpp> /* SYCL headers   */
 
 using namespace cl::sycl;
 
-namespace
-{
+namespace {
 // Create wrappers for C Binding types (see CBindingWrapping.h).
 DEFINE_SIMPLE_CONVERSION_FUNCTIONS(queue, DPPLSyclQueueRef)
 DEFINE_SIMPLE_CONVERSION_FUNCTIONS(context, DPPLSyclContextRef)
@@ -41,61 +40,54 @@ DEFINE_SIMPLE_CONVERSION_FUNCTIONS(void, DPPLSyclUSMRef)
 } /* end of anonymous namespace */
 
 __dppl_give DPPLSyclUSMRef
-DPPLmalloc_shared (size_t size, __dppl_keep const DPPLSyclQueueRef QRef)
-{
-    auto Q = unwrap(QRef);
-    auto Ptr = malloc_shared(size, *Q);
-    return wrap(Ptr);
+DPPLmalloc_shared(size_t size, __dppl_keep const DPPLSyclQueueRef QRef) {
+  auto Q = unwrap(QRef);
+  auto Ptr = malloc_shared(size, *Q);
+  return wrap(Ptr);
 }
 
 __dppl_give DPPLSyclUSMRef
-DPPLmalloc_host (size_t size, __dppl_keep const DPPLSyclQueueRef QRef)
-{
-    auto Q = unwrap(QRef);
-    auto Ptr = malloc_host(size, *Q);
-    return wrap(Ptr);
+DPPLmalloc_host(size_t size, __dppl_keep const DPPLSyclQueueRef QRef) {
+  auto Q = unwrap(QRef);
+  auto Ptr = malloc_host(size, *Q);
+  return wrap(Ptr);
 }
 
 __dppl_give DPPLSyclUSMRef
-DPPLmalloc_device (size_t size, __dppl_keep const DPPLSyclQueueRef QRef)
-{
-    auto Q = unwrap(QRef);
-    auto Ptr = malloc_device(size, *Q);
-    return wrap(Ptr);
+DPPLmalloc_device(size_t size, __dppl_keep const DPPLSyclQueueRef QRef) {
+  auto Q = unwrap(QRef);
+  auto Ptr = malloc_device(size, *Q);
+  return wrap(Ptr);
 }
 
-void DPPLfree_with_queue (__dppl_take DPPLSyclUSMRef MRef,
-                          __dppl_keep const DPPLSyclQueueRef QRef)
-{
-    auto Ptr = unwrap(MRef);
-    auto Q = unwrap(QRef);
-    free(Ptr, *Q);
+void DPPLfree_with_queue(__dppl_take DPPLSyclUSMRef MRef,
+                         __dppl_keep const DPPLSyclQueueRef QRef) {
+  auto Ptr = unwrap(MRef);
+  auto Q = unwrap(QRef);
+  free(Ptr, *Q);
 }
 
-void DPPLfree_with_context (__dppl_take DPPLSyclUSMRef MRef,
-                            __dppl_keep const DPPLSyclContextRef CRef)
-{
-    auto Ptr = unwrap(MRef);
-    auto C = unwrap(CRef);
-    free(Ptr, *C);
+void DPPLfree_with_context(__dppl_take DPPLSyclUSMRef MRef,
+                           __dppl_keep const DPPLSyclContextRef CRef) {
+  auto Ptr = unwrap(MRef);
+  auto C = unwrap(CRef);
+  free(Ptr, *C);
 }
 
-const char *
-DPPLUSM_GetPointerType (__dppl_keep const DPPLSyclUSMRef MRef,
-                        __dppl_keep const DPPLSyclContextRef CRef)
-{
-    auto Ptr = unwrap(MRef);
-    auto C = unwrap(CRef);
+const char *DPPLUSM_GetPointerType(__dppl_keep const DPPLSyclUSMRef MRef,
+                                   __dppl_keep const DPPLSyclContextRef CRef) {
+  auto Ptr = unwrap(MRef);
+  auto C = unwrap(CRef);
 
-    auto kind = get_pointer_type(Ptr, *C);
-    switch(kind) {
-        case usm::alloc::host:
-            return "host";
-        case usm::alloc::device:
-            return "device";
-        case usm::alloc::shared:
-            return "shared";
-        default:
-            return "unknown";
-    }
+  auto kind = get_pointer_type(Ptr, *C);
+  switch (kind) {
+  case usm::alloc::host:
+    return "host";
+  case usm::alloc::device:
+    return "device";
+  case usm::alloc::shared:
+    return "shared";
+  default:
+    return "unknown";
+  }
 }

--- a/backends/source/dppl_utils.cpp
+++ b/backends/source/dppl_utils.cpp
@@ -25,7 +25,4 @@
 
 #include "dppl_utils.h"
 
-void DPPLCString_Delete (__dppl_take const char* str)
-{
-    delete[] str;
-}
+void DPPLCString_Delete(__dppl_take const char *str) { delete[] str; }

--- a/backends/tests/test_sycl_kernel_interface.cpp
+++ b/backends/tests/test_sycl_kernel_interface.cpp
@@ -31,16 +31,14 @@
 #include "dppl_sycl_queue_manager.h"
 #include "dppl_utils.h"
 
+#include <CL/sycl.hpp>
 #include <array>
 #include <gtest/gtest.h>
-#include <CL/sycl.hpp>
 
 using namespace cl::sycl;
 
-
-struct TestDPPLSyclKernelInterface : public ::testing::Test
-{
-    const char *CLProgramStr = R"CLC(
+struct TestDPPLSyclKernelInterface : public ::testing::Test {
+  const char *CLProgramStr = R"CLC(
         kernel void add(global int* a, global int* b, global int* c) {
             size_t index = get_global_id(0);
             c[index] = a[index] + b[index];
@@ -51,67 +49,62 @@ struct TestDPPLSyclKernelInterface : public ::testing::Test
             c[index] = a[index] + d*b[index];
         }
     )CLC";
-    const char *CompileOpts ="-cl-fast-relaxed-math";
+  const char *CompileOpts = "-cl-fast-relaxed-math";
 
-    size_t nOpenCLGpuQ = 0;
-    TestDPPLSyclKernelInterface ()
-        : nOpenCLGpuQ(DPPLQueueMgr_GetNumQueues(DPPL_OPENCL, DPPL_GPU))
-    {  }
+  size_t nOpenCLGpuQ = 0;
+  TestDPPLSyclKernelInterface()
+      : nOpenCLGpuQ(DPPLQueueMgr_GetNumQueues(DPPL_OPENCL, DPPL_GPU)) {}
 };
 
-TEST_F (TestDPPLSyclKernelInterface, CheckGetFunctionName)
-{
-    if(!nOpenCLGpuQ)
-        GTEST_SKIP_("Skipping as no OpenCL GPU device found.\n");
+TEST_F(TestDPPLSyclKernelInterface, CheckGetFunctionName) {
+  if (!nOpenCLGpuQ)
+    GTEST_SKIP_("Skipping as no OpenCL GPU device found.\n");
 
-    auto QueueRef = DPPLQueueMgr_GetQueue(DPPL_OPENCL, DPPL_GPU, 0);
-    auto CtxRef   = DPPLQueue_GetContext(QueueRef);
-    auto PRef = DPPLProgram_CreateFromOCLSource(CtxRef, CLProgramStr,
-                                                CompileOpts);
-    auto AddKernel = DPPLProgram_GetKernel(PRef, "add");
-    auto AxpyKernel = DPPLProgram_GetKernel(PRef, "axpy");
+  auto QueueRef = DPPLQueueMgr_GetQueue(DPPL_OPENCL, DPPL_GPU, 0);
+  auto CtxRef = DPPLQueue_GetContext(QueueRef);
+  auto PRef =
+      DPPLProgram_CreateFromOCLSource(CtxRef, CLProgramStr, CompileOpts);
+  auto AddKernel = DPPLProgram_GetKernel(PRef, "add");
+  auto AxpyKernel = DPPLProgram_GetKernel(PRef, "axpy");
 
-    auto fnName1 = DPPLKernel_GetFunctionName(AddKernel);
-    auto fnName2 = DPPLKernel_GetFunctionName(AxpyKernel);
+  auto fnName1 = DPPLKernel_GetFunctionName(AddKernel);
+  auto fnName2 = DPPLKernel_GetFunctionName(AxpyKernel);
 
-    ASSERT_STREQ("add", fnName1);
-    ASSERT_STREQ("axpy", fnName2);
+  ASSERT_STREQ("add", fnName1);
+  ASSERT_STREQ("axpy", fnName2);
 
-    DPPLCString_Delete(fnName1);
-    DPPLCString_Delete(fnName2);
+  DPPLCString_Delete(fnName1);
+  DPPLCString_Delete(fnName2);
 
-    DPPLQueue_Delete(QueueRef);
-    DPPLContext_Delete(CtxRef);
-    DPPLProgram_Delete(PRef);
-    DPPLKernel_Delete(AddKernel);
-    DPPLKernel_Delete(AxpyKernel);
+  DPPLQueue_Delete(QueueRef);
+  DPPLContext_Delete(CtxRef);
+  DPPLProgram_Delete(PRef);
+  DPPLKernel_Delete(AddKernel);
+  DPPLKernel_Delete(AxpyKernel);
 }
 
-TEST_F (TestDPPLSyclKernelInterface, CheckGetNumArgs)
-{
-    if(!nOpenCLGpuQ)
-        GTEST_SKIP_("Skipping as no OpenCL GPU device found.\n");
+TEST_F(TestDPPLSyclKernelInterface, CheckGetNumArgs) {
+  if (!nOpenCLGpuQ)
+    GTEST_SKIP_("Skipping as no OpenCL GPU device found.\n");
 
-    auto QueueRef = DPPLQueueMgr_GetQueue(DPPL_OPENCL, DPPL_GPU, 0);
-    auto CtxRef   = DPPLQueue_GetContext(QueueRef);
-    auto PRef = DPPLProgram_CreateFromOCLSource(CtxRef, CLProgramStr,
-                                                CompileOpts);
-    auto AddKernel = DPPLProgram_GetKernel(PRef, "add");
-    auto AxpyKernel = DPPLProgram_GetKernel(PRef, "axpy");
+  auto QueueRef = DPPLQueueMgr_GetQueue(DPPL_OPENCL, DPPL_GPU, 0);
+  auto CtxRef = DPPLQueue_GetContext(QueueRef);
+  auto PRef =
+      DPPLProgram_CreateFromOCLSource(CtxRef, CLProgramStr, CompileOpts);
+  auto AddKernel = DPPLProgram_GetKernel(PRef, "add");
+  auto AxpyKernel = DPPLProgram_GetKernel(PRef, "axpy");
 
-    ASSERT_EQ(DPPLKernel_GetNumArgs(AddKernel), 3);
-    ASSERT_EQ(DPPLKernel_GetNumArgs(AxpyKernel), 4);
+  ASSERT_EQ(DPPLKernel_GetNumArgs(AddKernel), 3);
+  ASSERT_EQ(DPPLKernel_GetNumArgs(AxpyKernel), 4);
 
-    DPPLQueue_Delete(QueueRef);
-    DPPLContext_Delete(CtxRef);
-    DPPLProgram_Delete(PRef);
-    DPPLKernel_Delete(AddKernel);
-    DPPLKernel_Delete(AxpyKernel);
+  DPPLQueue_Delete(QueueRef);
+  DPPLContext_Delete(CtxRef);
+  DPPLProgram_Delete(PRef);
+  DPPLKernel_Delete(AddKernel);
+  DPPLKernel_Delete(AxpyKernel);
 }
 
-int
-main (int argc, char** argv)
-{
+int main(int argc, char **argv) {
   ::testing::InitGoogleTest(&argc, argv);
   int ret = RUN_ALL_TESTS();
   return ret;

--- a/backends/tests/test_sycl_platform_interface.cpp
+++ b/backends/tests/test_sycl_platform_interface.cpp
@@ -26,49 +26,40 @@
 #include "dppl_sycl_platform_interface.h"
 #include <gtest/gtest.h>
 
-struct TestDPPLSyclPlatformInterface : public ::testing::Test
-{ };
+struct TestDPPLSyclPlatformInterface : public ::testing::Test {};
 
-TEST_F (TestDPPLSyclPlatformInterface, CheckGetNumPlatforms)
-{
-    auto nplatforms = DPPLPlatform_GetNumNonHostPlatforms();
-    EXPECT_GE(nplatforms, 0);
+TEST_F(TestDPPLSyclPlatformInterface, CheckGetNumPlatforms) {
+  auto nplatforms = DPPLPlatform_GetNumNonHostPlatforms();
+  EXPECT_GE(nplatforms, 0);
 }
 
-TEST_F (TestDPPLSyclPlatformInterface, GetNumBackends)
-{
-    auto nbackends = DPPLPlatform_GetNumNonHostBackends();
-    EXPECT_GE(nbackends, 0);
+TEST_F(TestDPPLSyclPlatformInterface, GetNumBackends) {
+  auto nbackends = DPPLPlatform_GetNumNonHostBackends();
+  EXPECT_GE(nbackends, 0);
 }
 
-TEST_F (TestDPPLSyclPlatformInterface, GetListOfBackends)
-{
-    auto nbackends = DPPLPlatform_GetNumNonHostBackends();
+TEST_F(TestDPPLSyclPlatformInterface, GetListOfBackends) {
+  auto nbackends = DPPLPlatform_GetNumNonHostBackends();
 
-    if(!nbackends)
-      GTEST_SKIP_("No non host backends available");
+  if (!nbackends)
+    GTEST_SKIP_("No non host backends available");
 
-    auto backends = DPPLPlatform_GetListOfNonHostBackends();
-	  EXPECT_TRUE(backends != nullptr);
-    for(auto i = 0ul; i < nbackends; ++i) {
-        EXPECT_TRUE(
-          backends[i] == DPPLSyclBackendType::DPPL_CUDA   ||
-          backends[i] == DPPLSyclBackendType::DPPL_OPENCL ||
-          backends[i] == DPPLSyclBackendType::DPPL_LEVEL_ZERO
-          );
-    }
-	DPPLPlatform_DeleteListOfBackends(backends);
+  auto backends = DPPLPlatform_GetListOfNonHostBackends();
+  EXPECT_TRUE(backends != nullptr);
+  for (auto i = 0ul; i < nbackends; ++i) {
+    EXPECT_TRUE(backends[i] == DPPLSyclBackendType::DPPL_CUDA ||
+                backends[i] == DPPLSyclBackendType::DPPL_OPENCL ||
+                backends[i] == DPPLSyclBackendType::DPPL_LEVEL_ZERO);
+  }
+  DPPLPlatform_DeleteListOfBackends(backends);
 }
 
-TEST_F (TestDPPLSyclPlatformInterface, CheckDPPLPlatformDumpInfo)
-{
-    EXPECT_NO_FATAL_FAILURE(DPPLPlatform_DumpInfo());
+TEST_F(TestDPPLSyclPlatformInterface, CheckDPPLPlatformDumpInfo) {
+  EXPECT_NO_FATAL_FAILURE(DPPLPlatform_DumpInfo());
 }
 
-int
-main (int argc, char** argv)
-{
-    ::testing::InitGoogleTest(&argc, argv);
-    int ret = RUN_ALL_TESTS();
-    return ret;
+int main(int argc, char **argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  int ret = RUN_ALL_TESTS();
+  return ret;
 }

--- a/backends/tests/test_sycl_program_interface.cpp
+++ b/backends/tests/test_sycl_program_interface.cpp
@@ -30,87 +30,83 @@
 #include "dppl_sycl_queue_interface.h"
 #include "dppl_sycl_queue_manager.h"
 
-#include <array>
-#include <fstream>
-#include <filesystem>
-#include <gtest/gtest.h>
 #include <CL/sycl.hpp>
+#include <array>
+#include <filesystem>
+#include <fstream>
+#include <gtest/gtest.h>
 
 using namespace cl::sycl;
 
-namespace
-{
-    const size_t SIZE = 1024;
+namespace {
+const size_t SIZE = 1024;
 
-    void add_kernel_checker (queue *syclQueue, DPPLSyclKernelRef AddKernel)
-    {
-        range<1> a_size{SIZE};
-        std::array<int, SIZE> a, b, c;
+void add_kernel_checker(queue *syclQueue, DPPLSyclKernelRef AddKernel) {
+  range<1> a_size{SIZE};
+  std::array<int, SIZE> a, b, c;
 
-        for (int i = 0; i<SIZE; ++i) {
-            a[i] = i;
-            b[i] = i;
-            c[i] = 0;
-        }
+  for (int i = 0; i < SIZE; ++i) {
+    a[i] = i;
+    b[i] = i;
+    c[i] = 0;
+  }
 
-        {
-            buffer<int, 1> a_device(a.data(), a_size);
-            buffer<int, 1> b_device(b.data(), a_size);
-            buffer<int, 1> c_device(c.data(), a_size);
-            buffer<int, 1> buffs[3] = {a_device, b_device, c_device};
-            syclQueue->submit([&](handler& cgh) {
-                for (auto buff : buffs) {
-                    auto arg = buff.get_access<access::mode::read_write>(cgh);
-                    cgh.set_args(arg);
-                }
-                auto syclKernel = reinterpret_cast<kernel*>(AddKernel);
-                cgh.parallel_for(range<1>{SIZE}, *syclKernel);
-            });
-        }
+  {
+    buffer<int, 1> a_device(a.data(), a_size);
+    buffer<int, 1> b_device(b.data(), a_size);
+    buffer<int, 1> c_device(c.data(), a_size);
+    buffer<int, 1> buffs[3] = {a_device, b_device, c_device};
+    syclQueue->submit([&](handler &cgh) {
+      for (auto buff : buffs) {
+        auto arg = buff.get_access<access::mode::read_write>(cgh);
+        cgh.set_args(arg);
+      }
+      auto syclKernel = reinterpret_cast<kernel *>(AddKernel);
+      cgh.parallel_for(range<1>{SIZE}, *syclKernel);
+    });
+  }
 
-        // Validate the data
-        for(auto i = 0ul; i < SIZE; ++i) {
-            EXPECT_EQ(c[i], i + i);
-        }
-    }
-
-    void axpy_kernel_checker (queue *syclQueue, DPPLSyclKernelRef AxpyKernel)
-    {
-        range<1> a_size{SIZE};
-        std::array<int, SIZE> a, b, c;
-
-        for (int i = 0; i<SIZE; ++i) {
-            a[i] = i;
-            b[i] = i;
-            c[i] = 0;
-        }
-        int d = 10;
-        {
-            buffer<int, 1> a_device(a.data(), a_size);
-            buffer<int, 1> b_device(b.data(), a_size);
-            buffer<int, 1> c_device(c.data(), a_size);
-            buffer<int, 1> buffs[3] = {a_device, b_device, c_device};
-            syclQueue->submit([&](handler& cgh) {
-                for (auto i = 0ul; i < 3; ++i) {
-                    auto arg = buffs[i].get_access<access::mode::read_write>(cgh);
-                    cgh.set_arg(i, arg);
-                }
-                cgh.set_arg(3, d);
-                auto syclKernel = reinterpret_cast<kernel*>(AxpyKernel);
-                cgh.parallel_for(range<1>{SIZE}, *syclKernel);
-            });
-        }
-
-        // Validate the data
-        for(auto i = 0ul; i < SIZE; ++i) {
-            EXPECT_EQ(c[i], i + d*i);
-        }
-    }
+  // Validate the data
+  for (auto i = 0ul; i < SIZE; ++i) {
+    EXPECT_EQ(c[i], i + i);
+  }
 }
 
-struct TestDPPLSyclProgramInterface : public ::testing::Test
-{
-    const char *CLProgramStr = R"CLC(
+void axpy_kernel_checker(queue *syclQueue, DPPLSyclKernelRef AxpyKernel) {
+  range<1> a_size{SIZE};
+  std::array<int, SIZE> a, b, c;
+
+  for (int i = 0; i < SIZE; ++i) {
+    a[i] = i;
+    b[i] = i;
+    c[i] = 0;
+  }
+  int d = 10;
+  {
+    buffer<int, 1> a_device(a.data(), a_size);
+    buffer<int, 1> b_device(b.data(), a_size);
+    buffer<int, 1> c_device(c.data(), a_size);
+    buffer<int, 1> buffs[3] = {a_device, b_device, c_device};
+    syclQueue->submit([&](handler &cgh) {
+      for (auto i = 0ul; i < 3; ++i) {
+        auto arg = buffs[i].get_access<access::mode::read_write>(cgh);
+        cgh.set_arg(i, arg);
+      }
+      cgh.set_arg(3, d);
+      auto syclKernel = reinterpret_cast<kernel *>(AxpyKernel);
+      cgh.parallel_for(range<1>{SIZE}, *syclKernel);
+    });
+  }
+
+  // Validate the data
+  for (auto i = 0ul; i < SIZE; ++i) {
+    EXPECT_EQ(c[i], i + d * i);
+  }
+}
+} // namespace
+
+struct TestDPPLSyclProgramInterface : public ::testing::Test {
+  const char *CLProgramStr = R"CLC(
         kernel void add(global int* a, global int* b, global int* c) {
             size_t index = get_global_id(0);
             c[index] = a[index] + b[index];
@@ -121,122 +117,112 @@ struct TestDPPLSyclProgramInterface : public ::testing::Test
             c[index] = a[index] + d*b[index];
         }
     )CLC";
-    const char *CompileOpts ="-cl-fast-relaxed-math";
-    std::ifstream spirvFile;
-    size_t spirvFileSize = 0;
-    std::vector<char> spirvBuffer;
-    size_t nOpenCLGpuQ = 0;
+  const char *CompileOpts = "-cl-fast-relaxed-math";
+  std::ifstream spirvFile;
+  size_t spirvFileSize = 0;
+  std::vector<char> spirvBuffer;
+  size_t nOpenCLGpuQ = 0;
 
-    TestDPPLSyclProgramInterface () :
-        nOpenCLGpuQ(DPPLQueueMgr_GetNumQueues(DPPL_OPENCL, DPPL_GPU)),
+  TestDPPLSyclProgramInterface()
+      : nOpenCLGpuQ(DPPLQueueMgr_GetNumQueues(DPPL_OPENCL, DPPL_GPU)),
         spirvFile{"./multi_kernel.spv", std::ios::binary | std::ios::ate},
         spirvFileSize(std::filesystem::file_size("./multi_kernel.spv")),
-        spirvBuffer(spirvFileSize)
-    {
-        spirvFile.seekg(0, std::ios::beg);
-        spirvFile.read(spirvBuffer.data(), spirvFileSize);
-    }
+        spirvBuffer(spirvFileSize) {
+    spirvFile.seekg(0, std::ios::beg);
+    spirvFile.read(spirvBuffer.data(), spirvFileSize);
+  }
 
-    ~TestDPPLSyclProgramInterface ()
-    {
-        spirvFile.close();
-    }
+  ~TestDPPLSyclProgramInterface() { spirvFile.close(); }
 };
 
-TEST_F (TestDPPLSyclProgramInterface, CheckCreateFromOCLSource)
-{
-    if(!nOpenCLGpuQ)
-        GTEST_SKIP_("Skipping as no OpenCL GPU device found.\n");
+TEST_F(TestDPPLSyclProgramInterface, CheckCreateFromOCLSource) {
+  if (!nOpenCLGpuQ)
+    GTEST_SKIP_("Skipping as no OpenCL GPU device found.\n");
 
-    auto QueueRef = DPPLQueueMgr_GetQueue(DPPL_OPENCL, DPPL_GPU, 0);
-    auto CtxRef = DPPLQueue_GetContext(QueueRef);
-    auto PRef = DPPLProgram_CreateFromOCLSource(CtxRef, CLProgramStr,
-                                                CompileOpts);
-    ASSERT_TRUE(PRef != nullptr);
-    ASSERT_TRUE(DPPLProgram_HasKernel(PRef, "add"));
-    ASSERT_TRUE(DPPLProgram_HasKernel(PRef, "axpy"));
+  auto QueueRef = DPPLQueueMgr_GetQueue(DPPL_OPENCL, DPPL_GPU, 0);
+  auto CtxRef = DPPLQueue_GetContext(QueueRef);
+  auto PRef =
+      DPPLProgram_CreateFromOCLSource(CtxRef, CLProgramStr, CompileOpts);
+  ASSERT_TRUE(PRef != nullptr);
+  ASSERT_TRUE(DPPLProgram_HasKernel(PRef, "add"));
+  ASSERT_TRUE(DPPLProgram_HasKernel(PRef, "axpy"));
 
-    DPPLQueue_Delete(QueueRef);
-    DPPLContext_Delete(CtxRef);
-    DPPLProgram_Delete(PRef);
+  DPPLQueue_Delete(QueueRef);
+  DPPLContext_Delete(CtxRef);
+  DPPLProgram_Delete(PRef);
 }
 
-TEST_F (TestDPPLSyclProgramInterface, CheckCreateFromOCLSpirv)
-{
-    if(!nOpenCLGpuQ)
-        GTEST_SKIP_("Skipping as no OpenCL GPU device found.\n");
+TEST_F(TestDPPLSyclProgramInterface, CheckCreateFromOCLSpirv) {
+  if (!nOpenCLGpuQ)
+    GTEST_SKIP_("Skipping as no OpenCL GPU device found.\n");
 
-    auto QueueRef = DPPLQueueMgr_GetQueue(DPPL_OPENCL, DPPL_GPU, 0);
-    auto CtxRef = DPPLQueue_GetContext(QueueRef);
-    auto PRef = DPPLProgram_CreateFromOCLSpirv(CtxRef, spirvBuffer.data(),
-                                               spirvFileSize);
-    ASSERT_TRUE(PRef != nullptr);
-    ASSERT_TRUE(DPPLProgram_HasKernel(PRef, "add"));
-    ASSERT_TRUE(DPPLProgram_HasKernel(PRef, "axpy"));
+  auto QueueRef = DPPLQueueMgr_GetQueue(DPPL_OPENCL, DPPL_GPU, 0);
+  auto CtxRef = DPPLQueue_GetContext(QueueRef);
+  auto PRef =
+      DPPLProgram_CreateFromOCLSpirv(CtxRef, spirvBuffer.data(), spirvFileSize);
+  ASSERT_TRUE(PRef != nullptr);
+  ASSERT_TRUE(DPPLProgram_HasKernel(PRef, "add"));
+  ASSERT_TRUE(DPPLProgram_HasKernel(PRef, "axpy"));
 
-    DPPLQueue_Delete(QueueRef);
-    DPPLContext_Delete(CtxRef);
-    DPPLProgram_Delete(PRef);
+  DPPLQueue_Delete(QueueRef);
+  DPPLContext_Delete(CtxRef);
+  DPPLProgram_Delete(PRef);
 }
 
-TEST_F (TestDPPLSyclProgramInterface, CheckGetKernelOCLSource)
-{
-    if(!nOpenCLGpuQ)
-        GTEST_SKIP_("Skipping as no OpenCL GPU device found.\n");
+TEST_F(TestDPPLSyclProgramInterface, CheckGetKernelOCLSource) {
+  if (!nOpenCLGpuQ)
+    GTEST_SKIP_("Skipping as no OpenCL GPU device found.\n");
 
-    auto QueueRef = DPPLQueueMgr_GetQueue(DPPL_OPENCL, DPPL_GPU, 0);
-    auto CtxRef = DPPLQueue_GetContext(QueueRef);
-    auto PRef = DPPLProgram_CreateFromOCLSource(CtxRef, CLProgramStr,
-                                                CompileOpts);
-    auto AddKernel = DPPLProgram_GetKernel(PRef, "add");
-    auto AxpyKernel = DPPLProgram_GetKernel(PRef, "axpy");
+  auto QueueRef = DPPLQueueMgr_GetQueue(DPPL_OPENCL, DPPL_GPU, 0);
+  auto CtxRef = DPPLQueue_GetContext(QueueRef);
+  auto PRef =
+      DPPLProgram_CreateFromOCLSource(CtxRef, CLProgramStr, CompileOpts);
+  auto AddKernel = DPPLProgram_GetKernel(PRef, "add");
+  auto AxpyKernel = DPPLProgram_GetKernel(PRef, "axpy");
 
-    ASSERT_TRUE(AddKernel != nullptr);
-    ASSERT_TRUE(AxpyKernel != nullptr);
+  ASSERT_TRUE(AddKernel != nullptr);
+  ASSERT_TRUE(AxpyKernel != nullptr);
 
-    auto syclQueue = reinterpret_cast<queue*>(QueueRef);
+  auto syclQueue = reinterpret_cast<queue *>(QueueRef);
 
-    add_kernel_checker(syclQueue, AddKernel);
-    axpy_kernel_checker(syclQueue, AxpyKernel);
+  add_kernel_checker(syclQueue, AddKernel);
+  axpy_kernel_checker(syclQueue, AxpyKernel);
 
-    DPPLKernel_Delete(AddKernel);
-    DPPLKernel_Delete(AxpyKernel);
-    DPPLQueue_Delete(QueueRef);
-    DPPLContext_Delete(CtxRef);
-    DPPLProgram_Delete(PRef);
+  DPPLKernel_Delete(AddKernel);
+  DPPLKernel_Delete(AxpyKernel);
+  DPPLQueue_Delete(QueueRef);
+  DPPLContext_Delete(CtxRef);
+  DPPLProgram_Delete(PRef);
 }
 
-TEST_F (TestDPPLSyclProgramInterface, CheckGetKernelOCLSpirv)
-{
-    if(!nOpenCLGpuQ)
-        GTEST_SKIP_("Skipping as no OpenCL GPU device found.\n");
+TEST_F(TestDPPLSyclProgramInterface, CheckGetKernelOCLSpirv) {
+  if (!nOpenCLGpuQ)
+    GTEST_SKIP_("Skipping as no OpenCL GPU device found.\n");
 
-    auto QueueRef = DPPLQueueMgr_GetQueue(DPPL_OPENCL, DPPL_GPU, 0);
-    auto CtxRef = DPPLQueue_GetContext(QueueRef);
-    auto PRef = DPPLProgram_CreateFromOCLSpirv(CtxRef, spirvBuffer.data(),
-                                               spirvFileSize);
-    auto AddKernel = DPPLProgram_GetKernel(PRef, "add");
-    auto AxpyKernel = DPPLProgram_GetKernel(PRef, "axpy");
+  auto QueueRef = DPPLQueueMgr_GetQueue(DPPL_OPENCL, DPPL_GPU, 0);
+  auto CtxRef = DPPLQueue_GetContext(QueueRef);
+  auto PRef =
+      DPPLProgram_CreateFromOCLSpirv(CtxRef, spirvBuffer.data(), spirvFileSize);
+  auto AddKernel = DPPLProgram_GetKernel(PRef, "add");
+  auto AxpyKernel = DPPLProgram_GetKernel(PRef, "axpy");
 
-    ASSERT_TRUE(AddKernel != nullptr);
-    ASSERT_TRUE(AxpyKernel != nullptr);
+  ASSERT_TRUE(AddKernel != nullptr);
+  ASSERT_TRUE(AxpyKernel != nullptr);
 
-    auto syclQueue = reinterpret_cast<queue*>(QueueRef);
+  auto syclQueue = reinterpret_cast<queue *>(QueueRef);
 
-    add_kernel_checker(syclQueue, AddKernel);
-    axpy_kernel_checker(syclQueue, AxpyKernel);
+  add_kernel_checker(syclQueue, AddKernel);
+  axpy_kernel_checker(syclQueue, AxpyKernel);
 
-    DPPLKernel_Delete(AddKernel);
-    DPPLKernel_Delete(AxpyKernel);
-    DPPLQueue_Delete(QueueRef);
-    DPPLContext_Delete(CtxRef);
-    DPPLProgram_Delete(PRef);
+  DPPLKernel_Delete(AddKernel);
+  DPPLKernel_Delete(AxpyKernel);
+  DPPLQueue_Delete(QueueRef);
+  DPPLContext_Delete(CtxRef);
+  DPPLProgram_Delete(PRef);
 }
 
-int
-main (int argc, char** argv)
-{
-    ::testing::InitGoogleTest(&argc, argv);
-    int ret = RUN_ALL_TESTS();
-    return ret;
+int main(int argc, char **argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  int ret = RUN_ALL_TESTS();
+  return ret;
 }

--- a/backends/tests/test_sycl_queue_interface.cpp
+++ b/backends/tests/test_sycl_queue_interface.cpp
@@ -24,6 +24,7 @@
 ///
 //===----------------------------------------------------------------------===//
 
+#include "Support/CBindingWrapping.h"
 #include "dppl_sycl_context_interface.h"
 #include "dppl_sycl_event_interface.h"
 #include "dppl_sycl_kernel_interface.h"
@@ -31,53 +32,47 @@
 #include "dppl_sycl_queue_interface.h"
 #include "dppl_sycl_queue_manager.h"
 #include "dppl_sycl_usm_interface.h"
-#include "Support/CBindingWrapping.h"
 #include <CL/sycl.hpp>
 #include <gtest/gtest.h>
 
 using namespace cl::sycl;
 
-namespace
-{
+namespace {
 constexpr size_t SIZE = 1024;
 
 DEFINE_SIMPLE_CONVERSION_FUNCTIONS(void, DPPLSyclUSMRef);
 
-void add_kernel_checker (const float *a, const float *b, const float *c)
-{
-    // Validate the data
-    for(auto i = 0ul; i < SIZE; ++i) {
-        EXPECT_EQ(c[i], a[i] + b[i]);
+void add_kernel_checker(const float *a, const float *b, const float *c) {
+  // Validate the data
+  for (auto i = 0ul; i < SIZE; ++i) {
+    EXPECT_EQ(c[i], a[i] + b[i]);
+  }
+}
+
+void axpy_kernel_checker(const float *a, const float *b, const float *c,
+                         float d) {
+  for (auto i = 0ul; i < SIZE; ++i) {
+    EXPECT_EQ(c[i], a[i] + d * b[i]);
+  }
+}
+
+bool has_devices() {
+  bool ret = false;
+  for (auto &p : platform::get_platforms()) {
+    if (p.is_host())
+      continue;
+    if (!p.get_devices().empty()) {
+      ret = true;
+      break;
     }
+  }
+  return ret;
 }
 
-void axpy_kernel_checker (const float *a, const float *b, const float *c,
-                            float d)
-{
-    for(auto i = 0ul; i < SIZE; ++i) {
-        EXPECT_EQ(c[i], a[i] + d*b[i]);
-    }
-}
+} // namespace
 
-bool has_devices ()
-{
-    bool ret = false;
-    for (auto &p : platform::get_platforms()) {
-        if (p.is_host())
-            continue;
-        if(!p.get_devices().empty()) {
-            ret = true;
-            break;
-        }
-    }
-    return ret;
-}
-
-}
-
-struct TestDPPLSyclQueueInterface : public ::testing::Test
-{
-    const char *CLProgramStr = R"CLC(
+struct TestDPPLSyclQueueInterface : public ::testing::Test {
+  const char *CLProgramStr = R"CLC(
         kernel void init_arr (global float *a) {
             size_t index = get_global_id(0);
             a[index] = (float)index;
@@ -94,293 +89,257 @@ struct TestDPPLSyclQueueInterface : public ::testing::Test
             c[index] = a[index] + d*b[index];
         }
     )CLC";
-    const char *CompileOpts ="-cl-fast-relaxed-math";
+  const char *CompileOpts = "-cl-fast-relaxed-math";
 
-    TestDPPLSyclQueueInterface ()
-    {  }
+  TestDPPLSyclQueueInterface() {}
 
-    ~TestDPPLSyclQueueInterface ()
-    {  }
+  ~TestDPPLSyclQueueInterface() {}
 };
 
-TEST_F (TestDPPLSyclQueueInterface, CheckAreEq)
-{
-    if(!has_devices())
-        GTEST_SKIP_("Skipping: No Sycl devices.\n");
+TEST_F(TestDPPLSyclQueueInterface, CheckAreEq) {
+  if (!has_devices())
+    GTEST_SKIP_("Skipping: No Sycl devices.\n");
 
-    auto nOclGPU = DPPLQueueMgr_GetNumQueues(DPPLSyclBackendType::DPPL_OPENCL,
-                                             DPPLSyclDeviceType::DPPL_GPU);
-    if(!nOclGPU)
-        GTEST_SKIP_("Skipping: No OpenCL GPUs available.\n");
+  auto nOclGPU = DPPLQueueMgr_GetNumQueues(DPPLSyclBackendType::DPPL_OPENCL,
+                                           DPPLSyclDeviceType::DPPL_GPU);
+  if (!nOclGPU)
+    GTEST_SKIP_("Skipping: No OpenCL GPUs available.\n");
 
-    auto Q1 = DPPLQueueMgr_GetCurrentQueue();
-    auto Q2 = DPPLQueueMgr_GetCurrentQueue();
-    EXPECT_TRUE(DPPLQueue_AreEq(Q1, Q2));
+  auto Q1 = DPPLQueueMgr_GetCurrentQueue();
+  auto Q2 = DPPLQueueMgr_GetCurrentQueue();
+  EXPECT_TRUE(DPPLQueue_AreEq(Q1, Q2));
 
-    auto Def_Q = DPPLQueueMgr_SetAsDefaultQueue(
-                    DPPLSyclBackendType::DPPL_OPENCL,
-                    DPPLSyclDeviceType::DPPL_GPU,
-                    0
-                 );
-    auto OclGPU_Q0 = DPPLQueueMgr_PushQueue(
-                        DPPLSyclBackendType::DPPL_OPENCL,
-                        DPPLSyclDeviceType::DPPL_GPU,
-                        0
-                    );
-    auto OclGPU_Q1 = DPPLQueueMgr_PushQueue(
-                        DPPLSyclBackendType::DPPL_OPENCL,
-                        DPPLSyclDeviceType::DPPL_GPU,
-                        0
-                    );
-    EXPECT_TRUE(DPPLQueue_AreEq(Def_Q, OclGPU_Q0));
-    EXPECT_TRUE(DPPLQueue_AreEq(Def_Q, OclGPU_Q1));
-    EXPECT_TRUE(DPPLQueue_AreEq(OclGPU_Q0, OclGPU_Q1));
-    DPPLQueue_Delete(Def_Q);
-    DPPLQueue_Delete(OclGPU_Q0);
-    DPPLQueue_Delete(OclGPU_Q1);
-    DPPLQueueMgr_PopQueue();
-    DPPLQueueMgr_PopQueue();
+  auto Def_Q = DPPLQueueMgr_SetAsDefaultQueue(DPPLSyclBackendType::DPPL_OPENCL,
+                                              DPPLSyclDeviceType::DPPL_GPU, 0);
+  auto OclGPU_Q0 = DPPLQueueMgr_PushQueue(DPPLSyclBackendType::DPPL_OPENCL,
+                                          DPPLSyclDeviceType::DPPL_GPU, 0);
+  auto OclGPU_Q1 = DPPLQueueMgr_PushQueue(DPPLSyclBackendType::DPPL_OPENCL,
+                                          DPPLSyclDeviceType::DPPL_GPU, 0);
+  EXPECT_TRUE(DPPLQueue_AreEq(Def_Q, OclGPU_Q0));
+  EXPECT_TRUE(DPPLQueue_AreEq(Def_Q, OclGPU_Q1));
+  EXPECT_TRUE(DPPLQueue_AreEq(OclGPU_Q0, OclGPU_Q1));
+  DPPLQueue_Delete(Def_Q);
+  DPPLQueue_Delete(OclGPU_Q0);
+  DPPLQueue_Delete(OclGPU_Q1);
+  DPPLQueueMgr_PopQueue();
+  DPPLQueueMgr_PopQueue();
 }
 
-TEST_F (TestDPPLSyclQueueInterface, CheckAreEq2)
-{
-    if(!has_devices())
-        GTEST_SKIP_("Skipping: No Sycl devices.\n");
+TEST_F(TestDPPLSyclQueueInterface, CheckAreEq2) {
+  if (!has_devices())
+    GTEST_SKIP_("Skipping: No Sycl devices.\n");
 
-    auto nOclGPU = DPPLQueueMgr_GetNumQueues(DPPLSyclBackendType::DPPL_OPENCL,
-                                             DPPLSyclDeviceType::DPPL_GPU);
-    auto nOclCPU = DPPLQueueMgr_GetNumQueues(DPPLSyclBackendType::DPPL_OPENCL,
-                                             DPPLSyclDeviceType::DPPL_CPU);
-    if(!nOclGPU || !nOclCPU)
-        GTEST_SKIP_("OpenCL GPUs and CPU not available.\n");
-    auto GPU_Q = DPPLQueueMgr_PushQueue(
-                    DPPLSyclBackendType::DPPL_OPENCL,
-                    DPPLSyclDeviceType::DPPL_GPU,
-                    0
-                );
-    auto CPU_Q = DPPLQueueMgr_PushQueue(
-                    DPPLSyclBackendType::DPPL_OPENCL,
-                    DPPLSyclDeviceType::DPPL_CPU,
-                    0
-                );
-    EXPECT_FALSE(DPPLQueue_AreEq(GPU_Q, CPU_Q));
-    DPPLQueueMgr_PopQueue();
-    DPPLQueueMgr_PopQueue();
+  auto nOclGPU = DPPLQueueMgr_GetNumQueues(DPPLSyclBackendType::DPPL_OPENCL,
+                                           DPPLSyclDeviceType::DPPL_GPU);
+  auto nOclCPU = DPPLQueueMgr_GetNumQueues(DPPLSyclBackendType::DPPL_OPENCL,
+                                           DPPLSyclDeviceType::DPPL_CPU);
+  if (!nOclGPU || !nOclCPU)
+    GTEST_SKIP_("OpenCL GPUs and CPU not available.\n");
+  auto GPU_Q = DPPLQueueMgr_PushQueue(DPPLSyclBackendType::DPPL_OPENCL,
+                                      DPPLSyclDeviceType::DPPL_GPU, 0);
+  auto CPU_Q = DPPLQueueMgr_PushQueue(DPPLSyclBackendType::DPPL_OPENCL,
+                                      DPPLSyclDeviceType::DPPL_CPU, 0);
+  EXPECT_FALSE(DPPLQueue_AreEq(GPU_Q, CPU_Q));
+  DPPLQueueMgr_PopQueue();
+  DPPLQueueMgr_PopQueue();
 }
 
-TEST_F (TestDPPLSyclQueueInterface, CheckGetBackend)
-{
-    if(!has_devices())
-        GTEST_SKIP_("Skipping: No Sycl devices.\n");
+TEST_F(TestDPPLSyclQueueInterface, CheckGetBackend) {
+  if (!has_devices())
+    GTEST_SKIP_("Skipping: No Sycl devices.\n");
 
-    auto Q1 = DPPLQueueMgr_GetCurrentQueue();
-    auto BE = DPPLQueue_GetBackend(Q1);
-    EXPECT_TRUE((BE == DPPL_OPENCL) ||
-                (BE == DPPL_LEVEL_ZERO) ||
-                (BE == DPPL_CUDA) ||
-                (BE == DPPL_HOST)
-    );
-    DPPLQueue_Delete(Q1);
-    if(DPPLQueueMgr_GetNumQueues(DPPL_OPENCL, DPPL_GPU)) {
-        auto Q = DPPLQueueMgr_PushQueue(DPPL_OPENCL, DPPL_GPU, 0);
-        EXPECT_TRUE(DPPLQueue_GetBackend(Q) == DPPL_OPENCL);
-        DPPLQueue_Delete(Q);
-        DPPLQueueMgr_PopQueue();
-    }
-    if(DPPLQueueMgr_GetNumQueues(DPPL_OPENCL, DPPL_CPU)) {
-        auto Q = DPPLQueueMgr_PushQueue(DPPL_OPENCL, DPPL_CPU, 0);
-        EXPECT_TRUE(DPPLQueue_GetBackend(Q) == DPPL_OPENCL);
-        DPPLQueue_Delete(Q);
-        DPPLQueueMgr_PopQueue();
-    }
-    if(DPPLQueueMgr_GetNumQueues(DPPL_LEVEL_ZERO, DPPL_GPU)) {
-        auto Q = DPPLQueueMgr_PushQueue(DPPL_LEVEL_ZERO, DPPL_GPU, 0);
-        EXPECT_TRUE(DPPLQueue_GetBackend(Q) == DPPL_LEVEL_ZERO);
-        DPPLQueue_Delete(Q);
-        DPPLQueueMgr_PopQueue();
-    }
+  auto Q1 = DPPLQueueMgr_GetCurrentQueue();
+  auto BE = DPPLQueue_GetBackend(Q1);
+  EXPECT_TRUE((BE == DPPL_OPENCL) || (BE == DPPL_LEVEL_ZERO) ||
+              (BE == DPPL_CUDA) || (BE == DPPL_HOST));
+  DPPLQueue_Delete(Q1);
+  if (DPPLQueueMgr_GetNumQueues(DPPL_OPENCL, DPPL_GPU)) {
+    auto Q = DPPLQueueMgr_PushQueue(DPPL_OPENCL, DPPL_GPU, 0);
+    EXPECT_TRUE(DPPLQueue_GetBackend(Q) == DPPL_OPENCL);
+    DPPLQueue_Delete(Q);
+    DPPLQueueMgr_PopQueue();
+  }
+  if (DPPLQueueMgr_GetNumQueues(DPPL_OPENCL, DPPL_CPU)) {
+    auto Q = DPPLQueueMgr_PushQueue(DPPL_OPENCL, DPPL_CPU, 0);
+    EXPECT_TRUE(DPPLQueue_GetBackend(Q) == DPPL_OPENCL);
+    DPPLQueue_Delete(Q);
+    DPPLQueueMgr_PopQueue();
+  }
+  if (DPPLQueueMgr_GetNumQueues(DPPL_LEVEL_ZERO, DPPL_GPU)) {
+    auto Q = DPPLQueueMgr_PushQueue(DPPL_LEVEL_ZERO, DPPL_GPU, 0);
+    EXPECT_TRUE(DPPLQueue_GetBackend(Q) == DPPL_LEVEL_ZERO);
+    DPPLQueue_Delete(Q);
+    DPPLQueueMgr_PopQueue();
+  }
 }
 
-TEST_F (TestDPPLSyclQueueInterface, CheckGetContext)
-{
-    if(!has_devices())
-        GTEST_SKIP_("Skipping: No Sycl devices.\n");
+TEST_F(TestDPPLSyclQueueInterface, CheckGetContext) {
+  if (!has_devices())
+    GTEST_SKIP_("Skipping: No Sycl devices.\n");
 
-    auto Q1 = DPPLQueueMgr_GetCurrentQueue();
-    auto Ctx = DPPLQueue_GetContext(Q1);
+  auto Q1 = DPPLQueueMgr_GetCurrentQueue();
+  auto Ctx = DPPLQueue_GetContext(Q1);
+  ASSERT_TRUE(Ctx != nullptr);
+  DPPLQueue_Delete(Q1);
+  DPPLContext_Delete(Ctx);
+
+  if (DPPLQueueMgr_GetNumQueues(DPPL_OPENCL, DPPL_GPU)) {
+    auto Q = DPPLQueueMgr_PushQueue(DPPL_OPENCL, DPPL_GPU, 0);
+    auto OclGpuCtx = DPPLQueue_GetContext(Q);
+    ASSERT_TRUE(OclGpuCtx != nullptr);
+    DPPLQueue_Delete(Q);
+    DPPLContext_Delete(OclGpuCtx);
+    DPPLQueueMgr_PopQueue();
+  }
+  if (DPPLQueueMgr_GetNumQueues(DPPL_OPENCL, DPPL_CPU)) {
+    auto Q = DPPLQueueMgr_PushQueue(DPPL_OPENCL, DPPL_CPU, 0);
+    auto OclCpuCtx = DPPLQueue_GetContext(Q);
+    ASSERT_TRUE(OclCpuCtx != nullptr);
+    DPPLQueue_Delete(Q);
+    DPPLContext_Delete(OclCpuCtx);
+    DPPLQueueMgr_PopQueue();
+  }
+  if (DPPLQueueMgr_GetNumQueues(DPPL_LEVEL_ZERO, DPPL_GPU)) {
+    auto Q = DPPLQueueMgr_PushQueue(DPPL_LEVEL_ZERO, DPPL_GPU, 0);
+    auto L0Ctx = DPPLQueue_GetContext(Q);
     ASSERT_TRUE(Ctx != nullptr);
-    DPPLQueue_Delete(Q1);
-    DPPLContext_Delete(Ctx);
-
-    if(DPPLQueueMgr_GetNumQueues(DPPL_OPENCL, DPPL_GPU)) {
-        auto Q = DPPLQueueMgr_PushQueue(DPPL_OPENCL, DPPL_GPU, 0);
-        auto OclGpuCtx = DPPLQueue_GetContext(Q);
-        ASSERT_TRUE(OclGpuCtx != nullptr);
-        DPPLQueue_Delete(Q);
-        DPPLContext_Delete(OclGpuCtx);
-        DPPLQueueMgr_PopQueue();
-    }
-    if(DPPLQueueMgr_GetNumQueues(DPPL_OPENCL, DPPL_CPU)) {
-        auto Q = DPPLQueueMgr_PushQueue(DPPL_OPENCL, DPPL_CPU, 0);
-        auto OclCpuCtx = DPPLQueue_GetContext(Q);
-        ASSERT_TRUE(OclCpuCtx != nullptr);
-        DPPLQueue_Delete(Q);
-        DPPLContext_Delete(OclCpuCtx);
-        DPPLQueueMgr_PopQueue();
-    }
-    if(DPPLQueueMgr_GetNumQueues(DPPL_LEVEL_ZERO, DPPL_GPU)) {
-        auto Q = DPPLQueueMgr_PushQueue(DPPL_LEVEL_ZERO, DPPL_GPU, 0);
-        auto L0Ctx = DPPLQueue_GetContext(Q);
-        ASSERT_TRUE(Ctx != nullptr);
-        DPPLQueue_Delete(Q);
-        DPPLContext_Delete(L0Ctx);
-        DPPLQueueMgr_PopQueue();
-    }
+    DPPLQueue_Delete(Q);
+    DPPLContext_Delete(L0Ctx);
+    DPPLQueueMgr_PopQueue();
+  }
 }
 
-TEST_F (TestDPPLSyclQueueInterface, CheckGetDevice)
-{
-    if(!has_devices())
-        GTEST_SKIP_("Skipping: No Sycl devices.\n");
+TEST_F(TestDPPLSyclQueueInterface, CheckGetDevice) {
+  if (!has_devices())
+    GTEST_SKIP_("Skipping: No Sycl devices.\n");
 
-    auto Q1 = DPPLQueueMgr_GetCurrentQueue();
-    auto D = DPPLQueue_GetDevice(Q1);
-    ASSERT_TRUE(D != nullptr);
-    DPPLQueue_Delete(Q1);
-    DPPLDevice_Delete(D);
+  auto Q1 = DPPLQueueMgr_GetCurrentQueue();
+  auto D = DPPLQueue_GetDevice(Q1);
+  ASSERT_TRUE(D != nullptr);
+  DPPLQueue_Delete(Q1);
+  DPPLDevice_Delete(D);
 
-    if(DPPLQueueMgr_GetNumQueues(DPPL_OPENCL, DPPL_GPU)) {
-        auto Q = DPPLQueueMgr_PushQueue(DPPL_OPENCL, DPPL_GPU, 0);
-        auto OCLGPU_D = DPPLQueue_GetDevice(Q);
-        ASSERT_TRUE(OCLGPU_D != nullptr);
-        EXPECT_TRUE(DPPLDevice_IsGPU(OCLGPU_D));
-        DPPLQueue_Delete(Q);
-        DPPLDevice_Delete(OCLGPU_D);
-        DPPLQueueMgr_PopQueue();
-    }
-    if(DPPLQueueMgr_GetNumQueues(DPPL_OPENCL, DPPL_CPU)) {
-        auto Q = DPPLQueueMgr_PushQueue(DPPL_OPENCL, DPPL_CPU, 0);
-        auto OCLCPU_D = DPPLQueue_GetDevice(Q);
-        ASSERT_TRUE(OCLCPU_D != nullptr);
-        EXPECT_TRUE(DPPLDevice_IsCPU(OCLCPU_D));
-        DPPLQueue_Delete(Q);
-        DPPLDevice_Delete(OCLCPU_D);
-        DPPLQueueMgr_PopQueue();
-    }
-    if(DPPLQueueMgr_GetNumQueues(DPPL_LEVEL_ZERO, DPPL_GPU)) {
-        auto Q = DPPLQueueMgr_PushQueue(DPPL_LEVEL_ZERO, DPPL_GPU, 0);
-        auto L0GPU_D = DPPLQueue_GetDevice(Q);
-        ASSERT_TRUE(L0GPU_D != nullptr);
-        EXPECT_TRUE(DPPLDevice_IsGPU(L0GPU_D));
-        DPPLQueue_Delete(Q);
-        DPPLDevice_Delete(L0GPU_D);
-        DPPLQueueMgr_PopQueue();
-    }
+  if (DPPLQueueMgr_GetNumQueues(DPPL_OPENCL, DPPL_GPU)) {
+    auto Q = DPPLQueueMgr_PushQueue(DPPL_OPENCL, DPPL_GPU, 0);
+    auto OCLGPU_D = DPPLQueue_GetDevice(Q);
+    ASSERT_TRUE(OCLGPU_D != nullptr);
+    EXPECT_TRUE(DPPLDevice_IsGPU(OCLGPU_D));
+    DPPLQueue_Delete(Q);
+    DPPLDevice_Delete(OCLGPU_D);
+    DPPLQueueMgr_PopQueue();
+  }
+  if (DPPLQueueMgr_GetNumQueues(DPPL_OPENCL, DPPL_CPU)) {
+    auto Q = DPPLQueueMgr_PushQueue(DPPL_OPENCL, DPPL_CPU, 0);
+    auto OCLCPU_D = DPPLQueue_GetDevice(Q);
+    ASSERT_TRUE(OCLCPU_D != nullptr);
+    EXPECT_TRUE(DPPLDevice_IsCPU(OCLCPU_D));
+    DPPLQueue_Delete(Q);
+    DPPLDevice_Delete(OCLCPU_D);
+    DPPLQueueMgr_PopQueue();
+  }
+  if (DPPLQueueMgr_GetNumQueues(DPPL_LEVEL_ZERO, DPPL_GPU)) {
+    auto Q = DPPLQueueMgr_PushQueue(DPPL_LEVEL_ZERO, DPPL_GPU, 0);
+    auto L0GPU_D = DPPLQueue_GetDevice(Q);
+    ASSERT_TRUE(L0GPU_D != nullptr);
+    EXPECT_TRUE(DPPLDevice_IsGPU(L0GPU_D));
+    DPPLQueue_Delete(Q);
+    DPPLDevice_Delete(L0GPU_D);
+    DPPLQueueMgr_PopQueue();
+  }
 }
 
-TEST_F (TestDPPLSyclQueueInterface, CheckSubmit)
-{
-    if(!has_devices())
-        GTEST_SKIP_("Skipping: No Sycl devices.\n");
+TEST_F(TestDPPLSyclQueueInterface, CheckSubmit) {
+  if (!has_devices())
+    GTEST_SKIP_("Skipping: No Sycl devices.\n");
 
-    auto nOpenCLGpuQ = DPPLQueueMgr_GetNumQueues(DPPL_OPENCL, DPPL_GPU);
+  auto nOpenCLGpuQ = DPPLQueueMgr_GetNumQueues(DPPL_OPENCL, DPPL_GPU);
 
-    if(!nOpenCLGpuQ)
-        GTEST_SKIP_("Skipping: No OpenCL GPU device.\n");
+  if (!nOpenCLGpuQ)
+    GTEST_SKIP_("Skipping: No OpenCL GPU device.\n");
 
-    auto Queue  = DPPLQueueMgr_GetQueue(DPPL_OPENCL, DPPL_GPU, 0);
-    auto CtxRef = DPPLQueue_GetContext(Queue);
-    auto PRef   = DPPLProgram_CreateFromOCLSource(CtxRef, CLProgramStr,
-                                                  CompileOpts);
-    ASSERT_TRUE(PRef != nullptr);
-    ASSERT_TRUE(DPPLProgram_HasKernel(PRef, "init_arr"));
-    ASSERT_TRUE(DPPLProgram_HasKernel(PRef, "add"));
-    ASSERT_TRUE(DPPLProgram_HasKernel(PRef, "axpy"));
+  auto Queue = DPPLQueueMgr_GetQueue(DPPL_OPENCL, DPPL_GPU, 0);
+  auto CtxRef = DPPLQueue_GetContext(Queue);
+  auto PRef =
+      DPPLProgram_CreateFromOCLSource(CtxRef, CLProgramStr, CompileOpts);
+  ASSERT_TRUE(PRef != nullptr);
+  ASSERT_TRUE(DPPLProgram_HasKernel(PRef, "init_arr"));
+  ASSERT_TRUE(DPPLProgram_HasKernel(PRef, "add"));
+  ASSERT_TRUE(DPPLProgram_HasKernel(PRef, "axpy"));
 
-    auto InitKernel = DPPLProgram_GetKernel(PRef, "init_arr");
-    auto AddKernel  = DPPLProgram_GetKernel(PRef, "add");
-    auto AxpyKernel = DPPLProgram_GetKernel(PRef, "axpy");
+  auto InitKernel = DPPLProgram_GetKernel(PRef, "init_arr");
+  auto AddKernel = DPPLProgram_GetKernel(PRef, "add");
+  auto AxpyKernel = DPPLProgram_GetKernel(PRef, "axpy");
 
-    // Create the input args
-    auto a = DPPLmalloc_shared(SIZE, Queue);
-    ASSERT_TRUE(a != nullptr);
-    auto b = DPPLmalloc_shared(SIZE, Queue);
-    ASSERT_TRUE(b != nullptr);
-    auto c = DPPLmalloc_shared(SIZE, Queue);
-    ASSERT_TRUE(c != nullptr);
+  // Create the input args
+  auto a = DPPLmalloc_shared(SIZE, Queue);
+  ASSERT_TRUE(a != nullptr);
+  auto b = DPPLmalloc_shared(SIZE, Queue);
+  ASSERT_TRUE(b != nullptr);
+  auto c = DPPLmalloc_shared(SIZE, Queue);
+  ASSERT_TRUE(c != nullptr);
 
-    // Initialize a,b
-    DPPLKernelArgType argTypes[] = {DPPL_VOID_PTR};
-    size_t Range[] = {SIZE};
-    void *arg1[1] = { unwrap(a) };
-    void *arg2[1] = { unwrap(b) };
+  // Initialize a,b
+  DPPLKernelArgType argTypes[] = {DPPL_VOID_PTR};
+  size_t Range[] = {SIZE};
+  void *arg1[1] = {unwrap(a)};
+  void *arg2[1] = {unwrap(b)};
 
-    auto E1 = DPPLQueue_SubmitRange(InitKernel, Queue, arg1, argTypes, 1,
-                                    Range, 1, nullptr, 0);
-    auto E2 = DPPLQueue_SubmitRange(InitKernel, Queue, arg2, argTypes, 1,
-                                    Range, 1, nullptr, 0);
-    ASSERT_TRUE(E1 != nullptr);
-    ASSERT_TRUE(E2 != nullptr);
+  auto E1 = DPPLQueue_SubmitRange(InitKernel, Queue, arg1, argTypes, 1, Range,
+                                  1, nullptr, 0);
+  auto E2 = DPPLQueue_SubmitRange(InitKernel, Queue, arg2, argTypes, 1, Range,
+                                  1, nullptr, 0);
+  ASSERT_TRUE(E1 != nullptr);
+  ASSERT_TRUE(E2 != nullptr);
 
-    DPPLQueue_Wait(Queue);
+  DPPLQueue_Wait(Queue);
 
-    // Submit the add kernel
-    void *args[3] = { unwrap(a), unwrap(b), unwrap(c) };
-    DPPLKernelArgType addKernelArgTypes[] = {
-                                              DPPL_VOID_PTR,
-                                              DPPL_VOID_PTR,
-                                              DPPL_VOID_PTR
-                                            };
+  // Submit the add kernel
+  void *args[3] = {unwrap(a), unwrap(b), unwrap(c)};
+  DPPLKernelArgType addKernelArgTypes[] = {DPPL_VOID_PTR, DPPL_VOID_PTR,
+                                           DPPL_VOID_PTR};
 
-    auto E3 = DPPLQueue_SubmitRange(AddKernel, Queue, args,
-                                    addKernelArgTypes, 3, Range, 1, nullptr, 0);
-    ASSERT_TRUE(E3 != nullptr);
-    DPPLQueue_Wait(Queue);
+  auto E3 = DPPLQueue_SubmitRange(AddKernel, Queue, args, addKernelArgTypes, 3,
+                                  Range, 1, nullptr, 0);
+  ASSERT_TRUE(E3 != nullptr);
+  DPPLQueue_Wait(Queue);
 
-    // Verify the result of "add"
-    add_kernel_checker((float*)a, (float*)b, (float*)c);
+  // Verify the result of "add"
+  add_kernel_checker((float *)a, (float *)b, (float *)c);
 
-    // Create kernel args for axpy
-    float d = 10.0;
-    void *args2[4] = { unwrap(a), unwrap(b), unwrap(c) , (void*)&d };
-    DPPLKernelArgType addKernelArgTypes2[] = {
-                                               DPPL_VOID_PTR,
-                                               DPPL_VOID_PTR,
-                                               DPPL_VOID_PTR,
-                                               DPPL_FLOAT
-                                             };
-    auto E4 = DPPLQueue_SubmitRange(AxpyKernel, Queue, args2,
-                                    addKernelArgTypes2, 4, Range, 1,
-                                    nullptr, 0);
-    ASSERT_TRUE(E4 != nullptr);
-    DPPLQueue_Wait(Queue);
+  // Create kernel args for axpy
+  float d = 10.0;
+  void *args2[4] = {unwrap(a), unwrap(b), unwrap(c), (void *)&d};
+  DPPLKernelArgType addKernelArgTypes2[] = {DPPL_VOID_PTR, DPPL_VOID_PTR,
+                                            DPPL_VOID_PTR, DPPL_FLOAT};
+  auto E4 = DPPLQueue_SubmitRange(AxpyKernel, Queue, args2, addKernelArgTypes2,
+                                  4, Range, 1, nullptr, 0);
+  ASSERT_TRUE(E4 != nullptr);
+  DPPLQueue_Wait(Queue);
 
-    // Verify the result of "axpy"
-    axpy_kernel_checker((float*)a, (float*)b, (float*)c, d);
+  // Verify the result of "axpy"
+  axpy_kernel_checker((float *)a, (float *)b, (float *)c, d);
 
-    // clean ups
-    DPPLEvent_Delete(E1);
-    DPPLEvent_Delete(E2);
-    DPPLEvent_Delete(E3);
-    DPPLEvent_Delete(E4);
+  // clean ups
+  DPPLEvent_Delete(E1);
+  DPPLEvent_Delete(E2);
+  DPPLEvent_Delete(E3);
+  DPPLEvent_Delete(E4);
 
-    DPPLKernel_Delete(AddKernel);
-    DPPLKernel_Delete(AxpyKernel);
-    DPPLKernel_Delete(InitKernel);
+  DPPLKernel_Delete(AddKernel);
+  DPPLKernel_Delete(AxpyKernel);
+  DPPLKernel_Delete(InitKernel);
 
-    DPPLfree_with_queue((DPPLSyclUSMRef)a, Queue);
-    DPPLfree_with_queue((DPPLSyclUSMRef)b, Queue);
-    DPPLfree_with_queue((DPPLSyclUSMRef)c, Queue);
+  DPPLfree_with_queue((DPPLSyclUSMRef)a, Queue);
+  DPPLfree_with_queue((DPPLSyclUSMRef)b, Queue);
+  DPPLfree_with_queue((DPPLSyclUSMRef)c, Queue);
 
-    DPPLQueue_Delete(Queue);
-    DPPLContext_Delete(CtxRef);
-    DPPLProgram_Delete(PRef);
+  DPPLQueue_Delete(Queue);
+  DPPLContext_Delete(CtxRef);
+  DPPLProgram_Delete(PRef);
 }
 
-int
-main (int argc, char** argv)
-{
-    ::testing::InitGoogleTest(&argc, argv);
-    int ret = RUN_ALL_TESTS();
-    return ret;
+int main(int argc, char **argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  int ret = RUN_ALL_TESTS();
+  return ret;
 }


### PR DESCRIPTION
[clang-format](https://clang.llvm.org/docs/ClangFormat.html) is "A tool to format C/C++/Java/JavaScript/Objective-C/Protobuf/C# code."

- [ ] Add CI for check С/С++ code style
- [x] Update CONTRIBUTING.md for all developers to use clang-format in everyday work
- [x] Add configuration file `.clang-format`
- [x] Format all С/C++ code with clang-format (see command in  CONTRIBUTING.md)
- [x] Add ignoring revisions in blame so you can see meaningful blame info after global formatting commit

Unfortunately `clang-format` can not work with directories. It requires to list all files to format, so the command is long (See CONTRIBUTING.md).
See https://stackoverflow.com/questions/28896909/how-to-call-clang-format-over-a-cpp-project-folder.

This PR should be merged (not squashed) because `.git-blame-ignore-revs` contains commit hash.

Configuration file `.clang-format` should be discussed. There are projects like dpNP and daal4py which uses clang-format too. It is better to have similar style among projects.
See https://clang.llvm.org/docs/ClangFormatStyleOptions.html