### PR TITLE
Changes to build_for_develop.bat

### DIFF
--- a/scripts/build_for_develop.bat
+++ b/scripts/build_for_develop.bat
@@ -1,5 +1,10 @@
-call "%ONEAPI_ROOT%\compiler\latest\env\vars.bat"
-IF ERRORLEVEL 1 exit /b 1
+REM check if oneAPI has been activated, only try activating if not
+dpcpp.exe --version >nul 2>&1
+IF %ERRORLEVEL% NEQ 0 (
+    set ERRORLEVEL=
+    call "%ONEAPI_ROOT%\compiler\latest\env\vars.bat"
+    IF ERRORLEVEL 1 exit /b 1
+)
 REM conda uses %ERRORLEVEL% but FPGA scripts can set it. So it should be reseted.
 set ERRORLEVEL=
 
@@ -19,25 +24,34 @@ for /f "delims=" %%a in ('%CONDA_PREFIX%\python.exe -c "import numpy; print(nump
 set PYTHON_INC=
 for /f "delims=" %%a in ('%CONDA_PREFIX%\python.exe -c "import distutils.sysconfig as sc; print(sc.get_python_inc())"') do @set PYTHON_INC=%%a 
 
+if defined USE_GTEST (
+    set "_GTEST_INCLUDE_DIR=%CONDA_PREFIX%\Library\include"
+    set "_GTEST_LIB_DIR=%CONDA_PREFIX%\Library\lib"
+) else (
+    set "_GTEST_INCLUDE_DIR="
+    set "_GTEST_LIB_DIR="
+)
 cmake -G Ninja ^
-    -DCMAKE_BUILD_TYPE=Release ^
+    -DCMAKE_BUILD_TYPE=Debug ^
     "-DCMAKE_CXX_FLAGS=-Wno-unused-function /EHa" ^
     "-DCMAKE_INSTALL_PREFIX=%INSTALL_PREFIX%" ^
     "-DCMAKE_PREFIX_PATH=%INSTALL_PREFIX%" ^
     "-DDPCPP_ROOT=%DPCPP_ROOT%" ^
     "-DCMAKE_C_COMPILER:PATH=%DPCPP_ROOT%\bin\clang-cl.exe" ^
     "-DCMAKE_CXX_COMPILER:PATH=%DPCPP_ROOT%\bin\dpcpp.exe" ^
+    "-DGTEST_INCLUDE_DIR=%_GTEST_INCLUDE_DIR%" ^
+    "-DGTEST_LIB_DIR=%_GTEST_LIB_DIR%" ^
     "-DPYTHON_INCLUDE_DIR=%PYTHON_INC%" ^
-    "-DGTEST_INCLUDE_DIR=%CONDA_PREFIX%\Library\include" ^
-    "-DGTEST_LIB_DIR=%CONDA_PREFIX%\Library\lib" ^
     "-DNUMPY_INCLUDE_DIR=%NUMPY_INC%" ^
     "%cd%\..\backends"
 IF %ERRORLEVEL% NEQ 0 exit /b 1
 
 ninja -n 
 IF %ERRORLEVEL% NEQ 0 exit /b 1
-ninja check
-IF %ERRORLEVEL% NEQ 0 exit /b 1
+if defined USE_GTEST (
+    ninja check
+    IF %ERRORLEVEL% NEQ 0 exit /b 1
+)
 ninja install
 IF %ERRORLEVEL% NEQ 0 exit /b 1
 


### PR DESCRIPTION
1. Only source oneAPI compiler activation script if dpcpp.exe --version
   was not successful to avoid polluting env. variables
2. Script is responsive to USE_GTEST env. variable
   If it is undefined, GTEST portion will be skipped.

To build without GTEST
```
set USE_GTEST=
scripts\build_for_develop.bat
```

to build with GTEST:

```
set USE_GTEST=1
scripts\build_for_develop.bat
```