### PR TITLE
changes to compiler name usage from clang++ to dpcpp

### DIFF
--- a/dpctl-capi/cmake/modules/FindLevelZero.cmake
+++ b/dpctl-capi/cmake/modules/FindLevelZero.cmake
@@ -25,8 +25,8 @@
 # LEVEL_ZERO_LIBRARY - the full path to the ze_loader library
 # TODO: Add a way to record the version of the level_zero library
 
-find_library(LEVEL_ZERO_LIBRARY ze_loader)
-find_path(LEVEL_ZERO_INCLUDE_DIR NAMES level_zero/zet_api.h)
+find_library(LEVEL_ZERO_LIBRARY ze_loader HINTS $ENV{L0_LIB_DIR})
+find_path(LEVEL_ZERO_INCLUDE_DIR NAMES level_zero/zet_api.h HINTS $ENV{L0_INCLUDE_DIR})
 
 find_package_handle_standard_args(LevelZero DEFAULT_MSG
     LEVEL_ZERO_INCLUDE_DIR

--- a/scripts/build_backend.py
+++ b/scripts/build_backend.py
@@ -83,6 +83,8 @@ if IS_WIN:
         "-DCMAKE_INSTALL_PREFIX=" + INSTALL_PREFIX,
         "-DCMAKE_PREFIX_PATH=" + INSTALL_PREFIX,
         "-DDPCPP_INSTALL_DIR=" + DPCPP_ROOT,
+        "-DCMAKE_C_COMPILER:PATH=" + os.path.join(DPCPP_ROOT, "bin", "clang-cl.exe"),
+        "-DCMAKE_CXX_COMPILER:PATH=" + os.path.join(DPCPP_ROOT, "bin", "dpcpp.exe"),        
         backends,
     ]
     subprocess.check_call(cmake_args, stderr=subprocess.STDOUT, shell=True)

--- a/scripts/build_backend.py
+++ b/scripts/build_backend.py
@@ -62,7 +62,7 @@ if IS_LIN:
         "-DCMAKE_PREFIX_PATH=" + INSTALL_PREFIX,
         "-DDPCPP_INSTALL_DIR=" + DPCPP_ROOT,
         "-DCMAKE_C_COMPILER:PATH=" + os.path.join(DPCPP_ROOT, "bin", "clang"),
-        "-DCMAKE_CXX_COMPILER:PATH=" + os.path.join(DPCPP_ROOT, "bin", "clang++"),
+        "-DCMAKE_CXX_COMPILER:PATH=" + os.path.join(DPCPP_ROOT, "bin", "dpcpp"),
         "-DDPCTL_ENABLE_LO_PROGRAM_CREATION=ON",
         backends,
     ]

--- a/scripts/build_backend.py
+++ b/scripts/build_backend.py
@@ -84,7 +84,7 @@ if IS_WIN:
         "-DCMAKE_PREFIX_PATH=" + INSTALL_PREFIX,
         "-DDPCPP_INSTALL_DIR=" + DPCPP_ROOT,
         "-DCMAKE_C_COMPILER:PATH=" + os.path.join(DPCPP_ROOT, "bin", "clang-cl.exe"),
-        "-DCMAKE_CXX_COMPILER:PATH=" + os.path.join(DPCPP_ROOT, "bin", "dpcpp.exe"),        
+        "-DCMAKE_CXX_COMPILER:PATH=" + os.path.join(DPCPP_ROOT, "bin", "dpcpp.exe"),
         backends,
     ]
     subprocess.check_call(cmake_args, stderr=subprocess.STDOUT, shell=True)

--- a/setup.py
+++ b/setup.py
@@ -43,15 +43,11 @@ else:
 
 if IS_LIN:
     DPCPP_ROOT = os.environ["ONEAPI_ROOT"] + "/compiler/latest/linux"
-    os.environ["CC"] = DPCPP_ROOT + "/bin/clang"
-    os.environ["CXX"] = DPCPP_ROOT + "/bin/clang++"
     os.environ["DPCTL_SYCL_INTERFACE_LIBDIR"] = "dpctl"
     os.environ["DPCTL_SYCL_INTERFACE_INCLDIR"] = "dpctl/include"
     os.environ["CFLAGS"] = "-fPIC"
 
 elif IS_WIN:
-    os.environ["CC"] = "clang-cl.exe"
-    os.environ["CXX"] = "dpcpp.exe"
     os.environ["DPCTL_SYCL_INTERFACE_LIBDIR"] = "dpctl"
     os.environ["DPCTL_SYCL_INTERFACE_INCLDIR"] = "dpctl\include"
 
@@ -86,7 +82,7 @@ def get_sdl_ldflags():
 
 def get_other_cxxflags():
     if IS_LIN:
-        return ["-O3", "-fsycl", "-std=c++17"]
+        return ["-O3", "-std=c++17"]
     elif IS_MAC:
         return []
     elif IS_WIN:


### PR DESCRIPTION
- In `build_backend.py` changed compiler from clang++ to dpcpp.
- Removed CC and CXX vars in setup.py since we want to build the extensions using the system compiler and not DPC++
- Provided environment variable hint to find level zero library to build on systems where level zero is in non default path

All these changes were required to get dpctl to build on ANL's JLSE cluster.