### PR TITLE
CMake and Gtest improvements

### DIFF
--- a/backends/CMakeLists.txt
+++ b/backends/CMakeLists.txt
@@ -123,8 +123,17 @@ foreach(HEADER ${HEADERS})
   install(FILES "${HEADER}" DESTINATION include/Support)
 endforeach()
 
+option(
+    BUILD_CAPI_TESTS
+    "Build dpctl C API google tests"
+    OFF
+)
+
 # Enable to build the dpCtl backend test cases
-add_subdirectory(tests)
+if(BUILD_CAPI_TESTS)
+    add_subdirectory(tests)
+endif()
+
 
 # Todo : Add build rules for doxygen
 # maybe refer https://devblogs.microsoft.com/cppblog/clear-functional-c-documentation-with-sphinx-breathe-doxygen-cmake/

--- a/backends/CMakeLists.txt
+++ b/backends/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.3.2 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.10 FATAL_ERROR)
 project("dpCtl - A lightweight SYCL wrapper for Python")
 
 # The function checks is DPCPP_ROOT is valid and points to a dpcpp installation

--- a/backends/dbg_build.sh
+++ b/backends/dbg_build.sh
@@ -19,6 +19,11 @@ cmake                                                       \
     -DBUILD_CAPI_TESTS=ON                                   \
     ..
 
-make V=1 -n -j 4 && make check && make install
+make V=1 -n -j 4 make check && make install
+
+# For more verbose tests use:
+# cd tests
+# ctest -V --progress --output-on-failure -j 4
+# cd ..
 
 popd

--- a/backends/dbg_build.sh
+++ b/backends/dbg_build.sh
@@ -16,6 +16,7 @@ cmake                                                       \
     -DDPCPP_ROOT=${DPCPP_ROOT}                              \
     -DCMAKE_C_COMPILER:PATH=${DPCPP_ROOT}/bin/clang         \
     -DCMAKE_CXX_COMPILER:PATH=${DPCPP_ROOT}/bin/dpcpp       \
+    -DBUILD_CAPI_TESTS=ON                                   \
     ..
 
 make V=1 -n -j 4 && make check && make install

--- a/backends/dbg_build.sh
+++ b/backends/dbg_build.sh
@@ -19,7 +19,7 @@ cmake                                                       \
     -DBUILD_CAPI_TESTS=ON                                   \
     ..
 
-make V=1 -n -j 4 make check && make install
+make V=1 -n -j 4 && make check && make install
 
 # For more verbose tests use:
 # cd tests

--- a/backends/dbg_build.sh
+++ b/backends/dbg_build.sh
@@ -8,9 +8,6 @@ INSTALL_PREFIX=`pwd`/../install
 rm -rf ${INSTALL_PREFIX}
 export ONEAPI_ROOT=/opt/intel/oneapi
 DPCPP_ROOT=${ONEAPI_ROOT}/compiler/latest/linux
-PYTHON_INC=`python -c "import distutils.sysconfig;                  \
-                        print(distutils.sysconfig.get_python_inc())"`
-NUMPY_INC=`python -c "import numpy; print(numpy.get_include())"`
 
 cmake                                                       \
     -DCMAKE_BUILD_TYPE=Debug                                \
@@ -19,10 +16,6 @@ cmake                                                       \
     -DDPCPP_ROOT=${DPCPP_ROOT}                              \
     -DCMAKE_C_COMPILER:PATH=${DPCPP_ROOT}/bin/clang         \
     -DCMAKE_CXX_COMPILER:PATH=${DPCPP_ROOT}/bin/dpcpp       \
-    -DPYTHON_INCLUDE_DIR=${PYTHON_INC}                      \
-    -DNUMPY_INCLUDE_DIR=${NUMPY_INC}                        \
-    -DGTEST_INCLUDE_DIR=${CONDA_PREFIX}/include/            \
-    -DGTEST_LIB_DIR=${CONDA_PREFIX}/lib                     \
     ..
 
 make V=1 -n -j 4 && make check && make install

--- a/backends/tests/CMakeLists.txt
+++ b/backends/tests/CMakeLists.txt
@@ -1,28 +1,18 @@
-string(COMPARE EQUAL "${GTEST_INCLUDE_DIR}" "" no_gtest_incl_dir)
-string(COMPARE EQUAL "${GTEST_LIB_DIR}" "" no_gtest_lib_dir)
+find_package(GTest REQUIRED)
+# We need thread support for gtest
+find_package(Threads REQUIRED)
 
-if(${no_gtest_incl_dir} OR ${no_gtest_lib_dir})
-    message(WARNING
-            "GTest is needed to test dpCtl's C API test cases.  Pass in \
-            -DGTEST_INCLUDE_DIR and -DGTEST_LIB_DIR when you configure Cmake if\
-             you wish to run dpCtl backend tests."
-    )
-else()
-  # We need thread support for gtest
-  find_package(Threads REQUIRED)
+set(CMAKE_CTEST_COMMAND ctest -V)
 
-  set(CMAKE_CTEST_COMMAND ctest -V)
+# Emulate autotools like make check target to build tests
+add_custom_target(check COMMAND ${CMAKE_CTEST_COMMAND})
+enable_testing()
 
-  # Emulate autotools like make check target to build tests
-  add_custom_target(check COMMAND ${CMAKE_CTEST_COMMAND})
-  enable_testing()
+include_directories(../include)
 
-  include_directories(${GTEST_INCLUDE_DIR})
-  include_directories(../include)
+link_directories(${GTEST_LIB_DIR})
 
-  link_directories(${GTEST_LIB_DIR})
-
-  set(DPCTL_C_API_TEST_CASES
+set(DPCTL_C_API_TEST_CASES
     test_sycl_device_interface
     test_sycl_kernel_interface
     test_sycl_platform_interface
@@ -30,22 +20,21 @@ else()
     test_sycl_queue_interface
     test_sycl_queue_manager
     test_sycl_usm_interface
-  )
+)
 
-  # Copy the spir-v input files to test build directory
-  set(spirv-test-files
+# Copy the spir-v input files to test build directory
+set(spirv-test-files
     multi_kernel.spv
-  )
-  foreach(tf ${spirv-test-files})
+)
+foreach(tf ${spirv-test-files})
     file(COPY ${tf} DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
-  endforeach()
+endforeach()
 
-  foreach(TEST_CASE ${DPCTL_C_API_TEST_CASES})
+foreach(TEST_CASE ${DPCTL_C_API_TEST_CASES})
     add_executable(${TEST_CASE} EXCLUDE_FROM_ALL ${TEST_CASE}.cpp)
     target_link_libraries(
-      ${TEST_CASE} ${CMAKE_THREAD_LIBS_INIT} gtest DPPLSyclInterface
+        ${TEST_CASE} ${CMAKE_THREAD_LIBS_INIT} GTest::GTest DPPLSyclInterface
     )
     add_test(NAME ${TEST_CASE} COMMAND ${TEST_CASE})
     add_dependencies(check ${TEST_CASE})
-  endforeach()
-endif()
+endforeach()

--- a/backends/tests/CMakeLists.txt
+++ b/backends/tests/CMakeLists.txt
@@ -2,25 +2,13 @@ find_package(GTest REQUIRED)
 # We need thread support for gtest
 find_package(Threads REQUIRED)
 
-set(CMAKE_CTEST_COMMAND ctest -V)
-
 # Emulate autotools like make check target to build tests
+set(CMAKE_CTEST_COMMAND ctest -V)
 add_custom_target(check COMMAND ${CMAKE_CTEST_COMMAND})
 enable_testing()
 
 include_directories(../include)
-
 link_directories(${GTEST_LIB_DIR})
-
-set(DPCTL_C_API_TEST_CASES
-    test_sycl_device_interface
-    test_sycl_kernel_interface
-    test_sycl_platform_interface
-    test_sycl_program_interface
-    test_sycl_queue_interface
-    test_sycl_queue_manager
-    test_sycl_usm_interface
-)
 
 # Copy the spir-v input files to test build directory
 set(spirv-test-files

--- a/backends/tests/CMakeLists.txt
+++ b/backends/tests/CMakeLists.txt
@@ -37,4 +37,3 @@ target_link_libraries(
 )
 gtest_discover_tests(dpctl_c_api_tests)
 add_dependencies(check dpctl_c_api_tests)
-

--- a/backends/tests/CMakeLists.txt
+++ b/backends/tests/CMakeLists.txt
@@ -7,7 +7,7 @@ set(CMAKE_CTEST_COMMAND ctest --progress --output-on-failure -j 4)
 add_custom_target(check COMMAND ${CMAKE_CTEST_COMMAND})
 enable_testing()
 
-include_directories(../include)
+include_directories(${CMAKE_SOURCE_DIR}/include)
 link_directories(${GTEST_LIB_DIR})
 
 # Copy the spir-v input files to test build directory

--- a/backends/tests/CMakeLists.txt
+++ b/backends/tests/CMakeLists.txt
@@ -30,11 +30,11 @@ foreach(tf ${spirv-test-files})
     file(COPY ${tf} DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
 endforeach()
 
-foreach(TEST_CASE ${DPCTL_C_API_TEST_CASES})
-    add_executable(${TEST_CASE} EXCLUDE_FROM_ALL ${TEST_CASE}.cpp)
-    target_link_libraries(
-        ${TEST_CASE} ${CMAKE_THREAD_LIBS_INIT} GTest::GTest DPPLSyclInterface
-    )
-    gtest_discover_tests(${TEST_CASE})
-    add_dependencies(check ${TEST_CASE})
-endforeach()
+file(GLOB_RECURSE sources ${CMAKE_CURRENT_SOURCE_DIR}/*.cpp)
+add_executable(dpctl_c_api_tests EXCLUDE_FROM_ALL ${sources})
+target_link_libraries(
+    dpctl_c_api_tests ${CMAKE_THREAD_LIBS_INIT} GTest::GTest DPPLSyclInterface
+)
+gtest_discover_tests(dpctl_c_api_tests)
+add_dependencies(check dpctl_c_api_tests)
+

--- a/backends/tests/CMakeLists.txt
+++ b/backends/tests/CMakeLists.txt
@@ -35,6 +35,6 @@ foreach(TEST_CASE ${DPCTL_C_API_TEST_CASES})
     target_link_libraries(
         ${TEST_CASE} ${CMAKE_THREAD_LIBS_INIT} GTest::GTest DPPLSyclInterface
     )
-    add_test(NAME ${TEST_CASE} COMMAND ${TEST_CASE})
+    gtest_discover_tests(${TEST_CASE})
     add_dependencies(check ${TEST_CASE})
 endforeach()

--- a/backends/tests/CMakeLists.txt
+++ b/backends/tests/CMakeLists.txt
@@ -3,7 +3,7 @@ find_package(GTest REQUIRED)
 find_package(Threads REQUIRED)
 
 # Emulate autotools like make check target to build tests
-set(CMAKE_CTEST_COMMAND ctest -V)
+set(CMAKE_CTEST_COMMAND ctest --progress --output-on-failure -j 4)
 add_custom_target(check COMMAND ${CMAKE_CTEST_COMMAND})
 enable_testing()
 

--- a/backends/tests/test_main.cpp
+++ b/backends/tests/test_main.cpp
@@ -1,0 +1,34 @@
+//===-------------------- test_main.cpp - dpctl-C_API ---*--- C++ ----*----===//
+//
+//               Data Parallel Control Library (dpCtl)
+//
+// Copyright 2020 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// A common test runner for all tests in dpctl C API.
+///
+//===----------------------------------------------------------------------===//
+
+#include <gtest/gtest.h>
+
+int
+main (int argc, char** argv)
+{
+    ::testing::InitGoogleTest(&argc, argv);
+    int ret = RUN_ALL_TESTS();
+    return ret;
+}

--- a/backends/tests/test_sycl_device_interface.cpp
+++ b/backends/tests/test_sycl_device_interface.cpp
@@ -395,10 +395,3 @@ TEST_F (TestDPPLSyclDeviceInterface, CheckLevel0GPU_IsGPU)
     EXPECT_TRUE(DPPLDevice_IsGPU(OpenCL_Level0_gpu));
 }
 
-int
-main (int argc, char** argv)
-{
-    ::testing::InitGoogleTest(&argc, argv);
-    int ret = RUN_ALL_TESTS();
-    return ret;
-}

--- a/backends/tests/test_sycl_kernel_interface.cpp
+++ b/backends/tests/test_sycl_kernel_interface.cpp
@@ -109,10 +109,3 @@ TEST_F (TestDPPLSyclKernelInterface, CheckGetNumArgs)
     DPPLKernel_Delete(AxpyKernel);
 }
 
-int
-main (int argc, char** argv)
-{
-    ::testing::InitGoogleTest(&argc, argv);
-    int ret = RUN_ALL_TESTS();
-    return ret;
-}

--- a/backends/tests/test_sycl_platform_interface.cpp
+++ b/backends/tests/test_sycl_platform_interface.cpp
@@ -64,11 +64,3 @@ TEST_F (TestDPPLSyclPlatformInterface, CheckDPPLPlatformDumpInfo)
 {
     EXPECT_NO_FATAL_FAILURE(DPPLPlatform_DumpInfo());
 }
-
-int
-main (int argc, char** argv)
-{
-    ::testing::InitGoogleTest(&argc, argv);
-    int ret = RUN_ALL_TESTS();
-    return ret;
-}

--- a/backends/tests/test_sycl_program_interface.cpp
+++ b/backends/tests/test_sycl_program_interface.cpp
@@ -234,10 +234,3 @@ TEST_F (TestDPPLSyclProgramInterface, CheckGetKernelOCLSpirv)
     DPPLProgram_Delete(PRef);
 }
 
-int
-main (int argc, char** argv)
-{
-    ::testing::InitGoogleTest(&argc, argv);
-    int ret = RUN_ALL_TESTS();
-    return ret;
-}

--- a/backends/tests/test_sycl_queue_interface.cpp
+++ b/backends/tests/test_sycl_queue_interface.cpp
@@ -377,10 +377,3 @@ TEST_F (TestDPPLSyclQueueInterface, CheckSubmit)
     DPPLProgram_Delete(PRef);
 }
 
-int
-main (int argc, char** argv)
-{
-    ::testing::InitGoogleTest(&argc, argv);
-    int ret = RUN_ALL_TESTS();
-    return ret;
-}

--- a/backends/tests/test_sycl_queue_manager.cpp
+++ b/backends/tests/test_sycl_queue_manager.cpp
@@ -260,10 +260,3 @@ TEST_F (TestDPPLSyclQueueManager, CreateQueueFromDeviceAndContext)
     DPPLQueue_Delete(Q);
 }
 
-int
-main (int argc, char** argv)
-{
-    ::testing::InitGoogleTest(&argc, argv);
-    int ret = RUN_ALL_TESTS();
-    return ret;
-}

--- a/backends/tests/test_sycl_usm_interface.cpp
+++ b/backends/tests/test_sycl_usm_interface.cpp
@@ -183,10 +183,3 @@ TEST_F (TestDPPLSyclUSMInterface, AlignedAllocHost)
     DPPLfree_with_queue(Ptr, Q);
 }
 
-int
-main (int argc, char** argv)
-{
-    ::testing::InitGoogleTest(&argc, argv);
-    int ret = RUN_ALL_TESTS();
-    return ret;
-}

--- a/scripts/build_for_develop.bat
+++ b/scripts/build_for_develop.bat
@@ -21,11 +21,9 @@ cd ..\build_cmake
 set "DPCPP_ROOT=%ONEAPI_ROOT%\compiler\latest\windows"
 
 if defined USE_GTEST (
-    set "_GTEST_INCLUDE_DIR=%CONDA_PREFIX%\Library\include"
-    set "_GTEST_LIB_DIR=%CONDA_PREFIX%\Library\lib"
+    set "_BUILD_CAPI_TEST=ON"
 ) else (
-    set "_GTEST_INCLUDE_DIR="
-    set "_GTEST_LIB_DIR="
+    set "_BUILD_CAPI_TEST=OFF"
 )
 cmake -G Ninja ^
     -DCMAKE_BUILD_TYPE=Release ^
@@ -35,12 +33,11 @@ cmake -G Ninja ^
     "-DDPCPP_ROOT=%DPCPP_ROOT%" ^
     "-DCMAKE_C_COMPILER:PATH=%DPCPP_ROOT%\bin\clang-cl.exe" ^
     "-DCMAKE_CXX_COMPILER:PATH=%DPCPP_ROOT%\bin\dpcpp.exe" ^
-    "-DGTEST_INCLUDE_DIR=%_GTEST_INCLUDE_DIR%" ^
-    "-DGTEST_LIB_DIR=%_GTEST_LIB_DIR%" ^
+    "-DBUILD_CAPI_TESTS=%_BUILD_CAPI_TEST%" ^
     "%cd%\..\backends"
 IF %ERRORLEVEL% NEQ 0 exit /b 1
 
-ninja -n 
+ninja -n
 IF %ERRORLEVEL% NEQ 0 exit /b 1
 if defined USE_GTEST (
     ninja check

--- a/scripts/build_for_develop.sh
+++ b/scripts/build_for_develop.sh
@@ -21,7 +21,12 @@ cmake                                                       \
     ../backends
 
 make V=1 -n -j 4 && make check && make install
-#make V=1 -n -j 4 && make install
+
+# For more verbose tests use:
+# cd tests
+# ctest -V --progress --output-on-failure -j 4
+# cd ..
+
 popd
 cp install/lib/*.so dpctl/
 

--- a/scripts/build_for_develop.sh
+++ b/scripts/build_for_develop.sh
@@ -17,7 +17,7 @@ cmake                                                       \
     -DDPCPP_ROOT=${DPCPP_ROOT}                              \
     -DCMAKE_C_COMPILER:PATH=${DPCPP_ROOT}/bin/clang         \
     -DCMAKE_CXX_COMPILER:PATH=${DPCPP_ROOT}/bin/dpcpp       \
-    -DBUILD_CAPI_TESTS=ON                                    \
+    -DBUILD_CAPI_TESTS=ON                                   \
     ../backends
 
 make V=1 -n -j 4 && make check && make install

--- a/scripts/build_for_develop.sh
+++ b/scripts/build_for_develop.sh
@@ -17,8 +17,7 @@ cmake                                                       \
     -DDPCPP_ROOT=${DPCPP_ROOT}                              \
     -DCMAKE_C_COMPILER:PATH=${DPCPP_ROOT}/bin/clang         \
     -DCMAKE_CXX_COMPILER:PATH=${DPCPP_ROOT}/bin/dpcpp       \
-    -DGTEST_INCLUDE_DIR=${CONDA_PREFIX}/include/            \
-    -DGTEST_LIB_DIR=${CONDA_PREFIX}/lib                     \
+    -DBUILD_CAPI_TESTS=ON                                    \
     ../backends
 
 make V=1 -n -j 4 && make check && make install


### PR DESCRIPTION
Various clean ups and improvements to our gtest infrastructure:

- Use `find_package(GTest)` instead of the home grown gtest locator.
- Remove NumPy and Python includes as these are not needed and if required can be included using `finda_package`.
- Now building a single test runner executable for all tests.
- Do not print verbose `ctest` output by default and run tests in parallel.