### PR TITLE
Fix problems in dpctl identified with Klockwork static code analysis

### DIFF
--- a/backends/source/dppl_sycl_context_interface.cpp
+++ b/backends/source/dppl_sycl_context_interface.cpp
@@ -47,7 +47,11 @@ bool DPPLContext_AreEq (__dppl_keep const DPPLSyclContextRef CtxRef1,
 
 bool DPPLContext_IsHost (__dppl_keep const DPPLSyclContextRef CtxRef)
 {
-    return unwrap(CtxRef)->is_host();
+    auto Ctx = unwrap(CtxRef)
+    if (Ctx) {
+        return Ctx->is_host();
+    }
+    return false;
 }
 
 void DPPLContext_Delete (__dppl_take DPPLSyclContextRef CtxRef)

--- a/backends/source/dppl_sycl_context_interface.cpp
+++ b/backends/source/dppl_sycl_context_interface.cpp
@@ -47,7 +47,7 @@ bool DPPLContext_AreEq (__dppl_keep const DPPLSyclContextRef CtxRef1,
 
 bool DPPLContext_IsHost (__dppl_keep const DPPLSyclContextRef CtxRef)
 {
-    auto Ctx = unwrap(CtxRef)
+    auto Ctx = unwrap(CtxRef);
     if (Ctx) {
         return Ctx->is_host();
     }

--- a/backends/source/dppl_sycl_platform_interface.cpp
+++ b/backends/source/dppl_sycl_platform_interface.cpp
@@ -148,7 +148,12 @@ size_t DPPLPlatform_GetNumNonHostPlatforms ()
 
 size_t DPPLPlatform_GetNumNonHostBackends ()
 {
-    return get_set_of_non_hostbackends().size();
+    auto be_set = get_set_of_non_hostbackends();
+
+    if (be_set.empty())
+        return 0;
+
+    return be_set.size();
 }
 
 __dppl_give DPPLSyclBackendType *DPPLPlatform_GetListOfNonHostBackends ()


### PR DESCRIPTION
https://jira.devtools.intel.com/browse/SAT-3619

An up - to-date analysis of the klocwork master branch showed 3 warnings. 2 match the previous analysis and have been corrected. Warning memory leak is unchanged because it was created deliberately(Sergey Pokhodenko).

The memory leak warning is still displayed in the klocwork report. I don't know what to do with it. klocwork does not support comments in the code for skipping analysis. You can add a key to build the report table so that the warning is not displayed in the table.