### PR TITLE
Feature/memory zero copy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 ### Added
 - Device descriptors "max_compute_units", "max_work_item_dimensions", "max_work_item_sizes", "max_work_group_size", "max_num_sub_groups" and "aspects" for int64 atomics inside dpctl C API and inside the dpctl.SyclDevice class.
+- MemoryUSM* classes moved to `dpctl.memory` module, added support for aligned allocation, added support for `prefetch` and `mem_advise` (sychronous) methods, implemented `copy_to_host`, `copy_from_host` and `copy_from_device` methods, pickling support, and zero-copy interoperability with Python objects which implement `__sycl_usm_array_inerface__` protocol.
 
 ### Removed
 - The Legacy OpenCL interface.

--- a/backends/include/dppl_sycl_device_interface.h
+++ b/backends/include/dppl_sycl_device_interface.h
@@ -213,5 +213,5 @@ bool DPPLDevice_IsHostUnifiedMemory (__dppl_keep const DPPLSyclDeviceRef DRef);
  */
 DPPL_API
 bool DPPLDevice_AreEq (__dppl_keep const DPPLSyclDeviceRef DevRef1,
-                        __dppl_keep const DPPLSyclDeviceRef DevRef2);
+                       __dppl_keep const DPPLSyclDeviceRef DevRef2);
 DPPL_C_EXTERN_C_END

--- a/backends/include/dppl_sycl_device_interface.h
+++ b/backends/include/dppl_sycl_device_interface.h
@@ -133,4 +133,15 @@ DPPLDevice_GetVendorName (__dppl_keep const DPPLSyclDeviceRef DRef);
 DPPL_API
 bool DPPLDevice_IsHostUnifiedMemory (__dppl_keep const DPPLSyclDeviceRef DRef);
 
+/*!
+ * @brief Checks if two DPPLSyclDeviceRef objects point to the same
+ * sycl::device.
+ *
+ * @param    DevRef1       First opaque pointer to the sycl device.
+ * @param    DevRef2       Second opaque pointer to the sycl device.
+ * @return   True if the underlying sycl::device are same, false otherwise.
+ */
+DPPL_API
+bool DPPLDevice_AreEq (__dppl_keep const DPPLSyclDeviceRef DevRef1,
+                        __dppl_keep const DPPLSyclDeviceRef DevRef2);
 DPPL_C_EXTERN_C_END

--- a/backends/include/dppl_sycl_queue_interface.h
+++ b/backends/include/dppl_sycl_queue_interface.h
@@ -209,7 +209,7 @@ void DPPLQueue_Memcpy (__dppl_keep const DPPLSyclQueueRef QRef,
  */
 DPPL_API
 void DPPLQueue_Prefetch (__dppl_keep DPPLSyclQueueRef QRef,
-			 const void *Ptr, size_t Count);
+                         const void *Ptr, size_t Count);
 
 /*!
  * @brief C-API wrapper for sycl::queue::mem_advise, the function waits on an event
@@ -223,6 +223,6 @@ void DPPLQueue_Prefetch (__dppl_keep DPPLSyclQueueRef QRef,
  */
 DPPL_API
 void DPPLQueue_MemAdvise (__dppl_keep DPPLSyclQueueRef QRef,
-			  const void *Ptr, size_t Count, int Advice);
+                          const void *Ptr, size_t Count, int Advice);
 
 DPPL_C_EXTERN_C_END

--- a/backends/include/dppl_sycl_queue_interface.h
+++ b/backends/include/dppl_sycl_queue_interface.h
@@ -199,4 +199,30 @@ DPPL_API
 void DPPLQueue_Memcpy (__dppl_keep const DPPLSyclQueueRef QRef,
                        void *Dest, const void *Src, size_t Count);
 
+/*!
+ * @brief C-API wrapper for sycl::queue::prefetch, the function waits on an event
+ * till the prefetch operation completes.
+ *
+ * @param    QRef           An opaque pointer to the sycl queue.
+ * @param    Ptr            An USM pointer to memory.
+ * @param    Count          A number of bytes to prefetch.
+ */
+DPPL_API
+void DPPLQueue_Prefetch (__dppl_keep DPPLSyclQueueRef QRef,
+			 const void *Ptr, size_t Count);
+
+/*!
+ * @brief C-API wrapper for sycl::queue::mem_advise, the function waits on an event
+ * till the operation completes.
+ *
+ * @param    QRef           An opaque pointer to the sycl queue.
+ * @param    Ptr            An USM pointer to memory.
+ * @param    Count          A number of bytes to prefetch.
+ * @param    Advice         Device-defined advice for the specified allocation. 
+ *                           A value of 0 reverts the advice for Ptr to the default behavior.
+ */
+DPPL_API
+void DPPLQueue_MemAdvise (__dppl_keep DPPLSyclQueueRef QRef,
+			  const void *Ptr, size_t Count, int Advice);
+
 DPPL_C_EXTERN_C_END

--- a/backends/include/dppl_sycl_queue_manager.h
+++ b/backends/include/dppl_sycl_queue_manager.h
@@ -167,6 +167,11 @@ void DPPLQueueMgr_PopQueue ();
  * ownership of the queue reference and should deallocate it using
  * DPPLQueue_Delete.
  *
+ * @param    CRef           Sycl context reference
+ * @param    DRef           Sycl device reference
+ *
+ * @return A copy of the sycl::queue created from given context and device
+ * references.
  */
 DPPL_API
 __dppl_give DPPLSyclQueueRef

--- a/backends/include/dppl_sycl_queue_manager.h
+++ b/backends/include/dppl_sycl_queue_manager.h
@@ -171,7 +171,7 @@ void DPPLQueueMgr_PopQueue ();
 DPPL_API
 __dppl_give DPPLSyclQueueRef
 DPPLQueueMgr_GetQueueFromContextAndDevice(__dppl_keep DPPLSyclContextRef CRef,
-					  __dppl_keep DPPLSyclDeviceRef DRef);
+                                          __dppl_keep DPPLSyclDeviceRef DRef);
 
 
 DPPL_C_EXTERN_C_END

--- a/backends/include/dppl_sycl_queue_manager.h
+++ b/backends/include/dppl_sycl_queue_manager.h
@@ -158,4 +158,20 @@ DPPLQueueMgr_PushQueue (DPPLSyclBackendType BETy,
 DPPL_API
 void DPPLQueueMgr_PopQueue ();
 
+
+/*!
+ * @brief Creates a new instance of SYCL queue from SYCL context and
+ * SYCL device.
+ *
+ * The instance is not placed into queue manager. The user assumes
+ * ownership of the queue reference and should deallocate it using
+ * DPPLQueue_Delete.
+ *
+ */
+DPPL_API
+__dppl_give DPPLSyclQueueRef
+DPPLQueueMgr_GetQueueFromContextAndDevice(__dppl_keep DPPLSyclContextRef CRef,
+					  __dppl_keep DPPLSyclDeviceRef DRef);
+
+
 DPPL_C_EXTERN_C_END

--- a/backends/include/dppl_sycl_usm_interface.h
+++ b/backends/include/dppl_sycl_usm_interface.h
@@ -36,6 +36,9 @@ DPPL_C_EXTERN_C_BEGIN
 /*!
  * @brief Crete USM shared memory.
  *
+ * @param    size     Number of bytes to allocate
+ * @param    QRef     Sycl queue reference to use in allocation
+ *
  * @return The pointer to USM shared memory.
  */
 DPPL_API
@@ -45,7 +48,11 @@ DPPLmalloc_shared (size_t size, __dppl_keep const DPPLSyclQueueRef QRef);
 /*!
  * @brief Crete USM shared memory.
  *
- * @return The pointer to USM shared memory with requested alignment.
+ * @param  alignment   Allocation's byte alignment
+ * @param  size        Number of bytes to allocate
+ * @param  QRef        Sycl queue reference to use in allocation
+ *
+ * @return The pointer to USM shared memory with the requested alignment.
  */
 DPPL_API
 __dppl_give DPPLSyclUSMRef
@@ -54,6 +61,9 @@ DPPLaligned_alloc_shared (size_t alignment, size_t size,
 
 /*!
  * @brief Crete USM host memory.
+ *
+ * @param    size     Number of bytes to allocate
+ * @param    QRef     Sycl queue reference to use in allocation
  *
  * @return The pointer to USM host memory.
  */
@@ -64,7 +74,11 @@ DPPLmalloc_host (size_t size, __dppl_keep const DPPLSyclQueueRef QRef);
 /*!
  * @brief Crete USM host memory.
  *
- * @return The pointer to USM host memory with requested alignment.
+ * @param  alignment   Allocation's byte alignment
+ * @param  size        Number of bytes to allocate
+ * @param  QRef        Sycl queue reference to use in allocation
+ *
+ * @return The pointer to USM host memory with the requested alignment.
  */
 DPPL_API
 __dppl_give DPPLSyclUSMRef
@@ -74,6 +88,9 @@ DPPLaligned_alloc_host (size_t alignment, size_t size,
 /*!
  * @brief Crete USM device memory.
  *
+ * @param    size     Number of bytes to allocate
+ * @param    QRef     Sycl queue reference to use in allocation
+ *
  * @return The pointer to USM device memory.
  */
 DPPL_API
@@ -82,6 +99,10 @@ DPPLmalloc_device (size_t size, __dppl_keep const DPPLSyclQueueRef QRef);
 
 /*!
  * @brief Crete USM device memory.
+ *
+ * @param    alignment   Allocation's byte alignment
+ * @param    size        Number of bytes to allocate
+ * @param    QRef        Sycl queue reference to use in allocation
  *
  * @return The pointer to USM device memory with requested alignment.
  */
@@ -93,6 +114,11 @@ DPPLaligned_alloc_device (size_t alignment, size_t size,
 /*!
  * @brief Free USM memory.
  *
+ * @param   MRef      USM pointer to free
+ * @param   QRef      Sycl queue reference to use.
+ *
+ * USM pointer must have been allocated using the same context as the one
+ * used to construct the queue.
  */
 DPPL_API
 void DPPLfree_with_queue (__dppl_take DPPLSyclUSMRef MRef,
@@ -109,6 +135,9 @@ void DPPLfree_with_context (__dppl_take DPPLSyclUSMRef MRef,
 /*!
  * @brief Get pointer type.
  *
+ * @param    MRef      USM Memory 
+ * @param    CRef 
+ *
  * @return "host", "device", "shared" or "unknown"
  */
 DPPL_API
@@ -118,6 +147,9 @@ DPPLUSM_GetPointerType (__dppl_keep const DPPLSyclUSMRef MRef,
 
 /*!
  * @brief Get the device associated with USM pointer.
+ *
+ * @param  MRef    USM pointer
+ * @param  CRef    Sycl context reference associated with the pointer
  *
  * @return A DPPLSyclDeviceRef pointer to the sycl device.
  */

--- a/backends/include/dppl_sycl_usm_interface.h
+++ b/backends/include/dppl_sycl_usm_interface.h
@@ -139,7 +139,7 @@ void DPPLfree_with_context (__dppl_take DPPLSyclUSMRef MRef,
  * @brief Get pointer type.
  *
  * @param    MRef      USM Memory 
- * @param    CRef 
+ * @param    CRef      Sycl context reference associated with the pointer
  *
  * @return "host", "device", "shared" or "unknown"
  */

--- a/backends/include/dppl_sycl_usm_interface.h
+++ b/backends/include/dppl_sycl_usm_interface.h
@@ -50,7 +50,7 @@ DPPLmalloc_shared (size_t size, __dppl_keep const DPPLSyclQueueRef QRef);
 DPPL_API
 __dppl_give DPPLSyclUSMRef
 DPPLaligned_alloc_shared (size_t alignment, size_t size,
-			  __dppl_keep const DPPLSyclQueueRef QRef);
+                          __dppl_keep const DPPLSyclQueueRef QRef);
 
 /*!
  * @brief Crete USM host memory.
@@ -69,7 +69,7 @@ DPPLmalloc_host (size_t size, __dppl_keep const DPPLSyclQueueRef QRef);
 DPPL_API
 __dppl_give DPPLSyclUSMRef
 DPPLaligned_alloc_host (size_t alignment, size_t size,
-			__dppl_keep const DPPLSyclQueueRef QRef);
+                        __dppl_keep const DPPLSyclQueueRef QRef);
 
 /*!
  * @brief Crete USM device memory.
@@ -88,7 +88,7 @@ DPPLmalloc_device (size_t size, __dppl_keep const DPPLSyclQueueRef QRef);
 DPPL_API
 __dppl_give DPPLSyclUSMRef
 DPPLaligned_alloc_device (size_t alignment, size_t size,
-			  __dppl_keep const DPPLSyclQueueRef QRef);
+                          __dppl_keep const DPPLSyclQueueRef QRef);
 
 /*!
  * @brief Free USM memory.
@@ -124,5 +124,5 @@ DPPLUSM_GetPointerType (__dppl_keep const DPPLSyclUSMRef MRef,
 DPPL_API
 DPPLSyclDeviceRef
 DPPLUSM_GetPointerDevice (__dppl_keep const DPPLSyclUSMRef MRef,
-			  __dppl_keep const DPPLSyclContextRef CRef);
+                          __dppl_keep const DPPLSyclContextRef CRef);
 DPPL_C_EXTERN_C_END

--- a/backends/include/dppl_sycl_usm_interface.h
+++ b/backends/include/dppl_sycl_usm_interface.h
@@ -43,6 +43,16 @@ __dppl_give DPPLSyclUSMRef
 DPPLmalloc_shared (size_t size, __dppl_keep const DPPLSyclQueueRef QRef);
 
 /*!
+ * @brief Crete USM shared memory.
+ *
+ * @return The pointer to USM shared memory with requested alignment.
+ */
+DPPL_API
+__dppl_give DPPLSyclUSMRef
+DPPLaligned_alloc_shared (size_t alignment, size_t size,
+			  __dppl_keep const DPPLSyclQueueRef QRef);
+
+/*!
  * @brief Crete USM host memory.
  *
  * @return The pointer to USM host memory.
@@ -52,6 +62,16 @@ __dppl_give DPPLSyclUSMRef
 DPPLmalloc_host (size_t size, __dppl_keep const DPPLSyclQueueRef QRef);
 
 /*!
+ * @brief Crete USM host memory.
+ *
+ * @return The pointer to USM host memory with requested alignment.
+ */
+DPPL_API
+__dppl_give DPPLSyclUSMRef
+DPPLaligned_alloc_host (size_t alignment, size_t size,
+			__dppl_keep const DPPLSyclQueueRef QRef);
+
+/*!
  * @brief Crete USM device memory.
  *
  * @return The pointer to USM device memory.
@@ -59,6 +79,16 @@ DPPLmalloc_host (size_t size, __dppl_keep const DPPLSyclQueueRef QRef);
 DPPL_API
 __dppl_give DPPLSyclUSMRef
 DPPLmalloc_device (size_t size, __dppl_keep const DPPLSyclQueueRef QRef);
+
+/*!
+ * @brief Crete USM device memory.
+ *
+ * @return The pointer to USM device memory with requested alignment.
+ */
+DPPL_API
+__dppl_give DPPLSyclUSMRef
+DPPLaligned_alloc_device (size_t alignment, size_t size,
+			  __dppl_keep const DPPLSyclQueueRef QRef);
 
 /*!
  * @brief Free USM memory.

--- a/backends/include/dppl_sycl_usm_interface.h
+++ b/backends/include/dppl_sycl_usm_interface.h
@@ -116,4 +116,13 @@ const char *
 DPPLUSM_GetPointerType (__dppl_keep const DPPLSyclUSMRef MRef,
                         __dppl_keep const DPPLSyclContextRef CRef);
 
+/*!
+ * @brief Get the device associated with USM pointer.
+ *
+ * @return A DPPLSyclDeviceRef pointer to the sycl device.
+ */
+DPPL_API
+DPPLSyclDeviceRef
+DPPLUSM_GetPointerDevice (__dppl_keep const DPPLSyclUSMRef MRef,
+			  __dppl_keep const DPPLSyclContextRef CRef);
 DPPL_C_EXTERN_C_END

--- a/backends/include/dppl_sycl_usm_interface.h
+++ b/backends/include/dppl_sycl_usm_interface.h
@@ -34,25 +34,26 @@
 DPPL_C_EXTERN_C_BEGIN
 
 /*!
- * @brief Crete USM shared memory.
+ * @brief Create USM shared memory.
  *
  * @param    size     Number of bytes to allocate
  * @param    QRef     Sycl queue reference to use in allocation
  *
- * @return The pointer to USM shared memory.
+ * @return The pointer to USM shared memory. On failure, returns nullptr.
  */
 DPPL_API
 __dppl_give DPPLSyclUSMRef
 DPPLmalloc_shared (size_t size, __dppl_keep const DPPLSyclQueueRef QRef);
 
 /*!
- * @brief Crete USM shared memory.
+ * @brief Create USM shared memory.
  *
  * @param  alignment   Allocation's byte alignment
  * @param  size        Number of bytes to allocate
  * @param  QRef        Sycl queue reference to use in allocation
  *
  * @return The pointer to USM shared memory with the requested alignment.
+ * On failure, returns nullptr.
  */
 DPPL_API
 __dppl_give DPPLSyclUSMRef
@@ -60,25 +61,26 @@ DPPLaligned_alloc_shared (size_t alignment, size_t size,
                           __dppl_keep const DPPLSyclQueueRef QRef);
 
 /*!
- * @brief Crete USM host memory.
+ * @brief Create USM host memory.
  *
  * @param    size     Number of bytes to allocate
  * @param    QRef     Sycl queue reference to use in allocation
  *
- * @return The pointer to USM host memory.
+ * @return The pointer to USM host memory. On failure, returns nullptr.
  */
 DPPL_API
 __dppl_give DPPLSyclUSMRef
 DPPLmalloc_host (size_t size, __dppl_keep const DPPLSyclQueueRef QRef);
 
 /*!
- * @brief Crete USM host memory.
+ * @brief Create USM host memory.
  *
  * @param  alignment   Allocation's byte alignment
  * @param  size        Number of bytes to allocate
  * @param  QRef        Sycl queue reference to use in allocation
  *
  * @return The pointer to USM host memory with the requested alignment.
+ * On failure, returns nullptr.
  */
 DPPL_API
 __dppl_give DPPLSyclUSMRef
@@ -86,25 +88,26 @@ DPPLaligned_alloc_host (size_t alignment, size_t size,
                         __dppl_keep const DPPLSyclQueueRef QRef);
 
 /*!
- * @brief Crete USM device memory.
+ * @brief Create USM device memory.
  *
  * @param    size     Number of bytes to allocate
  * @param    QRef     Sycl queue reference to use in allocation
  *
- * @return The pointer to USM device memory.
+ * @return The pointer to USM device memory. On failure, returns nullptr.
  */
 DPPL_API
 __dppl_give DPPLSyclUSMRef
 DPPLmalloc_device (size_t size, __dppl_keep const DPPLSyclQueueRef QRef);
 
 /*!
- * @brief Crete USM device memory.
+ * @brief Create USM device memory.
  *
  * @param    alignment   Allocation's byte alignment
  * @param    size        Number of bytes to allocate
  * @param    QRef        Sycl queue reference to use in allocation
  *
  * @return The pointer to USM device memory with requested alignment.
+ * On failure, returns nullptr.
  */
 DPPL_API
 __dppl_give DPPLSyclUSMRef

--- a/backends/source/dppl_sycl_device_interface.cpp
+++ b/backends/source/dppl_sycl_device_interface.cpp
@@ -263,7 +263,7 @@ bool DPPLDevice_IsHostUnifiedMemory (__dppl_keep const DPPLSyclDeviceRef DRef)
 }
 
 bool DPPLDevice_AreEq(__dppl_keep const DPPLSyclDeviceRef DevRef1,
-		      __dppl_keep const DPPLSyclDeviceRef DevRef2)
+                      __dppl_keep const DPPLSyclDeviceRef DevRef2)
 {
     if(!(DevRef1 && DevRef2))
         // \todo handle error

--- a/backends/source/dppl_sycl_device_interface.cpp
+++ b/backends/source/dppl_sycl_device_interface.cpp
@@ -153,3 +153,12 @@ bool DPPLDevice_IsHostUnifiedMemory (__dppl_keep const DPPLSyclDeviceRef DRef)
 {
     return unwrap(DRef)->get_info<info::device::host_unified_memory>();
 }
+
+bool DPPLDevice_AreEq(__dppl_keep const DPPLSyclDeviceRef DevRef1,
+		      __dppl_keep const DPPLSyclDeviceRef DevRef2)
+{
+    if(!(DevRef1 && DevRef2))
+        // \todo handle error
+        return false;
+    return (*unwrap(DevRef1) == *unwrap(DevRef2));
+}

--- a/backends/source/dppl_sycl_platform_interface.cpp
+++ b/backends/source/dppl_sycl_platform_interface.cpp
@@ -41,7 +41,7 @@ get_set_of_non_hostbackends ()
 {
     std::set<DPPLSyclBackendType> be_set;
     for (auto p : platform::get_platforms()) {
-                if(p.is_host())
+        if(p.is_host())
             continue;
         auto be = p.get_backend();
         switch (be)
@@ -155,12 +155,12 @@ void DPPLPlatform_DumpInfo ()
 */
 size_t DPPLPlatform_GetNumNonHostPlatforms ()
 {
-        auto nNonHostPlatforms = 0ul;
-        for (auto &p : platform::get_platforms()) {
-                if (p.is_host())
-                        continue;
-                ++nNonHostPlatforms;
-        }
+    auto nNonHostPlatforms = 0ul;
+    for (auto &p : platform::get_platforms()) {
+        if (p.is_host())
+            continue;
+        ++nNonHostPlatforms;
+    }
     return nNonHostPlatforms;
 }
 

--- a/backends/source/dppl_sycl_platform_interface.cpp
+++ b/backends/source/dppl_sycl_platform_interface.cpp
@@ -41,7 +41,7 @@ get_set_of_non_hostbackends ()
 {
     std::set<DPPLSyclBackendType> be_set;
     for (auto p : platform::get_platforms()) {
-		if(p.is_host())
+                if(p.is_host())
             continue;
         auto be = p.get_backend();
         switch (be)
@@ -155,12 +155,12 @@ void DPPLPlatform_DumpInfo ()
 */
 size_t DPPLPlatform_GetNumNonHostPlatforms ()
 {
-	auto nNonHostPlatforms = 0ul;
-	for (auto &p : platform::get_platforms()) {
-		if (p.is_host())
-			continue;
-		++nNonHostPlatforms;
-	}
+        auto nNonHostPlatforms = 0ul;
+        for (auto &p : platform::get_platforms()) {
+                if (p.is_host())
+                        continue;
+                ++nNonHostPlatforms;
+        }
     return nNonHostPlatforms;
 }
 

--- a/backends/source/dppl_sycl_queue_interface.cpp
+++ b/backends/source/dppl_sycl_queue_interface.cpp
@@ -300,7 +300,7 @@ void DPPLQueue_Memcpy (__dppl_keep const DPPLSyclQueueRef QRef,
 
 void
 DPPLQueue_Prefetch (__dppl_keep DPPLSyclQueueRef QRef,
-		    const void *Ptr, size_t Count)
+                    const void *Ptr, size_t Count)
 {
     auto Q = unwrap(QRef);
     auto event = Q->prefetch(Ptr, Count);
@@ -309,7 +309,7 @@ DPPLQueue_Prefetch (__dppl_keep DPPLSyclQueueRef QRef,
 
 void
 DPPLQueue_MemAdvise (__dppl_keep DPPLSyclQueueRef QRef,
-		     const void *Ptr, size_t Count, int Advice)
+                     const void *Ptr, size_t Count, int Advice)
 {
     auto Q = unwrap(QRef);
     auto event = Q->mem_advise(Ptr, Count, static_cast<pi_mem_advice>(Advice));

--- a/backends/source/dppl_sycl_queue_interface.cpp
+++ b/backends/source/dppl_sycl_queue_interface.cpp
@@ -297,3 +297,21 @@ void DPPLQueue_Memcpy (__dppl_take const DPPLSyclQueueRef QRef,
     auto event = Q->memcpy(Dest, Src, Count);
     event.wait();
 }
+
+void
+DPPLQueue_Prefetch (__dppl_keep DPPLSyclQueueRef QRef,
+		    const void *Ptr, size_t Count)
+{
+    auto Q = unwrap(QRef);
+    auto event = Q->prefetch(Ptr, Count);
+    event.wait();
+}
+
+void
+DPPLQueue_MemAdvise (__dppl_keep DPPLSyclQueueRef QRef,
+		     const void *Ptr, size_t Count, int Advice)
+{
+    auto Q = unwrap(QRef);
+    auto event = Q->mem_advise(Ptr, Count, static_cast<pi_mem_advice>(Advice));
+    event.wait();
+}

--- a/backends/source/dppl_sycl_queue_interface.cpp
+++ b/backends/source/dppl_sycl_queue_interface.cpp
@@ -290,7 +290,7 @@ DPPLQueue_Wait (__dppl_keep DPPLSyclQueueRef QRef)
     SyclQueue->wait();
 }
 
-void DPPLQueue_Memcpy (__dppl_take const DPPLSyclQueueRef QRef,
+void DPPLQueue_Memcpy (__dppl_keep const DPPLSyclQueueRef QRef,
                        void *Dest, const void *Src, size_t Count)
 {
     auto Q = unwrap(QRef);

--- a/backends/source/dppl_sycl_queue_manager.cpp
+++ b/backends/source/dppl_sycl_queue_manager.cpp
@@ -543,7 +543,7 @@ void DPPLQueueMgr_PopQueue ()
  */
 DPPLSyclQueueRef
 DPPLQueueMgr_GetQueueFromContextAndDevice(__dppl_keep DPPLSyclContextRef CRef,
-					  __dppl_keep DPPLSyclDeviceRef DRef)
+                                          __dppl_keep DPPLSyclDeviceRef DRef)
 {
     auto dev = unwrap(DRef);
     auto ctx = unwrap(CRef);

--- a/backends/source/dppl_sycl_queue_manager.cpp
+++ b/backends/source/dppl_sycl_queue_manager.cpp
@@ -547,7 +547,6 @@ DPPLQueueMgr_GetQueueFromContextAndDevice(__dppl_keep DPPLSyclContextRef CRef,
 {
     auto dev = unwrap(DRef);
     auto ctx = unwrap(CRef);
-    auto q = queue(*ctx, *dev);
 
-    return wrap(new queue(q));
+    return wrap(new queue(*ctx, *dev));
 }

--- a/backends/source/dppl_sycl_queue_manager.cpp
+++ b/backends/source/dppl_sycl_queue_manager.cpp
@@ -40,6 +40,8 @@ namespace
 
 // Create wrappers for C Binding types (see CBindingWrapping.h).
 DEFINE_SIMPLE_CONVERSION_FUNCTIONS(queue, DPPLSyclQueueRef)
+DEFINE_SIMPLE_CONVERSION_FUNCTIONS(device, DPPLSyclDeviceRef)
+DEFINE_SIMPLE_CONVERSION_FUNCTIONS(context, DPPLSyclContextRef)
 
 /*!
  * @brief A helper class to support the DPPLSyclQueuemanager.
@@ -533,4 +535,19 @@ DPPLQueueMgr_PushQueue (DPPLSyclBackendType BETy,
 void DPPLQueueMgr_PopQueue ()
 {
     QMgrHelper::popSyclQueue();
+}
+
+/*!
+ * The function constructs a new SYCL queue instance from SYCL conext and
+ * SYCL device.
+ */
+DPPLSyclQueueRef
+DPPLQueueMgr_GetQueueFromContextAndDevice(__dppl_keep DPPLSyclContextRef CRef,
+					  __dppl_keep DPPLSyclDeviceRef DRef)
+{
+    auto dev = unwrap(DRef);
+    auto ctx = unwrap(CRef);
+    auto q = queue(*ctx, *dev);
+
+    return wrap(new queue(q));
 }

--- a/backends/source/dppl_sycl_queue_manager.cpp
+++ b/backends/source/dppl_sycl_queue_manager.cpp
@@ -542,8 +542,8 @@ void DPPLQueueMgr_PopQueue ()
  * SYCL device.
  */
 DPPLSyclQueueRef
-DPPLQueueMgr_GetQueueFromContextAndDevice(__dppl_keep DPPLSyclContextRef CRef,
-                                          __dppl_keep DPPLSyclDeviceRef DRef)
+DPPLQueueMgr_GetQueueFromContextAndDevice (__dppl_keep DPPLSyclContextRef CRef,
+                                           __dppl_keep DPPLSyclDeviceRef DRef)
 {
     auto dev = unwrap(DRef);
     auto ctx = unwrap(CRef);

--- a/backends/source/dppl_sycl_queue_manager.cpp
+++ b/backends/source/dppl_sycl_queue_manager.cpp
@@ -101,7 +101,7 @@ public:
     {
         QVec *active_queues;
         try {
-            auto def_device = std::move(default_selector().select_device());
+            auto def_device { default_selector().select_device() };
             auto BE = def_device.get_platform().get_backend();
             auto DevTy = def_device.get_info<info::device::device_type>();
 

--- a/backends/source/dppl_sycl_usm_interface.cpp
+++ b/backends/source/dppl_sycl_usm_interface.cpp
@@ -130,8 +130,8 @@ DPPLUSM_GetPointerType (__dppl_keep const DPPLSyclUSMRef MRef,
 }
 
 DPPLSyclDeviceRef
-DPPLUSM_GetPointerDevice(__dppl_keep const DPPLSyclUSMRef MRef,
-                         __dppl_keep const DPPLSyclContextRef CRef)
+DPPLUSM_GetPointerDevice (__dppl_keep const DPPLSyclUSMRef MRef,
+                          __dppl_keep const DPPLSyclContextRef CRef)
 {
     auto Ptr = unwrap(MRef);
     auto C = unwrap(CRef);

--- a/backends/source/dppl_sycl_usm_interface.cpp
+++ b/backends/source/dppl_sycl_usm_interface.cpp
@@ -52,7 +52,7 @@ DPPLmalloc_shared (size_t size, __dppl_keep const DPPLSyclQueueRef QRef)
 
 __dppl_give DPPLSyclUSMRef
 DPPLaligned_alloc_shared (size_t alignment, size_t size,
-			  __dppl_keep const DPPLSyclQueueRef QRef)
+                          __dppl_keep const DPPLSyclQueueRef QRef)
 {
     auto Q = unwrap(QRef);
     auto Ptr = aligned_alloc_shared(alignment, size, *Q);
@@ -69,7 +69,7 @@ DPPLmalloc_host (size_t size, __dppl_keep const DPPLSyclQueueRef QRef)
 
 __dppl_give DPPLSyclUSMRef
 DPPLaligned_alloc_host (size_t alignment, size_t size,
-			__dppl_keep const DPPLSyclQueueRef QRef)
+                        __dppl_keep const DPPLSyclQueueRef QRef)
 {
     auto Q = unwrap(QRef);
     auto Ptr = aligned_alloc_host(alignment, size, *Q);
@@ -86,7 +86,7 @@ DPPLmalloc_device (size_t size, __dppl_keep const DPPLSyclQueueRef QRef)
 
 __dppl_give DPPLSyclUSMRef
 DPPLaligned_alloc_device (size_t alignment, size_t size,
-			  __dppl_keep const DPPLSyclQueueRef QRef)
+                          __dppl_keep const DPPLSyclQueueRef QRef)
 {
     auto Q = unwrap(QRef);
     auto Ptr = aligned_alloc_device(alignment, size, *Q);
@@ -131,7 +131,7 @@ DPPLUSM_GetPointerType (__dppl_keep const DPPLSyclUSMRef MRef,
 
 DPPLSyclDeviceRef
 DPPLUSM_GetPointerDevice(__dppl_keep const DPPLSyclUSMRef MRef,
-			 __dppl_keep const DPPLSyclContextRef CRef)
+                         __dppl_keep const DPPLSyclContextRef CRef)
 {
     auto Ptr = unwrap(MRef);
     auto C = unwrap(CRef);

--- a/backends/source/dppl_sycl_usm_interface.cpp
+++ b/backends/source/dppl_sycl_usm_interface.cpp
@@ -25,6 +25,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "dppl_sycl_usm_interface.h"
+#include "dppl_sycl_device_interface.h"
 #include "Support/CBindingWrapping.h"
 
 #include <CL/sycl.hpp>                /* SYCL headers   */
@@ -35,6 +36,7 @@ namespace
 {
 // Create wrappers for C Binding types (see CBindingWrapping.h).
 DEFINE_SIMPLE_CONVERSION_FUNCTIONS(queue, DPPLSyclQueueRef)
+DEFINE_SIMPLE_CONVERSION_FUNCTIONS(device, DPPLSyclDeviceRef)
 DEFINE_SIMPLE_CONVERSION_FUNCTIONS(context, DPPLSyclContextRef)
 DEFINE_SIMPLE_CONVERSION_FUNCTIONS(void, DPPLSyclUSMRef)
 
@@ -125,4 +127,16 @@ DPPLUSM_GetPointerType (__dppl_keep const DPPLSyclUSMRef MRef,
         default:
             return "unknown";
     }
+}
+
+DPPLSyclDeviceRef
+DPPLUSM_GetPointerDevice(__dppl_keep const DPPLSyclUSMRef MRef,
+			 __dppl_keep const DPPLSyclContextRef CRef)
+{
+    auto Ptr = unwrap(MRef);
+    auto C = unwrap(CRef);
+
+    auto Dev = get_pointer_device(Ptr, *C);
+
+    return wrap(new device(Dev));
 }

--- a/backends/source/dppl_sycl_usm_interface.cpp
+++ b/backends/source/dppl_sycl_usm_interface.cpp
@@ -49,6 +49,15 @@ DPPLmalloc_shared (size_t size, __dppl_keep const DPPLSyclQueueRef QRef)
 }
 
 __dppl_give DPPLSyclUSMRef
+DPPLaligned_alloc_shared (size_t alignment, size_t size,
+			  __dppl_keep const DPPLSyclQueueRef QRef)
+{
+    auto Q = unwrap(QRef);
+    auto Ptr = aligned_alloc_shared(alignment, size, *Q);
+    return wrap(Ptr);
+}
+
+__dppl_give DPPLSyclUSMRef
 DPPLmalloc_host (size_t size, __dppl_keep const DPPLSyclQueueRef QRef)
 {
     auto Q = unwrap(QRef);
@@ -57,10 +66,28 @@ DPPLmalloc_host (size_t size, __dppl_keep const DPPLSyclQueueRef QRef)
 }
 
 __dppl_give DPPLSyclUSMRef
+DPPLaligned_alloc_host (size_t alignment, size_t size,
+			__dppl_keep const DPPLSyclQueueRef QRef)
+{
+    auto Q = unwrap(QRef);
+    auto Ptr = aligned_alloc_host(alignment, size, *Q);
+    return wrap(Ptr);
+}
+
+__dppl_give DPPLSyclUSMRef
 DPPLmalloc_device (size_t size, __dppl_keep const DPPLSyclQueueRef QRef)
 {
     auto Q = unwrap(QRef);
     auto Ptr = malloc_device(size, *Q);
+    return wrap(Ptr);
+}
+
+__dppl_give DPPLSyclUSMRef
+DPPLaligned_alloc_device (size_t alignment, size_t size,
+			  __dppl_keep const DPPLSyclQueueRef QRef)
+{
+    auto Q = unwrap(QRef);
+    auto Ptr = aligned_alloc_device(alignment, size, *Q);
     return wrap(Ptr);
 }
 

--- a/backends/tests/CMakeLists.txt
+++ b/backends/tests/CMakeLists.txt
@@ -28,6 +28,7 @@ else()
     test_sycl_program_interface
     test_sycl_queue_interface
     test_sycl_queue_manager
+    test_sycl_usm_interface
   )
 
   # Copy the spir-v input files to test build directory

--- a/backends/tests/test_sycl_queue_manager.cpp
+++ b/backends/tests/test_sycl_queue_manager.cpp
@@ -258,6 +258,7 @@ TEST_F (TestDPPLSyclQueueManager, CreateQueueFromDeviceAndContext)
     EXPECT_TRUE(DPPLContext_AreEq(C, C2));
 
     DPPLQueue_Delete(Q2);
+    DPPLQueue_Delete(Q);
 }
 
 int

--- a/backends/tests/test_sycl_queue_manager.cpp
+++ b/backends/tests/test_sycl_queue_manager.cpp
@@ -244,6 +244,22 @@ TEST_F (TestDPPLSyclQueueManager, CheckIsCurrentQueue2)
     DPPLQueueMgr_PopQueue();
 }
 
+TEST_F (TestDPPLSyclQueueManager, CreateQueueFromDeviceAndContext)
+{
+    auto Q = DPPLQueueMgr_GetCurrentQueue();
+    auto D = DPPLQueue_GetDevice(Q);
+    auto C = DPPLQueue_GetContext(Q);
+
+    auto Q2 = DPPLQueueMgr_GetQueueFromContextAndDevice(C, D);
+    auto D2 = DPPLQueue_GetDevice(Q2);
+    auto C2 = DPPLQueue_GetContext(Q2);
+
+    EXPECT_TRUE(DPPLDevice_AreEq(D, D2));
+    EXPECT_TRUE(DPPLContext_AreEq(C, C2));
+
+    DPPLQueue_Delete(Q2);
+}
+
 int
 main (int argc, char** argv)
 {

--- a/backends/tests/test_sycl_usm_interface.cpp
+++ b/backends/tests/test_sycl_usm_interface.cpp
@@ -56,8 +56,10 @@ bool has_devices ()
     return ret;
 }
 
-void common_test_body(size_t nbytes, const DPPLSyclUSMRef Ptr, const DPPLSyclQueueRef Q, const char *expected) {
-
+void
+common_test_body(size_t nbytes, const DPPLSyclUSMRef Ptr,
+		 const DPPLSyclQueueRef Q, const char *expected)
+{
     auto Ctx = DPPLQueue_GetContext(Q);
 
     auto kind = DPPLUSM_GetPointerType(Ptr, Ctx);
@@ -70,7 +72,7 @@ void common_test_body(size_t nbytes, const DPPLSyclUSMRef Ptr, const DPPLSyclQue
     DPPLQueue_Prefetch(Q, Ptr, nbytes);
 }
     
-}
+} // end of namespace
 
 struct TestDPPLSyclUSMInterface : public ::testing::Test
 {

--- a/backends/tests/test_sycl_usm_interface.cpp
+++ b/backends/tests/test_sycl_usm_interface.cpp
@@ -1,0 +1,181 @@
+//===-------- test_sycl_usm_interface.cpp - dpctl-C_API ---*--- C++ --*--===//
+//
+//               Data Parallel Control Library (dpCtl)
+//
+// Copyright 2020 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// This file has unit test cases for functions defined in
+/// dppl_sycl_usm_interface.h.
+///
+//===----------------------------------------------------------------------===//
+
+#include "dppl_sycl_context_interface.h"
+#include "dppl_sycl_device_interface.h"
+#include "dppl_sycl_event_interface.h"
+#include "dppl_sycl_queue_interface.h"
+#include "dppl_sycl_queue_manager.h"
+#include "dppl_sycl_usm_interface.h"
+#include "Support/CBindingWrapping.h"
+#include <CL/sycl.hpp>
+#include <gtest/gtest.h>
+
+using namespace cl::sycl;
+
+namespace
+{
+constexpr size_t SIZE = 1024;
+
+DEFINE_SIMPLE_CONVERSION_FUNCTIONS(void, DPPLSyclUSMRef);
+
+bool has_devices ()
+{
+    bool ret = false;
+    for (auto &p : platform::get_platforms()) {
+        if (p.is_host())
+            continue;
+        if(!p.get_devices().empty()) {
+            ret = true;
+            break;
+        }
+    }
+    return ret;
+}
+
+void common_test_body(size_t nbytes, const DPPLSyclUSMRef Ptr, const DPPLSyclQueueRef Q, const char *expected) {
+
+    auto Ctx = DPPLQueue_GetContext(Q);
+
+    auto kind = DPPLUSM_GetPointerType(Ptr, Ctx);
+    EXPECT_TRUE(0 == std::strncmp(kind, expected, 4));
+
+    auto Dev = DPPLUSM_GetPointerDevice(Ptr, Ctx);
+    auto QueueDev = DPPLQueue_GetDevice(Q);
+    EXPECT_TRUE(DPPLDevice_AreEq(Dev, QueueDev));
+
+    DPPLQueue_Prefetch(Q, Ptr, nbytes);
+}
+    
+}
+
+struct TestDPPLSyclUSMInterface : public ::testing::Test
+{
+
+    TestDPPLSyclUSMInterface ()
+    {  }
+
+    ~TestDPPLSyclUSMInterface ()
+    {  }
+};
+
+TEST_F(TestDPPLSyclUSMInterface, MallocShared)
+{
+    if (!has_devices())
+	GTEST_SKIP_("Skipping: No Sycl Devices.\n");
+
+    auto Q = DPPLQueueMgr_GetCurrentQueue();
+    const size_t nbytes = 1024;
+
+    auto Ptr = DPPLmalloc_shared(nbytes, Q);
+    EXPECT_TRUE(bool(Ptr));
+
+    common_test_body(nbytes, Ptr, Q, "shared");
+    DPPLfree_with_queue(Ptr, Q);
+}
+
+TEST_F(TestDPPLSyclUSMInterface, MallocDevice)
+{
+    if (!has_devices())
+	GTEST_SKIP_("Skipping: No Sycl Devices.\n");
+
+    auto Q = DPPLQueueMgr_GetCurrentQueue();
+    const size_t nbytes = 1024;
+
+    auto Ptr = DPPLmalloc_device(nbytes, Q);
+    EXPECT_TRUE(bool(Ptr));
+
+    common_test_body(nbytes, Ptr, Q, "device");	
+    DPPLfree_with_queue(Ptr, Q);
+}
+
+TEST_F(TestDPPLSyclUSMInterface, MallocHost)
+{
+    if (!has_devices())
+	GTEST_SKIP_("Skipping: No Sycl Devices.\n");
+
+    auto Q = DPPLQueueMgr_GetCurrentQueue();
+    const size_t nbytes = 1024;
+
+    auto Ptr = DPPLmalloc_host(nbytes, Q);
+    EXPECT_TRUE(bool(Ptr));
+
+    common_test_body(nbytes, Ptr, Q, "host");
+    DPPLfree_with_queue(Ptr, Q);
+}
+
+TEST_F(TestDPPLSyclUSMInterface, AlignedAllocShared)
+{
+    if (!has_devices())
+	GTEST_SKIP_("Skipping: No Sycl Devices.\n");
+
+    auto Q = DPPLQueueMgr_GetCurrentQueue();
+    const size_t nbytes = 1024;
+
+    auto Ptr = DPPLaligned_alloc_shared(64, nbytes, Q);
+    EXPECT_TRUE(bool(Ptr));
+
+    common_test_body(nbytes, Ptr, Q, "shared");
+    DPPLfree_with_queue(Ptr, Q);
+}
+
+TEST_F(TestDPPLSyclUSMInterface, AlignedAllocDevice)
+{
+    if (!has_devices())
+	GTEST_SKIP_("Skipping: No Sycl Devices.\n");
+
+    auto Q = DPPLQueueMgr_GetCurrentQueue();
+    const size_t nbytes = 1024;
+
+    auto Ptr = DPPLaligned_alloc_device(64, nbytes, Q);
+    EXPECT_TRUE(bool(Ptr));
+
+    common_test_body(nbytes, Ptr, Q, "device");
+    DPPLfree_with_queue(Ptr, Q);
+}
+
+TEST_F(TestDPPLSyclUSMInterface, AlignedAllocHost)
+{
+    if (!has_devices())
+	GTEST_SKIP_("Skipping: No Sycl Devices.\n");
+
+    auto Q = DPPLQueueMgr_GetCurrentQueue();
+    const size_t nbytes = 1024;
+
+    auto Ptr = DPPLaligned_alloc_host(64, nbytes, Q);
+    EXPECT_TRUE(bool(Ptr));
+
+    common_test_body(nbytes, Ptr, Q, "host");
+    DPPLfree_with_queue(Ptr, Q);
+}
+
+int
+main (int argc, char** argv)
+{
+    ::testing::InitGoogleTest(&argc, argv);
+    int ret = RUN_ALL_TESTS();
+    return ret;
+}

--- a/backends/tests/test_sycl_usm_interface.cpp
+++ b/backends/tests/test_sycl_usm_interface.cpp
@@ -57,8 +57,8 @@ bool has_devices ()
 }
 
 void
-common_test_body(size_t nbytes, const DPPLSyclUSMRef Ptr,
-		 const DPPLSyclQueueRef Q, const char *expected)
+common_test_body (size_t nbytes, const DPPLSyclUSMRef Ptr,
+		  const DPPLSyclQueueRef Q, const char *expected)
 {
     auto Ctx = DPPLQueue_GetContext(Q);
 
@@ -69,9 +69,11 @@ common_test_body(size_t nbytes, const DPPLSyclUSMRef Ptr,
     auto QueueDev = DPPLQueue_GetDevice(Q);
     EXPECT_TRUE(DPPLDevice_AreEq(Dev, QueueDev));
 
-    DPPLQueue_Prefetch(Q, Ptr, nbytes);
+    EXPECT_NO_FATAL_FAILURE(DPPLQueue_Prefetch(Q, Ptr, nbytes));
+
     DPPLDevice_Delete(QueueDev);
     DPPLDevice_Delete(Dev);
+    DPPLContext_Delete(Ctx);
 }
     
 } // end of namespace
@@ -86,7 +88,7 @@ struct TestDPPLSyclUSMInterface : public ::testing::Test
     {  }
 };
 
-TEST_F(TestDPPLSyclUSMInterface, MallocShared)
+TEST_F (TestDPPLSyclUSMInterface, MallocShared)
 {
     if (!has_devices())
 	GTEST_SKIP_("Skipping: No Sycl Devices.\n");
@@ -102,7 +104,7 @@ TEST_F(TestDPPLSyclUSMInterface, MallocShared)
     DPPLQueue_Delete(Q);
 }
 
-TEST_F(TestDPPLSyclUSMInterface, MallocDevice)
+TEST_F (TestDPPLSyclUSMInterface, MallocDevice)
 {
     if (!has_devices())
 	GTEST_SKIP_("Skipping: No Sycl Devices.\n");
@@ -118,7 +120,7 @@ TEST_F(TestDPPLSyclUSMInterface, MallocDevice)
     DPPLQueue_Delete(Q);
 }
 
-TEST_F(TestDPPLSyclUSMInterface, MallocHost)
+TEST_F (TestDPPLSyclUSMInterface, MallocHost)
 {
     if (!has_devices())
 	GTEST_SKIP_("Skipping: No Sycl Devices.\n");
@@ -134,7 +136,7 @@ TEST_F(TestDPPLSyclUSMInterface, MallocHost)
     DPPLQueue_Delete(Q);
 }
 
-TEST_F(TestDPPLSyclUSMInterface, AlignedAllocShared)
+TEST_F (TestDPPLSyclUSMInterface, AlignedAllocShared)
 {
     if (!has_devices())
 	GTEST_SKIP_("Skipping: No Sycl Devices.\n");
@@ -150,7 +152,7 @@ TEST_F(TestDPPLSyclUSMInterface, AlignedAllocShared)
     DPPLQueue_Delete(Q);
 }
 
-TEST_F(TestDPPLSyclUSMInterface, AlignedAllocDevice)
+TEST_F (TestDPPLSyclUSMInterface, AlignedAllocDevice)
 {
     if (!has_devices())
 	GTEST_SKIP_("Skipping: No Sycl Devices.\n");
@@ -166,7 +168,7 @@ TEST_F(TestDPPLSyclUSMInterface, AlignedAllocDevice)
     DPPLQueue_Delete(Q);
 }
 
-TEST_F(TestDPPLSyclUSMInterface, AlignedAllocHost)
+TEST_F (TestDPPLSyclUSMInterface, AlignedAllocHost)
 {
     if (!has_devices())
 	GTEST_SKIP_("Skipping: No Sycl Devices.\n");

--- a/backends/tests/test_sycl_usm_interface.cpp
+++ b/backends/tests/test_sycl_usm_interface.cpp
@@ -70,7 +70,7 @@ common_test_body(size_t nbytes, const DPPLSyclUSMRef Ptr,
     EXPECT_TRUE(DPPLDevice_AreEq(Dev, QueueDev));
 
     DPPLQueue_Prefetch(Q, Ptr, nbytes);
-    DPPLQueue_Delete(QueueDev);
+    DPPLDevice_Delete(QueueDev);
     DPPLDevice_Delete(Dev);
 }
     

--- a/backends/tests/test_sycl_usm_interface.cpp
+++ b/backends/tests/test_sycl_usm_interface.cpp
@@ -70,6 +70,8 @@ common_test_body(size_t nbytes, const DPPLSyclUSMRef Ptr,
     EXPECT_TRUE(DPPLDevice_AreEq(Dev, QueueDev));
 
     DPPLQueue_Prefetch(Q, Ptr, nbytes);
+    DPPLQueue_Delete(QueueDev);
+    DPPLDevice_Delete(Dev);
 }
     
 } // end of namespace
@@ -97,6 +99,7 @@ TEST_F(TestDPPLSyclUSMInterface, MallocShared)
 
     common_test_body(nbytes, Ptr, Q, "shared");
     DPPLfree_with_queue(Ptr, Q);
+    DPPLQueue_Delete(Q);
 }
 
 TEST_F(TestDPPLSyclUSMInterface, MallocDevice)
@@ -112,6 +115,7 @@ TEST_F(TestDPPLSyclUSMInterface, MallocDevice)
 
     common_test_body(nbytes, Ptr, Q, "device");	
     DPPLfree_with_queue(Ptr, Q);
+    DPPLQueue_Delete(Q);
 }
 
 TEST_F(TestDPPLSyclUSMInterface, MallocHost)
@@ -127,6 +131,7 @@ TEST_F(TestDPPLSyclUSMInterface, MallocHost)
 
     common_test_body(nbytes, Ptr, Q, "host");
     DPPLfree_with_queue(Ptr, Q);
+    DPPLQueue_Delete(Q);
 }
 
 TEST_F(TestDPPLSyclUSMInterface, AlignedAllocShared)
@@ -142,6 +147,7 @@ TEST_F(TestDPPLSyclUSMInterface, AlignedAllocShared)
 
     common_test_body(nbytes, Ptr, Q, "shared");
     DPPLfree_with_queue(Ptr, Q);
+    DPPLQueue_Delete(Q);
 }
 
 TEST_F(TestDPPLSyclUSMInterface, AlignedAllocDevice)
@@ -157,6 +163,7 @@ TEST_F(TestDPPLSyclUSMInterface, AlignedAllocDevice)
 
     common_test_body(nbytes, Ptr, Q, "device");
     DPPLfree_with_queue(Ptr, Q);
+    DPPLQueue_Delete(Q);
 }
 
 TEST_F(TestDPPLSyclUSMInterface, AlignedAllocHost)

--- a/conda-recipe/bld.bat
+++ b/conda-recipe/bld.bat
@@ -1,5 +1,5 @@
 call "%ONEAPI_ROOT%compiler\latest\env\vars.bat"
-IF ERRORLEVEL 1 exit 1
+IF ERRORLEVEL 1 exit /b 1
 REM conda uses %ERRORLEVEL% but FPGA scripts can set it. So it should be reseted.
 set ERRORLEVEL=
 
@@ -21,11 +21,11 @@ cmake -G Ninja ^
     "-DCMAKE_PREFIX_PATH=%LIBRARY_PREFIX%" ^
     "-DDPCPP_ROOT=%DPCPP_ROOT%" ^
     "%SRC_DIR%/backends"
-IF %ERRORLEVEL% NEQ 0 exit 1
+IF %ERRORLEVEL% NEQ 0 exit /b 1
 
 ninja -n
 ninja install
-IF %ERRORLEVEL% NEQ 0 exit 1
+IF %ERRORLEVEL% NEQ 0 exit /b 1
 
 cd ..
 xcopy install\lib\*.lib dpctl /E /Y
@@ -41,4 +41,4 @@ set "DPPL_SYCL_INTERFACE_INCLDIR=dpctl\include"
 
 "%PYTHON%" setup.py clean --all
 "%PYTHON%" setup.py build install
-IF %ERRORLEVEL% NEQ 0 exit 1
+IF %ERRORLEVEL% NEQ 0 exit /b 1

--- a/dpctl/__init__.pxd
+++ b/dpctl/__init__.pxd
@@ -1,4 +1,4 @@
-##===------------- sycl_core.pxd - dpctl module --------*- Cython -*-------===##
+##===------------- __init__.pxd - dpctl module --------*- Cython -*-------===##
 ##
 ##                      Data Parallel Control (dpCtl)
 ##

--- a/dpctl/__init__.pxd
+++ b/dpctl/__init__.pxd
@@ -28,3 +28,5 @@
 # cython: language_level=3
 
 from dpctl._sycl_core cimport *
+from dpctl._memory import *
+

--- a/dpctl/__init__.py
+++ b/dpctl/__init__.py
@@ -1,4 +1,4 @@
-##===----------------- _memory.pyx - dpctl module -------*- Cython -*------===##
+##===----------------- __init__.py - dpctl module -------*- Cython -*------===##
 ##
 ##                      Data Parallel Control (dpCtl)
 ##

--- a/dpctl/__init__.py
+++ b/dpctl/__init__.py
@@ -47,6 +47,7 @@
 __author__ = "Intel Corp."
 
 from ._sycl_core import *
+from ._memory import MemoryUSMShared, MemoryUSMDevice, MemoryUSMHost
 from ._version import get_versions
 
 

--- a/dpctl/__init__.py
+++ b/dpctl/__init__.py
@@ -47,7 +47,6 @@
 __author__ = "Intel Corp."
 
 from ._sycl_core import *
-from ._memory import MemoryUSMShared, MemoryUSMDevice, MemoryUSMHost
 from ._version import get_versions
 
 

--- a/dpctl/_backend.pxd
+++ b/dpctl/_backend.pxd
@@ -219,3 +219,5 @@ cdef extern from "dppl_sycl_usm_interface.h":
                                      DPPLSyclContextRef CRef)
     cdef const char* DPPLUSM_GetPointerType (DPPLSyclUSMRef MRef,
                                              DPPLSyclContextRef CRef)
+    cdef DPPLSyclDeviceRef DPPLUSM_GetPointerDevice (DPPLSyclUSMRef MRef,
+                                                     DPPLSyclContextRef CRef)

--- a/dpctl/_backend.pxd
+++ b/dpctl/_backend.pxd
@@ -210,6 +210,9 @@ cdef extern from "dppl_sycl_queue_manager.h":
                               DPPLSyclDeviceType DeviceTy,
                               size_t DNum
                           )
+    cdef DPPLSyclQueueRef DPPLQueueMgr_GetQueueFromContextAndDevice(
+        DPPLSyclContextRef CRef,
+        DPPLSyclDeviceRef DRef)
 
 
 cdef extern from "dppl_sycl_usm_interface.h":

--- a/dpctl/_backend.pxd
+++ b/dpctl/_backend.pxd
@@ -203,6 +203,12 @@ cdef extern from "dppl_sycl_usm_interface.h":
     cdef DPPLSyclUSMRef DPPLmalloc_shared (size_t size, DPPLSyclQueueRef QRef)
     cdef DPPLSyclUSMRef DPPLmalloc_host (size_t size, DPPLSyclQueueRef QRef)
     cdef DPPLSyclUSMRef DPPLmalloc_device (size_t size, DPPLSyclQueueRef QRef)
+    cdef DPPLSyclUSMRef DPPLaligned_alloc_shared (size_t alignment,
+                                                  size_t size, DPPLSyclQueueRef QRef)
+    cdef DPPLSyclUSMRef DPPLaligned_alloc_host (size_t alignment,
+                                                size_t size, DPPLSyclQueueRef QRef)
+    cdef DPPLSyclUSMRef DPPLaligned_alloc_device (size_t alignment,
+                                                  size_t size, DPPLSyclQueueRef QRef)
     cdef void DPPLfree_with_queue (DPPLSyclUSMRef MRef,
                                    DPPLSyclQueueRef QRef)
     cdef void DPPLfree_with_context (DPPLSyclUSMRef MRef,

--- a/dpctl/_backend.pxd
+++ b/dpctl/_backend.pxd
@@ -177,6 +177,10 @@ cdef extern from "dppl_sycl_queue_interface.h":
     cdef void DPPLQueue_Wait (const DPPLSyclQueueRef QRef)
     cdef void DPPLQueue_Memcpy (const DPPLSyclQueueRef Q,
                                 void *Dest, const void *Src, size_t Count)
+    cdef void DPPLQueue_Prefetch (const DPPLSyclQueueRef Q,
+                                const void *Src, size_t Count)
+    cdef void DPPLQueue_MemAdvise (const DPPLSyclQueueRef Q,
+                                   const void *Src, size_t Count, int Advice)
 
 
 cdef extern from "dppl_sycl_queue_manager.h":

--- a/dpctl/_backend.pxd
+++ b/dpctl/_backend.pxd
@@ -187,7 +187,7 @@ cdef extern from "dppl_sycl_queue_interface.h":
     cdef void DPPLQueue_Memcpy (const DPPLSyclQueueRef Q,
                                 void *Dest, const void *Src, size_t Count)
     cdef void DPPLQueue_Prefetch (const DPPLSyclQueueRef Q,
-                                const void *Src, size_t Count)
+                                  const void *Src, size_t Count)
     cdef void DPPLQueue_MemAdvise (const DPPLSyclQueueRef Q,
                                    const void *Src, size_t Count, int Advice)
 

--- a/dpctl/_memory.pxd
+++ b/dpctl/_memory.pxd
@@ -22,7 +22,7 @@
 # cython: language_level=3
 
 from ._backend cimport DPPLSyclUSMRef
-from ._sycl_core cimport SyclQueue
+from ._sycl_core cimport SyclQueue, SyclDevice, SyclContext
 
 
 cdef class Memory:
@@ -42,6 +42,9 @@ cdef class Memory:
     cpdef copy_from_device(self, object obj)
 
     cpdef bytes tobytes(self)
+
+    @staticmethod
+    cdef SyclDevice get_pointer_device(DPPLSyclUSMRef p, SyclContext ctx)
 
 
 cdef class MemoryUSMShared(Memory):

--- a/dpctl/_memory.pxd
+++ b/dpctl/_memory.pxd
@@ -32,7 +32,8 @@ cdef class Memory:
     cdef object refobj
 
     cdef _cinit_empty(self)
-    cdef _cinit_alloc(self, Py_ssize_t nbytes, bytes ptr_type, SyclQueue queue)
+    cdef _cinit_alloc(self, Py_ssize_t alignment, Py_ssize_t nbytes,
+                      bytes ptr_type, SyclQueue queue)
     cdef _cinit_other(self, object other)
     cdef _getbuffer(self, Py_buffer *buffer, int flags)
 

--- a/dpctl/_memory.pxd
+++ b/dpctl/_memory.pxd
@@ -29,9 +29,18 @@ cdef class Memory:
     cdef DPPLSyclUSMRef memory_ptr
     cdef Py_ssize_t nbytes
     cdef SyclQueue queue
+    cdef object refobj
 
-    cdef _cinit(self, Py_ssize_t nbytes, ptr_type, SyclQueue queue)
+    cdef _cinit_empty(self)
+    cdef _cinit_alloc(self, Py_ssize_t nbytes, bytes ptr_type, SyclQueue queue)
+    cdef _cinit_other(self, object other)
     cdef _getbuffer(self, Py_buffer *buffer, int flags)
+
+    cpdef copy_to_host(self, object obj=*)
+    cpdef copy_from_host(self, object obj)
+    cpdef copy_from_device(self, object obj)
+
+    cpdef bytes tobytes(self)
 
 
 cdef class MemoryUSMShared(Memory):

--- a/dpctl/_memory.pxd
+++ b/dpctl/_memory.pxd
@@ -25,7 +25,7 @@ from ._backend cimport DPPLSyclUSMRef
 from ._sycl_core cimport SyclQueue, SyclDevice, SyclContext
 
 
-cdef class Memory:
+cdef class _Memory:
     cdef DPPLSyclUSMRef memory_ptr
     cdef Py_ssize_t nbytes
     cdef SyclQueue queue
@@ -47,13 +47,13 @@ cdef class Memory:
     cdef SyclDevice get_pointer_device(DPPLSyclUSMRef p, SyclContext ctx)
 
 
-cdef class MemoryUSMShared(Memory):
+cdef class MemoryUSMShared(_Memory):
     pass
 
 
-cdef class MemoryUSMHost(Memory):
+cdef class MemoryUSMHost(_Memory):
     pass
 
 
-cdef class MemoryUSMDevice(Memory):
+cdef class MemoryUSMDevice(_Memory):
     pass

--- a/dpctl/_memory.pyx
+++ b/dpctl/_memory.pyx
@@ -31,32 +31,131 @@
 import dpctl
 from dpctl._backend cimport *
 from ._sycl_core cimport SyclContext, SyclQueue
+from ._sycl_core cimport get_current_queue
 
 from cpython cimport Py_buffer
+from cpython.bytes cimport PyBytes_AS_STRING, PyBytes_FromStringAndSize
+
+import numpy as np
+
+cdef _throw_sycl_usm_ary_iface():
+    raise ValueError("__sycl_usm_array_interface__ is malformed")
+
+
+cdef void copy_via_host(void *dest_ptr, SyclQueue dest_queue,
+                   void *src_ptr, SyclQueue src_queue, size_t nbytes):
+   """
+   Copies `nbytes` bytes from `src_ptr` USM memory to 
+   `dest_ptr` USM memory using host as the intemediary.
+
+   This is useful when `src_ptr` and `dest_ptr` are bound to incompatible
+   SYCL contexts.
+   """
+   cdef unsigned char[::1] host_buf = bytearray(nbytes)
+   
+   DPPLQueue_Memcpy(
+       src_queue.get_queue_ref(),
+       <void *>&host_buf[0],
+       src_ptr,
+       nbytes
+   )
+
+   DPPLQueue_Memcpy(
+       dest_queue.get_queue_ref(),
+       dest_ptr,
+       <void *>&host_buf[0],
+       nbytes
+   )
+
+
+cdef class _BufferData:
+    cdef DPPLSyclUSMRef p
+    cdef int writeable
+    cdef object dt
+    cdef Py_ssize_t itemsize
+    cdef Py_ssize_t nbytes
+    cdef SyclQueue queue
+
+    @staticmethod
+    cdef _BufferData from_sycl_usm_ary_iface(dict ary_iface):
+        cdef object ary_data_tuple = ary_iface.get('data', None)
+        cdef object ary_typestr = ary_iface.get('typestr', None)
+        cdef object ary_shape = ary_iface.get('shape', None)
+        cdef object ary_strides = ary_iface.get('strides', None)
+        cdef object ary_syclobj = ary_iface.get('syclobj', None)
+        cdef Py_ssize_t ary_offset = ary_iface.get('offset', 0)
+        cdef int ary_version = ary_iface.get('version', 0)
+        cdef object dt
+        cdef _BufferData buf
+        cdef Py_ssize_t arr_data_ptr
+
+        if ary_version != 1:
+            _throw_sycl_usm_ary_iface()
+        if not ary_data_tuple or len(ary_data_tuple) != 2:
+            _throw_sycl_usm_ary_iface()
+        if not ary_shape or len(ary_shape) != 1 or ary_shape[0] < 1:
+            raise ValueError
+        try:
+            dt = np.dtype(ary_typestr)
+        except TypeError:
+            _throw_sycl_usm_ary_iface()
+        if ary_strides and len(ary_strides) != dt.itemsize:
+            raise ValueError("Must be contiguous")
+
+        if not ary_syclobj or not isinstance(ary_syclobj,
+                                             (dpctl.SyclQueue, dpctl.SyclContext)):
+            _throw_sycl_usm_ary_iface()
+
+        buf = _BufferData.__new__(_BufferData)
+        arr_data_ptr = <Py_ssize_t>ary_data_tuple[0]
+        buf.p = <DPPLSyclUSMRef>(<void*>arr_data_ptr)
+        buf.writeable = 1 if ary_data_tuple[1] else 0
+        buf.itemsize = <Py_ssize_t>(dt.itemsize)
+        buf.nbytes = (<Py_ssize_t>ary_shape[0]) * buf.itemsize
+
+        if isinstance(ary_syclobj, dpctl.SyclQueue):
+            buf.queue = <SyclQueue>ary_syclobj
+        else:
+            # FIXME: need a way to construct a queue from 
+            buf.queue = get_current_queue()
+
+        return buf
+
+
+def _to_memory(unsigned char [::1] b):
+    """Constructs Memory of the same size as the argument and 
+    copies data into it"""
+    cdef Memory res = MemoryUSMShared(len(b))
+    res.copy_from_host(b)
+
+    return res
 
 
 cdef class Memory:
-
-    cdef _cinit(self, Py_ssize_t nbytes, ptr_type, SyclQueue queue):
-        cdef DPPLSyclUSMRef p
-
+    cdef _cinit_empty(self):
         self.memory_ptr = NULL
         self.nbytes = 0
         self.queue = None
+        self.refobj = None        
+
+    cdef _cinit_alloc(self, Py_ssize_t nbytes, bytes ptr_type, SyclQueue queue):
+        cdef DPPLSyclUSMRef p
+
+        self._cinit_empty()
 
         if (nbytes > 0):
             if queue is None:
-                queue = dpctl.get_current_queue()
+                queue = get_current_queue()
 
-            if (ptr_type == "shared"):
+            if (ptr_type == b"shared"):
                 p = DPPLmalloc_shared(nbytes, queue.get_queue_ref())
-            elif (ptr_type == "host"):
+            elif (ptr_type == b"host"):
                 p = DPPLmalloc_host(nbytes, queue.get_queue_ref())
-            elif (ptr_type == "device"):
+            elif (ptr_type == b"device"):
                 p = DPPLmalloc_device(nbytes, queue.get_queue_ref())
             else:
                 raise RuntimeError("Pointer type is unknown: {}" \
-                    .format(ptr_type))
+                    .format(ptr_type.decode("UTF-8")))
 
             if (p):
                 self.memory_ptr = p
@@ -67,13 +166,32 @@ cdef class Memory:
         else:
             raise ValueError("Non-positive number of bytes found.")
 
+    cdef _cinit_other(self, object other):
+        if hasattr(other, '__sycl_usm_array_interface__'):
+            other_iface = other.__sycl_usm_array_interface__
+            if isinstance(other_iface, dict):
+                other_buf = _BufferData.from_sycl_usm_ary_iface(other_iface)
+                self.memory_ptr = other_buf.p
+                self.nbytes = other_buf.nbytes
+                self.queue = other_buf.queue
+                # self.writeable = other_buf.writeable
+                self.refobj = other
+            else:
+                raise ValueError(
+                    "Argument {} does not correctly expose"
+                    "`__sycl_usm_array_interface__`.".format(other)
+                )
+        else:
+            raise ValueError(
+                "Argument {} does not expose "
+                "`__sycl_usm_array_interface__`.".format(other)                
+            )
+
     def __dealloc__(self):
-        if (self.memory_ptr):
+        if (self.refobj is None and self.memory_ptr):
             DPPLfree_with_queue(self.memory_ptr,
                                 self.queue.get_queue_ref())
-        self.memory_ptr = NULL
-        self.nbytes = 0
-        self.queue = None
+        self._cinit_empty()
 
     cdef _getbuffer(self, Py_buffer *buffer, int flags):
         # memory_ptr is Ref which is pointer to SYCL type. For USM it is void*.
@@ -93,6 +211,10 @@ cdef class Memory:
         def __get__(self):
             return self.nbytes
 
+    property size:
+        def __get__(self):
+            return self.nbytes
+
     property _pointer:
         def __get__(self):
             return <size_t>(self.memory_ptr)
@@ -105,11 +227,40 @@ cdef class Memory:
         def __get__(self):
             return self.queue
 
+    property reference_obj:
+        def __get__(self):
+            return self.refobj
+
     def __repr__(self):
         return "<Intel(R) USM allocated memory block of {} bytes at {}>" \
             .format(self.nbytes, hex(<object>(<Py_ssize_t>self.memory_ptr)))
 
-    def _usm_type(self, syclobj=None):
+    def __len__(self):
+        return self.nbytes
+
+    def __sizeof__(self):
+        return self.nbytes
+
+    def __bytes__(self):
+        return self.tobytes()
+
+    def __reduce__(self):
+        return _to_memory, (self.copy_to_host(), )
+    
+    property __sycl_usm_array_interface__:
+        def __get__ (self):
+            cdef dict iface = {
+                "data": (<Py_ssize_t>(<void *>self.memory_ptr),
+                         True), # bool(self.writeable)),
+                "shape": (self.nbytes,),
+                "strides": None,
+                "typestr": "|u1",
+                "version": 1,
+                "syclobj": self.queue
+            }
+            return iface
+
+    def get_usm_type(self, syclobj=None):
         cdef const char* kind
         cdef SyclContext ctx
         cdef SyclQueue q
@@ -131,11 +282,99 @@ cdef class Memory:
                              "or an instance of SyclConext or SyclQueue")
         return kind.decode('UTF-8')
 
+    cpdef copy_to_host (self, obj=None):
+        """Copy content of instance's memory into memory of 
+        `obj`, or allocate NumPy array of obj is None"""
+        # Cython does the right thing here
+        cdef unsigned char[::1] host_buf = obj
+
+        if (host_buf is None):
+            # Python object did not have buffer interface
+            # allocate new memory
+            obj = np.empty((self.nbytes,), dtype="|u1")
+            host_buf = obj
+        elif (<Py_ssize_t>len(host_buf) < self.nbytes):
+            raise ValueError("Destination object is too small to "
+                             "accommodate {} bytes".format(self.nbytes))
+        # call kernel to copy from
+        DPPLQueue_Memcpy(
+            self.queue.get_queue_ref(),
+            <void *>&host_buf[0],     # destination
+            <void *>self.memory_ptr,  # source
+            <size_t>self.nbytes
+        )
+
+        return obj
+
+    cpdef copy_from_host (self, object obj):
+        """Copy contant of Python buffer provided by `obj` to instance memory."""
+        cdef const unsigned char[::1] host_buf = obj
+        cdef Py_ssize_t buf_len = len(host_buf)
+
+        if (buf_len > self.nbytes):
+            raise ValueError("Source object is too large to be "
+                             "accommodated in {} bytes buffer".format(self.nbytes))
+        # call kernel to copy from
+        DPPLQueue_Memcpy(
+            self.queue.get_queue_ref(),
+            <void *>self.memory_ptr,  # destination
+            <void *>&host_buf[0],     # source
+            <size_t>buf_len
+        )
+
+    cpdef copy_from_device (self, object sycl_usm_ary):
+        """Copy SYCL memory underlying the argument object into 
+        the memory of the instance"""
+        cdef _BufferData src_buf
+        cdef const char* kind
+    
+        if not hasattr(sycl_usm_ary, '__sycl_usm_array_interface__'):
+            raise ValueError("Object does not implement "
+                             "`__sycl_usm_array_interface__` protocol")
+        sycl_usm_ary_iface = sycl_usm_ary.__sycl_usm_array_interface__
+        if isinstance(sycl_usm_ary_iface, dict):
+            src_buf = _BufferData.from_sycl_usm_ary_iface(sycl_usm_ary_iface)
+
+            if (src_buf.nbytes > self.nbytes):
+                raise ValueError("Source object is too large to "
+                                 "be accommondated in {} bytes buffer".format(self.nbytes))
+            kind = DPPLUSM_GetPointerType(
+                src_buf.p, self.queue.get_sycl_context().get_context_ref())
+            if (kind == b'unknown'):
+                copy_via_host(
+                    <void *>self.memory_ptr, self.queue,  # dest
+                    <void *>src_buf.p, src_buf.queue,     # src
+                    <size_t>src_buf.nbytes
+                )
+            else:
+                DPPLQueue_Memcpy(
+                    self.queue.get_queue_ref(),
+                    <void *>self.memory_ptr,
+                    <void *>src_buf.p,
+                    <size_t>src_buf.nbytes
+                )
+        else:
+            raise TypeError
+    
+    cpdef bytes tobytes (self):
+        """"""
+        cdef Py_ssize_t nb = self.nbytes
+        cdef bytes b = PyBytes_FromStringAndSize(NULL, nb)
+        # convert bytes to memory view
+        cdef unsigned char* ptr = <unsigned char*>PyBytes_AS_STRING(b)
+        # string is null terminated
+        cdef unsigned char[::1] mv = (<unsigned char[:(nb + 1):1]>ptr)[:nb]
+        self.copy_to_host(mv) # output is discarded
+        return b
+
 
 cdef class MemoryUSMShared(Memory):
 
-    def __cinit__(self, Py_ssize_t nbytes, SyclQueue queue=None):
-        self._cinit(nbytes, "shared", queue)
+    def __cinit__(self, other,  SyclQueue queue=None):
+        if isinstance(other, int):
+            self._cinit_alloc(<Py_ssize_t>other, b"shared", queue)
+        else:
+            self._cinit_other(other)
 
     def __getbuffer__(self, Py_buffer *buffer, int flags):
         self._getbuffer(buffer, flags)
@@ -143,8 +382,11 @@ cdef class MemoryUSMShared(Memory):
 
 cdef class MemoryUSMHost(Memory):
 
-    def __cinit__(self, Py_ssize_t nbytes, SyclQueue queue=None):
-        self._cinit(nbytes, "host", queue)
+    def __cinit__(self, other, SyclQueue queue=None):
+        if isinstance(other, int):
+            self._cinit_alloc(<Py_ssize_t>other, b"host", queue)
+        else:
+            self._cinit_other(other)
 
     def __getbuffer__(self, Py_buffer *buffer, int flags):
         self._getbuffer(buffer, flags)
@@ -152,5 +394,8 @@ cdef class MemoryUSMHost(Memory):
 
 cdef class MemoryUSMDevice(Memory):
 
-    def __cinit__(self, Py_ssize_t nbytes, SyclQueue queue=None):
-        self._cinit(nbytes, "device", queue)
+    def __cinit__(self, other, SyclQueue queue=None):
+        if isinstance(other, int):
+            self._cinit_alloc(<Py_ssize_t>other, b"device", queue)
+        else:
+            self._cinit_other(other)

--- a/dpctl/_memory.pyx
+++ b/dpctl/_memory.pyx
@@ -94,6 +94,7 @@ cdef class _BufferData:
         cdef _BufferData buf
         cdef Py_ssize_t arr_data_ptr
         cdef SyclDevice dev
+        cdef SyclContext ctx
 
         if ary_version != 1:
             _throw_sycl_usm_ary_iface()
@@ -128,8 +129,9 @@ cdef class _BufferData:
             # 
             # cdef SyclQueue new_queue = SyclQueue._create_from_dev_context(dev, <SyclContext> ary_syclobj)
             # buf.queue = new_queue
-            dev = Memory.get_pointer_device(buf.p, <SyclContext> ary_syclobj)
-            buf.queue = get_current_queue()
+            ctx = <SyclContext> ary_syclobj
+            dev = Memory.get_pointer_device(buf.p, ctx)
+            buf.queue = SyclQueue._create_from_context_and_device(ctx, dev)
 
         return buf
 

--- a/dpctl/_memory.pyx
+++ b/dpctl/_memory.pyx
@@ -121,7 +121,12 @@ cdef class _BufferData:
         if isinstance(ary_syclobj, dpctl.SyclQueue):
             buf.queue = <SyclQueue>ary_syclobj
         else:
-            # FIXME: need a way to construct a queue from 
+            # FIXME: need a way to construct a queue from
+            # context and device, which can be obtaine from the
+            # pointer and the context.
+            # cdef SyclDevice dev = DPPLget_pointer_device(arr_data_ptr, <SyclContext> ary_syclobj)
+            # cdef SyclQueue new_queue = SyclQueue._create_from_dev_context(dev, <SyclContext> ary_syclobj)
+            # buf.queue = new_queue
             buf.queue = get_current_queue()
 
         return buf

--- a/dpctl/_memory.pyx
+++ b/dpctl/_memory.pyx
@@ -431,14 +431,14 @@ cdef class Memory:
 
 cdef class MemoryUSMShared(Memory):
     """
-    MemoryUSMShared(nbytes, alignment=0, queue=None, copy=False) allocates nbytes of 
+    MemoryUSMShared(nbytes, alignment=0, queue=None, copy=False) allocates nbytes of
     USM shared memory.
 
     Non-positive alignments are not used (malloc_shared is used instead).
     The queue=None the current `dpctl.get_current_queue()` is used to allocate memory.
 
-    MemoryUSMShared(usm_obj) constructor create instance from `usm_obj` expected to 
-    implement `__sycl_usm_array_interface__` protocol and exposing a contiguous block of 
+    MemoryUSMShared(usm_obj) constructor create instance from `usm_obj` expected to
+    implement `__sycl_usm_array_interface__` protocol and exposing a contiguous block of
     USM memory of USM shared type. Using copy=True to perform a copy if USM type is other
     than 'shared'.
     """
@@ -463,14 +463,14 @@ cdef class MemoryUSMShared(Memory):
 
 cdef class MemoryUSMHost(Memory):
     """
-    MemoryUSMHost(nbytes, alignment=0, queue=None, copy=False) allocates nbytes of 
+    MemoryUSMHost(nbytes, alignment=0, queue=None, copy=False) allocates nbytes of
     USM host memory.
 
     Non-positive alignments are not used (malloc_host is used instead).
     The queue=None the current `dpctl.get_current_queue()` is used to allocate memory.
 
-    MemoryUSMDevice(usm_obj) constructor create instance from `usm_obj` expected to 
-    implement `__sycl_usm_array_interface__` protocol and exposing a contiguous block of 
+    MemoryUSMDevice(usm_obj) constructor create instance from `usm_obj` expected to
+    implement `__sycl_usm_array_interface__` protocol and exposing a contiguous block of
     USM memory of USM host type. Using copy=True to perform a copy if USM type is other
     than 'host'.
     """
@@ -495,14 +495,14 @@ cdef class MemoryUSMHost(Memory):
 
 cdef class MemoryUSMDevice(Memory):
     """
-    MemoryUSMDevice(nbytes, alignment=0, queue=None, copy=False) allocates nbytes of 
+    MemoryUSMDevice(nbytes, alignment=0, queue=None, copy=False) allocates nbytes of
     USM device memory.
 
     Non-positive alignments are not used (malloc_device is used instead).
     The queue=None the current `dpctl.get_current_queue()` is used to allocate memory.
 
-    MemoryUSMDevice(usm_obj) constructor create instance from `usm_obj` expected to 
-    implement `__sycl_usm_array_interface__` protocol and exposing a contiguous block of 
+    MemoryUSMDevice(usm_obj) constructor create instance from `usm_obj` expected to
+    implement `__sycl_usm_array_interface__` protocol and exposing a contiguous block of
     USM memory of USM device type. Using copy=True to perform a copy if USM type is other
     than 'device'.
     """

--- a/dpctl/_memory.pyx
+++ b/dpctl/_memory.pyx
@@ -106,11 +106,13 @@ cdef class _BufferData:
             dt = np.dtype(ary_typestr)
         except TypeError:
             _throw_sycl_usm_ary_iface()
-        if ary_strides and len(ary_strides) != dt.itemsize:
+        if (ary_strides and len(ary_strides) != 1
+            and ary_strides[0] != dt.itemsize):
             raise ValueError("Must be contiguous")
 
-        if not ary_syclobj or not isinstance(ary_syclobj,
-                                             (dpctl.SyclQueue, dpctl.SyclContext)):
+        if (not ary_syclobj or
+            not isinstance(ary_syclobj,
+                           (dpctl.SyclQueue, dpctl.SyclContext))):
             _throw_sycl_usm_ary_iface()
 
         buf = _BufferData.__new__(_BufferData)

--- a/dpctl/_memory.pyx
+++ b/dpctl/_memory.pyx
@@ -204,7 +204,17 @@ cdef class Memory:
             raise ValueError("Non-positive number of bytes found.")
 
     cdef _cinit_other(self, object other):
-        if hasattr(other, '__sycl_usm_array_interface__'):
+        cdef Memory other_mem
+        if isinstance(other, Memory):
+            other_mem = <Memory> other
+            self.memory_ptr = other_mem.memory_ptr
+            self.nbytes = other_mem.nbytes
+            self.queue = other_mem.queue
+            if other_mem.refobj is None:
+                self.refobj = other
+            else:
+                self.refobj = other_mem.refobj
+        elif hasattr(other, '__sycl_usm_array_interface__'):
             other_iface = other.__sycl_usm_array_interface__
             if isinstance(other_iface, dict):
                 other_buf = _BufferData.from_sycl_usm_ary_iface(other_iface)

--- a/dpctl/_memory.pyx
+++ b/dpctl/_memory.pyx
@@ -244,6 +244,12 @@ cdef class Memory:
 
     cdef _getbuffer(self, Py_buffer *buffer, int flags):
         # memory_ptr is Ref which is pointer to SYCL type. For USM it is void*.
+        cdef SyclContext ctx = self._context
+        cdef const char * kind = DPPLUSM_GetPointerType(
+            self.memory_ptr,
+            ctx.get_context_ref())
+        if kind == b'device':
+            raise ValueError('USM Device memory is not host accessible')
         buffer.buf = <char *>self.memory_ptr
         buffer.format = 'B'                     # byte
         buffer.internal = NULL                  # see References

--- a/dpctl/_memory.pyx
+++ b/dpctl/_memory.pyx
@@ -127,7 +127,7 @@ cdef class _BufferData:
         else:
             # Obtain device from pointer and context
             ctx = <SyclContext> ary_syclobj
-            dev = Memory.get_pointer_device(buf.p, ctx)
+            dev = _Memory.get_pointer_device(buf.p, ctx)
             # Use context and device to create a queue to
             # be able to copy memory
             buf.queue = SyclQueue._create_from_context_and_device(ctx, dev)
@@ -139,7 +139,7 @@ def _to_memory(unsigned char [::1] b, str usm_kind):
     """
     Constructs Memory of the same size as the argument 
     and copies data into it"""
-    cdef Memory res
+    cdef _Memory res
 
     if (usm_kind == "shared"):
         res = MemoryUSMShared(len(b))
@@ -156,7 +156,7 @@ def _to_memory(unsigned char [::1] b, str usm_kind):
     return res
 
 
-cdef class Memory:
+cdef class _Memory:
     cdef _cinit_empty(self):
         self.memory_ptr = NULL
         self.nbytes = 0
@@ -205,9 +205,9 @@ cdef class Memory:
             raise ValueError("Non-positive number of bytes found.")
 
     cdef _cinit_other(self, object other):
-        cdef Memory other_mem
-        if isinstance(other, Memory):
-            other_mem = <Memory> other
+        cdef _Memory other_mem
+        if isinstance(other, _Memory):
+            other_mem = <_Memory> other
             self.memory_ptr = other_mem.memory_ptr
             self.nbytes = other_mem.nbytes
             self.queue = other_mem.queue
@@ -428,7 +428,7 @@ cdef class Memory:
         return SyclDevice._create(dref)
 
 
-cdef class MemoryUSMShared(Memory):
+cdef class MemoryUSMShared(_Memory):
     """
     MemoryUSMShared(nbytes, alignment=0, queue=None, copy=False) allocates nbytes of
     USM shared memory.
@@ -460,7 +460,7 @@ cdef class MemoryUSMShared(Memory):
         self._getbuffer(buffer, flags)
 
 
-cdef class MemoryUSMHost(Memory):
+cdef class MemoryUSMHost(_Memory):
     """
     MemoryUSMHost(nbytes, alignment=0, queue=None, copy=False) allocates nbytes of
     USM host memory.
@@ -492,7 +492,7 @@ cdef class MemoryUSMHost(Memory):
         self._getbuffer(buffer, flags)
 
 
-cdef class MemoryUSMDevice(Memory):
+cdef class MemoryUSMDevice(_Memory):
     """
     MemoryUSMDevice(nbytes, alignment=0, queue=None, copy=False) allocates nbytes of
     USM device memory.

--- a/dpctl/_memory.pyx
+++ b/dpctl/_memory.pyx
@@ -123,14 +123,11 @@ cdef class _BufferData:
         if isinstance(ary_syclobj, dpctl.SyclQueue):
             buf.queue = <SyclQueue>ary_syclobj
         else:
-            # FIXME: need a way to construct a queue from
-            # context and device, which can be obtaine from the
-            # pointer and the context.
-            # 
-            # cdef SyclQueue new_queue = SyclQueue._create_from_dev_context(dev, <SyclContext> ary_syclobj)
-            # buf.queue = new_queue
+            # Obtain device from pointer and context
             ctx = <SyclContext> ary_syclobj
             dev = Memory.get_pointer_device(buf.p, ctx)
+            # Use context and device to create a queue to
+            # be able to copy memory
             buf.queue = SyclQueue._create_from_context_and_device(ctx, dev)
 
         return buf

--- a/dpctl/_memory.pyx
+++ b/dpctl/_memory.pyx
@@ -51,8 +51,8 @@ cdef void copy_via_host(void *dest_ptr, SyclQueue dest_queue,
    This is useful when `src_ptr` and `dest_ptr` are bound to incompatible
    SYCL contexts.
    """
-   # could also use numpy.empty((nbytes,), dtype="|u1")
-   cdef unsigned char[::1] host_buf = bytearray(nbytes)
+   # could also have used bytearray(nbytes)
+   cdef unsigned char[::1] host_buf = np.empty((nbytes,), dtype="|u1")
    
    DPPLQueue_Memcpy(
        src_queue.get_queue_ref(),

--- a/dpctl/_sycl_core.pxd
+++ b/dpctl/_sycl_core.pxd
@@ -128,6 +128,8 @@ cdef class SyclQueue:
 
     @staticmethod
     cdef  SyclQueue _create (DPPLSyclQueueRef qref)
+    @staticmethod
+    cdef  SyclQueue _create_from_context_and_device (SyclContext ctx, SyclDevice dev)
     cpdef bool equals (self, SyclQueue q)
     cpdef SyclContext get_sycl_context (self)
     cpdef SyclDevice get_sycl_device (self)

--- a/dpctl/_sycl_core.pxd
+++ b/dpctl/_sycl_core.pxd
@@ -117,7 +117,9 @@ cdef class SyclQueue:
                             list lS=*, list dEvents=*)
     cpdef void wait (self)
     cdef DPPLSyclQueueRef get_queue_ref (self)
-    cpdef memcpy (self, dest, src, int count)
+    cpdef memcpy (self, dest, src, size_t count)
+    cpdef prefetch (self, ptr, size_t count=*)
+    cpdef mem_advise (self, ptr, size_t count, int mem)
 
 
 cpdef SyclQueue get_current_queue()

--- a/dpctl/_sycl_core.pyx
+++ b/dpctl/_sycl_core.pyx
@@ -30,7 +30,7 @@ from __future__ import print_function
 from enum import Enum, auto
 import logging
 from ._backend cimport *
-from ._memory cimport _Memory
+from .memory._memory cimport _Memory
 from libc.stdlib cimport malloc, free
 
 

--- a/dpctl/_sycl_core.pyx
+++ b/dpctl/_sycl_core.pyx
@@ -373,6 +373,21 @@ cdef class SyclQueue:
         ret._queue_ref = qref
         return ret
 
+    @staticmethod
+    cdef SyclQueue _create_from_context_and_device(SyclContext ctx, SyclDevice dev):
+        cdef SyclQueue ret = SyclQueue.__new__(SyclQueue)
+        cdef DPPLSyclContextRef cref = ctx.get_context_ref()
+        cdef DPPLSyclDeviceRef dref = dev.get_device_ref()
+        cdef DPPLSyclQueueRef qref = DPPLQueueMgr_GetQueueFromContextAndDevice(
+            cref, dref)
+
+        if qref is NULL:
+            raise SyclQueueCreationError("Queue creation failed.")
+        ret._queue_ref = qref
+        ret._context = ctx
+        ret._device = dev
+        return ret
+    
     def __dealloc__ (self):
         DPPLQueue_Delete(self._queue_ref)
 

--- a/dpctl/_sycl_core.pyx
+++ b/dpctl/_sycl_core.pyx
@@ -541,21 +541,47 @@ cdef class SyclQueue:
     cpdef void wait (self):
         DPPLQueue_Wait(self._queue_ref)
 
-    cpdef memcpy (self, dest, src, int count):
+    cpdef memcpy (self, dest, src, size_t count):
         cdef void *c_dest
         cdef void *c_src
 
         if isinstance(dest, Memory):
             c_dest = <void*>(<Memory>dest).memory_ptr
         else:
-            raise TypeError("Parameter dest should be Memory.")
+            raise TypeError("Parameter dest should have type Memory.")
 
         if isinstance(src, Memory):
             c_src = <void*>(<Memory>src).memory_ptr
         else:
-            raise TypeError("Parameter src should be Memory.")
+            raise TypeError("Parameter src should have type Memory.")
 
         DPPLQueue_Memcpy(self._queue_ref, c_dest, c_src, count)
+
+    cpdef prefetch (self, mem, size_t count=0):
+       cdef void *ptr
+
+       if isinstance(mem, Memory):
+           ptr = <void*>(<Memory>mem).memory_ptr
+       else:
+           raise TypeError("Parameter mem should have type Memory")
+
+       if (count <=0 or count > self.nbytes):
+           count = self.nbytes
+
+       DPPLQueue_Prefetch(self._queue_ref, ptr, count)
+
+    cpdef mem_advise (self, mem, size_t count, int advice):
+       cdef void *ptr
+
+       if isinstance(mem, Memory):
+           ptr = <void*>(<Memory>mem).memory_ptr
+       else:
+           raise TypeError("Parameter mem should have type Memory")
+
+       if (count <=0 or count > self.nbytes):
+           count = self.nbytes
+
+       DPPLQueue_MemAdvise(self._queue_ref, ptr, count, advice)
 
 
 cdef class _SyclRTManager:

--- a/dpctl/_sycl_core.pyx
+++ b/dpctl/_sycl_core.pyx
@@ -30,7 +30,7 @@ from __future__ import print_function
 from enum import Enum, auto
 import logging
 from ._backend cimport *
-from ._memory cimport Memory
+from ._memory cimport _Memory
 from libc.stdlib cimport malloc, free
 
 
@@ -445,7 +445,7 @@ cdef class SyclQueue:
             elif isinstance(arg, ctypes.c_double):
                 kargs[idx] = <void*><size_t>(ctypes.addressof(arg))
                 kargty[idx] = _arg_data_type._DOUBLE
-            elif isinstance(arg, Memory):
+            elif isinstance(arg, _Memory):
                 kargs[idx]= <void*>(<size_t>arg._pointer)
                 kargty[idx] = _arg_data_type._VOID_PTR
             else:
@@ -620,25 +620,25 @@ cdef class SyclQueue:
         cdef void *c_dest
         cdef void *c_src
 
-        if isinstance(dest, Memory):
-            c_dest = <void*>(<Memory>dest).memory_ptr
+        if isinstance(dest, _Memory):
+            c_dest = <void*>(<_Memory>dest).memory_ptr
         else:
-            raise TypeError("Parameter dest should have type Memory.")
+            raise TypeError("Parameter `dest` should have type _Memory.")
 
-        if isinstance(src, Memory):
-            c_src = <void*>(<Memory>src).memory_ptr
+        if isinstance(src, _Memory):
+            c_src = <void*>(<_Memory>src).memory_ptr
         else:
-            raise TypeError("Parameter src should have type Memory.")
+            raise TypeError("Parameter `src` should have type _Memory.")
 
         DPPLQueue_Memcpy(self._queue_ref, c_dest, c_src, count)
 
     cpdef prefetch (self, mem, size_t count=0):
        cdef void *ptr
 
-       if isinstance(mem, Memory):
-           ptr = <void*>(<Memory>mem).memory_ptr
+       if isinstance(mem, _Memory):
+           ptr = <void*>(<_Memory>mem).memory_ptr
        else:
-           raise TypeError("Parameter mem should have type Memory")
+           raise TypeError("Parameter `mem` should have type _Memory")
 
        if (count <=0 or count > self.nbytes):
            count = self.nbytes
@@ -648,10 +648,10 @@ cdef class SyclQueue:
     cpdef mem_advise (self, mem, size_t count, int advice):
        cdef void *ptr
 
-       if isinstance(mem, Memory):
-           ptr = <void*>(<Memory>mem).memory_ptr
+       if isinstance(mem, _Memory):
+           ptr = <void*>(<_Memory>mem).memory_ptr
        else:
-           raise TypeError("Parameter mem should have type Memory")
+           raise TypeError("Parameter `mem` should have type _Memory")
 
        if (count <=0 or count > self.nbytes):
            count = self.nbytes

--- a/dpctl/memory.py
+++ b/dpctl/memory.py
@@ -1,3 +1,0 @@
-from ._memory import MemoryUSMShared, MemoryUSMDevice, MemoryUSMHost
-
-__all__ = ["MemoryUSMShared", "MemoryUSMDevice", "MemoryUSMHost"]

--- a/dpctl/memory.py
+++ b/dpctl/memory.py
@@ -1,0 +1,3 @@
+from ._memory import MemoryUSMShared, MemoryUSMDevice, MemoryUSMHost
+
+__all__ = ["MemoryUSMShared", "MemoryUSMDevice", "MemoryUSMHost"]

--- a/dpctl/memory/__init__.pxd
+++ b/dpctl/memory/__init__.pxd
@@ -1,0 +1,30 @@
+##===------------- __init__.pxd - dpctl module --------*- Cython -*-------===##
+##
+##                      Data Parallel Control (dpCtl)
+##
+## Copyright 2020 Intel Corporation
+##
+## Licensed under the Apache License, Version 2.0 (the "License");
+## you may not use this file except in compliance with the License.
+## You may obtain a copy of the License at
+##
+##    http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+##
+##===----------------------------------------------------------------------===##
+##
+## \file
+## This file declares the extension types and functions for the Cython API
+## implemented in sycl_core.pyx.
+##
+##===----------------------------------------------------------------------===##
+
+# distutils: language = c++
+# cython: language_level=3
+
+from ._memory cimport *

--- a/dpctl/memory/__init__.py
+++ b/dpctl/memory/__init__.py
@@ -1,0 +1,41 @@
+##===---------- memory/__init__.py - dpctl module -------*- Python -*------===##
+##
+##                      Data Parallel Control (dpCtl)
+##
+## Copyright 2020 Intel Corporation
+##
+## Licensed under the Apache License, Version 2.0 (the "License");
+## you may not use this file except in compliance with the License.
+## You may obtain a copy of the License at
+##
+##    http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+##
+##===----------------------------------------------------------------------===##
+##
+## \file
+## This top-level dpctl module.
+##
+##===----------------------------------------------------------------------===##
+"""
+    Data Parallel Control Memory
+
+    `dpctl.memory` provides Python objects for untyped USM memory 
+    container of bytes for each kind of USM pointers: shared pointers,
+    device pointers and host pointers.
+
+    Shared and host pointers are accessible from both host and a device,
+    while device pointers are only accessible from device.
+
+    Python objects corresponding to shared and host pointers implement 
+    Python simple buffer protocol. It is therefore possible to use these
+    objects to maniputalate USM memory using NumPy or `bytearray`, 
+    `memoryview`, or `array.array` classes.
+    
+"""
+from ._memory import MemoryUSMShared, MemoryUSMDevice, MemoryUSMHost

--- a/dpctl/memory/_memory.pxd
+++ b/dpctl/memory/_memory.pxd
@@ -21,8 +21,8 @@
 # distutils: language = c++
 # cython: language_level=3
 
-from ._backend cimport DPPLSyclUSMRef
-from ._sycl_core cimport SyclQueue, SyclDevice, SyclContext
+from .._backend cimport DPPLSyclUSMRef
+from .._sycl_core cimport SyclQueue, SyclDevice, SyclContext
 
 
 cdef class _Memory:

--- a/dpctl/memory/_memory.pyx
+++ b/dpctl/memory/_memory.pyx
@@ -30,8 +30,8 @@
 
 import dpctl
 from dpctl._backend cimport *
-from ._sycl_core cimport SyclContext, SyclQueue, SyclDevice
-from ._sycl_core cimport get_current_queue
+from .._sycl_core cimport SyclContext, SyclQueue, SyclDevice
+from .._sycl_core cimport get_current_queue
 
 from cpython cimport Py_buffer
 from cpython.bytes cimport PyBytes_AS_STRING, PyBytes_FromStringAndSize

--- a/dpctl/memory/_memory.pyx
+++ b/dpctl/memory/_memory.pyx
@@ -302,7 +302,7 @@ cdef class _Memory:
         return _to_memory, (self.copy_to_host(), self.get_usm_type())
     
     property __sycl_usm_array_interface__:
-        def __get__ (self):
+        def __get__(self):
             cdef dict iface = {
                 "data": (<Py_ssize_t>(<void *>self.memory_ptr),
                          True), # bool(self.writeable)),
@@ -336,7 +336,7 @@ cdef class _Memory:
                              "or an instance of SyclContext or SyclQueue")
         return kind.decode('UTF-8')
 
-    cpdef copy_to_host (self, obj=None):
+    cpdef copy_to_host(self, obj=None):
         """Copy content of instance's memory into memory of 
         `obj`, or allocate NumPy array of obj is None"""
         # Cython does the right thing here
@@ -360,8 +360,8 @@ cdef class _Memory:
 
         return obj
 
-    cpdef copy_from_host (self, object obj):
-        """Copy contant of Python buffer provided by `obj` to instance memory."""
+    cpdef copy_from_host(self, object obj):
+        """Copy content of Python buffer provided by `obj` to instance memory."""
         cdef const unsigned char[::1] host_buf = obj
         cdef Py_ssize_t buf_len = len(host_buf)
 
@@ -376,7 +376,7 @@ cdef class _Memory:
             <size_t>buf_len
         )
 
-    cpdef copy_from_device (self, object sycl_usm_ary):
+    cpdef copy_from_device(self, object sycl_usm_ary):
         """Copy SYCL memory underlying the argument object into 
         the memory of the instance"""
         cdef _BufferData src_buf
@@ -410,8 +410,8 @@ cdef class _Memory:
         else:
             raise TypeError
     
-    cpdef bytes tobytes (self):
-        """"""
+    cpdef bytes tobytes(self):
+        """Constructs bytes object populated with copy of USM memory"""
         cdef Py_ssize_t nb = self.nbytes
         cdef bytes b = PyBytes_FromStringAndSize(NULL, nb)
         # convert bytes to memory view

--- a/dpctl/tests/test_sycl_kernel_submit.py
+++ b/dpctl/tests/test_sycl_kernel_submit.py
@@ -25,7 +25,7 @@
 import ctypes
 import dpctl
 import unittest
-import dpctl._memory as dpctl_mem
+import dpctl.memory as dpctl_mem
 import numpy as np
 
 

--- a/dpctl/tests/test_sycl_queue_memcpy.py
+++ b/dpctl/tests/test_sycl_queue_memcpy.py
@@ -23,14 +23,13 @@
 ##===----------------------------------------------------------------------===##
 
 import dpctl
-import dpctl.memory
 import unittest
 
 
 class TestQueueMemcpy(unittest.TestCase):
     def _create_memory(self):
         nbytes = 1024
-        mobj = dpctl.memory.MemoryUSMShared(nbytes)
+        mobj = dpctl.MemoryUSMShared(nbytes)
         return mobj
 
     @unittest.skipUnless(

--- a/dpctl/tests/test_sycl_queue_memcpy.py
+++ b/dpctl/tests/test_sycl_queue_memcpy.py
@@ -23,14 +23,14 @@
 ##===----------------------------------------------------------------------===##
 
 import dpctl
+import dpctl.memory
 import unittest
 
 
 class TestQueueMemcpy(unittest.TestCase):
     def _create_memory(self):
         nbytes = 1024
-        queue = dpctl.get_current_queue()
-        mobj = dpctl._memory.MemoryUSMShared(nbytes, queue)
+        mobj = dpctl.memory.MemoryUSMShared(nbytes)
         return mobj
 
     @unittest.skipUnless(

--- a/dpctl/tests/test_sycl_queue_memcpy.py
+++ b/dpctl/tests/test_sycl_queue_memcpy.py
@@ -60,13 +60,13 @@ class TestQueueMemcpy(unittest.TestCase):
             q.memcpy(None, mobj, 3)
 
         self.assertEqual(type(cm.exception), TypeError)
-        self.assertEqual(str(cm.exception), "Parameter dest should have type Memory.")
+        self.assertEqual(str(cm.exception), "Parameter `dest` should have type _Memory.")
 
         with self.assertRaises(TypeError) as cm:
             q.memcpy(mobj, None, 3)
 
         self.assertEqual(type(cm.exception), TypeError)
-        self.assertEqual(str(cm.exception), "Parameter src should have type Memory.")
+        self.assertEqual(str(cm.exception), "Parameter `src` should have type _Memory.")
 
 
 if __name__ == "__main__":

--- a/dpctl/tests/test_sycl_queue_memcpy.py
+++ b/dpctl/tests/test_sycl_queue_memcpy.py
@@ -23,13 +23,14 @@
 ##===----------------------------------------------------------------------===##
 
 import dpctl
+import dpctl.memory
 import unittest
 
 
 class TestQueueMemcpy(unittest.TestCase):
     def _create_memory(self):
         nbytes = 1024
-        mobj = dpctl.MemoryUSMShared(nbytes)
+        mobj = dpctl.memory.MemoryUSMShared(nbytes)
         return mobj
 
     @unittest.skipUnless(
@@ -60,7 +61,9 @@ class TestQueueMemcpy(unittest.TestCase):
             q.memcpy(None, mobj, 3)
 
         self.assertEqual(type(cm.exception), TypeError)
-        self.assertEqual(str(cm.exception), "Parameter `dest` should have type _Memory.")
+        self.assertEqual(
+            str(cm.exception), "Parameter `dest` should have type _Memory."
+        )
 
         with self.assertRaises(TypeError) as cm:
             q.memcpy(mobj, None, 3)

--- a/dpctl/tests/test_sycl_queue_memcpy.py
+++ b/dpctl/tests/test_sycl_queue_memcpy.py
@@ -61,13 +61,13 @@ class TestQueueMemcpy(unittest.TestCase):
             q.memcpy(None, mobj, 3)
 
         self.assertEqual(type(cm.exception), TypeError)
-        self.assertEqual(str(cm.exception), "Parameter dest should be Memory.")
+        self.assertEqual(str(cm.exception), "Parameter dest should have type Memory.")
 
         with self.assertRaises(TypeError) as cm:
             q.memcpy(mobj, None, 3)
 
         self.assertEqual(type(cm.exception), TypeError)
-        self.assertEqual(str(cm.exception), "Parameter src should be Memory.")
+        self.assertEqual(str(cm.exception), "Parameter src should have type Memory.")
 
 
 if __name__ == "__main__":

--- a/dpctl/tests/test_sycl_usm.py
+++ b/dpctl/tests/test_sycl_usm.py
@@ -206,8 +206,8 @@ class TestMemoryUSMBase:
     )
     def test_sycl_usm_array_interface(self):
         import sys
-        if (self.MemoryUSMClass is MemoryUSMHost and
-            sys.platform in ["win32", "cygwin"]):
+
+        if self.MemoryUSMClass is MemoryUSMHost and sys.platform in ["win32", "cygwin"]:
             # MemoryUSMHost.copy_to_host() hangs on Windows. TODO: investigate
             raise unittest.SkipTest
         m = self.MemoryUSMClass(256)

--- a/dpctl/tests/test_sycl_usm.py
+++ b/dpctl/tests/test_sycl_usm.py
@@ -31,7 +31,7 @@ import numpy as np
 
 class Dummy(MemoryUSMShared):
     """
-    Class that exposes `__sycl_usm_array_interface__` with 
+    Class that exposes `__sycl_usm_array_interface__` with
     SYCL context for sycl object, instead of Sycl queue.
     """
 

--- a/dpctl/tests/test_sycl_usm.py
+++ b/dpctl/tests/test_sycl_usm.py
@@ -34,14 +34,14 @@ class TestMemory(unittest.TestCase):
     def test_memory_create(self):
         nbytes = 1024
         queue = dpctl.get_current_queue()
-        mobj = MemoryUSMShared(nbytes, queue)
+        mobj = MemoryUSMShared(nbytes, alignment=64, queue=queue)
         self.assertEqual(mobj.nbytes, nbytes)
         self.assertTrue(hasattr(mobj, "__sycl_usm_array_interface__"))
 
     def _create_memory(self):
         nbytes = 1024
         queue = dpctl.get_current_queue()
-        mobj = MemoryUSMShared(nbytes, queue)
+        mobj = MemoryUSMShared(nbytes, alignment=64, queue=queue)
         return mobj
 
     def _create_host_buf(self, nbytes):
@@ -156,16 +156,33 @@ class TestMemoryUSMBase:
     @unittest.skipUnless(
         dpctl.has_sycl_platforms(), "No SYCL devices except the default host device."
     )
-    def test_create_with_queue(self):
+    def test_create_with_size_and_alignment_and_queue(self):
         q = dpctl.get_current_queue()
-        m = self.MemoryUSMClass(1024, q)
+        m = self.MemoryUSMClass(1024, alignment=64, queue=q)
         self.assertEqual(m.nbytes, 1024)
         self.assertEqual(m.get_usm_type(), self.usm_type)
 
     @unittest.skipUnless(
         dpctl.has_sycl_platforms(), "No SYCL devices except the default host device."
     )
-    def test_create_without_queue(self):
+    def test_create_with_size_and_queue(self):
+        q = dpctl.get_current_queue()
+        m = self.MemoryUSMClass(1024, queue=q)
+        self.assertEqual(m.nbytes, 1024)
+        self.assertEqual(m.get_usm_type(), self.usm_type)
+
+    @unittest.skipUnless(
+        dpctl.has_sycl_platforms(), "No SYCL devices except the default host device."
+    )
+    def test_create_with_size_and_alignment(self):
+        m = self.MemoryUSMClass(1024, alignment=64)
+        self.assertEqual(m.nbytes, 1024)
+        self.assertEqual(m.get_usm_type(), self.usm_type)
+
+    @unittest.skipUnless(
+        dpctl.has_sycl_platforms(), "No SYCL devices except the default host device."
+    )
+    def test_create_with_only_size(self):
         m = self.MemoryUSMClass(1024)
         self.assertEqual(m.nbytes, 1024)
         self.assertEqual(m.get_usm_type(), self.usm_type)

--- a/dpctl/tests/test_sycl_usm.py
+++ b/dpctl/tests/test_sycl_usm.py
@@ -132,8 +132,19 @@ class TestMemory(unittest.TestCase):
         mobj.copy_from_host(host_src_obj)
 
         mobj_reconstructed = pickle.loads(pickle.dumps(mobj))
-        self.assertEqual(mobj.tobytes(), mobj_reconstructed.tobytes())
-        self.assertNotEqual(mobj._pointer, mobj_reconstructed._pointer)
+        self.assertEqual(
+            type(mobj), type(mobj_reconstructed), "Pickling should preserve type"
+        )
+        self.assertEqual(
+            mobj.tobytes(),
+            mobj_reconstructed.tobytes(),
+            "Pickling should preserve buffer content"
+        )
+        self.assertNotEqual(
+            mobj._pointer,
+            mobj_reconstructed._pointer,
+            "Pickling/unpickling changes pointer"
+        )
 
 
 class TestMemoryUSMBase:

--- a/dpctl/tests/test_sycl_usm.py
+++ b/dpctl/tests/test_sycl_usm.py
@@ -24,8 +24,7 @@
 
 import unittest
 import dpctl
-from dpctl import MemoryUSMShared, MemoryUSMHost, MemoryUSMDevice
-import dpctl._memory
+from dpctl.memory import MemoryUSMShared, MemoryUSMHost, MemoryUSMDevice
 import numpy as np
 
 

--- a/dpctl/tests/test_sycl_usm.py
+++ b/dpctl/tests/test_sycl_usm.py
@@ -138,12 +138,12 @@ class TestMemory(unittest.TestCase):
         self.assertEqual(
             mobj.tobytes(),
             mobj_reconstructed.tobytes(),
-            "Pickling should preserve buffer content"
+            "Pickling should preserve buffer content",
         )
         self.assertNotEqual(
             mobj._pointer,
             mobj_reconstructed._pointer,
-            "Pickling/unpickling changes pointer"
+            "Pickling/unpickling changes pointer",
         )
 
 

--- a/dpctl/tests/test_sycl_usm.py
+++ b/dpctl/tests/test_sycl_usm.py
@@ -205,6 +205,11 @@ class TestMemoryUSMBase:
         dpctl.has_sycl_platforms(), "No SYCL Devices except the default host device."
     )
     def test_sycl_usm_array_interface(self):
+        import sys
+        if (self.MemoryUSMClass is MemoryUSMHost and
+            sys.platform in ["win32", "cygwin"]):
+            # MemoryUSMHost.copy_to_host() hangs on Windows. TODO: investigate
+            raise unittest.SkipTest
         m = self.MemoryUSMClass(256)
         m2 = Dummy(m.nbytes)
         hb = np.random.randint(0, 256, size=256, dtype="|u1")

--- a/dpctl/tests/test_sycl_usm.py
+++ b/dpctl/tests/test_sycl_usm.py
@@ -28,17 +28,19 @@ from dpctl import MemoryUSMShared, MemoryUSMHost, MemoryUSMDevice
 import dpctl._memory
 import numpy as np
 
+
 class Dummy(MemoryUSMShared):
     """
     Class that exposes `__sycl_usm_array_interface__` with 
     SYCL context for sycl object, instead of Sycl queue.
     """
+
     @property
     def __sycl_usm_array_interface(self):
         iface = super().__sycl_usm_array_interface__
-        iface['syclob'] = iface['syclobj'].get_sycl_context()
+        iface["syclob"] = iface["syclobj"].get_sycl_context()
         return iface
-               
+
 
 class TestMemory(unittest.TestCase):
     @unittest.skipUnless(

--- a/scripts/build_for_develop.bat
+++ b/scripts/build_for_develop.bat
@@ -18,9 +18,9 @@ rmdir /S /Q "%INSTALL_PREFIX%"
 cmake -G Ninja ^
     -DCMAKE_BUILD_TYPE=Release ^
     "-DCMAKE_INSTALL_PREFIX=%INSTALL_PREFIX%" ^
-    "-DCMAKE_PREFIX_PATH=%LIBRARY_PREFIX%" ^
+    "-DCMAKE_PREFIX_PATH=%CONDA_PREFIX%" ^
     "-DDPCPP_ROOT=%DPCPP_ROOT%" ^
-    "%SRC_DIR%/backends"
+    "%cd%\..\backends"
 IF %ERRORLEVEL% NEQ 0 exit 1
 
 ninja -n
@@ -39,6 +39,7 @@ REM required by _sycl_core(dpctl)
 set "DPPL_SYCL_INTERFACE_LIBDIR=dpctl"
 set "DPPL_SYCL_INTERFACE_INCLDIR=dpctl\include"
 
-"%PYTHON%" setup.py clean --all
-"%PYTHON%" setup.py build install
+python setup.py clean --all
+python setup.py build develop
+python -m unittest dpctl.tests
 IF %ERRORLEVEL% NEQ 0 exit 1

--- a/scripts/build_for_develop.bat
+++ b/scripts/build_for_develop.bat
@@ -24,17 +24,21 @@ for /f "delims=" %%a in ('%CONDA_PREFIX%\python.exe -c "import distutils.sysconf
 
 cmake -G Ninja ^
     -DCMAKE_BUILD_TYPE=Debug ^
+    "-DCMAKE_CXX_FLAGS=-Wno-unused-function" ^
     "-DCMAKE_INSTALL_PREFIX=%INSTALL_PREFIX%" ^
     "-DCMAKE_PREFIX_PATH=%INSTALL_PREFIX%" ^
     "-DDPCPP_ROOT=%DPCPP_ROOT%" ^
     "-DPYTHON_INCLUDE_DIR=%PYTHON_INC%" ^
-    "-DGTEST_INCLUDE_DIR=%CONDA_PREFIX\Library\include" ^
+    "-DGTEST_INCLUDE_DIR=%CONDA_PREFIX%\Library\include" ^
     "-DGTEST_LIB_DIR=%CONDA_PREFIX%\Library\lib" ^
     "-DNUMPY_INCLUDE_DIR=%NUMPY_DIR%" ^
     "%cd%\..\backends"
 IF %ERRORLEVEL% NEQ 0 exit /b 1
 
-ninja -n
+ninja -n 
+IF %ERRORLEVEL% NEQ 0 exit /b 1
+ninja check
+IF %ERRORLEVEL% NEQ 0 exit /b 1
 ninja install
 IF %ERRORLEVEL% NEQ 0 exit /b 1
 

--- a/scripts/build_for_develop.bat
+++ b/scripts/build_for_develop.bat
@@ -3,9 +3,6 @@ IF ERRORLEVEL 1 exit /b 1
 REM conda uses %ERRORLEVEL% but FPGA scripts can set it. So it should be reseted.
 set ERRORLEVEL=
 
-set "CC=clang-cl.exe"
-set "CXX=dpcpp.exe"
-
 rmdir /S /Q build_cmake
 mkdir build_cmake
 
@@ -23,15 +20,17 @@ set PYTHON_INC=
 for /f "delims=" %%a in ('%CONDA_PREFIX%\python.exe -c "import distutils.sysconfig as sc; print(sc.get_python_inc())"') do @set PYTHON_INC=%%a 
 
 cmake -G Ninja ^
-    -DCMAKE_BUILD_TYPE=Debug ^
-    "-DCMAKE_CXX_FLAGS=-Wno-unused-function" ^
+    -DCMAKE_BUILD_TYPE=Release ^
+    "-DCMAKE_CXX_FLAGS=-Wno-unused-function /EHa" ^
     "-DCMAKE_INSTALL_PREFIX=%INSTALL_PREFIX%" ^
     "-DCMAKE_PREFIX_PATH=%INSTALL_PREFIX%" ^
     "-DDPCPP_ROOT=%DPCPP_ROOT%" ^
+    "-DCMAKE_C_COMPILER:PATH=%DPCPP_ROOT%\bin\clang-cl.exe" ^
+    "-DCMAKE_CXX_COMPILER:PATH=%DPCPP_ROOT%\bin\dpcpp.exe" ^
     "-DPYTHON_INCLUDE_DIR=%PYTHON_INC%" ^
     "-DGTEST_INCLUDE_DIR=%CONDA_PREFIX%\Library\include" ^
     "-DGTEST_LIB_DIR=%CONDA_PREFIX%\Library\lib" ^
-    "-DNUMPY_INCLUDE_DIR=%NUMPY_DIR%" ^
+    "-DNUMPY_INCLUDE_DIR=%NUMPY_INC%" ^
     "%cd%\..\backends"
 IF %ERRORLEVEL% NEQ 0 exit /b 1
 
@@ -53,6 +52,8 @@ xcopy backends\include dpctl\include /E /Y
 REM required by _sycl_core(dpctl)
 set "DPPL_SYCL_INTERFACE_LIBDIR=dpctl"
 set "DPPL_SYCL_INTERFACE_INCLDIR=dpctl\include"
+set "CC=clang-cl.exe"
+set "CXX=dpcpp.exe"
 
 python setup.py clean --all
 python setup.py build_ext --inplace develop

--- a/setup.py
+++ b/setup.py
@@ -115,9 +115,7 @@ def extensions():
         runtime_library_dirs = []
 
     extension_args = {
-        "depends": [
-            dppl_sycl_interface_include,
-        ],
+        "depends": [dppl_sycl_interface_include,],
         "include_dirs": [np.get_include(), dppl_sycl_interface_include],
         "extra_compile_args": eca + get_other_cxxflags(),
         "extra_link_args": ela,
@@ -130,16 +128,12 @@ def extensions():
     extensions = [
         Extension(
             "dpctl._sycl_core",
-            [
-                os.path.join("dpctl", "_sycl_core.pyx"),
-            ],
+            [os.path.join("dpctl", "_sycl_core.pyx"),],
             **extension_args
         ),
         Extension(
-            "dpctl._memory",
-            [
-                os.path.join("dpctl", "_memory.pyx"),
-            ],
+            "dpctl.memory._memory",
+            [os.path.join("dpctl", "memory", "_memory.pyx"),],
             **extension_args
         ),
     ]

--- a/setup.py
+++ b/setup.py
@@ -115,7 +115,9 @@ def extensions():
         runtime_library_dirs = []
 
     extension_args = {
-        "depends": [dppl_sycl_interface_include,],
+        "depends": [
+            dppl_sycl_interface_include,
+        ],
         "include_dirs": [np.get_include(), dppl_sycl_interface_include],
         "extra_compile_args": eca + get_other_cxxflags(),
         "extra_link_args": ela,
@@ -128,12 +130,16 @@ def extensions():
     extensions = [
         Extension(
             "dpctl._sycl_core",
-            [os.path.join("dpctl", "_sycl_core.pyx"),],
+            [
+                os.path.join("dpctl", "_sycl_core.pyx"),
+            ],
             **extension_args
         ),
         Extension(
             "dpctl.memory._memory",
-            [os.path.join("dpctl", "memory", "_memory.pyx"),],
+            [
+                os.path.join("dpctl", "memory", "_memory.pyx"),
+            ],
             **extension_args
         ),
     ]


### PR DESCRIPTION
Closes #43, closes #76, closes #45, closes #120.

Work on `Memory` class and its derivatives. 

Classes `MemoryUSMShared`, `MemoryUSMDevice`, and `MemoryUSMHost` constructors allow  to specify the number of bytes to allocate, and optionally the `queue`, or give a Python object expected to implement `__sycl_usm_array_interface__` attribute to create the USM memory object pointing the same USM memory with zero copy.

Classes also implement several new features. 

 - Method `copy_from_host(pyobj)` to copy content of Python object buffer to USM memory
 - Method `copy_to_hist(pyobj=None)` to copy content of USM memory to pre-allocated Python object buffer. If object does not implement the buffer protocol, `bytearray` of the appropriate size is allocated and populated. The method returns the populated object.
- Method `copy_from_device(sycl_usm_obj)` to copy content of USM memory behind Python object that is expected to implement ``__sycl_usm_array_interface__`` to the USM memory of the instance.

Classes are now pickleable, with it being implemented via copying to host and picking that. 

@Alexander-Makaryev 