### PR TITLE
Add _Memory.get_pointer_type static method

### DIFF
--- a/dpctl/memory/_memory.pxd
+++ b/dpctl/memory/_memory.pxd
@@ -45,6 +45,8 @@ cdef class _Memory:
 
     @staticmethod
     cdef SyclDevice get_pointer_device(DPPLSyclUSMRef p, SyclContext ctx)
+    @staticmethod
+    cdef bytes get_pointer_type(DPPLSyclUSMRef p, SyclContext ctx)
 
 
 cdef class MemoryUSMShared(_Memory):

--- a/dpctl/memory/_memory.pyx
+++ b/dpctl/memory/_memory.pyx
@@ -429,10 +429,18 @@ cdef class _Memory:
 
     @staticmethod
     cdef SyclDevice get_pointer_device(DPPLSyclUSMRef p, SyclContext ctx):
+        """Returns sycl device used to allocate given pointer `p` in given sycl context `ctx`"""
         cdef DPPLSyclDeviceRef dref = DPPLUSM_GetPointerDevice(p, ctx.get_context_ref())
 
         return SyclDevice._create(dref)
 
+    @staticmethod
+    cdef bytes get_pointer_type(DPPLSyclUSMRef p, SyclContext ctx):
+        """Returns USM-type of given pointer `p` in given sycl context `ctx`"""
+        cdef const char * usm_type = DPPLUSM_GetPointerType(p, ctx.get_context_ref())
+
+        return <bytes>usm_type
+    
 
 cdef class MemoryUSMShared(_Memory):
     """


### PR DESCRIPTION
Add `_Memory.get_pointer_type(DPPLSyclUSMRef p, SyclContext ctx)` to return `bytes` that stores the kind.