### PR TITLE
Use public keyword in _sycl_core.pxd on SyclContext/SyclQueue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -87,3 +87,12 @@ _dpctl_bindings*
 
 # generated C API coverage reports
 dpctl-c-api-coverage
+
+# generated header files
+dpctl/_sycl_queue.h
+dpctl/_sycl_context.h
+dpctl/_sycl_device.h
+dpctl/_sycl_event.h
+dpctl/_sycl_queue.h
+dpctl/_sycl_queue_manager.h
+dpctl/memory/_memory.h

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,12 @@
 include versioneer.py
 recursive-include dpctl/include *.h *.hpp
 recursive-include dpctl *.pxd
+include dpctl/_sycl_context.h
+include dpctl/_sycl_device.h
+include dpctl/_sycl_queue.h
+include dpctl/_sycl_queue_manager.h
+include dpctl/_sycl_event.h
+include dpctl/memory/_memory.h
 include dpctl/*DPCTL*Interface.*
 include dpctl/tests/input_files/*
 global-exclude *.cpp

--- a/dpctl/_sycl_context.pxd
+++ b/dpctl/_sycl_context.pxd
@@ -30,7 +30,7 @@ cdef class _SyclContext:
     cdef DPCTLSyclContextRef _ctxt_ref
 
 
-cdef class SyclContext(_SyclContext):
+cdef public class SyclContext(_SyclContext) [object PySyclContextObject, type PySyclContextType]:
     ''' Wrapper class for a Sycl Context
     '''
 

--- a/dpctl/_sycl_device.pxd
+++ b/dpctl/_sycl_device.pxd
@@ -38,7 +38,7 @@ cdef class _SyclDevice:
     cdef size_t *_max_work_item_sizes
 
 
-cdef class SyclDevice(_SyclDevice):
+cdef public class SyclDevice(_SyclDevice) [object PySyclDeviceObject, type PySyclDeviceType]:
     @staticmethod
     cdef SyclDevice _create(DPCTLSyclDeviceRef dref)
     @staticmethod

--- a/dpctl/_sycl_event.pxd
+++ b/dpctl/_sycl_event.pxd
@@ -23,7 +23,7 @@
 from ._backend cimport DPCTLSyclEventRef
 
 
-cdef class SyclEvent:
+cdef public class SyclEvent [object PySyclEventObject, type PySyclEventType]:
     ''' Wrapper class for a Sycl Event
     '''
     cdef  DPCTLSyclEventRef _event_ref

--- a/dpctl/_sycl_queue.pxd
+++ b/dpctl/_sycl_queue.pxd
@@ -41,7 +41,7 @@ cdef class _SyclQueue:
     cdef SyclDevice _device
 
 
-cdef class SyclQueue (_SyclQueue):
+cdef public class SyclQueue (_SyclQueue) [object PySyclQueueObject, type PySyclQueueType]:
     """ Python wrapper class for a sycl::queue.
     """
     cdef int _init_queue_default(self, int)

--- a/dpctl/_sycl_queue_manager.pxd
+++ b/dpctl/_sycl_queue_manager.pxd
@@ -20,6 +20,6 @@
 from ._sycl_queue cimport SyclQueue
 
 
-cpdef SyclQueue get_current_queue()
+cpdef public SyclQueue get_current_queue()
 cpdef get_current_device_type ()
 cpdef get_current_backend()

--- a/dpctl/memory/_memory.pxd
+++ b/dpctl/memory/_memory.pxd
@@ -28,7 +28,7 @@ from .._sycl_device cimport SyclDevice
 from .._sycl_queue cimport SyclQueue
 
 
-cdef class _Memory:
+cdef public class _Memory [object Py_MemoryObject, type Py_MemoryType]:
     cdef DPCTLSyclUSMRef memory_ptr
     cdef Py_ssize_t nbytes
     cdef SyclQueue queue
@@ -47,18 +47,18 @@ cdef class _Memory:
     cpdef bytes tobytes(self)
 
     @staticmethod
-    cdef SyclDevice get_pointer_device(DPCTLSyclUSMRef p, SyclContext ctx)
+    cdef public SyclDevice get_pointer_device(DPCTLSyclUSMRef p, SyclContext ctx)
     @staticmethod
-    cdef bytes get_pointer_type(DPCTLSyclUSMRef p, SyclContext ctx)
+    cdef public bytes get_pointer_type(DPCTLSyclUSMRef p, SyclContext ctx)
 
 
-cdef class MemoryUSMShared(_Memory):
+cdef public class MemoryUSMShared(_Memory) [object PyMemoryUSMSharedObject, type PyMemoryUSMSharedType]:
     pass
 
 
-cdef class MemoryUSMHost(_Memory):
+cdef public class MemoryUSMHost(_Memory) [object PyMemoryUSMHostObject, type PyMemoryUSMHostType]:
     pass
 
 
-cdef class MemoryUSMDevice(_Memory):
+cdef public class MemoryUSMDevice(_Memory) [object PyMemoryUSMDeviceObject, type PyMemoryUSMDeviceType]:
     pass


### PR DESCRIPTION
This causes Cython to convert `_sycl_core.pxd`, `_sycl_core.pyx`
into `_sycl_core.h` and `_sycl_core.cpp`.

The header file can be used by external C++/C projects to be aware
of SyclContext and SyclQueue python objects defined by dpctl.

These are PySyclContextObject, PySyclQueueObject, which are instances
of PyObject, and `PySyclContextType`, `PySyclQueueType` which can be used
in `PyObject_TypeCheck` calls, validating that a Python object is
a valid `syclobj` entry in `__sycl_usm_array_interface__`.