### PR TITLE
Adding __array_function__ so that Numpy calls with dparrays work.

### DIFF
--- a/dpctl/tests/test_dparray.py
+++ b/dpctl/tests/test_dparray.py
@@ -77,7 +77,6 @@ class Test_dparray(unittest.TestCase):
         res = numpy.ravel(self.X)
         self.assertEqual(res.shape, (1024,))
 
-    @unittest.expectedFailure
     def test_numpy_sum_with_dparray(self):
         res = numpy.sum(self.X)
         self.assertEqual(res, 1024.0)


### PR DESCRIPTION
Calling numpy.sum with a dparray should work now.  __array_function__ is now implemented.  I changed the way that we determine if a class or function is defined in this file from using eval to getting the module from sys.modules[__name__] and then using hasattr on the module.

Resolves #206 