### PR TITLE
Tools/clang format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,25 @@
+BasedOnStyle: LLVM
+IndentWidth: 4
+AccessModifierOffset: -4
+AlignEscapedNewlines: Right
+AllowAllParametersOfDeclarationOnNextLine: false
+BinPackParameters: false
+BreakBeforeBraces: Custom
+BraceWrapping:
+  AfterCaseLabel:  true
+  AfterClass:      true
+  AfterControlStatement: MultiLine
+  AfterEnum:       true
+  AfterFunction:   true
+  AfterNamespace:  true
+  AfterObjCDeclaration: false
+  AfterStruct:     true
+  AfterUnion:      true
+  AfterExternBlock: true
+  BeforeCatch:     false
+  BeforeElse:      true
+  IndentBraces:    false
+  SplitEmptyFunction: true
+  SplitEmptyRecord: true
+  SplitEmptyNamespace: true
+  

--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -2,3 +2,6 @@
 
 # Migrate code style to Black
 41ccd65e2e659aa0add0e5ab59f1a46e32cc4c46
+
+# Migrate code style to clang-format
+4b0ecc01669bb2d281ee85b54fb76f8a9b94d63f

--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -1,0 +1,23 @@
+# This is a workflow to format C/C++ sources with clang-format
+
+name: clang-format Check
+
+# Controls when the action will run. Triggers the workflow on push or pull request
+# events but only for the master branch
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  formatting-check:
+    name: Formatting Check
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Run clang-format style check for C/C++ programs.
+      uses: jidicula/clang-format-action@v3.1.0
+      with:
+        clang-format-version: '11'
+        check-path: 'dpctl-capi'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,17 @@
 
 ## Source Code Formatting¶
 
+### C/C++ code style
+
+We use [clang-format](https://clang.llvm.org/docs/ClangFormat.html) code formatter.
+
+Install: `pip install clang`
+
+- Revision: `10.0.1`
+- See the default configuration used by dpCtl in `.clang-format`.
+
+Run before each commit: `clang-format -style=file -i dpctl-capi/include/*.h dpctl-capi/include/Support/*.h dpctl-capi/source/*.cpp dpctl-capi/tests/*.cpp dpctl-capi/helper/include/*.h dpctl-capi/helper/source/*.cpp`
+
 ### Python code style
 
 

--- a/dpctl-capi/helper/include/dpctl_dynamic_lib_helper.h
+++ b/dpctl-capi/helper/include/dpctl_dynamic_lib_helper.h
@@ -27,16 +27,16 @@
 
 #if defined(__linux__) || defined(_WIN32) || defined(_WIN64)
 
-    #ifdef __linux__
+#ifdef __linux__
 
-        #include <dlfcn.h>
+#include <dlfcn.h>
 
-    #elif defined(_WIN32) || defined(_WIN64)
+#elif defined(_WIN32) || defined(_WIN64)
 
-        #define NOMINMAX
-        #include <windows.h>
+#define NOMINMAX
+#include <windows.h>
 
-    #endif // __linux__
+#endif // __linux__
 
 #include <cstdint>
 
@@ -46,51 +46,48 @@ namespace dpctl
 class DynamicLibHelper final
 {
 public:
-    DynamicLibHelper()                         = delete;
+    DynamicLibHelper() = delete;
     DynamicLibHelper(const DynamicLibHelper &) = delete;
-    DynamicLibHelper(const char * libName, int flag)
+    DynamicLibHelper(const char *libName, int flag)
     {
 
-    #ifdef __linux__
+#ifdef __linux__
         _handle = dlopen(libName, flag);
-    #elif defined(_WIN32) || defined(_WIN64)
+#elif defined(_WIN32) || defined(_WIN64)
         _handle = LoadLibraryA(libName);
-    #endif
+#endif
     }
 
     ~DynamicLibHelper()
     {
-    #ifdef __linux__
+#ifdef __linux__
         dlclose(_handle);
-    #elif defined(_WIN32) || defined(_WIN64)
+#elif defined(_WIN32) || defined(_WIN64)
         FreeLibrary((HMODULE)_handle);
-    #endif
+#endif
     };
 
-    template <typename T>
-    T getSymbol(const char * symName)
+    template <typename T> T getSymbol(const char *symName)
     {
-    #ifdef __linux__
-        void * sym   = dlsym(_handle, symName);
-        char * error = dlerror();
+#ifdef __linux__
+        void *sym = dlsym(_handle, symName);
+        char *error = dlerror();
 
-        if (NULL != error)
-        {
+        if (NULL != error) {
             return nullptr;
         }
-    #elif defined(_WIN32) || defined(_WIN64)
-        void * sym = (void *)GetProcAddress((HMODULE)_handle, symName);
+#elif defined(_WIN32) || defined(_WIN64)
+        void *sym = (void *)GetProcAddress((HMODULE)_handle, symName);
 
-        if (NULL == sym)
-        {
+        if (NULL == sym) {
             return nullptr;
         }
-    #endif
+#endif
 
         return (T)sym;
     }
 
-    bool opened () const
+    bool opened() const
     {
         if (!_handle)
             return false;
@@ -99,7 +96,7 @@ public:
     }
 
 private:
-    void * _handle = nullptr;
+    void *_handle = nullptr;
 };
 
 } // namespace dpctl

--- a/dpctl-capi/helper/source/dpctl_utils_helper.cpp
+++ b/dpctl-capi/helper/source/dpctl_utils_helper.cpp
@@ -24,19 +24,18 @@
 //===----------------------------------------------------------------------===//
 
 #include "dpctl_utils_helper.h"
-#include <string>
 #include <sstream>
+#include <string>
 
 using namespace cl::sycl;
 
 /*!
-* Transforms enum info::device_type to string.
-*/
+ * Transforms enum info::device_type to string.
+ */
 std::string DPCTL_DeviceTypeToStr(info::device_type devTy)
 {
     std::stringstream ss;
-    switch (devTy)
-    {
+    switch (devTy) {
     case info::device_type::cpu:
         ss << "cpu" << '\n';
         break;
@@ -59,22 +58,27 @@ std::string DPCTL_DeviceTypeToStr(info::device_type devTy)
 }
 
 /*!
-* Transforms string to enum info::device_type.
-*/
+ * Transforms string to enum info::device_type.
+ */
 info::device_type DPCTL_StrToDeviceType(std::string devTyStr)
 {
     info::device_type devTy;
     if (devTyStr == "cpu") {
         devTy = info::device_type::cpu;
-    } else if(devTyStr == "gpu") {
+    }
+    else if (devTyStr == "gpu") {
         devTy = info::device_type::gpu;
-    } else if(devTyStr == "accelerator") {
+    }
+    else if (devTyStr == "accelerator") {
         devTy = info::device_type::accelerator;
-    } else if(devTyStr == "custom") {
+    }
+    else if (devTyStr == "custom") {
         devTy = info::device_type::custom;
-    } else if(devTyStr == "host") {
+    }
+    else if (devTyStr == "host") {
         devTy = info::device_type::host;
-    } else {
+    }
+    else {
         // \todo handle the error
         throw std::runtime_error("Unknown device type.");
     }

--- a/dpctl-capi/include/Support/CBindingWrapping.h
+++ b/dpctl-capi/include/Support/CBindingWrapping.h
@@ -32,12 +32,12 @@
 #define DEFINE_SIMPLE_CONVERSION_FUNCTIONS(ty, ref)                            \
     __attribute__((unused)) inline ty *unwrap(ref P)                           \
     {                                                                          \
-        return reinterpret_cast<ty*>(P);                                       \
+        return reinterpret_cast<ty *>(P);                                      \
     }                                                                          \
                                                                                \
     __attribute__((unused)) inline ref wrap(const ty *P)                       \
     {                                                                          \
-            return reinterpret_cast<ref>(const_cast<ty*>(P));                  \
+        return reinterpret_cast<ref>(const_cast<ty *>(P));                     \
     }
 
 /*!
@@ -47,10 +47,9 @@
 #define DEFINE_STDCXX_CONVERSION_FUNCTIONS(ty, ref)                            \
     DEFINE_SIMPLE_CONVERSION_FUNCTIONS(ty, ref)                                \
                                                                                \
-    template<typename T>                                                       \
-    __attribute__((unused)) inline T *unwrap(ref P)                            \
+    template <typename T> __attribute__((unused)) inline T *unwrap(ref P)      \
     {                                                                          \
-        T *Q = (T*)unwrap(P);                                                  \
+        T *Q = (T *)unwrap(P);                                                 \
         assert(Q && "Invalid cast!");                                          \
         return Q;                                                              \
     }

--- a/dpctl-capi/include/Support/DllExport.h
+++ b/dpctl-capi/include/Support/DllExport.h
@@ -26,11 +26,11 @@
 #pragma once
 
 #ifdef _WIN32
-#    ifdef DPCTLSyclInterface_EXPORTS
-#        define DPCTL_API __declspec(dllexport)
-#    else
-#        define DPCTL_API __declspec(dllimport)
-#    endif
+#ifdef DPCTLSyclInterface_EXPORTS
+#define DPCTL_API __declspec(dllexport)
 #else
-#    define DPCTL_API
+#define DPCTL_API __declspec(dllimport)
+#endif
+#else
+#define DPCTL_API
 #endif

--- a/dpctl-capi/include/Support/ExternC.h
+++ b/dpctl-capi/include/Support/ExternC.h
@@ -1,4 +1,4 @@
-//===----------- ExternC.h - Defines a extern C helper macro     -*-C++-*- ===//
+//===----------- ExternC.h - Defines an extern C helper macro    -*-C++-*- ===//
 //
 //                      Data Parallel Control (dpCtl)
 //
@@ -26,8 +26,10 @@
 #pragma once
 
 #ifdef __cplusplus
-#define DPCTL_C_EXTERN_C_BEGIN  extern "C" {
-#define DPCTL_C_EXTERN_C_END    }
+#define DPCTL_C_EXTERN_C_BEGIN                                                 \
+    extern "C"                                                                 \
+    {
+#define DPCTL_C_EXTERN_C_END }
 #else
 #define DPCTL_C_EXTERN_C_BEGIN
 #define DPCTL_C_EXTERN_C_END

--- a/dpctl-capi/include/Support/MemOwnershipAttrs.h
+++ b/dpctl-capi/include/Support/MemOwnershipAttrs.h
@@ -51,9 +51,9 @@
 #endif
 /*!
  * @def __dpctl_take
- * @brief The __dpctl_take attribute indicates that the function "takes" over the
- * ownership of the object and the user must not use the object as an argument
- * to another function.
+ * @brief The __dpctl_take attribute indicates that the function "takes" over
+ * the ownership of the object and the user must not use the object as an
+ * argument to another function.
  *
  * The __dpctl_take attribute mens that the function destroys it before the
  * function returns, and the caller must not use the object again in any other

--- a/dpctl-capi/include/dpctl_data_types.h
+++ b/dpctl-capi/include/dpctl_data_types.h
@@ -40,12 +40,12 @@
 #ifndef _MSC_VER
 
 #if !defined(UINT32_MAX)
-# error "The standard header <cstdint> is not C++11 compliant. Must #define "\
+#error "The standard header <cstdint> is not C++11 compliant. Must #define "\
         "__STDC_LIMIT_MACROS before #including llvm-c/DataTypes.h"
 #endif
 
 #if !defined(UINT32_C)
-# error "The standard header <cstdint> is not C++11 compliant. Must #define "\
+#error "The standard header <cstdint> is not C++11 compliant. Must #define "\
         "__STDC_CONSTANT_MACROS before #including llvm-c/DataTypes.h"
 #endif
 
@@ -80,21 +80,21 @@ typedef signed int ssize_t;
     @brief Represents tha largest possible value of a 64 bit signed integer.
 */
 #if !defined(INT64_MAX)
-# define INT64_MAX 9223372036854775807LL
+#define INT64_MAX 9223372036854775807LL
 #endif
 
 /*!
     @brief Represents tha smallest possible value of a 64 bit signed integer.
 */
 #if !defined(INT64_MIN)
-# define INT64_MIN ((-INT64_MAX)-1)
+#define INT64_MIN ((-INT64_MAX) - 1)
 #endif
 
 /*!
     @brief Represents tha largest possible value of a 64bit unsigned integer.
 */
 #if !defined(UINT64_MAX)
-# define UINT64_MAX 0xffffffffffffffffULL
+#define UINT64_MAX 0xffffffffffffffffULL
 #endif
 
 /*!

--- a/dpctl-capi/include/dpctl_sycl_context_interface.h
+++ b/dpctl-capi/include/dpctl_sycl_context_interface.h
@@ -25,12 +25,12 @@
 
 #pragma once
 
-#include "dpctl_data_types.h"
-#include "dpctl_sycl_types.h"
-#include "dpctl_sycl_platform_interface.h"
 #include "Support/DllExport.h"
 #include "Support/ExternC.h"
 #include "Support/MemOwnershipAttrs.h"
+#include "dpctl_data_types.h"
+#include "dpctl_sycl_platform_interface.h"
+#include "dpctl_sycl_types.h"
 #include <stdbool.h>
 
 DPCTL_C_EXTERN_C_BEGIN
@@ -44,8 +44,8 @@ DPCTL_C_EXTERN_C_BEGIN
  * @return   True if the underlying sycl::context are same, false otherwise.
  */
 DPCTL_API
-bool DPCTLContext_AreEq (__dpctl_keep const DPCTLSyclContextRef CtxRef1,
-                         __dpctl_keep const DPCTLSyclContextRef CtxRef2);
+bool DPCTLContext_AreEq(__dpctl_keep const DPCTLSyclContextRef CtxRef1,
+                        __dpctl_keep const DPCTLSyclContextRef CtxRef2);
 
 /*!
  * @brief Returns true if this SYCL context is a host context.
@@ -54,7 +54,7 @@ bool DPCTLContext_AreEq (__dpctl_keep const DPCTLSyclContextRef CtxRef1,
  * @return   True if the SYCL context is a host context, else False.
  */
 DPCTL_API
-bool DPCTLContext_IsHost (__dpctl_keep const DPCTLSyclContextRef CtxRef);
+bool DPCTLContext_IsHost(__dpctl_keep const DPCTLSyclContextRef CtxRef);
 
 /*!
  * @brief Returns the sycl backend for the DPCTLSyclContextRef pointer.
@@ -65,7 +65,7 @@ bool DPCTLContext_IsHost (__dpctl_keep const DPCTLSyclContextRef CtxRef);
  */
 DPCTL_API
 DPCTLSyclBackendType
-DPCTLContext_GetBackend (__dpctl_keep const DPCTLSyclContextRef CtxRef);
+DPCTLContext_GetBackend(__dpctl_keep const DPCTLSyclContextRef CtxRef);
 
 /*!
  * @brief Delete the pointer after casting it to sycl::context
@@ -73,6 +73,6 @@ DPCTLContext_GetBackend (__dpctl_keep const DPCTLSyclContextRef CtxRef);
  * @param    CtxRef        The DPCTLSyclContextRef pointer to be deleted.
  */
 DPCTL_API
-void DPCTLContext_Delete (__dpctl_take DPCTLSyclContextRef CtxRef);
+void DPCTLContext_Delete(__dpctl_take DPCTLSyclContextRef CtxRef);
 
 DPCTL_C_EXTERN_C_END

--- a/dpctl-capi/include/dpctl_sycl_device_interface.h
+++ b/dpctl-capi/include/dpctl_sycl_device_interface.h
@@ -27,12 +27,12 @@
 
 #pragma once
 
-#include "dpctl_data_types.h"
-#include "dpctl_sycl_enum_types.h"
-#include "dpctl_sycl_types.h"
 #include "Support/DllExport.h"
 #include "Support/ExternC.h"
 #include "Support/MemOwnershipAttrs.h"
+#include "dpctl_data_types.h"
+#include "dpctl_sycl_enum_types.h"
+#include "dpctl_sycl_types.h"
 
 DPCTL_C_EXTERN_C_BEGIN
 
@@ -42,7 +42,7 @@ DPCTL_C_EXTERN_C_BEGIN
  * @param    DRef           A DPCTLSyclDeviceRef pointer.
  */
 DPCTL_API
-void DPCTLDevice_DumpInfo (__dpctl_keep const DPCTLSyclDeviceRef DRef);
+void DPCTLDevice_DumpInfo(__dpctl_keep const DPCTLSyclDeviceRef DRef);
 
 /*!
  * @brief Deletes a DPCTLSyclDeviceRef pointer after casting to to sycl::device.
@@ -50,7 +50,7 @@ void DPCTLDevice_DumpInfo (__dpctl_keep const DPCTLSyclDeviceRef DRef);
  * @param    DRef           The DPCTLSyclDeviceRef pointer to be freed.
  */
 DPCTL_API
-void DPCTLDevice_Delete (__dpctl_take DPCTLSyclDeviceRef DRef);
+void DPCTLDevice_Delete(__dpctl_take DPCTLSyclDeviceRef DRef);
 
 /*!
  * @brief Returns true if this SYCL device is an OpenCL device and the device
@@ -60,7 +60,7 @@ void DPCTLDevice_Delete (__dpctl_take DPCTLSyclDeviceRef DRef);
  * @return   True if the device type is an accelerator, else False.
  */
 DPCTL_API
-bool DPCTLDevice_IsAccelerator (__dpctl_keep const DPCTLSyclDeviceRef DRef);
+bool DPCTLDevice_IsAccelerator(__dpctl_keep const DPCTLSyclDeviceRef DRef);
 
 /*!
  * @brief Returns true if this SYCL device is an OpenCL device and the device
@@ -70,7 +70,7 @@ bool DPCTLDevice_IsAccelerator (__dpctl_keep const DPCTLSyclDeviceRef DRef);
  * @return   True if the device type is a cpu, else False.
  */
 DPCTL_API
-bool DPCTLDevice_IsCPU (__dpctl_keep const DPCTLSyclDeviceRef DRef);
+bool DPCTLDevice_IsCPU(__dpctl_keep const DPCTLSyclDeviceRef DRef);
 
 /*!
  * @brief Returns true if this SYCL device is an OpenCL device and the device
@@ -80,7 +80,7 @@ bool DPCTLDevice_IsCPU (__dpctl_keep const DPCTLSyclDeviceRef DRef);
  * @return    True if the device type is a gpu, else False.
  */
 DPCTL_API
-bool DPCTLDevice_IsGPU (__dpctl_keep const DPCTLSyclDeviceRef DRef);
+bool DPCTLDevice_IsGPU(__dpctl_keep const DPCTLSyclDeviceRef DRef);
 
 /*!
  * @brief Returns true if this SYCL device is a host device.
@@ -89,7 +89,7 @@ bool DPCTLDevice_IsGPU (__dpctl_keep const DPCTLSyclDeviceRef DRef);
  * @return   True if the device is a host device, else False.
  */
 DPCTL_API
-bool DPCTLDevice_IsHost (__dpctl_keep const DPCTLSyclDeviceRef DRef);
+bool DPCTLDevice_IsHost(__dpctl_keep const DPCTLSyclDeviceRef DRef);
 
 /*!
  * @brief Returns the OpenCL software driver version as a C string.
@@ -99,8 +99,8 @@ bool DPCTLDevice_IsHost (__dpctl_keep const DPCTLSyclDeviceRef DRef);
  *           to the OpenCL driver version if this is a OpenCL device.
  */
 DPCTL_API
-__dpctl_give const char*
-DPCTLDevice_GetDriverInfo (__dpctl_keep const DPCTLSyclDeviceRef DRef);
+__dpctl_give const char *
+DPCTLDevice_GetDriverInfo(__dpctl_keep const DPCTLSyclDeviceRef DRef);
 
 /*!
  * @brief Wrapper over device.get_info<info::device::max_compute_units>().
@@ -110,7 +110,7 @@ DPCTLDevice_GetDriverInfo (__dpctl_keep const DPCTLSyclDeviceRef DRef);
  */
 DPCTL_API
 uint32_t
-DPCTLDevice_GetMaxComputeUnits (__dpctl_keep const DPCTLSyclDeviceRef DRef);
+DPCTLDevice_GetMaxComputeUnits(__dpctl_keep const DPCTLSyclDeviceRef DRef);
 
 /*!
  * @brief Wrapper for get_info<info::device::max_work_item_dimensions>().
@@ -120,7 +120,7 @@ DPCTLDevice_GetMaxComputeUnits (__dpctl_keep const DPCTLSyclDeviceRef DRef);
  */
 DPCTL_API
 uint32_t
-DPCTLDevice_GetMaxWorkItemDims (__dpctl_keep const DPCTLSyclDeviceRef DRef);
+DPCTLDevice_GetMaxWorkItemDims(__dpctl_keep const DPCTLSyclDeviceRef DRef);
 
 /*!
  * @brief Wrapper for get_info<info::device::max_work_item_sizes>().
@@ -129,8 +129,8 @@ DPCTLDevice_GetMaxWorkItemDims (__dpctl_keep const DPCTLSyclDeviceRef DRef);
  * @return   Returns the valid result if device exists else returns NULL.
  */
 DPCTL_API
-__dpctl_keep size_t*
-DPCTLDevice_GetMaxWorkItemSizes (__dpctl_keep const DPCTLSyclDeviceRef DRef);
+__dpctl_keep size_t *
+DPCTLDevice_GetMaxWorkItemSizes(__dpctl_keep const DPCTLSyclDeviceRef DRef);
 
 /*!
  * @brief Wrapper for get_info<info::device::max_work_group_size>().
@@ -140,7 +140,7 @@ DPCTLDevice_GetMaxWorkItemSizes (__dpctl_keep const DPCTLSyclDeviceRef DRef);
  */
 DPCTL_API
 size_t
-DPCTLDevice_GetMaxWorkGroupSize (__dpctl_keep const DPCTLSyclDeviceRef DRef);
+DPCTLDevice_GetMaxWorkGroupSize(__dpctl_keep const DPCTLSyclDeviceRef DRef);
 
 /*!
  * @brief Wrapper over device.get_info<info::device::max_num_sub_groups>.
@@ -150,27 +150,30 @@ DPCTLDevice_GetMaxWorkGroupSize (__dpctl_keep const DPCTLSyclDeviceRef DRef);
  */
 DPCTL_API
 uint32_t
-DPCTLDevice_GetMaxNumSubGroups (__dpctl_keep const DPCTLSyclDeviceRef DRef);
+DPCTLDevice_GetMaxNumSubGroups(__dpctl_keep const DPCTLSyclDeviceRef DRef);
 
 /*!
- * @brief Wrapper over device.get_info<info::device::aspect::int64_base_atomics>.
+ * @brief Wrapper over
+ * device.get_info<info::device::aspect::int64_base_atomics>.
  *
  * @param    DRef           Opaque pointer to a sycl::device
  * @return   Returns true if device has int64_base_atomics else returns false.
  */
 DPCTL_API
-bool
-DPCTLDevice_HasInt64BaseAtomics (__dpctl_keep const DPCTLSyclDeviceRef DRef);
+bool DPCTLDevice_HasInt64BaseAtomics(
+    __dpctl_keep const DPCTLSyclDeviceRef DRef);
 
 /*!
- * @brief Wrapper over device.get_info<info::device::aspect::int64_extended_atomics>.
+ * @brief Wrapper over
+ * device.get_info<info::device::aspect::int64_extended_atomics>.
  *
  * @param    DRef           Opaque pointer to a sycl::device
- * @return   Returns true if device has int64_extended_atomics else returns false.
+ * @return   Returns true if device has int64_extended_atomics else returns
+ * false.
  */
 DPCTL_API
-bool
-DPCTLDevice_HasInt64ExtendedAtomics (__dpctl_keep const DPCTLSyclDeviceRef DRef);
+bool DPCTLDevice_HasInt64ExtendedAtomics(
+    __dpctl_keep const DPCTLSyclDeviceRef DRef);
 
 /*!
  * @brief Returns a C string for the device name.
@@ -179,8 +182,8 @@ DPCTLDevice_HasInt64ExtendedAtomics (__dpctl_keep const DPCTLSyclDeviceRef DRef)
  * @return   A C string containing the OpenCL device name.
  */
 DPCTL_API
-__dpctl_give const char*
-DPCTLDevice_GetName (__dpctl_keep const DPCTLSyclDeviceRef DRef);
+__dpctl_give const char *
+DPCTLDevice_GetName(__dpctl_keep const DPCTLSyclDeviceRef DRef);
 
 /*!
  * @brief Returns a C string corresponding to the vendor name.
@@ -189,8 +192,8 @@ DPCTLDevice_GetName (__dpctl_keep const DPCTLSyclDeviceRef DRef);
  * @return    A C string containing the OpenCL device vendor name.
  */
 DPCTL_API
-__dpctl_give const char*
-DPCTLDevice_GetVendorName (__dpctl_keep const DPCTLSyclDeviceRef DRef);
+__dpctl_give const char *
+DPCTLDevice_GetVendorName(__dpctl_keep const DPCTLSyclDeviceRef DRef);
 
 /*!
  * @brief Returns True if the device and the host share a unified memory
@@ -201,7 +204,8 @@ DPCTLDevice_GetVendorName (__dpctl_keep const DPCTLSyclDeviceRef DRef);
  * with the host.
  */
 DPCTL_API
-bool DPCTLDevice_IsHostUnifiedMemory (__dpctl_keep const DPCTLSyclDeviceRef DRef);
+bool DPCTLDevice_IsHostUnifiedMemory(
+    __dpctl_keep const DPCTLSyclDeviceRef DRef);
 
 /*!
  * @brief Checks if two DPCTLSyclDeviceRef objects point to the same
@@ -212,6 +216,6 @@ bool DPCTLDevice_IsHostUnifiedMemory (__dpctl_keep const DPCTLSyclDeviceRef DRef
  * @return   True if the underlying sycl::device are same, false otherwise.
  */
 DPCTL_API
-bool DPCTLDevice_AreEq (__dpctl_keep const DPCTLSyclDeviceRef DevRef1,
-                        __dpctl_keep const DPCTLSyclDeviceRef DevRef2);
+bool DPCTLDevice_AreEq(__dpctl_keep const DPCTLSyclDeviceRef DevRef1,
+                       __dpctl_keep const DPCTLSyclDeviceRef DevRef2);
 DPCTL_C_EXTERN_C_END

--- a/dpctl-capi/include/dpctl_sycl_enum_types.h
+++ b/dpctl-capi/include/dpctl_sycl_enum_types.h
@@ -37,11 +37,13 @@ DPCTL_C_EXTERN_C_BEGIN
  */
 enum DPCTLSyclBackendType
 {
+    // clang-format off
     DPCTL_UNKNOWN_BACKEND = 0x0,
     DPCTL_OPENCL          = 1 << 16,
     DPCTL_HOST            = 1 << 15,
     DPCTL_LEVEL_ZERO      = 1 << 14,
     DPCTL_CUDA            = 1 << 13
+    // clang-format on
 };
 
 /*!
@@ -50,6 +52,7 @@ enum DPCTLSyclBackendType
  */
 enum DPCTLSyclDeviceType
 {
+    // clang-format off
     DPCTL_CPU         = 1 << 0,
     DPCTL_GPU         = 1 << 1,
     DPCTL_ACCELERATOR = 1 << 2,
@@ -59,6 +62,7 @@ enum DPCTLSyclDeviceType
     DPCTL_ALL         = 1 << 6
     // IMP: before adding new values here look at DPCTLSyclBackendType enum. The
     // values should not overlap.
+    // clang-format on
 };
 
 /*!

--- a/dpctl-capi/include/dpctl_sycl_event_interface.h
+++ b/dpctl-capi/include/dpctl_sycl_event_interface.h
@@ -25,22 +25,22 @@
 
 #pragma once
 
-#include "dpctl_data_types.h"
-#include "dpctl_sycl_types.h"
 #include "Support/DllExport.h"
 #include "Support/ExternC.h"
 #include "Support/MemOwnershipAttrs.h"
-
+#include "dpctl_data_types.h"
+#include "dpctl_sycl_types.h"
 
 DPCTL_C_EXTERN_C_BEGIN
 
 /*!
  * @brief C-API wrapper for sycl::event.wait.
  *
- * @param    ERef           An opaque DPCTLSyclEventRef pointer on which to wait.
+ * @param    ERef           An opaque DPCTLSyclEventRef pointer on which to
+ *                          wait.
  */
 DPCTL_API
-void DPCTLEvent_Wait (__dpctl_keep DPCTLSyclEventRef ERef);
+void DPCTLEvent_Wait(__dpctl_keep DPCTLSyclEventRef ERef);
 
 /*!
  * @brief Deletes the DPCTLSyclEventRef after casting it to a sycl::event.
@@ -49,7 +49,6 @@ void DPCTLEvent_Wait (__dpctl_keep DPCTLSyclEventRef ERef);
  *                          freed.
  */
 DPCTL_API
-void
-DPCTLEvent_Delete (__dpctl_take DPCTLSyclEventRef ERef);
+void DPCTLEvent_Delete(__dpctl_take DPCTLSyclEventRef ERef);
 
 DPCTL_C_EXTERN_C_END

--- a/dpctl-capi/include/dpctl_sycl_kernel_interface.h
+++ b/dpctl-capi/include/dpctl_sycl_kernel_interface.h
@@ -26,11 +26,11 @@
 
 #pragma once
 
-#include "dpctl_data_types.h"
-#include "dpctl_sycl_types.h"
 #include "Support/DllExport.h"
 #include "Support/ExternC.h"
 #include "Support/MemOwnershipAttrs.h"
+#include "dpctl_data_types.h"
+#include "dpctl_sycl_types.h"
 
 DPCTL_C_EXTERN_C_BEGIN
 
@@ -43,8 +43,8 @@ DPCTL_C_EXTERN_C_BEGIN
  *           returns a nullptr.
  */
 DPCTL_API
-__dpctl_give const char*
-DPCTLKernel_GetFunctionName (__dpctl_keep const DPCTLSyclKernelRef KRef);
+__dpctl_give const char *
+DPCTLKernel_GetFunctionName(__dpctl_keep const DPCTLSyclKernelRef KRef);
 
 /*!
  * @brief Returns the number of arguments for the OpenCL kernel.
@@ -55,8 +55,7 @@ DPCTLKernel_GetFunctionName (__dpctl_keep const DPCTLSyclKernelRef KRef);
  *           kernel.
  */
 DPCTL_API
-size_t
-DPCTLKernel_GetNumArgs (__dpctl_keep const DPCTLSyclKernelRef KRef);
+size_t DPCTLKernel_GetNumArgs(__dpctl_keep const DPCTLSyclKernelRef KRef);
 
 /*!
  * @brief Deletes the DPCTLSyclKernelRef after casting it to a sycl::kernel.
@@ -65,7 +64,6 @@ DPCTLKernel_GetNumArgs (__dpctl_keep const DPCTLSyclKernelRef KRef);
  *                          interoperability kernel.
  */
 DPCTL_API
-void
-DPCTLKernel_Delete (__dpctl_take DPCTLSyclKernelRef KRef);
+void DPCTLKernel_Delete(__dpctl_take DPCTLSyclKernelRef KRef);
 
 DPCTL_C_EXTERN_C_END

--- a/dpctl-capi/include/dpctl_sycl_platform_interface.h
+++ b/dpctl-capi/include/dpctl_sycl_platform_interface.h
@@ -25,11 +25,11 @@
 
 #pragma once
 
-#include "dpctl_data_types.h"
-#include "dpctl_sycl_enum_types.h"
 #include "Support/DllExport.h"
 #include "Support/ExternC.h"
 #include "Support/MemOwnershipAttrs.h"
+#include "dpctl_data_types.h"
+#include "dpctl_sycl_enum_types.h"
 
 DPCTL_C_EXTERN_C_BEGIN
 
@@ -40,7 +40,7 @@ DPCTL_C_EXTERN_C_BEGIN
  * @return The number of available sycl::platforms.
  */
 DPCTL_API
-size_t DPCTLPlatform_GetNumNonHostPlatforms ();
+size_t DPCTLPlatform_GetNumNonHostPlatforms();
 
 /*!
  * @brief Returns the number of unique non-host sycl backends on the system.
@@ -48,7 +48,7 @@ size_t DPCTLPlatform_GetNumNonHostPlatforms ();
  * @return   The number of unique sycl backends.
  */
 DPCTL_API
-size_t DPCTLPlatform_GetNumNonHostBackends ();
+size_t DPCTLPlatform_GetNumNonHostBackends();
 
 /*!
  * @brief Returns an array of the unique non-host DPCTLSyclBackendType values on
@@ -57,21 +57,23 @@ size_t DPCTLPlatform_GetNumNonHostBackends ();
  * @return   An array of DPCTLSyclBackendType enum values.
  */
 DPCTL_API
-__dpctl_give DPCTLSyclBackendType* DPCTLPlatform_GetListOfNonHostBackends ();
+__dpctl_give DPCTLSyclBackendType *DPCTLPlatform_GetListOfNonHostBackends();
 
 /*!
  * @brief Frees an array of DPCTLSyclBackendType enum values.
  *
- * @param    BEArr      An array of DPCTLSyclBackendType enum values to be freed.
+ * @param    BEArr      An array of DPCTLSyclBackendType enum values to be
+ *                      freed.
  */
 DPCTL_API
-void DPCTLPlatform_DeleteListOfBackends (__dpctl_take DPCTLSyclBackendType* BEArr);
+void DPCTLPlatform_DeleteListOfBackends(
+    __dpctl_take DPCTLSyclBackendType *BEArr);
 
 /*!
  * @brief Prints out some selected info about all sycl::platform on the system.
  *
  */
 DPCTL_API
-void DPCTLPlatform_DumpInfo ();
+void DPCTLPlatform_DumpInfo();
 
 DPCTL_C_EXTERN_C_END

--- a/dpctl-capi/include/dpctl_sycl_program_interface.h
+++ b/dpctl-capi/include/dpctl_sycl_program_interface.h
@@ -26,11 +26,11 @@
 
 #pragma once
 
-#include "dpctl_data_types.h"
-#include "dpctl_sycl_types.h"
 #include "Support/DllExport.h"
 #include "Support/ExternC.h"
 #include "Support/MemOwnershipAttrs.h"
+#include "dpctl_data_types.h"
+#include "dpctl_sycl_types.h"
 
 DPCTL_C_EXTERN_C_BEGIN
 
@@ -56,10 +56,10 @@ DPCTL_C_EXTERN_C_BEGIN
  */
 DPCTL_API
 __dpctl_give DPCTLSyclProgramRef
-DPCTLProgram_CreateFromSpirv (__dpctl_keep const DPCTLSyclContextRef Ctx,
-                              __dpctl_keep const void *IL,
-                              size_t Length,
-                              const char *CompileOpts);
+DPCTLProgram_CreateFromSpirv(__dpctl_keep const DPCTLSyclContextRef Ctx,
+                             __dpctl_keep const void *IL,
+                             size_t Length,
+                             const char *CompileOpts);
 
 /*!
  * @brief Create a Sycl program from an OpenCL kernel source string.
@@ -72,9 +72,9 @@ DPCTLProgram_CreateFromSpirv (__dpctl_keep const DPCTLSyclContextRef Ctx,
  */
 DPCTL_API
 __dpctl_give DPCTLSyclProgramRef
-DPCTLProgram_CreateFromOCLSource (__dpctl_keep const DPCTLSyclContextRef Ctx,
-                                  __dpctl_keep const char *Source,
-                                  __dpctl_keep const char *CompileOpts);
+DPCTLProgram_CreateFromOCLSource(__dpctl_keep const DPCTLSyclContextRef Ctx,
+                                 __dpctl_keep const char *Source,
+                                 __dpctl_keep const char *CompileOpts);
 
 /*!
  * @brief Returns the SyclKernel with given name from the program, if not found
@@ -86,8 +86,8 @@ DPCTLProgram_CreateFromOCLSource (__dpctl_keep const DPCTLSyclContextRef Ctx,
  */
 DPCTL_API
 __dpctl_give DPCTLSyclKernelRef
-DPCTLProgram_GetKernel (__dpctl_keep DPCTLSyclProgramRef PRef,
-                        __dpctl_keep const char *KernelName);
+DPCTLProgram_GetKernel(__dpctl_keep DPCTLSyclProgramRef PRef,
+                       __dpctl_keep const char *KernelName);
 
 /*!
  * @brief Return True if a SyclKernel with given name exists in the program, if
@@ -98,9 +98,8 @@ DPCTLProgram_GetKernel (__dpctl_keep DPCTLSyclProgramRef PRef,
  * @return   True if the kernel exists, else False
  */
 DPCTL_API
-bool
-DPCTLProgram_HasKernel (__dpctl_keep DPCTLSyclProgramRef PRef,
-                        __dpctl_keep const char *KernelName);
+bool DPCTLProgram_HasKernel(__dpctl_keep DPCTLSyclProgramRef PRef,
+                            __dpctl_keep const char *KernelName);
 
 /*!
  * @brief Frees the DPCTLSyclProgramRef pointer.
@@ -108,7 +107,6 @@ DPCTLProgram_HasKernel (__dpctl_keep DPCTLSyclProgramRef PRef,
  * @param    PRef           Opaque pointer to a sycl::program
  */
 DPCTL_API
-void
-DPCTLProgram_Delete (__dpctl_take DPCTLSyclProgramRef PRef);
+void DPCTLProgram_Delete(__dpctl_take DPCTLSyclProgramRef PRef);
 
 DPCTL_C_EXTERN_C_END

--- a/dpctl-capi/include/dpctl_sycl_queue_interface.h
+++ b/dpctl-capi/include/dpctl_sycl_queue_interface.h
@@ -27,12 +27,12 @@
 
 #pragma once
 
-#include "dpctl_data_types.h"
-#include "dpctl_sycl_enum_types.h"
-#include "dpctl_sycl_types.h"
 #include "Support/DllExport.h"
 #include "Support/ExternC.h"
 #include "Support/MemOwnershipAttrs.h"
+#include "dpctl_data_types.h"
+#include "dpctl_sycl_enum_types.h"
+#include "dpctl_sycl_types.h"
 
 DPCTL_C_EXTERN_C_BEGIN
 
@@ -42,7 +42,7 @@ DPCTL_C_EXTERN_C_BEGIN
  * @param    QRef           A DPCTLSyclQueueRef pointer that gets deleted.
  */
 DPCTL_API
-void DPCTLQueue_Delete (__dpctl_take DPCTLSyclQueueRef QRef);
+void DPCTLQueue_Delete(__dpctl_take DPCTLSyclQueueRef QRef);
 
 /*!
  * @brief Checks if two DPCTLSyclQueueRef objects point to the same sycl::queue.
@@ -52,8 +52,8 @@ void DPCTLQueue_Delete (__dpctl_take DPCTLSyclQueueRef QRef);
  * @return   True if the underlying sycl::queue are same, false otherwise.
  */
 DPCTL_API
-bool DPCTLQueue_AreEq (__dpctl_keep const DPCTLSyclQueueRef QRef1,
-                       __dpctl_keep const DPCTLSyclQueueRef QRef2);
+bool DPCTLQueue_AreEq(__dpctl_keep const DPCTLSyclQueueRef QRef1,
+                      __dpctl_keep const DPCTLSyclQueueRef QRef2);
 
 /*!
  * @brief Returns the Sycl backend for the provided sycl::queue.
@@ -63,7 +63,7 @@ bool DPCTLQueue_AreEq (__dpctl_keep const DPCTLSyclQueueRef QRef1,
  * queue.
  */
 DPCTL_API
-DPCTLSyclBackendType DPCTLQueue_GetBackend (__dpctl_keep DPCTLSyclQueueRef QRef);
+DPCTLSyclBackendType DPCTLQueue_GetBackend(__dpctl_keep DPCTLSyclQueueRef QRef);
 
 /*!
  * @brief Returns the Sycl context for the queue.
@@ -73,7 +73,7 @@ DPCTLSyclBackendType DPCTLQueue_GetBackend (__dpctl_keep DPCTLSyclQueueRef QRef)
  */
 DPCTL_API
 __dpctl_give DPCTLSyclContextRef
-DPCTLQueue_GetContext (__dpctl_keep const DPCTLSyclQueueRef QRef);
+DPCTLQueue_GetContext(__dpctl_keep const DPCTLSyclQueueRef QRef);
 
 /*!
  * @brief returns the Sycl device for the queue.
@@ -83,7 +83,7 @@ DPCTLQueue_GetContext (__dpctl_keep const DPCTLSyclQueueRef QRef);
  */
 DPCTL_API
 __dpctl_give DPCTLSyclDeviceRef
-DPCTLQueue_GetDevice (__dpctl_keep const DPCTLSyclQueueRef QRef);
+DPCTLQueue_GetDevice(__dpctl_keep const DPCTLSyclQueueRef QRef);
 
 /*!
  * @brief Submits the kernel to the specified queue with the provided range
@@ -118,15 +118,15 @@ DPCTLQueue_GetDevice (__dpctl_keep const DPCTLSyclQueueRef QRef);
  */
 DPCTL_API
 DPCTLSyclEventRef
-DPCTLQueue_SubmitRange (__dpctl_keep const DPCTLSyclKernelRef KRef,
-                        __dpctl_keep const DPCTLSyclQueueRef QRef,
-                        __dpctl_keep void **Args,
-                        __dpctl_keep const DPCTLKernelArgType *ArgTypes,
-                        size_t NArgs,
-                        __dpctl_keep const size_t Range[3],
-                        size_t NRange,
-                        __dpctl_keep const DPCTLSyclEventRef *DepEvents,
-                        size_t NDepEvents);
+DPCTLQueue_SubmitRange(__dpctl_keep const DPCTLSyclKernelRef KRef,
+                       __dpctl_keep const DPCTLSyclQueueRef QRef,
+                       __dpctl_keep void **Args,
+                       __dpctl_keep const DPCTLKernelArgType *ArgTypes,
+                       size_t NArgs,
+                       __dpctl_keep const size_t Range[3],
+                       size_t NRange,
+                       __dpctl_keep const DPCTLSyclEventRef *DepEvents,
+                       size_t NDepEvents);
 
 /*!
  * @brief Submits the kernel to the specified queue with the provided nd_range
@@ -183,8 +183,7 @@ DPCTLQueue_SubmitNDRange(__dpctl_keep const DPCTLSyclKernelRef KRef,
  * @param    QRef           Opaque pointer to a sycl::queue.
  */
 DPCTL_API
-void
-DPCTLQueue_Wait (__dpctl_keep const DPCTLSyclQueueRef QRef);
+void DPCTLQueue_Wait(__dpctl_keep const DPCTLSyclQueueRef QRef);
 
 /*!
  * @brief C-API wrapper for sycl::queue::memcpy, the function waits on an event
@@ -196,33 +195,39 @@ DPCTLQueue_Wait (__dpctl_keep const DPCTLSyclQueueRef QRef);
  * @param    Count          A number of bytes to copy.
  */
 DPCTL_API
-void DPCTLQueue_Memcpy (__dpctl_keep const DPCTLSyclQueueRef QRef,
-                        void *Dest, const void *Src, size_t Count);
+void DPCTLQueue_Memcpy(__dpctl_keep const DPCTLSyclQueueRef QRef,
+                       void *Dest,
+                       const void *Src,
+                       size_t Count);
 
 /*!
- * @brief C-API wrapper for sycl::queue::prefetch, the function waits on an event
- * till the prefetch operation completes.
+ * @brief C-API wrapper for sycl::queue::prefetch, the function waits on an
+ * event till the prefetch operation completes.
  *
  * @param    QRef           An opaque pointer to the sycl queue.
  * @param    Ptr            An USM pointer to memory.
  * @param    Count          A number of bytes to prefetch.
  */
 DPCTL_API
-void DPCTLQueue_Prefetch (__dpctl_keep DPCTLSyclQueueRef QRef,
-                          const void *Ptr, size_t Count);
+void DPCTLQueue_Prefetch(__dpctl_keep DPCTLSyclQueueRef QRef,
+                         const void *Ptr,
+                         size_t Count);
 
 /*!
- * @brief C-API wrapper for sycl::queue::mem_advise, the function waits on an event
- * till the operation completes.
+ * @brief C-API wrapper for sycl::queue::mem_advise, the function waits on an
+ * event till the operation completes.
  *
  * @param    QRef           An opaque pointer to the sycl queue.
  * @param    Ptr            An USM pointer to memory.
  * @param    Count          A number of bytes to prefetch.
  * @param    Advice         Device-defined advice for the specified allocation.
- *                           A value of 0 reverts the advice for Ptr to the default behavior.
+ *                          A value of 0 reverts the advice for Ptr to the
+ *                          default behavior.
  */
 DPCTL_API
-void DPCTLQueue_MemAdvise (__dpctl_keep DPCTLSyclQueueRef QRef,
-                           const void *Ptr, size_t Count, int Advice);
+void DPCTLQueue_MemAdvise(__dpctl_keep DPCTLSyclQueueRef QRef,
+                          const void *Ptr,
+                          size_t Count,
+                          int Advice);
 
 DPCTL_C_EXTERN_C_END

--- a/dpctl-capi/include/dpctl_sycl_queue_manager.h
+++ b/dpctl-capi/include/dpctl_sycl_queue_manager.h
@@ -33,13 +33,13 @@
 
 #pragma once
 
-#include "dpctl_data_types.h"
-#include "dpctl_sycl_types.h"
-#include "dpctl_sycl_context_interface.h"
-#include "dpctl_sycl_device_interface.h"
 #include "Support/DllExport.h"
 #include "Support/ExternC.h"
 #include "Support/MemOwnershipAttrs.h"
+#include "dpctl_data_types.h"
+#include "dpctl_sycl_context_interface.h"
+#include "dpctl_sycl_device_interface.h"
+#include "dpctl_sycl_types.h"
 
 DPCTL_C_EXTERN_C_BEGIN
 
@@ -51,7 +51,7 @@ DPCTL_C_EXTERN_C_BEGIN
  * wrapped inside an opaque DPCTLSyclQueueRef pointer.
  */
 DPCTL_API
-__dpctl_give DPCTLSyclQueueRef DPCTLQueueMgr_GetCurrentQueue ();
+__dpctl_give DPCTLSyclQueueRef DPCTLQueueMgr_GetCurrentQueue();
 
 /*!
  * @brief Get a sycl::queue object of the specified type and device id.
@@ -66,9 +66,9 @@ __dpctl_give DPCTLSyclQueueRef DPCTLQueueMgr_GetCurrentQueue ();
  */
 DPCTL_API
 __dpctl_give DPCTLSyclQueueRef
-DPCTLQueueMgr_GetQueue (DPCTLSyclBackendType BETy,
-                        DPCTLSyclDeviceType DeviceTy,
-                        size_t DNum);
+DPCTLQueueMgr_GetQueue(DPCTLSyclBackendType BETy,
+                       DPCTLSyclDeviceType DeviceTy,
+                       size_t DNum);
 
 /*!
  * @brief Get the number of activated queues not including the global or
@@ -77,7 +77,7 @@ DPCTLQueueMgr_GetQueue (DPCTLSyclBackendType BETy,
  * @return The number of activated queues.
  */
 DPCTL_API
-size_t DPCTLQueueMgr_GetNumActivatedQueues ();
+size_t DPCTLQueueMgr_GetNumActivatedQueues();
 
 /*!
  * @brief Get the number of available queues for given backend and device type
@@ -88,8 +88,8 @@ size_t DPCTLQueueMgr_GetNumActivatedQueues ();
  * @return   The number of available queues.
  */
 DPCTL_API
-size_t DPCTLQueueMgr_GetNumQueues (DPCTLSyclBackendType BETy,
-                                   DPCTLSyclDeviceType DeviceTy);
+size_t DPCTLQueueMgr_GetNumQueues(DPCTLSyclBackendType BETy,
+                                  DPCTLSyclDeviceType DeviceTy);
 
 /*!
  * @brief Returns True if the passed in queue and the current queue are the
@@ -100,24 +100,24 @@ size_t DPCTLQueueMgr_GetNumQueues (DPCTLSyclBackendType BETy,
  * the currently activated queue.
  */
 DPCTL_API
-bool DPCTLQueueMgr_IsCurrentQueue (__dpctl_keep const DPCTLSyclQueueRef QRef);
+bool DPCTLQueueMgr_IsCurrentQueue(__dpctl_keep const DPCTLSyclQueueRef QRef);
 
 /*!
-* @brief Set the default DPCTL queue to the sycl::queue for the given backend
-* and device type combination and return a DPCTLSyclQueueRef for that queue.
-* If no queue was created Null is returned to caller.
-*
-* @param    BETy           Type of Sycl backend.
-* @param    DeviceTy       The type of Sycl device (sycl_device_type)
-* @param    DNum           Device id for the device
-* @return A copy of the sycl::queue that was set as the new default queue. If no
-* queue could be created then returns Null.
-*/
+ * @brief Set the default DPCTL queue to the sycl::queue for the given backend
+ * and device type combination and return a DPCTLSyclQueueRef for that queue.
+ * If no queue was created Null is returned to caller.
+ *
+ * @param    BETy           Type of Sycl backend.
+ * @param    DeviceTy       The type of Sycl device (sycl_device_type)
+ * @param    DNum           Device id for the device
+ * @return A copy of the sycl::queue that was set as the new default queue. If
+ * no queue could be created then returns Null.
+ */
 DPCTL_API
 __dpctl_give DPCTLSyclQueueRef
-DPCTLQueueMgr_SetAsDefaultQueue (DPCTLSyclBackendType BETy,
-                                 DPCTLSyclDeviceType DeviceTy,
-                                 size_t DNum);
+DPCTLQueueMgr_SetAsDefaultQueue(DPCTLSyclBackendType BETy,
+                                DPCTLSyclDeviceType DeviceTy,
+                                size_t DNum);
 
 /*!
  * @brief Pushes a new sycl::queue object to the top of DPCTL's thread-local
@@ -141,9 +141,9 @@ DPCTLQueueMgr_SetAsDefaultQueue (DPCTLSyclBackendType BETy,
  */
 DPCTL_API
 __dpctl_give DPCTLSyclQueueRef
-DPCTLQueueMgr_PushQueue (DPCTLSyclBackendType BETy,
-                         DPCTLSyclDeviceType DeviceTy,
-                         size_t DNum);
+DPCTLQueueMgr_PushQueue(DPCTLSyclBackendType BETy,
+                        DPCTLSyclDeviceType DeviceTy,
+                        size_t DNum);
 
 /*!
  * @brief Pops the top of stack element from DPCTL's stack of activated
@@ -157,8 +157,7 @@ DPCTLQueueMgr_PushQueue (DPCTLSyclBackendType BETy,
  *
  */
 DPCTL_API
-void DPCTLQueueMgr_PopQueue ();
-
+void DPCTLQueueMgr_PopQueue();
 
 /*!
  * @brief Creates a new instance of SYCL queue from SYCL context and
@@ -175,9 +174,8 @@ void DPCTLQueueMgr_PopQueue ();
  * references.
  */
 DPCTL_API
-__dpctl_give DPCTLSyclQueueRef
-DPCTLQueueMgr_GetQueueFromContextAndDevice(__dpctl_keep DPCTLSyclContextRef CRef,
-                                           __dpctl_keep DPCTLSyclDeviceRef DRef);
-
+__dpctl_give DPCTLSyclQueueRef DPCTLQueueMgr_GetQueueFromContextAndDevice(
+    __dpctl_keep DPCTLSyclContextRef CRef,
+    __dpctl_keep DPCTLSyclDeviceRef DRef);
 
 DPCTL_C_EXTERN_C_END

--- a/dpctl-capi/include/dpctl_sycl_types.h
+++ b/dpctl-capi/include/dpctl_sycl_types.h
@@ -65,11 +65,11 @@ typedef struct DPCTLOpaqueSyclPlatform *DPCTLSyclPlatformRef;
  */
 typedef struct DPCTLOpaqueSyclProgram *DPCTLSyclProgramRef;
 
- /*!
-  * @brief Opaque pointer to a sycl::queue
-  *
-  * @see sycl::queue
-  */
+/*!
+ * @brief Opaque pointer to a sycl::queue
+ *
+ * @see sycl::queue
+ */
 typedef struct DPCTLOpaqueSyclQueue *DPCTLSyclQueueRef;
 
 /*!

--- a/dpctl-capi/include/dpctl_sycl_usm_interface.h
+++ b/dpctl-capi/include/dpctl_sycl_usm_interface.h
@@ -25,11 +25,11 @@
 
 #pragma once
 
-#include "dpctl_data_types.h"
-#include "dpctl_sycl_types.h"
 #include "Support/DllExport.h"
 #include "Support/ExternC.h"
 #include "Support/MemOwnershipAttrs.h"
+#include "dpctl_data_types.h"
+#include "dpctl_sycl_types.h"
 
 DPCTL_C_EXTERN_C_BEGIN
 
@@ -43,7 +43,7 @@ DPCTL_C_EXTERN_C_BEGIN
  */
 DPCTL_API
 __dpctl_give DPCTLSyclUSMRef
-DPCTLmalloc_shared (size_t size, __dpctl_keep const DPCTLSyclQueueRef QRef);
+DPCTLmalloc_shared(size_t size, __dpctl_keep const DPCTLSyclQueueRef QRef);
 
 /*!
  * @brief Create USM shared memory.
@@ -57,8 +57,9 @@ DPCTLmalloc_shared (size_t size, __dpctl_keep const DPCTLSyclQueueRef QRef);
  */
 DPCTL_API
 __dpctl_give DPCTLSyclUSMRef
-DPCTLaligned_alloc_shared (size_t alignment, size_t size,
-                           __dpctl_keep const DPCTLSyclQueueRef QRef);
+DPCTLaligned_alloc_shared(size_t alignment,
+                          size_t size,
+                          __dpctl_keep const DPCTLSyclQueueRef QRef);
 
 /*!
  * @brief Create USM host memory.
@@ -70,7 +71,7 @@ DPCTLaligned_alloc_shared (size_t alignment, size_t size,
  */
 DPCTL_API
 __dpctl_give DPCTLSyclUSMRef
-DPCTLmalloc_host (size_t size, __dpctl_keep const DPCTLSyclQueueRef QRef);
+DPCTLmalloc_host(size_t size, __dpctl_keep const DPCTLSyclQueueRef QRef);
 
 /*!
  * @brief Create USM host memory.
@@ -84,8 +85,9 @@ DPCTLmalloc_host (size_t size, __dpctl_keep const DPCTLSyclQueueRef QRef);
  */
 DPCTL_API
 __dpctl_give DPCTLSyclUSMRef
-DPCTLaligned_alloc_host (size_t alignment, size_t size,
-                         __dpctl_keep const DPCTLSyclQueueRef QRef);
+DPCTLaligned_alloc_host(size_t alignment,
+                        size_t size,
+                        __dpctl_keep const DPCTLSyclQueueRef QRef);
 
 /*!
  * @brief Create USM device memory.
@@ -97,7 +99,7 @@ DPCTLaligned_alloc_host (size_t alignment, size_t size,
  */
 DPCTL_API
 __dpctl_give DPCTLSyclUSMRef
-DPCTLmalloc_device (size_t size, __dpctl_keep const DPCTLSyclQueueRef QRef);
+DPCTLmalloc_device(size_t size, __dpctl_keep const DPCTLSyclQueueRef QRef);
 
 /*!
  * @brief Create USM device memory.
@@ -111,8 +113,9 @@ DPCTLmalloc_device (size_t size, __dpctl_keep const DPCTLSyclQueueRef QRef);
  */
 DPCTL_API
 __dpctl_give DPCTLSyclUSMRef
-DPCTLaligned_alloc_device (size_t alignment, size_t size,
-                           __dpctl_keep const DPCTLSyclQueueRef QRef);
+DPCTLaligned_alloc_device(size_t alignment,
+                          size_t size,
+                          __dpctl_keep const DPCTLSyclQueueRef QRef);
 
 /*!
  * @brief Free USM memory.
@@ -124,16 +127,16 @@ DPCTLaligned_alloc_device (size_t alignment, size_t size,
  * used to construct the queue.
  */
 DPCTL_API
-void DPCTLfree_with_queue (__dpctl_take DPCTLSyclUSMRef MRef,
-                           __dpctl_keep const DPCTLSyclQueueRef QRef);
+void DPCTLfree_with_queue(__dpctl_take DPCTLSyclUSMRef MRef,
+                          __dpctl_keep const DPCTLSyclQueueRef QRef);
 
 /*!
  * @brief Free USM memory.
  *
  */
 DPCTL_API
-void DPCTLfree_with_context (__dpctl_take DPCTLSyclUSMRef MRef,
-                             __dpctl_keep const DPCTLSyclContextRef CRef);
+void DPCTLfree_with_context(__dpctl_take DPCTLSyclUSMRef MRef,
+                            __dpctl_keep const DPCTLSyclContextRef CRef);
 
 /*!
  * @brief Get pointer type.
@@ -145,8 +148,8 @@ void DPCTLfree_with_context (__dpctl_take DPCTLSyclUSMRef MRef,
  */
 DPCTL_API
 const char *
-DPCTLUSM_GetPointerType (__dpctl_keep const DPCTLSyclUSMRef MRef,
-                         __dpctl_keep const DPCTLSyclContextRef CRef);
+DPCTLUSM_GetPointerType(__dpctl_keep const DPCTLSyclUSMRef MRef,
+                        __dpctl_keep const DPCTLSyclContextRef CRef);
 
 /*!
  * @brief Get the device associated with USM pointer.
@@ -158,6 +161,6 @@ DPCTLUSM_GetPointerType (__dpctl_keep const DPCTLSyclUSMRef MRef,
  */
 DPCTL_API
 DPCTLSyclDeviceRef
-DPCTLUSM_GetPointerDevice (__dpctl_keep const DPCTLSyclUSMRef MRef,
-                           __dpctl_keep const DPCTLSyclContextRef CRef);
+DPCTLUSM_GetPointerDevice(__dpctl_keep const DPCTLSyclUSMRef MRef,
+                          __dpctl_keep const DPCTLSyclContextRef CRef);
 DPCTL_C_EXTERN_C_END

--- a/dpctl-capi/include/dpctl_utils.h
+++ b/dpctl-capi/include/dpctl_utils.h
@@ -24,10 +24,10 @@
 
 #pragma once
 
-#include "dpctl_data_types.h"
 #include "Support/DllExport.h"
 #include "Support/ExternC.h"
 #include "Support/MemOwnershipAttrs.h"
+#include "dpctl_data_types.h"
 
 DPCTL_C_EXTERN_C_BEGIN
 
@@ -37,7 +37,7 @@ DPCTL_C_EXTERN_C_BEGIN
  * @param    str            C string to be deleted
  */
 DPCTL_API
-void DPCTLCString_Delete (__dpctl_take const char* str);
+void DPCTLCString_Delete(__dpctl_take const char *str);
 
 /*!
  * @brief Deletes an array of size_t elements.
@@ -45,6 +45,6 @@ void DPCTLCString_Delete (__dpctl_take const char* str);
  * @param    arr            Array to be deleted.
  */
 DPCTL_API
-void DPCTLSize_t_Array_Delete (__dpctl_take size_t* arr);
+void DPCTLSize_t_Array_Delete(__dpctl_take size_t *arr);
 
 DPCTL_C_EXTERN_C_END

--- a/dpctl-capi/source/dpctl_sycl_context_interface.cpp
+++ b/dpctl-capi/source/dpctl_sycl_context_interface.cpp
@@ -36,16 +36,16 @@ namespace
 DEFINE_SIMPLE_CONVERSION_FUNCTIONS(context, DPCTLSyclContextRef)
 } /* end of anonymous namespace */
 
-bool DPCTLContext_AreEq (__dpctl_keep const DPCTLSyclContextRef CtxRef1,
+bool DPCTLContext_AreEq(__dpctl_keep const DPCTLSyclContextRef CtxRef1,
                         __dpctl_keep const DPCTLSyclContextRef CtxRef2)
 {
-    if(!(CtxRef1 && CtxRef2))
+    if (!(CtxRef1 && CtxRef2))
         // \todo handle error
         return false;
     return (*unwrap(CtxRef1) == *unwrap(CtxRef2));
 }
 
-bool DPCTLContext_IsHost (__dpctl_keep const DPCTLSyclContextRef CtxRef)
+bool DPCTLContext_IsHost(__dpctl_keep const DPCTLSyclContextRef CtxRef)
 {
     auto Ctx = unwrap(CtxRef);
     if (Ctx) {
@@ -54,27 +54,26 @@ bool DPCTLContext_IsHost (__dpctl_keep const DPCTLSyclContextRef CtxRef)
     return false;
 }
 
-void DPCTLContext_Delete (__dpctl_take DPCTLSyclContextRef CtxRef)
+void DPCTLContext_Delete(__dpctl_take DPCTLSyclContextRef CtxRef)
 {
     delete unwrap(CtxRef);
 }
 
 DPCTLSyclBackendType
-DPCTLContext_GetBackend (__dpctl_keep const DPCTLSyclContextRef CtxRef)
+DPCTLContext_GetBackend(__dpctl_keep const DPCTLSyclContextRef CtxRef)
 {
     auto BE = unwrap(CtxRef)->get_platform().get_backend();
 
-    switch(BE)
-    {
-        case backend::host:
-            return DPCTL_HOST;
-        case backend::opencl:
-            return DPCTL_OPENCL;
-        case backend::level_zero:
-            return DPCTL_LEVEL_ZERO;
-        case backend::cuda:
-            return DPCTL_CUDA;
-        default:
-            return DPCTL_UNKNOWN_BACKEND;
+    switch (BE) {
+    case backend::host:
+        return DPCTL_HOST;
+    case backend::opencl:
+        return DPCTL_OPENCL;
+    case backend::level_zero:
+        return DPCTL_LEVEL_ZERO;
+    case backend::cuda:
+        return DPCTL_CUDA;
+    default:
+        return DPCTL_UNKNOWN_BACKEND;
     }
 }

--- a/dpctl-capi/source/dpctl_sycl_device_interface.cpp
+++ b/dpctl-capi/source/dpctl_sycl_device_interface.cpp
@@ -25,12 +25,12 @@
 //===----------------------------------------------------------------------===//
 
 #include "dpctl_sycl_device_interface.h"
+#include "../helper/include/dpctl_utils_helper.h"
 #include "Support/CBindingWrapping.h"
+#include <CL/sycl.hpp> /* SYCL headers   */
+#include <cstring>
 #include <iomanip>
 #include <iostream>
-#include <cstring>
-#include <CL/sycl.hpp>                /* SYCL headers   */
-#include "../helper/include/dpctl_utils_helper.h"
 
 using namespace cl::sycl;
 
@@ -39,12 +39,12 @@ namespace
 // Create wrappers for C Binding types (see CBindingWrapping.h).
 DEFINE_SIMPLE_CONVERSION_FUNCTIONS(device, DPCTLSyclDeviceRef)
 
- /*!
+/*!
  * @brief Helper function to print the metadata for a sycl::device.
  *
  * @param    Device         My Param doc
  */
-void dump_device_info (const device & Device)
+void dump_device_info(const device &Device)
 {
     std::stringstream ss;
 
@@ -72,19 +72,18 @@ void dump_device_info (const device & Device)
  * vendor, and device profile are printed out. More attributed may be added
  * later.
  */
-void DPCTLDevice_DumpInfo (__dpctl_keep const DPCTLSyclDeviceRef DRef)
+void DPCTLDevice_DumpInfo(__dpctl_keep const DPCTLSyclDeviceRef DRef)
 {
     auto Device = unwrap(DRef);
     dump_device_info(*Device);
 }
 
-
-void DPCTLDevice_Delete (__dpctl_take DPCTLSyclDeviceRef DRef)
+void DPCTLDevice_Delete(__dpctl_take DPCTLSyclDeviceRef DRef)
 {
     delete unwrap(DRef);
 }
 
-bool DPCTLDevice_IsAccelerator (__dpctl_keep const DPCTLSyclDeviceRef DRef)
+bool DPCTLDevice_IsAccelerator(__dpctl_keep const DPCTLSyclDeviceRef DRef)
 {
     auto D = unwrap(DRef);
     if (D) {
@@ -93,7 +92,7 @@ bool DPCTLDevice_IsAccelerator (__dpctl_keep const DPCTLSyclDeviceRef DRef)
     return false;
 }
 
-bool DPCTLDevice_IsCPU (__dpctl_keep const DPCTLSyclDeviceRef DRef)
+bool DPCTLDevice_IsCPU(__dpctl_keep const DPCTLSyclDeviceRef DRef)
 {
     auto D = unwrap(DRef);
     if (D) {
@@ -102,7 +101,7 @@ bool DPCTLDevice_IsCPU (__dpctl_keep const DPCTLSyclDeviceRef DRef)
     return false;
 }
 
-bool DPCTLDevice_IsGPU (__dpctl_keep const DPCTLSyclDeviceRef DRef)
+bool DPCTLDevice_IsGPU(__dpctl_keep const DPCTLSyclDeviceRef DRef)
 {
     auto D = unwrap(DRef);
     if (D) {
@@ -111,8 +110,7 @@ bool DPCTLDevice_IsGPU (__dpctl_keep const DPCTLSyclDeviceRef DRef)
     return false;
 }
 
-
-bool DPCTLDevice_IsHost (__dpctl_keep const DPCTLSyclDeviceRef DRef)
+bool DPCTLDevice_IsHost(__dpctl_keep const DPCTLSyclDeviceRef DRef)
 {
     auto D = unwrap(DRef);
     if (D) {
@@ -121,9 +119,8 @@ bool DPCTLDevice_IsHost (__dpctl_keep const DPCTLSyclDeviceRef DRef)
     return false;
 }
 
-
 uint32_t
-DPCTLDevice_GetMaxComputeUnits (__dpctl_keep const DPCTLSyclDeviceRef DRef)
+DPCTLDevice_GetMaxComputeUnits(__dpctl_keep const DPCTLSyclDeviceRef DRef)
 {
     auto D = unwrap(DRef);
     if (D) {
@@ -133,7 +130,7 @@ DPCTLDevice_GetMaxComputeUnits (__dpctl_keep const DPCTLSyclDeviceRef DRef)
 }
 
 uint32_t
-DPCTLDevice_GetMaxWorkItemDims (__dpctl_keep const DPCTLSyclDeviceRef DRef)
+DPCTLDevice_GetMaxWorkItemDims(__dpctl_keep const DPCTLSyclDeviceRef DRef)
 {
     auto D = unwrap(DRef);
     if (D) {
@@ -142,15 +139,15 @@ DPCTLDevice_GetMaxWorkItemDims (__dpctl_keep const DPCTLSyclDeviceRef DRef)
     return 0;
 }
 
-__dpctl_keep size_t*
-DPCTLDevice_GetMaxWorkItemSizes (__dpctl_keep const DPCTLSyclDeviceRef DRef)
+__dpctl_keep size_t *
+DPCTLDevice_GetMaxWorkItemSizes(__dpctl_keep const DPCTLSyclDeviceRef DRef)
 {
     size_t *sizes = nullptr;
     auto D = unwrap(DRef);
     if (D) {
         auto id_sizes = D->get_info<info::device::max_work_item_sizes>();
         sizes = new size_t[3];
-        for(auto i = 0ul; i < 3; ++i) {
+        for (auto i = 0ul; i < 3; ++i) {
             sizes[i] = id_sizes[i];
         }
     }
@@ -158,7 +155,7 @@ DPCTLDevice_GetMaxWorkItemSizes (__dpctl_keep const DPCTLSyclDeviceRef DRef)
 }
 
 size_t
-DPCTLDevice_GetMaxWorkGroupSize (__dpctl_keep const DPCTLSyclDeviceRef DRef)
+DPCTLDevice_GetMaxWorkGroupSize(__dpctl_keep const DPCTLSyclDeviceRef DRef)
 {
     auto D = unwrap(DRef);
     if (D) {
@@ -168,7 +165,7 @@ DPCTLDevice_GetMaxWorkGroupSize (__dpctl_keep const DPCTLSyclDeviceRef DRef)
 }
 
 uint32_t
-DPCTLDevice_GetMaxNumSubGroups (__dpctl_keep const DPCTLSyclDeviceRef DRef)
+DPCTLDevice_GetMaxNumSubGroups(__dpctl_keep const DPCTLSyclDeviceRef DRef)
 {
     auto D = unwrap(DRef);
     if (D) {
@@ -177,8 +174,7 @@ DPCTLDevice_GetMaxNumSubGroups (__dpctl_keep const DPCTLSyclDeviceRef DRef)
     return 0;
 }
 
-bool
-DPCTLDevice_HasInt64BaseAtomics (__dpctl_keep const DPCTLSyclDeviceRef DRef)
+bool DPCTLDevice_HasInt64BaseAtomics(__dpctl_keep const DPCTLSyclDeviceRef DRef)
 {
     auto D = unwrap(DRef);
     if (D) {
@@ -187,8 +183,8 @@ DPCTLDevice_HasInt64BaseAtomics (__dpctl_keep const DPCTLSyclDeviceRef DRef)
     return false;
 }
 
-bool
-DPCTLDevice_HasInt64ExtendedAtomics (__dpctl_keep const DPCTLSyclDeviceRef DRef)
+bool DPCTLDevice_HasInt64ExtendedAtomics(
+    __dpctl_keep const DPCTLSyclDeviceRef DRef)
 {
     auto D = unwrap(DRef);
     if (D) {
@@ -197,13 +193,13 @@ DPCTLDevice_HasInt64ExtendedAtomics (__dpctl_keep const DPCTLSyclDeviceRef DRef)
     return false;
 }
 
-__dpctl_give const char*
-DPCTLDevice_GetName (__dpctl_keep const DPCTLSyclDeviceRef DRef)
+__dpctl_give const char *
+DPCTLDevice_GetName(__dpctl_keep const DPCTLSyclDeviceRef DRef)
 {
     auto D = unwrap(DRef);
     if (D) {
         auto name = D->get_info<info::device::name>();
-        auto cstr_len = name.length()+1;
+        auto cstr_len = name.length() + 1;
         auto cstr_name = new char[cstr_len];
 #ifdef _WIN32
         strncpy_s(cstr_name, cstr_len, name.c_str(), cstr_len);
@@ -215,13 +211,13 @@ DPCTLDevice_GetName (__dpctl_keep const DPCTLSyclDeviceRef DRef)
     return nullptr;
 }
 
-__dpctl_give const char*
-DPCTLDevice_GetVendorName (__dpctl_keep const DPCTLSyclDeviceRef DRef)
+__dpctl_give const char *
+DPCTLDevice_GetVendorName(__dpctl_keep const DPCTLSyclDeviceRef DRef)
 {
     auto D = unwrap(DRef);
     if (D) {
         auto vendor = D->get_info<info::device::vendor>();
-        auto cstr_len = vendor.length()+1;
+        auto cstr_len = vendor.length() + 1;
         auto cstr_vendor = new char[cstr_len];
 #ifdef _WIN32
         strncpy_s(cstr_vendor, cstr_len, vendor.c_str(), cstr_len);
@@ -233,13 +229,13 @@ DPCTLDevice_GetVendorName (__dpctl_keep const DPCTLSyclDeviceRef DRef)
     return nullptr;
 }
 
-__dpctl_give const char*
-DPCTLDevice_GetDriverInfo (__dpctl_keep const DPCTLSyclDeviceRef DRef)
+__dpctl_give const char *
+DPCTLDevice_GetDriverInfo(__dpctl_keep const DPCTLSyclDeviceRef DRef)
 {
     auto D = unwrap(DRef);
     if (D) {
         auto driver = D->get_info<info::device::driver_version>();
-        auto cstr_len = driver.length()+1;
+        auto cstr_len = driver.length() + 1;
         auto cstr_driver = new char[cstr_len];
 #ifdef _WIN32
         strncpy_s(cstr_driver, cstr_len, driver.c_str(), cstr_len);
@@ -251,7 +247,7 @@ DPCTLDevice_GetDriverInfo (__dpctl_keep const DPCTLSyclDeviceRef DRef)
     return nullptr;
 }
 
-bool DPCTLDevice_IsHostUnifiedMemory (__dpctl_keep const DPCTLSyclDeviceRef DRef)
+bool DPCTLDevice_IsHostUnifiedMemory(__dpctl_keep const DPCTLSyclDeviceRef DRef)
 {
     auto D = unwrap(DRef);
     if (D) {
@@ -261,9 +257,9 @@ bool DPCTLDevice_IsHostUnifiedMemory (__dpctl_keep const DPCTLSyclDeviceRef DRef
 }
 
 bool DPCTLDevice_AreEq(__dpctl_keep const DPCTLSyclDeviceRef DevRef1,
-                      __dpctl_keep const DPCTLSyclDeviceRef DevRef2)
+                       __dpctl_keep const DPCTLSyclDeviceRef DevRef2)
 {
-    if(!(DevRef1 && DevRef2))
+    if (!(DevRef1 && DevRef2))
         // \todo handle error
         return false;
     return (*unwrap(DevRef1) == *unwrap(DevRef2));

--- a/dpctl-capi/source/dpctl_sycl_event_interface.cpp
+++ b/dpctl-capi/source/dpctl_sycl_event_interface.cpp
@@ -26,8 +26,7 @@
 
 #include "dpctl_sycl_event_interface.h"
 #include "Support/CBindingWrapping.h"
-
-#include <CL/sycl.hpp>                /* SYCL headers   */
+#include <CL/sycl.hpp> /* SYCL headers   */
 
 using namespace cl::sycl;
 
@@ -37,16 +36,14 @@ namespace
 DEFINE_SIMPLE_CONVERSION_FUNCTIONS(event, DPCTLSyclEventRef)
 } /* end of anonymous namespace */
 
-
-void DPCTLEvent_Wait (__dpctl_keep DPCTLSyclEventRef ERef)
+void DPCTLEvent_Wait(__dpctl_keep DPCTLSyclEventRef ERef)
 {
     // \todo How to handle errors? E.g. when ERef is null or not a valid event.
     auto SyclEvent = unwrap(ERef);
     SyclEvent->wait();
 }
 
-void
-DPCTLEvent_Delete (__dpctl_take DPCTLSyclEventRef ERef)
+void DPCTLEvent_Delete(__dpctl_take DPCTLSyclEventRef ERef)
 {
     delete unwrap(ERef);
 }

--- a/dpctl-capi/source/dpctl_sycl_kernel_interface.cpp
+++ b/dpctl-capi/source/dpctl_sycl_kernel_interface.cpp
@@ -26,7 +26,6 @@
 
 #include "dpctl_sycl_kernel_interface.h"
 #include "Support/CBindingWrapping.h"
-
 #include <CL/sycl.hpp> /* Sycl headers */
 
 using namespace cl::sycl;
@@ -38,32 +37,31 @@ DEFINE_SIMPLE_CONVERSION_FUNCTIONS(kernel, DPCTLSyclKernelRef)
 
 } /* end of anonymous namespace */
 
-__dpctl_give const char*
-DPCTLKernel_GetFunctionName (__dpctl_keep const DPCTLSyclKernelRef Kernel)
+__dpctl_give const char *
+DPCTLKernel_GetFunctionName(__dpctl_keep const DPCTLSyclKernelRef Kernel)
 {
-    if(!Kernel) {
+    if (!Kernel) {
         // \todo record error
         return nullptr;
     }
 
     auto SyclKernel = unwrap(Kernel);
     auto kernel_name = SyclKernel->get_info<info::kernel::function_name>();
-    if(kernel_name.empty())
+    if (kernel_name.empty())
         return nullptr;
-    auto cstr_len = kernel_name.length()+1;
+    auto cstr_len = kernel_name.length() + 1;
     auto cstr_name = new char[cstr_len];
 #ifdef _WIN32
     strncpy_s(cstr_name, cstr_len, kernel_name.c_str(), cstr_len);
 #else
-    std::strncpy (cstr_name, kernel_name.c_str(), cstr_len);
+    std::strncpy(cstr_name, kernel_name.c_str(), cstr_len);
 #endif
     return cstr_name;
 }
 
-size_t
-DPCTLKernel_GetNumArgs (__dpctl_keep const DPCTLSyclKernelRef Kernel)
+size_t DPCTLKernel_GetNumArgs(__dpctl_keep const DPCTLSyclKernelRef Kernel)
 {
-    if(!Kernel) {
+    if (!Kernel) {
         // \todo record error
         return -1;
     }
@@ -73,8 +71,7 @@ DPCTLKernel_GetNumArgs (__dpctl_keep const DPCTLSyclKernelRef Kernel)
     return (size_t)num_args;
 }
 
-void
-DPCTLKernel_Delete (__dpctl_take DPCTLSyclKernelRef Kernel)
+void DPCTLKernel_Delete(__dpctl_take DPCTLSyclKernelRef Kernel)
 {
     delete unwrap(Kernel);
 }

--- a/dpctl-capi/source/dpctl_sycl_platform_interface.cpp
+++ b/dpctl-capi/source/dpctl_sycl_platform_interface.cpp
@@ -25,28 +25,25 @@
 //===----------------------------------------------------------------------===//
 
 #include "dpctl_sycl_platform_interface.h"
+#include "../helper/include/dpctl_utils_helper.h"
+#include <CL/sycl.hpp>
 #include <iomanip>
 #include <iostream>
 #include <set>
 #include <sstream>
-#include "../helper/include/dpctl_utils_helper.h"
-
-#include <CL/sycl.hpp>
 
 using namespace cl::sycl;
 
 namespace
 {
-std::set<DPCTLSyclBackendType>
-get_set_of_non_hostbackends ()
+std::set<DPCTLSyclBackendType> get_set_of_non_hostbackends()
 {
     std::set<DPCTLSyclBackendType> be_set;
     for (auto p : platform::get_platforms()) {
-        if(p.is_host())
+        if (p.is_host())
             continue;
         auto be = p.get_backend();
-        switch (be)
-        {
+        switch (be) {
         case backend::host:
             break;
         case backend::cuda:
@@ -68,21 +65,21 @@ get_set_of_non_hostbackends ()
 } // namespace
 
 /*!
-* Prints out the following sycl::info::platform attributes for each platform
-* found on the system:
-*      - info::platform::name
-*      - info::platform::version
-*      - info::platform::vendor
-*      - info::platform::profile
-*      - backend (opencl, cuda, level-zero, host)
-*      - number of devices on the platform
-*
-* Additionally, for each device we print out:
-*      - info::device::name
-*      - info::device::driver_version
-*      - type of the device based on the aspects cpu, gpu, accelerator.
-*/
-void DPCTLPlatform_DumpInfo ()
+ * Prints out the following sycl::info::platform attributes for each platform
+ * found on the system:
+ *      - info::platform::name
+ *      - info::platform::version
+ *      - info::platform::vendor
+ *      - info::platform::profile
+ *      - backend (opencl, cuda, level-zero, host)
+ *      - number of devices on the platform
+ *
+ * Additionally, for each device we print out:
+ *      - info::device::name
+ *      - info::device::driver_version
+ *      - type of the device based on the aspects cpu, gpu, accelerator.
+ */
+void DPCTLPlatform_DumpInfo()
 {
     size_t i = 0;
 
@@ -116,8 +113,8 @@ void DPCTLPlatform_DumpInfo ()
         // Print some of the device information
         for (auto dn = 0ul; dn < devices.size(); ++dn) {
             ss << std::setw(4) << "---Device " << dn << '\n';
-            ss << std::setw(8) << " " << std::left << std::setw(20)
-               << "Name" << devices[dn].get_info<info::device::name>() << '\n';
+            ss << std::setw(8) << " " << std::left << std::setw(20) << "Name"
+               << devices[dn].get_info<info::device::name>() << '\n';
             ss << std::setw(8) << " " << std::left << std::setw(20)
                << "Driver version"
                << devices[dn].get_info<info::device::driver_version>() << '\n';
@@ -133,9 +130,9 @@ void DPCTLPlatform_DumpInfo ()
 }
 
 /*!
-* Returns the number of sycl::platform on the system.
-*/
-size_t DPCTLPlatform_GetNumNonHostPlatforms ()
+ * Returns the number of sycl::platform on the system.
+ */
+size_t DPCTLPlatform_GetNumNonHostPlatforms()
 {
     auto nNonHostPlatforms = 0ul;
     for (auto &p : platform::get_platforms()) {
@@ -146,7 +143,7 @@ size_t DPCTLPlatform_GetNumNonHostPlatforms ()
     return nNonHostPlatforms;
 }
 
-size_t DPCTLPlatform_GetNumNonHostBackends ()
+size_t DPCTLPlatform_GetNumNonHostBackends()
 {
     auto be_set = get_set_of_non_hostbackends();
 
@@ -156,7 +153,7 @@ size_t DPCTLPlatform_GetNumNonHostBackends ()
     return be_set.size();
 }
 
-__dpctl_give DPCTLSyclBackendType *DPCTLPlatform_GetListOfNonHostBackends ()
+__dpctl_give DPCTLSyclBackendType *DPCTLPlatform_GetListOfNonHostBackends()
 {
     auto be_set = get_set_of_non_hostbackends();
 
@@ -174,7 +171,8 @@ __dpctl_give DPCTLSyclBackendType *DPCTLPlatform_GetListOfNonHostBackends ()
     return BEArr;
 }
 
-void DPCTLPlatform_DeleteListOfBackends (__dpctl_take DPCTLSyclBackendType *BEArr)
+void DPCTLPlatform_DeleteListOfBackends(
+    __dpctl_take DPCTLSyclBackendType *BEArr)
 {
     delete[] BEArr;
 }

--- a/dpctl-capi/source/dpctl_sycl_program_interface.cpp
+++ b/dpctl-capi/source/dpctl_sycl_program_interface.cpp
@@ -27,13 +27,15 @@
 #include "dpctl_sycl_program_interface.h"
 #include "Config/dpctl_config.h"
 #include "Support/CBindingWrapping.h"
+#include <CL/cl.h>     /* OpenCL headers     */
+#include <CL/sycl.hpp> /* Sycl headers       */
 
-#include <CL/sycl.hpp>          /* Sycl headers       */
-#include <CL/cl.h>              /* OpenCL headers     */
 #ifdef DPCTL_ENABLE_LO_PROGRAM_CREATION
-#include <level_zero/zet_api.h> /* Level Zero headers */
-#include <CL/sycl/backend/level_zero.hpp>
 #include "../helper/include/dpctl_dynamic_lib_helper.h"
+#include <level_zero/zet_api.h> /* Level Zero headers */
+// Note: include ze_api.h before level_zero.hpp. Make sure clang-format does
+// not reorder the includes.
+#include <CL/sycl/backend/level_zero.hpp>
 #endif
 
 using namespace cl::sycl;
@@ -43,10 +45,10 @@ namespace
 #ifdef DPCTL_ENABLE_LO_PROGRAM_CREATION
 
 #ifdef __linux__
-static const char * zeLoaderName = "libze_loader.so";
-static const int libLoadFlags    = RTLD_NOLOAD | RTLD_NOW | RTLD_LOCAL;
+static const char *zeLoaderName = "libze_loader.so";
+static const int libLoadFlags = RTLD_NOLOAD | RTLD_NOW | RTLD_LOCAL;
 #else
-    #error "Level Zero program compilation is unavailable for this platform"
+#error "Level Zero program compilation is unavailable for this platform"
 #endif
 
 typedef ze_result_t (*zeModuleCreateFT)(ze_context_handle_t,
@@ -55,7 +57,7 @@ typedef ze_result_t (*zeModuleCreateFT)(ze_context_handle_t,
                                         ze_module_handle_t *,
                                         ze_module_build_log_handle_t *);
 
-const char * zeModuleCreateFuncName  = "zeModuleCreate";
+const char *zeModuleCreateFuncName = "zeModuleCreate";
 
 #endif // #ifdef DPCTL_ENABLE_LO_PROGRAM_CREATION
 
@@ -64,18 +66,19 @@ DEFINE_SIMPLE_CONVERSION_FUNCTIONS(program, DPCTLSyclProgramRef)
 DEFINE_SIMPLE_CONVERSION_FUNCTIONS(kernel, DPCTLSyclKernelRef)
 
 __dpctl_give DPCTLSyclProgramRef
-createOpenCLInterOpProgram (const context &SyclCtx,
-                            __dpctl_keep const void *IL,
-                            size_t length,
-                            const char * /* */)
+createOpenCLInterOpProgram(const context &SyclCtx,
+                           __dpctl_keep const void *IL,
+                           size_t length,
+                           const char * /* */)
 {
     cl_int err;
-    auto CLCtx   = SyclCtx.get();
+    auto CLCtx = SyclCtx.get();
     auto CLProgram = clCreateProgramWithIL(CLCtx, IL, length, &err);
     if (err) {
         // \todo: record the error string and any other information.
         std::cerr << "OpenCL program could not be created from the SPIR-V "
-                     "binary. OpenCL Error " << err << ".\n";
+                     "binary. OpenCL Error "
+                  << err << ".\n";
         return nullptr;
     }
     auto SyclDevices = SyclCtx.get_devices();
@@ -93,8 +96,8 @@ createOpenCLInterOpProgram (const context &SyclCtx,
 
     if (err) {
         // \todo: record the error string and any other information.
-        std::cerr << "OpenCL program could not be built. OpenCL Error "
-                  << err << ".\n";
+        std::cerr << "OpenCL program could not be built. OpenCL Error " << err
+                  << ".\n";
         return nullptr;
     }
 
@@ -111,31 +114,30 @@ createOpenCLInterOpProgram (const context &SyclCtx,
 
 #ifdef DPCTL_ENABLE_LO_PROGRAM_CREATION
 
-zeModuleCreateFT getZeModuleCreateFn ()
+zeModuleCreateFT getZeModuleCreateFn()
 {
     static dpctl::DynamicLibHelper zeLib(zeLoaderName, libLoadFlags);
-    if(!zeLib.opened()) {
+    if (!zeLib.opened()) {
         // TODO: handle error
         std::cerr << "The level zero loader dynamic library could not "
                      "be opened.\n";
         return nullptr;
     }
-    static auto stZeModuleCreateF = zeLib.getSymbol<zeModuleCreateFT>(
-                                        zeModuleCreateFuncName
-                                    );
+    static auto stZeModuleCreateF =
+        zeLib.getSymbol<zeModuleCreateFT>(zeModuleCreateFuncName);
 
     return stZeModuleCreateF;
 }
 
 __dpctl_give DPCTLSyclProgramRef
-createLevelZeroInterOpProgram (const context &SyclCtx,
-                               const void *IL,
-                               size_t length,
-                               const char *CompileOpts)
+createLevelZeroInterOpProgram(const context &SyclCtx,
+                              const void *IL,
+                              size_t length,
+                              const char *CompileOpts)
 {
-    auto ZeCtx   = SyclCtx.get_native<backend::level_zero>();
+    auto ZeCtx = SyclCtx.get_native<backend::level_zero>();
     auto SyclDevices = SyclCtx.get_devices();
-    if(SyclDevices.size() > 1) {
+    if (SyclDevices.size() > 1) {
         std::cerr << "Level zero program can be created for only one device.\n";
         // TODO: handle error
         return nullptr;
@@ -150,7 +152,7 @@ createLevelZeroInterOpProgram (const context &SyclCtx,
     ze_module_desc_t ZeModuleDesc = {};
     ZeModuleDesc.format = ZE_MODULE_FORMAT_IL_SPIRV;
     ZeModuleDesc.inputSize = length;
-    ZeModuleDesc.pInputModule = (uint8_t*)IL;
+    ZeModuleDesc.pInputModule = (uint8_t *)IL;
     ZeModuleDesc.pBuildFlags = CompileOpts;
     ZeModuleDesc.pConstants = &ZeSpecConstants;
 
@@ -159,12 +161,12 @@ createLevelZeroInterOpProgram (const context &SyclCtx,
 
     auto stZeModuleCreateF = getZeModuleCreateFn();
 
-    if(!stZeModuleCreateF)
+    if (!stZeModuleCreateF)
         return nullptr;
 
-    auto ret = stZeModuleCreateF(ZeCtx, ZeDevice, &ZeModuleDesc, &ZeModule,
-                                 nullptr);
-    if(ret != ZE_RESULT_SUCCESS) {
+    auto ret =
+        stZeModuleCreateF(ZeCtx, ZeDevice, &ZeModuleDesc, &ZeModule, nullptr);
+    if (ret != ZE_RESULT_SUCCESS) {
         // TODO: handle error
         return nullptr;
     }
@@ -172,8 +174,7 @@ createLevelZeroInterOpProgram (const context &SyclCtx,
     // Create the Sycl program from the ZeModule
     try {
         auto ZeProgram = new program(sycl::level_zero::make_program(
-            SyclCtx, reinterpret_cast<uintptr_t>(ZeModule))
-        );
+            SyclCtx, reinterpret_cast<uintptr_t>(ZeModule)));
         return wrap(ZeProgram);
     } catch (invalid_object_error &e) {
         // \todo record error
@@ -186,29 +187,27 @@ createLevelZeroInterOpProgram (const context &SyclCtx,
 } /* end of anonymous namespace */
 
 __dpctl_give DPCTLSyclProgramRef
-DPCTLProgram_CreateFromSpirv (__dpctl_keep const DPCTLSyclContextRef CtxRef,
-                              __dpctl_keep const void *IL,
-                              size_t length,
-                              const char *CompileOpts)
+DPCTLProgram_CreateFromSpirv(__dpctl_keep const DPCTLSyclContextRef CtxRef,
+                             __dpctl_keep const void *IL,
+                             size_t length,
+                             const char *CompileOpts)
 {
     DPCTLSyclProgramRef Pref = nullptr;
     context *SyclCtx = nullptr;
-    if(!CtxRef) {
+    if (!CtxRef) {
         // \todo handle error
         return Pref;
     }
     SyclCtx = unwrap(CtxRef);
     // get the backend type
     auto BE = SyclCtx->get_platform().get_backend();
-    switch(BE)
-    {
+    switch (BE) {
     case backend::opencl:
         Pref = createOpenCLInterOpProgram(*SyclCtx, IL, length, CompileOpts);
         break;
     case backend::level_zero:
 #ifdef DPCTL_ENABLE_LO_PROGRAM_CREATION
-        Pref = createLevelZeroInterOpProgram(*SyclCtx, IL, length,
-                                             CompileOpts);
+        Pref = createLevelZeroInterOpProgram(*SyclCtx, IL, length, CompileOpts);
 #endif
         break;
     default:
@@ -218,20 +217,20 @@ DPCTLProgram_CreateFromSpirv (__dpctl_keep const DPCTLSyclContextRef CtxRef,
 }
 
 __dpctl_give DPCTLSyclProgramRef
-DPCTLProgram_CreateFromOCLSource (__dpctl_keep const DPCTLSyclContextRef Ctx,
-                                  __dpctl_keep const char *Source,
-                                  __dpctl_keep const char *CompileOpts)
+DPCTLProgram_CreateFromOCLSource(__dpctl_keep const DPCTLSyclContextRef Ctx,
+                                 __dpctl_keep const char *Source,
+                                 __dpctl_keep const char *CompileOpts)
 {
     std::string compileOpts;
     context *SyclCtx = nullptr;
     program *SyclProgram = nullptr;
 
-    if(!Ctx) {
+    if (!Ctx) {
         // \todo handle error
         return nullptr;
     }
 
-    if(!Source) {
+    if (!Source) {
         // \todo handle error message
         return nullptr;
     }
@@ -240,14 +239,13 @@ DPCTLProgram_CreateFromOCLSource (__dpctl_keep const DPCTLSyclContextRef Ctx,
     SyclProgram = new program(*SyclCtx);
     std::string source = Source;
 
-    if(CompileOpts) {
+    if (CompileOpts) {
         compileOpts = CompileOpts;
     }
 
     // get the backend type
     auto BE = SyclCtx->get_platform().get_backend();
-    switch (BE)
-    {
+    switch (BE) {
     case backend::opencl:
         try {
             SyclProgram->build_with_source(source, compileOpts);
@@ -279,15 +277,15 @@ DPCTLProgram_CreateFromOCLSource (__dpctl_keep const DPCTLSyclContextRef Ctx,
 }
 
 __dpctl_give DPCTLSyclKernelRef
-DPCTLProgram_GetKernel (__dpctl_keep DPCTLSyclProgramRef PRef,
-                        __dpctl_keep const char *KernelName)
+DPCTLProgram_GetKernel(__dpctl_keep DPCTLSyclProgramRef PRef,
+                       __dpctl_keep const char *KernelName)
 {
-    if(!PRef) {
+    if (!PRef) {
         // \todo record error
         return nullptr;
     }
     auto SyclProgram = unwrap(PRef);
-    if(!KernelName) {
+    if (!KernelName) {
         // \todo record error
         return nullptr;
     }
@@ -302,11 +300,10 @@ DPCTLProgram_GetKernel (__dpctl_keep DPCTLSyclProgramRef PRef,
     }
 }
 
-bool
-DPCTLProgram_HasKernel (__dpctl_keep DPCTLSyclProgramRef PRef,
-                        __dpctl_keep const char *KernelName)
+bool DPCTLProgram_HasKernel(__dpctl_keep DPCTLSyclProgramRef PRef,
+                            __dpctl_keep const char *KernelName)
 {
-    if(!PRef) {
+    if (!PRef) {
         // \todo handle error
         return false;
     }
@@ -320,8 +317,7 @@ DPCTLProgram_HasKernel (__dpctl_keep DPCTLSyclProgramRef PRef,
     }
 }
 
-void
-DPCTLProgram_Delete (__dpctl_take DPCTLSyclProgramRef PRef)
+void DPCTLProgram_Delete(__dpctl_take DPCTLSyclProgramRef PRef)
 {
     delete unwrap(PRef);
 }

--- a/dpctl-capi/source/dpctl_sycl_queue_interface.cpp
+++ b/dpctl-capi/source/dpctl_sycl_queue_interface.cpp
@@ -25,12 +25,11 @@
 //===----------------------------------------------------------------------===//
 
 #include "dpctl_sycl_queue_interface.h"
-#include "dpctl_sycl_context_interface.h"
 #include "Support/CBindingWrapping.h"
+#include "dpctl_sycl_context_interface.h"
+#include <CL/sycl.hpp> /* SYCL headers   */
 #include <exception>
 #include <stdexcept>
-
-#include <CL/sycl.hpp>                /* SYCL headers   */
 
 using namespace cl::sycl;
 
@@ -49,57 +48,58 @@ DEFINE_SIMPLE_CONVERSION_FUNCTIONS(queue, DPCTLSyclQueueRef)
  * @param    cgh            My Param doc
  * @param    Arg            My Param doc
  */
-bool set_kernel_arg (handler &cgh, size_t idx, __dpctl_keep void *Arg,
-                     DPCTLKernelArgType ArgTy)
+bool set_kernel_arg(handler &cgh,
+                    size_t idx,
+                    __dpctl_keep void *Arg,
+                    DPCTLKernelArgType ArgTy)
 {
     bool arg_set = true;
 
-    switch (ArgTy)
-    {
+    switch (ArgTy) {
     case DPCTL_CHAR:
-        cgh.set_arg(idx, *(char*)Arg);
+        cgh.set_arg(idx, *(char *)Arg);
         break;
     case DPCTL_SIGNED_CHAR:
-        cgh.set_arg(idx, *(signed char*)Arg);
+        cgh.set_arg(idx, *(signed char *)Arg);
         break;
     case DPCTL_UNSIGNED_CHAR:
-        cgh.set_arg(idx, *(unsigned char*)Arg);
+        cgh.set_arg(idx, *(unsigned char *)Arg);
         break;
     case DPCTL_SHORT:
-        cgh.set_arg(idx, *(short*)Arg);
+        cgh.set_arg(idx, *(short *)Arg);
         break;
     case DPCTL_INT:
-        cgh.set_arg(idx, *(int*)Arg);
+        cgh.set_arg(idx, *(int *)Arg);
         break;
     case DPCTL_UNSIGNED_INT:
-        cgh.set_arg(idx, *(unsigned int*)Arg);
+        cgh.set_arg(idx, *(unsigned int *)Arg);
         break;
     case DPCTL_UNSIGNED_INT8:
-        cgh.set_arg(idx, *(uint8_t*)Arg);
+        cgh.set_arg(idx, *(uint8_t *)Arg);
         break;
     case DPCTL_LONG:
-        cgh.set_arg(idx, *(long*)Arg);
+        cgh.set_arg(idx, *(long *)Arg);
         break;
     case DPCTL_UNSIGNED_LONG:
-        cgh.set_arg(idx, *(unsigned long*)Arg);
+        cgh.set_arg(idx, *(unsigned long *)Arg);
         break;
     case DPCTL_LONG_LONG:
-        cgh.set_arg(idx, *(long long*)Arg);
+        cgh.set_arg(idx, *(long long *)Arg);
         break;
     case DPCTL_UNSIGNED_LONG_LONG:
-        cgh.set_arg(idx, *(unsigned long long*)Arg);
+        cgh.set_arg(idx, *(unsigned long long *)Arg);
         break;
     case DPCTL_SIZE_T:
-        cgh.set_arg(idx, *(size_t*)Arg);
+        cgh.set_arg(idx, *(size_t *)Arg);
         break;
     case DPCTL_FLOAT:
-        cgh.set_arg(idx, *(float*)Arg);
+        cgh.set_arg(idx, *(float *)Arg);
         break;
     case DPCTL_DOUBLE:
-        cgh.set_arg(idx, *(double*)Arg);
+        cgh.set_arg(idx, *(double *)Arg);
         break;
     case DPCTL_LONG_DOUBLE:
-        cgh.set_arg(idx, *(long double*)Arg);
+        cgh.set_arg(idx, *(long double *)Arg);
         break;
     case DPCTL_VOID_PTR:
         cgh.set_arg(idx, Arg);
@@ -118,29 +118,27 @@ bool set_kernel_arg (handler &cgh, size_t idx, __dpctl_keep void *Arg,
 /*!
  * Delete the passed in pointer after verifying it points to a sycl::queue.
  */
-void DPCTLQueue_Delete (__dpctl_take DPCTLSyclQueueRef QRef)
+void DPCTLQueue_Delete(__dpctl_take DPCTLSyclQueueRef QRef)
 {
     delete unwrap(QRef);
 }
 
-
-bool DPCTLQueue_AreEq (__dpctl_keep const DPCTLSyclQueueRef QRef1,
+bool DPCTLQueue_AreEq(__dpctl_keep const DPCTLSyclQueueRef QRef1,
                       __dpctl_keep const DPCTLSyclQueueRef QRef2)
 {
-    if(!(QRef1 && QRef2))
+    if (!(QRef1 && QRef2))
         // \todo handle error
         return false;
     return (*unwrap(QRef1) == *unwrap(QRef2));
 }
 
-DPCTLSyclBackendType DPCTLQueue_GetBackend (__dpctl_keep DPCTLSyclQueueRef QRef)
+DPCTLSyclBackendType DPCTLQueue_GetBackend(__dpctl_keep DPCTLSyclQueueRef QRef)
 {
     auto Q = unwrap(QRef);
     try {
         auto C = Q->get_context();
         return DPCTLContext_GetBackend(wrap(&C));
-    }
-    catch (runtime_error &re) {
+    } catch (runtime_error &re) {
         std::cerr << re.what() << '\n';
         // store error message
         return DPCTL_UNKNOWN_BACKEND;
@@ -148,7 +146,7 @@ DPCTLSyclBackendType DPCTLQueue_GetBackend (__dpctl_keep DPCTLSyclQueueRef QRef)
 }
 
 __dpctl_give DPCTLSyclDeviceRef
-DPCTLQueue_GetDevice (__dpctl_keep const DPCTLSyclQueueRef QRef)
+DPCTLQueue_GetDevice(__dpctl_keep const DPCTLSyclQueueRef QRef)
 {
     auto Q = unwrap(QRef);
     auto Device = new device(Q->get_device());
@@ -156,7 +154,7 @@ DPCTLQueue_GetDevice (__dpctl_keep const DPCTLSyclQueueRef QRef)
 }
 
 __dpctl_give DPCTLSyclContextRef
-DPCTLQueue_GetContext (__dpctl_keep const DPCTLSyclQueueRef QRef)
+DPCTLQueue_GetContext(__dpctl_keep const DPCTLSyclQueueRef QRef)
 {
     auto Q = unwrap(QRef);
     auto Context = new context(Q->get_context());
@@ -164,7 +162,7 @@ DPCTLQueue_GetContext (__dpctl_keep const DPCTLSyclQueueRef QRef)
 }
 
 __dpctl_give DPCTLSyclEventRef
-DPCTLQueue_SubmitRange (__dpctl_keep const DPCTLSyclKernelRef KRef,
+DPCTLQueue_SubmitRange(__dpctl_keep const DPCTLSyclKernelRef KRef,
                        __dpctl_keep const DPCTLSyclQueueRef QRef,
                        __dpctl_keep void **Args,
                        __dpctl_keep const DPCTLKernelArgType *ArgTypes,
@@ -175,24 +173,23 @@ DPCTLQueue_SubmitRange (__dpctl_keep const DPCTLSyclKernelRef KRef,
                        size_t NDepEvents)
 {
     auto Kernel = unwrap(KRef);
-    auto Queue  = unwrap(QRef);
+    auto Queue = unwrap(QRef);
     event e;
 
     try {
-        e = Queue->submit([&](handler& cgh) {
+        e = Queue->submit([&](handler &cgh) {
             // Depend on any event that was specified by the caller.
-            if(NDepEvents)
-                for(auto i = 0ul; i < NDepEvents; ++i)
+            if (NDepEvents)
+                for (auto i = 0ul; i < NDepEvents; ++i)
                     cgh.depends_on(*unwrap(DepEvents[i]));
 
             for (auto i = 0ul; i < NArgs; ++i) {
                 // \todo add support for Sycl buffers
                 // \todo handle errors properly
-                if(!set_kernel_arg(cgh, i, Args[i], ArgTypes[i]))
+                if (!set_kernel_arg(cgh, i, Args[i], ArgTypes[i]))
                     exit(1);
             }
-            switch(NDims)
-            {
+            switch (NDims) {
             case 1:
                 cgh.parallel_for(range<1>{Range[0]}, *Kernel);
                 break;
@@ -223,46 +220,47 @@ DPCTLQueue_SubmitRange (__dpctl_keep const DPCTLSyclKernelRef KRef,
 
 DPCTLSyclEventRef
 DPCTLQueue_SubmitNDRange(__dpctl_keep const DPCTLSyclKernelRef KRef,
-                        __dpctl_keep const DPCTLSyclQueueRef QRef,
-                        __dpctl_keep void **Args,
-                        __dpctl_keep const DPCTLKernelArgType *ArgTypes,
-                        size_t NArgs,
-                        __dpctl_keep const size_t gRange[3],
-                        __dpctl_keep const size_t lRange[3],
-                        size_t NDims,
-                        __dpctl_keep const DPCTLSyclEventRef *DepEvents,
-                        size_t NDepEvents)
+                         __dpctl_keep const DPCTLSyclQueueRef QRef,
+                         __dpctl_keep void **Args,
+                         __dpctl_keep const DPCTLKernelArgType *ArgTypes,
+                         size_t NArgs,
+                         __dpctl_keep const size_t gRange[3],
+                         __dpctl_keep const size_t lRange[3],
+                         size_t NDims,
+                         __dpctl_keep const DPCTLSyclEventRef *DepEvents,
+                         size_t NDepEvents)
 {
     auto Kernel = unwrap(KRef);
-    auto Queue  = unwrap(QRef);
+    auto Queue = unwrap(QRef);
     event e;
 
     try {
-        e = Queue->submit([&](handler& cgh) {
+        e = Queue->submit([&](handler &cgh) {
             // Depend on any event that was specified by the caller.
-            if(NDepEvents)
-                for(auto i = 0ul; i < NDepEvents; ++i)
+            if (NDepEvents)
+                for (auto i = 0ul; i < NDepEvents; ++i)
                     cgh.depends_on(*unwrap(DepEvents[i]));
 
             for (auto i = 0ul; i < NArgs; ++i) {
                 // \todo add support for Sycl buffers
                 // \todo handle errors properly
-                if(!set_kernel_arg(cgh, i, Args[i], ArgTypes[i]))
+                if (!set_kernel_arg(cgh, i, Args[i], ArgTypes[i]))
                     exit(1);
             }
-            switch(NDims)
-            {
+            switch (NDims) {
             case 1:
-                cgh.parallel_for(nd_range<1>{{gRange[0]},{lRange[0]}}, *Kernel);
+                cgh.parallel_for(nd_range<1>{{gRange[0]}, {lRange[0]}},
+                                 *Kernel);
                 break;
             case 2:
-                cgh.parallel_for(nd_range<2>{{gRange[0], gRange[1]},
-                                             {lRange[0], lRange[1]}}, *Kernel);
+                cgh.parallel_for(
+                    nd_range<2>{{gRange[0], gRange[1]}, {lRange[0], lRange[1]}},
+                    *Kernel);
                 break;
             case 3:
                 cgh.parallel_for(nd_range<3>{{gRange[0], gRange[1], gRange[2]},
                                              {lRange[0], lRange[1], lRange[2]}},
-                                             *Kernel);
+                                 *Kernel);
                 break;
             default:
                 // \todo handle the error
@@ -282,34 +280,36 @@ DPCTLQueue_SubmitNDRange(__dpctl_keep const DPCTLSyclKernelRef KRef,
     return wrap(new event(e));
 }
 
-void
-DPCTLQueue_Wait (__dpctl_keep DPCTLSyclQueueRef QRef)
+void DPCTLQueue_Wait(__dpctl_keep DPCTLSyclQueueRef QRef)
 {
     // \todo what happens if the QRef is null or a pointer to a valid sycl queue
     auto SyclQueue = unwrap(QRef);
     SyclQueue->wait();
 }
 
-void DPCTLQueue_Memcpy (__dpctl_keep const DPCTLSyclQueueRef QRef,
-                       void *Dest, const void *Src, size_t Count)
+void DPCTLQueue_Memcpy(__dpctl_keep const DPCTLSyclQueueRef QRef,
+                       void *Dest,
+                       const void *Src,
+                       size_t Count)
 {
     auto Q = unwrap(QRef);
     auto event = Q->memcpy(Dest, Src, Count);
     event.wait();
 }
 
-void
-DPCTLQueue_Prefetch (__dpctl_keep DPCTLSyclQueueRef QRef,
-                    const void *Ptr, size_t Count)
+void DPCTLQueue_Prefetch(__dpctl_keep DPCTLSyclQueueRef QRef,
+                         const void *Ptr,
+                         size_t Count)
 {
     auto Q = unwrap(QRef);
     auto event = Q->prefetch(Ptr, Count);
     event.wait();
 }
 
-void
-DPCTLQueue_MemAdvise (__dpctl_keep DPCTLSyclQueueRef QRef,
-                     const void *Ptr, size_t Count, int Advice)
+void DPCTLQueue_MemAdvise(__dpctl_keep DPCTLSyclQueueRef QRef,
+                          const void *Ptr,
+                          size_t Count,
+                          int Advice)
 {
     auto Q = unwrap(QRef);
     auto event = Q->mem_advise(Ptr, Count, static_cast<pi_mem_advice>(Advice));

--- a/dpctl-capi/source/dpctl_sycl_usm_interface.cpp
+++ b/dpctl-capi/source/dpctl_sycl_usm_interface.cpp
@@ -25,10 +25,9 @@
 //===----------------------------------------------------------------------===//
 
 #include "dpctl_sycl_usm_interface.h"
-#include "dpctl_sycl_device_interface.h"
 #include "Support/CBindingWrapping.h"
-
-#include <CL/sycl.hpp>                /* SYCL headers   */
+#include "dpctl_sycl_device_interface.h"
+#include <CL/sycl.hpp> /* SYCL headers   */
 
 using namespace cl::sycl;
 
@@ -43,7 +42,7 @@ DEFINE_SIMPLE_CONVERSION_FUNCTIONS(void, DPCTLSyclUSMRef)
 } /* end of anonymous namespace */
 
 __dpctl_give DPCTLSyclUSMRef
-DPCTLmalloc_shared (size_t size, __dpctl_keep const DPCTLSyclQueueRef QRef)
+DPCTLmalloc_shared(size_t size, __dpctl_keep const DPCTLSyclQueueRef QRef)
 {
     auto Q = unwrap(QRef);
     auto Ptr = malloc_shared(size, *Q);
@@ -51,7 +50,8 @@ DPCTLmalloc_shared (size_t size, __dpctl_keep const DPCTLSyclQueueRef QRef)
 }
 
 __dpctl_give DPCTLSyclUSMRef
-DPCTLaligned_alloc_shared (size_t alignment, size_t size,
+DPCTLaligned_alloc_shared(size_t alignment,
+                          size_t size,
                           __dpctl_keep const DPCTLSyclQueueRef QRef)
 {
     auto Q = unwrap(QRef);
@@ -60,7 +60,7 @@ DPCTLaligned_alloc_shared (size_t alignment, size_t size,
 }
 
 __dpctl_give DPCTLSyclUSMRef
-DPCTLmalloc_host (size_t size, __dpctl_keep const DPCTLSyclQueueRef QRef)
+DPCTLmalloc_host(size_t size, __dpctl_keep const DPCTLSyclQueueRef QRef)
 {
     auto Q = unwrap(QRef);
     auto Ptr = malloc_host(size, *Q);
@@ -68,7 +68,8 @@ DPCTLmalloc_host (size_t size, __dpctl_keep const DPCTLSyclQueueRef QRef)
 }
 
 __dpctl_give DPCTLSyclUSMRef
-DPCTLaligned_alloc_host (size_t alignment, size_t size,
+DPCTLaligned_alloc_host(size_t alignment,
+                        size_t size,
                         __dpctl_keep const DPCTLSyclQueueRef QRef)
 {
     auto Q = unwrap(QRef);
@@ -77,7 +78,7 @@ DPCTLaligned_alloc_host (size_t alignment, size_t size,
 }
 
 __dpctl_give DPCTLSyclUSMRef
-DPCTLmalloc_device (size_t size, __dpctl_keep const DPCTLSyclQueueRef QRef)
+DPCTLmalloc_device(size_t size, __dpctl_keep const DPCTLSyclQueueRef QRef)
 {
     auto Q = unwrap(QRef);
     auto Ptr = malloc_device(size, *Q);
@@ -85,7 +86,8 @@ DPCTLmalloc_device (size_t size, __dpctl_keep const DPCTLSyclQueueRef QRef)
 }
 
 __dpctl_give DPCTLSyclUSMRef
-DPCTLaligned_alloc_device (size_t alignment, size_t size,
+DPCTLaligned_alloc_device(size_t alignment,
+                          size_t size,
                           __dpctl_keep const DPCTLSyclQueueRef QRef)
 {
     auto Q = unwrap(QRef);
@@ -93,7 +95,7 @@ DPCTLaligned_alloc_device (size_t alignment, size_t size,
     return wrap(Ptr);
 }
 
-void DPCTLfree_with_queue (__dpctl_take DPCTLSyclUSMRef MRef,
+void DPCTLfree_with_queue(__dpctl_take DPCTLSyclUSMRef MRef,
                           __dpctl_keep const DPCTLSyclQueueRef QRef)
 {
     auto Ptr = unwrap(MRef);
@@ -101,7 +103,7 @@ void DPCTLfree_with_queue (__dpctl_take DPCTLSyclUSMRef MRef,
     free(Ptr, *Q);
 }
 
-void DPCTLfree_with_context (__dpctl_take DPCTLSyclUSMRef MRef,
+void DPCTLfree_with_context(__dpctl_take DPCTLSyclUSMRef MRef,
                             __dpctl_keep const DPCTLSyclContextRef CRef)
 {
     auto Ptr = unwrap(MRef);
@@ -109,28 +111,27 @@ void DPCTLfree_with_context (__dpctl_take DPCTLSyclUSMRef MRef,
     free(Ptr, *C);
 }
 
-const char *
-DPCTLUSM_GetPointerType (__dpctl_keep const DPCTLSyclUSMRef MRef,
-                        __dpctl_keep const DPCTLSyclContextRef CRef)
+const char *DPCTLUSM_GetPointerType(__dpctl_keep const DPCTLSyclUSMRef MRef,
+                                    __dpctl_keep const DPCTLSyclContextRef CRef)
 {
     auto Ptr = unwrap(MRef);
     auto C = unwrap(CRef);
 
     auto kind = get_pointer_type(Ptr, *C);
-    switch(kind) {
-        case usm::alloc::host:
-            return "host";
-        case usm::alloc::device:
-            return "device";
-        case usm::alloc::shared:
-            return "shared";
-        default:
-            return "unknown";
+    switch (kind) {
+    case usm::alloc::host:
+        return "host";
+    case usm::alloc::device:
+        return "device";
+    case usm::alloc::shared:
+        return "shared";
+    default:
+        return "unknown";
     }
 }
 
 DPCTLSyclDeviceRef
-DPCTLUSM_GetPointerDevice (__dpctl_keep const DPCTLSyclUSMRef MRef,
+DPCTLUSM_GetPointerDevice(__dpctl_keep const DPCTLSyclUSMRef MRef,
                           __dpctl_keep const DPCTLSyclContextRef CRef)
 {
     auto Ptr = unwrap(MRef);

--- a/dpctl-capi/source/dpctl_utils.cpp
+++ b/dpctl-capi/source/dpctl_utils.cpp
@@ -25,12 +25,12 @@
 
 #include "dpctl_utils.h"
 
-void DPCTLCString_Delete (__dpctl_take const char* str)
+void DPCTLCString_Delete(__dpctl_take const char *str)
 {
     delete[] str;
 }
 
-void DPCTLSize_t_Array_Delete (__dpctl_take size_t* arr)
+void DPCTLSize_t_Array_Delete(__dpctl_take size_t *arr)
 {
     delete[] arr;
 }

--- a/dpctl-capi/tests/test_main.cpp
+++ b/dpctl-capi/tests/test_main.cpp
@@ -25,8 +25,7 @@
 
 #include <gtest/gtest.h>
 
-int
-main (int argc, char** argv)
+int main(int argc, char **argv)
 {
     ::testing::InitGoogleTest(&argc, argv);
     int ret = RUN_ALL_TESTS();

--- a/dpctl-capi/tests/test_sycl_device_interface.cpp
+++ b/dpctl-capi/tests/test_sycl_device_interface.cpp
@@ -28,11 +28,10 @@
 #include "dpctl_sycl_queue_interface.h"
 #include "dpctl_sycl_queue_manager.h"
 #include "dpctl_utils.h"
-#include <gtest/gtest.h>
 #include <CL/sycl.hpp>
+#include <gtest/gtest.h>
 
 using namespace cl::sycl;
-
 
 struct TestDPCTLSyclDeviceInterface : public ::testing::Test
 {
@@ -40,39 +39,38 @@ struct TestDPCTLSyclDeviceInterface : public ::testing::Test
     DPCTLSyclDeviceRef OpenCL_gpu = nullptr;
     DPCTLSyclDeviceRef OpenCL_Level0_gpu = nullptr;
 
-    TestDPCTLSyclDeviceInterface ()
+    TestDPCTLSyclDeviceInterface()
     {
-        if(DPCTLQueueMgr_GetNumQueues(DPCTL_OPENCL, DPCTL_CPU)) {
+        if (DPCTLQueueMgr_GetNumQueues(DPCTL_OPENCL, DPCTL_CPU)) {
             auto Q = DPCTLQueueMgr_GetQueue(DPCTL_OPENCL, DPCTL_CPU, 0);
             OpenCL_cpu = DPCTLQueue_GetDevice(Q);
             DPCTLQueue_Delete(Q);
         }
 
-        if(DPCTLQueueMgr_GetNumQueues(DPCTL_OPENCL, DPCTL_GPU)) {
+        if (DPCTLQueueMgr_GetNumQueues(DPCTL_OPENCL, DPCTL_GPU)) {
             auto Q = DPCTLQueueMgr_GetQueue(DPCTL_OPENCL, DPCTL_GPU, 0);
             OpenCL_gpu = DPCTLQueue_GetDevice(Q);
             DPCTLQueue_Delete(Q);
         }
 
-        if(DPCTLQueueMgr_GetNumQueues(DPCTL_LEVEL_ZERO, DPCTL_GPU)) {
+        if (DPCTLQueueMgr_GetNumQueues(DPCTL_LEVEL_ZERO, DPCTL_GPU)) {
             auto Q = DPCTLQueueMgr_GetQueue(DPCTL_LEVEL_ZERO, DPCTL_GPU, 0);
             OpenCL_Level0_gpu = DPCTLQueue_GetDevice(Q);
             DPCTLQueue_Delete(Q);
         }
     }
 
-    ~TestDPCTLSyclDeviceInterface ()
+    ~TestDPCTLSyclDeviceInterface()
     {
         DPCTLDevice_Delete(OpenCL_cpu);
         DPCTLDevice_Delete(OpenCL_gpu);
         DPCTLDevice_Delete(OpenCL_Level0_gpu);
     }
-
 };
 
-TEST_F (TestDPCTLSyclDeviceInterface, CheckOCLCPU_GetDriverInfo)
+TEST_F(TestDPCTLSyclDeviceInterface, CheckOCLCPU_GetDriverInfo)
 {
-    if(!OpenCL_cpu)
+    if (!OpenCL_cpu)
         GTEST_SKIP_("Skipping as no OpenCL CPU device found.");
 
     auto DriverInfo = DPCTLDevice_GetDriverInfo(OpenCL_cpu);
@@ -80,9 +78,9 @@ TEST_F (TestDPCTLSyclDeviceInterface, CheckOCLCPU_GetDriverInfo)
     DPCTLCString_Delete(DriverInfo);
 }
 
-TEST_F (TestDPCTLSyclDeviceInterface, CheckOCLGPU_GetDriverInfo)
+TEST_F(TestDPCTLSyclDeviceInterface, CheckOCLGPU_GetDriverInfo)
 {
-    if(!OpenCL_gpu)
+    if (!OpenCL_gpu)
         GTEST_SKIP_("Skipping as no OpenCL CPU device found.");
 
     auto DriverInfo = DPCTLDevice_GetDriverInfo(OpenCL_gpu);
@@ -90,9 +88,9 @@ TEST_F (TestDPCTLSyclDeviceInterface, CheckOCLGPU_GetDriverInfo)
     DPCTLCString_Delete(DriverInfo);
 }
 
-TEST_F (TestDPCTLSyclDeviceInterface, CheckLevel0GPU_GetDriverInfo)
+TEST_F(TestDPCTLSyclDeviceInterface, CheckLevel0GPU_GetDriverInfo)
 {
-    if(!OpenCL_Level0_gpu)
+    if (!OpenCL_Level0_gpu)
         GTEST_SKIP_("Skipping as no Level0 GPU device found.");
 
     auto DriverInfo = DPCTLDevice_GetDriverInfo(OpenCL_Level0_gpu);
@@ -100,63 +98,63 @@ TEST_F (TestDPCTLSyclDeviceInterface, CheckLevel0GPU_GetDriverInfo)
     DPCTLCString_Delete(DriverInfo);
 }
 
-TEST_F (TestDPCTLSyclDeviceInterface, CheckOCLCPU_GetMaxComputeUnits)
+TEST_F(TestDPCTLSyclDeviceInterface, CheckOCLCPU_GetMaxComputeUnits)
 {
-    if(!OpenCL_cpu)
+    if (!OpenCL_cpu)
         GTEST_SKIP_("Skipping as no OpenCL CPU device found.");
 
     auto n = DPCTLDevice_GetMaxComputeUnits(OpenCL_cpu);
     EXPECT_TRUE(n > 0);
 }
 
-TEST_F (TestDPCTLSyclDeviceInterface, CheckOCLGPU_GetMaxComputeUnits)
+TEST_F(TestDPCTLSyclDeviceInterface, CheckOCLGPU_GetMaxComputeUnits)
 {
-    if(!OpenCL_gpu)
+    if (!OpenCL_gpu)
         GTEST_SKIP_("Skipping as no OpenCL GPU device found.");
 
     auto n = DPCTLDevice_GetMaxComputeUnits(OpenCL_gpu);
     EXPECT_TRUE(n > 0);
 }
 
-TEST_F (TestDPCTLSyclDeviceInterface, CheckLevel0GPU_GetMaxComputeUnits)
+TEST_F(TestDPCTLSyclDeviceInterface, CheckLevel0GPU_GetMaxComputeUnits)
 {
-    if(!OpenCL_Level0_gpu)
+    if (!OpenCL_Level0_gpu)
         GTEST_SKIP_("Skipping as no Level0 GPU device found.");
 
     auto n = DPCTLDevice_GetMaxComputeUnits(OpenCL_Level0_gpu);
     EXPECT_TRUE(n > 0);
 }
 
-TEST_F (TestDPCTLSyclDeviceInterface, CheckOCLCPU_GetMaxWorkItemDims)
+TEST_F(TestDPCTLSyclDeviceInterface, CheckOCLCPU_GetMaxWorkItemDims)
 {
-    if(!OpenCL_cpu)
+    if (!OpenCL_cpu)
         GTEST_SKIP_("Skipping as no OpenCL CPU device found.");
 
     auto n = DPCTLDevice_GetMaxWorkItemDims(OpenCL_cpu);
     EXPECT_TRUE(n > 0);
 }
 
-TEST_F (TestDPCTLSyclDeviceInterface, CheckOCLGPU_GetMaxWorkItemDims)
+TEST_F(TestDPCTLSyclDeviceInterface, CheckOCLGPU_GetMaxWorkItemDims)
 {
-    if(!OpenCL_gpu)
+    if (!OpenCL_gpu)
         GTEST_SKIP_("Skipping as no OpenCL GPU device found.");
 
     auto n = DPCTLDevice_GetMaxWorkItemDims(OpenCL_gpu);
     EXPECT_TRUE(n > 0);
 }
 
-TEST_F (TestDPCTLSyclDeviceInterface, CheckLevel0GPU_GetMaxWorkItemDims)
+TEST_F(TestDPCTLSyclDeviceInterface, CheckLevel0GPU_GetMaxWorkItemDims)
 {
-    if(!OpenCL_Level0_gpu)
+    if (!OpenCL_Level0_gpu)
         GTEST_SKIP_("Skipping as no Level0 GPU device found.");
 
     auto n = DPCTLDevice_GetMaxWorkItemDims(OpenCL_Level0_gpu);
     EXPECT_TRUE(n > 0);
 }
 
-TEST_F (TestDPCTLSyclDeviceInterface, CheckOCLCPU_GetMaxWorkItemSizes)
+TEST_F(TestDPCTLSyclDeviceInterface, CheckOCLCPU_GetMaxWorkItemSizes)
 {
-    if(!OpenCL_cpu)
+    if (!OpenCL_cpu)
         GTEST_SKIP_("Skipping as no OpenCL CPU device found.");
 
     auto item_sizes = DPCTLDevice_GetMaxWorkItemSizes(OpenCL_cpu);
@@ -164,9 +162,9 @@ TEST_F (TestDPCTLSyclDeviceInterface, CheckOCLCPU_GetMaxWorkItemSizes)
     DPCTLSize_t_Array_Delete(item_sizes);
 }
 
-TEST_F (TestDPCTLSyclDeviceInterface, CheckOCLGPU_GetMaxWorkItemSizes)
+TEST_F(TestDPCTLSyclDeviceInterface, CheckOCLGPU_GetMaxWorkItemSizes)
 {
-    if(!OpenCL_gpu)
+    if (!OpenCL_gpu)
         GTEST_SKIP_("Skipping as no OpenCL GPU device found.");
 
     auto item_sizes = DPCTLDevice_GetMaxWorkItemSizes(OpenCL_gpu);
@@ -174,9 +172,9 @@ TEST_F (TestDPCTLSyclDeviceInterface, CheckOCLGPU_GetMaxWorkItemSizes)
     DPCTLSize_t_Array_Delete(item_sizes);
 }
 
-TEST_F (TestDPCTLSyclDeviceInterface, CheckLevel0GPU_GetMaxWorkItemSizes)
+TEST_F(TestDPCTLSyclDeviceInterface, CheckLevel0GPU_GetMaxWorkItemSizes)
 {
-    if(!OpenCL_Level0_gpu)
+    if (!OpenCL_Level0_gpu)
         GTEST_SKIP_("Skipping as no Level0 GPU device found.");
 
     auto item_sizes = DPCTLDevice_GetMaxWorkItemSizes(OpenCL_Level0_gpu);
@@ -184,135 +182,135 @@ TEST_F (TestDPCTLSyclDeviceInterface, CheckLevel0GPU_GetMaxWorkItemSizes)
     DPCTLSize_t_Array_Delete(item_sizes);
 }
 
-TEST_F (TestDPCTLSyclDeviceInterface, CheckOCLCPU_GetMaxWorkGroupSize)
+TEST_F(TestDPCTLSyclDeviceInterface, CheckOCLCPU_GetMaxWorkGroupSize)
 {
-    if(!OpenCL_cpu)
+    if (!OpenCL_cpu)
         GTEST_SKIP_("Skipping as no OpenCL CPU device found.");
 
     auto n = DPCTLDevice_GetMaxWorkGroupSize(OpenCL_cpu);
     EXPECT_TRUE(n > 0);
 }
 
-TEST_F (TestDPCTLSyclDeviceInterface, CheckOCLGPU_GetMaxWorkGroupSize)
+TEST_F(TestDPCTLSyclDeviceInterface, CheckOCLGPU_GetMaxWorkGroupSize)
 {
-    if(!OpenCL_gpu)
+    if (!OpenCL_gpu)
         GTEST_SKIP_("Skipping as no OpenCL GPU device found.");
 
     auto n = DPCTLDevice_GetMaxWorkGroupSize(OpenCL_gpu);
     EXPECT_TRUE(n > 0);
 }
 
-TEST_F (TestDPCTLSyclDeviceInterface, CheckLevel0GPU_GetMaxWorkGroupSize)
+TEST_F(TestDPCTLSyclDeviceInterface, CheckLevel0GPU_GetMaxWorkGroupSize)
 {
-    if(!OpenCL_Level0_gpu)
+    if (!OpenCL_Level0_gpu)
         GTEST_SKIP_("Skipping as no Level0 GPU device found.");
 
     auto n = DPCTLDevice_GetMaxWorkGroupSize(OpenCL_Level0_gpu);
     EXPECT_TRUE(n > 0);
 }
 
-TEST_F (TestDPCTLSyclDeviceInterface, CheckOCLCPU_GetMaxNumSubGroups)
+TEST_F(TestDPCTLSyclDeviceInterface, CheckOCLCPU_GetMaxNumSubGroups)
 {
-    if(!OpenCL_cpu)
+    if (!OpenCL_cpu)
         GTEST_SKIP_("Skipping as no OpenCL CPU device found.");
 
     auto n = DPCTLDevice_GetMaxNumSubGroups(OpenCL_cpu);
     EXPECT_TRUE(n > 0);
 }
 
-TEST_F (TestDPCTLSyclDeviceInterface, CheckOCLGPU_GetMaxNumSubGroups)
+TEST_F(TestDPCTLSyclDeviceInterface, CheckOCLGPU_GetMaxNumSubGroups)
 {
-    if(!OpenCL_gpu)
+    if (!OpenCL_gpu)
         GTEST_SKIP_("Skipping as no OpenCL GPU device found.");
 
     auto n = DPCTLDevice_GetMaxNumSubGroups(OpenCL_gpu);
     EXPECT_TRUE(n > 0);
 }
 
-TEST_F (TestDPCTLSyclDeviceInterface, CheckLevel0GPU_GetMaxNumSubGroups)
+TEST_F(TestDPCTLSyclDeviceInterface, CheckLevel0GPU_GetMaxNumSubGroups)
 {
-    if(!OpenCL_Level0_gpu)
+    if (!OpenCL_Level0_gpu)
         GTEST_SKIP_("Skipping as no Level0 GPU device found.");
 
     auto n = DPCTLDevice_GetMaxNumSubGroups(OpenCL_Level0_gpu);
     EXPECT_TRUE(n > 0);
 }
 
-//TODO: Update when DPC++ properly supports aspects
-TEST_F (TestDPCTLSyclDeviceInterface, CheckOCLCPU_HasInt64BaseAtomics)
+// TODO: Update when DPC++ properly supports aspects
+TEST_F(TestDPCTLSyclDeviceInterface, CheckOCLCPU_HasInt64BaseAtomics)
 {
-    if(!OpenCL_cpu)
+    if (!OpenCL_cpu)
         GTEST_SKIP_("Skipping as no OpenCL CPU device found.");
 
     auto atomics = DPCTLDevice_HasInt64BaseAtomics(OpenCL_cpu);
-    auto D = reinterpret_cast<device*>(OpenCL_cpu);
-    auto has_atomics= D->has(aspect::int64_base_atomics);
+    auto D = reinterpret_cast<device *>(OpenCL_cpu);
+    auto has_atomics = D->has(aspect::int64_base_atomics);
     EXPECT_TRUE(has_atomics == atomics);
 }
 
-//TODO: Update when DPC++ properly supports aspects
-TEST_F (TestDPCTLSyclDeviceInterface, CheckOCLGPU_HasInt64BaseAtomics)
+// TODO: Update when DPC++ properly supports aspects
+TEST_F(TestDPCTLSyclDeviceInterface, CheckOCLGPU_HasInt64BaseAtomics)
 {
-    if(!OpenCL_gpu)
+    if (!OpenCL_gpu)
         GTEST_SKIP_("Skipping as no OpenCL GPU device found.");
 
     auto atomics = DPCTLDevice_HasInt64BaseAtomics(OpenCL_gpu);
-    auto D = reinterpret_cast<device*>(OpenCL_gpu);
-    auto has_atomics= D->has(aspect::int64_base_atomics);
+    auto D = reinterpret_cast<device *>(OpenCL_gpu);
+    auto has_atomics = D->has(aspect::int64_base_atomics);
     EXPECT_TRUE(has_atomics == atomics);
 }
 
-//TODO: Update when DPC++ properly supports aspects
-TEST_F (TestDPCTLSyclDeviceInterface, CheckLevel0GPU_HasInt64BaseAtomics)
+// TODO: Update when DPC++ properly supports aspects
+TEST_F(TestDPCTLSyclDeviceInterface, CheckLevel0GPU_HasInt64BaseAtomics)
 {
-    if(!OpenCL_Level0_gpu)
+    if (!OpenCL_Level0_gpu)
         GTEST_SKIP_("Skipping as no Level0 GPU device found.");
 
     auto atomics = DPCTLDevice_HasInt64BaseAtomics(OpenCL_Level0_gpu);
-    auto D = reinterpret_cast<device*>(OpenCL_Level0_gpu);
-    auto has_atomics= D->has(aspect::int64_base_atomics);
+    auto D = reinterpret_cast<device *>(OpenCL_Level0_gpu);
+    auto has_atomics = D->has(aspect::int64_base_atomics);
     EXPECT_TRUE(has_atomics == atomics);
 }
 
-//TODO: Update when DPC++ properly supports aspects
-TEST_F (TestDPCTLSyclDeviceInterface, CheckOCLCPU_HasInt64ExtendedAtomics)
+// TODO: Update when DPC++ properly supports aspects
+TEST_F(TestDPCTLSyclDeviceInterface, CheckOCLCPU_HasInt64ExtendedAtomics)
 {
-    if(!OpenCL_cpu)
+    if (!OpenCL_cpu)
         GTEST_SKIP_("Skipping as no OpenCL CPU device found.");
 
     auto atomics = DPCTLDevice_HasInt64ExtendedAtomics(OpenCL_cpu);
-    auto D = reinterpret_cast<device*>(OpenCL_cpu);
-    auto has_atomics= D->has(aspect::int64_extended_atomics);
+    auto D = reinterpret_cast<device *>(OpenCL_cpu);
+    auto has_atomics = D->has(aspect::int64_extended_atomics);
     EXPECT_TRUE(has_atomics == atomics);
 }
 
-//TODO: Update when DPC++ properly supports aspects
-TEST_F (TestDPCTLSyclDeviceInterface, CheckOCLGPU_HasInt64ExtendedAtomics)
+// TODO: Update when DPC++ properly supports aspects
+TEST_F(TestDPCTLSyclDeviceInterface, CheckOCLGPU_HasInt64ExtendedAtomics)
 {
-    if(!OpenCL_gpu)
+    if (!OpenCL_gpu)
         GTEST_SKIP_("Skipping as no OpenCL GPU device found.");
 
     auto atomics = DPCTLDevice_HasInt64ExtendedAtomics(OpenCL_gpu);
-    auto D = reinterpret_cast<device*>(OpenCL_gpu);
-    auto has_atomics= D->has(aspect::int64_extended_atomics);
+    auto D = reinterpret_cast<device *>(OpenCL_gpu);
+    auto has_atomics = D->has(aspect::int64_extended_atomics);
     EXPECT_TRUE(has_atomics == atomics);
 }
 
-//TODO: Update when DPC++ properly supports aspects
-TEST_F (TestDPCTLSyclDeviceInterface, CheckLevel0GPU_HasInt64ExtendedAtomics)
+// TODO: Update when DPC++ properly supports aspects
+TEST_F(TestDPCTLSyclDeviceInterface, CheckLevel0GPU_HasInt64ExtendedAtomics)
 {
-    if(!OpenCL_Level0_gpu)
+    if (!OpenCL_Level0_gpu)
         GTEST_SKIP_("Skipping as no Level0 GPU device found.");
 
     auto atomics = DPCTLDevice_HasInt64ExtendedAtomics(OpenCL_Level0_gpu);
-    auto D = reinterpret_cast<device*>(OpenCL_Level0_gpu);
-    auto has_atomics= D->has(aspect::int64_extended_atomics);
+    auto D = reinterpret_cast<device *>(OpenCL_Level0_gpu);
+    auto has_atomics = D->has(aspect::int64_extended_atomics);
     EXPECT_TRUE(has_atomics == atomics);
 }
 
-TEST_F (TestDPCTLSyclDeviceInterface, CheckOCLCPU_GetName)
+TEST_F(TestDPCTLSyclDeviceInterface, CheckOCLCPU_GetName)
 {
-    if(!OpenCL_cpu)
+    if (!OpenCL_cpu)
         GTEST_SKIP_("Skipping as no OpenCL CPU device found.");
 
     auto DevName = DPCTLDevice_GetName(OpenCL_cpu);
@@ -320,9 +318,9 @@ TEST_F (TestDPCTLSyclDeviceInterface, CheckOCLCPU_GetName)
     DPCTLCString_Delete(DevName);
 }
 
-TEST_F (TestDPCTLSyclDeviceInterface, CheckOCLGPU_GetName)
+TEST_F(TestDPCTLSyclDeviceInterface, CheckOCLGPU_GetName)
 {
-    if(!OpenCL_gpu)
+    if (!OpenCL_gpu)
         GTEST_SKIP_("Skipping as no OpenCL CPU device found.");
 
     auto DevName = DPCTLDevice_GetName(OpenCL_gpu);
@@ -330,9 +328,9 @@ TEST_F (TestDPCTLSyclDeviceInterface, CheckOCLGPU_GetName)
     DPCTLCString_Delete(DevName);
 }
 
-TEST_F (TestDPCTLSyclDeviceInterface, CheckLevel0GPU_GetName)
+TEST_F(TestDPCTLSyclDeviceInterface, CheckLevel0GPU_GetName)
 {
-    if(!OpenCL_Level0_gpu)
+    if (!OpenCL_Level0_gpu)
         GTEST_SKIP_("Skipping as no Level0 GPU device found.");
 
     auto DevName = DPCTLDevice_GetName(OpenCL_Level0_gpu);
@@ -340,9 +338,9 @@ TEST_F (TestDPCTLSyclDeviceInterface, CheckLevel0GPU_GetName)
     DPCTLCString_Delete(DevName);
 }
 
-TEST_F (TestDPCTLSyclDeviceInterface, CheckOCLCPU_GetVendorName)
+TEST_F(TestDPCTLSyclDeviceInterface, CheckOCLCPU_GetVendorName)
 {
-    if(!OpenCL_cpu)
+    if (!OpenCL_cpu)
         GTEST_SKIP_("Skipping as no OpenCL CPU device found.");
 
     auto VendorName = DPCTLDevice_GetVendorName(OpenCL_cpu);
@@ -350,9 +348,9 @@ TEST_F (TestDPCTLSyclDeviceInterface, CheckOCLCPU_GetVendorName)
     DPCTLCString_Delete(VendorName);
 }
 
-TEST_F (TestDPCTLSyclDeviceInterface, CheckOCLGPU_GetVendorName)
+TEST_F(TestDPCTLSyclDeviceInterface, CheckOCLGPU_GetVendorName)
 {
-    if(!OpenCL_gpu)
+    if (!OpenCL_gpu)
         GTEST_SKIP_("Skipping as no OpenCL CPU device found.");
 
     auto VendorName = DPCTLDevice_GetVendorName(OpenCL_gpu);
@@ -360,9 +358,9 @@ TEST_F (TestDPCTLSyclDeviceInterface, CheckOCLGPU_GetVendorName)
     DPCTLCString_Delete(VendorName);
 }
 
-TEST_F (TestDPCTLSyclDeviceInterface, CheckLevel0GPU_GetVendorName)
+TEST_F(TestDPCTLSyclDeviceInterface, CheckLevel0GPU_GetVendorName)
 {
-    if(!OpenCL_Level0_gpu)
+    if (!OpenCL_Level0_gpu)
         GTEST_SKIP_("Skipping as no Level0 GPU device found.");
 
     auto VendorName = DPCTLDevice_GetVendorName(OpenCL_Level0_gpu);
@@ -370,27 +368,26 @@ TEST_F (TestDPCTLSyclDeviceInterface, CheckLevel0GPU_GetVendorName)
     DPCTLCString_Delete(VendorName);
 }
 
-TEST_F (TestDPCTLSyclDeviceInterface, CheckOCLCPU_IsCPU)
+TEST_F(TestDPCTLSyclDeviceInterface, CheckOCLCPU_IsCPU)
 {
-    if(!OpenCL_cpu)
+    if (!OpenCL_cpu)
         GTEST_SKIP_("Skipping as no OpenCL CPU device found.");
 
     EXPECT_TRUE(DPCTLDevice_IsCPU(OpenCL_cpu));
 }
 
-TEST_F (TestDPCTLSyclDeviceInterface, CheckOCLGPU_IsGPU)
+TEST_F(TestDPCTLSyclDeviceInterface, CheckOCLGPU_IsGPU)
 {
-    if(!OpenCL_gpu)
+    if (!OpenCL_gpu)
         GTEST_SKIP_("Skipping as no OpenCL CPU device found.");
 
     EXPECT_TRUE(DPCTLDevice_IsGPU(OpenCL_gpu));
 }
 
-TEST_F (TestDPCTLSyclDeviceInterface, CheckLevel0GPU_IsGPU)
+TEST_F(TestDPCTLSyclDeviceInterface, CheckLevel0GPU_IsGPU)
 {
-    if(!OpenCL_Level0_gpu)
+    if (!OpenCL_Level0_gpu)
         GTEST_SKIP_("Skipping as no Level0 GPU device found.");
 
     EXPECT_TRUE(DPCTLDevice_IsGPU(OpenCL_Level0_gpu));
 }
-

--- a/dpctl-capi/tests/test_sycl_kernel_interface.cpp
+++ b/dpctl-capi/tests/test_sycl_kernel_interface.cpp
@@ -30,13 +30,11 @@
 #include "dpctl_sycl_queue_interface.h"
 #include "dpctl_sycl_queue_manager.h"
 #include "dpctl_utils.h"
-
+#include <CL/sycl.hpp>
 #include <array>
 #include <gtest/gtest.h>
-#include <CL/sycl.hpp>
 
 using namespace cl::sycl;
-
 
 struct TestDPCTLSyclKernelInterface : public ::testing::Test
 {
@@ -51,23 +49,24 @@ struct TestDPCTLSyclKernelInterface : public ::testing::Test
             c[index] = a[index] + d*b[index];
         }
     )CLC";
-    const char *CompileOpts ="-cl-fast-relaxed-math";
+    const char *CompileOpts = "-cl-fast-relaxed-math";
 
     size_t nOpenCLGpuQ = 0;
-    TestDPCTLSyclKernelInterface ()
+    TestDPCTLSyclKernelInterface()
         : nOpenCLGpuQ(DPCTLQueueMgr_GetNumQueues(DPCTL_OPENCL, DPCTL_GPU))
-    {  }
+    {
+    }
 };
 
-TEST_F (TestDPCTLSyclKernelInterface, CheckGetFunctionName)
+TEST_F(TestDPCTLSyclKernelInterface, CheckGetFunctionName)
 {
-    if(!nOpenCLGpuQ)
+    if (!nOpenCLGpuQ)
         GTEST_SKIP_("Skipping as no OpenCL GPU device found.\n");
 
     auto QueueRef = DPCTLQueueMgr_GetQueue(DPCTL_OPENCL, DPCTL_GPU, 0);
-    auto CtxRef   = DPCTLQueue_GetContext(QueueRef);
-    auto PRef = DPCTLProgram_CreateFromOCLSource(CtxRef, CLProgramStr,
-                                                CompileOpts);
+    auto CtxRef = DPCTLQueue_GetContext(QueueRef);
+    auto PRef =
+        DPCTLProgram_CreateFromOCLSource(CtxRef, CLProgramStr, CompileOpts);
     auto AddKernel = DPCTLProgram_GetKernel(PRef, "add");
     auto AxpyKernel = DPCTLProgram_GetKernel(PRef, "axpy");
 
@@ -87,15 +86,15 @@ TEST_F (TestDPCTLSyclKernelInterface, CheckGetFunctionName)
     DPCTLKernel_Delete(AxpyKernel);
 }
 
-TEST_F (TestDPCTLSyclKernelInterface, CheckGetNumArgs)
+TEST_F(TestDPCTLSyclKernelInterface, CheckGetNumArgs)
 {
-    if(!nOpenCLGpuQ)
+    if (!nOpenCLGpuQ)
         GTEST_SKIP_("Skipping as no OpenCL GPU device found.\n");
 
     auto QueueRef = DPCTLQueueMgr_GetQueue(DPCTL_OPENCL, DPCTL_GPU, 0);
-    auto CtxRef   = DPCTLQueue_GetContext(QueueRef);
-    auto PRef = DPCTLProgram_CreateFromOCLSource(CtxRef, CLProgramStr,
-                                                CompileOpts);
+    auto CtxRef = DPCTLQueue_GetContext(QueueRef);
+    auto PRef =
+        DPCTLProgram_CreateFromOCLSource(CtxRef, CLProgramStr, CompileOpts);
     auto AddKernel = DPCTLProgram_GetKernel(PRef, "add");
     auto AxpyKernel = DPCTLProgram_GetKernel(PRef, "axpy");
 
@@ -108,4 +107,3 @@ TEST_F (TestDPCTLSyclKernelInterface, CheckGetNumArgs)
     DPCTLKernel_Delete(AddKernel);
     DPCTLKernel_Delete(AxpyKernel);
 }
-

--- a/dpctl-capi/tests/test_sycl_platform_interface.cpp
+++ b/dpctl-capi/tests/test_sycl_platform_interface.cpp
@@ -27,40 +27,39 @@
 #include <gtest/gtest.h>
 
 struct TestDPCTLSyclPlatformInterface : public ::testing::Test
-{ };
+{
+};
 
-TEST_F (TestDPCTLSyclPlatformInterface, CheckGetNumPlatforms)
+TEST_F(TestDPCTLSyclPlatformInterface, CheckGetNumPlatforms)
 {
     auto nplatforms = DPCTLPlatform_GetNumNonHostPlatforms();
     EXPECT_GE(nplatforms, 0ul);
 }
 
-TEST_F (TestDPCTLSyclPlatformInterface, GetNumBackends)
+TEST_F(TestDPCTLSyclPlatformInterface, GetNumBackends)
 {
     auto nbackends = DPCTLPlatform_GetNumNonHostBackends();
     EXPECT_GE(nbackends, 0ul);
 }
 
-TEST_F (TestDPCTLSyclPlatformInterface, GetListOfBackends)
+TEST_F(TestDPCTLSyclPlatformInterface, GetListOfBackends)
 {
     auto nbackends = DPCTLPlatform_GetNumNonHostBackends();
 
-    if(!nbackends)
-      GTEST_SKIP_("No non host backends available");
+    if (!nbackends)
+        GTEST_SKIP_("No non host backends available");
 
     auto backends = DPCTLPlatform_GetListOfNonHostBackends();
-	  EXPECT_TRUE(backends != nullptr);
-    for(auto i = 0ul; i < nbackends; ++i) {
-        EXPECT_TRUE(
-          backends[i] == DPCTLSyclBackendType::DPCTL_CUDA   ||
-          backends[i] == DPCTLSyclBackendType::DPCTL_OPENCL ||
-          backends[i] == DPCTLSyclBackendType::DPCTL_LEVEL_ZERO
-          );
+    EXPECT_TRUE(backends != nullptr);
+    for (auto i = 0ul; i < nbackends; ++i) {
+        EXPECT_TRUE(backends[i] == DPCTLSyclBackendType::DPCTL_CUDA ||
+                    backends[i] == DPCTLSyclBackendType::DPCTL_OPENCL ||
+                    backends[i] == DPCTLSyclBackendType::DPCTL_LEVEL_ZERO);
     }
-	DPCTLPlatform_DeleteListOfBackends(backends);
+    DPCTLPlatform_DeleteListOfBackends(backends);
 }
 
-TEST_F (TestDPCTLSyclPlatformInterface, CheckDPCTLPlatformDumpInfo)
+TEST_F(TestDPCTLSyclPlatformInterface, CheckDPCTLPlatformDumpInfo)
 {
     EXPECT_NO_FATAL_FAILURE(DPCTLPlatform_DumpInfo());
 }

--- a/dpctl-capi/tests/test_sycl_program_interface.cpp
+++ b/dpctl-capi/tests/test_sycl_program_interface.cpp
@@ -24,17 +24,17 @@
 ///
 //===----------------------------------------------------------------------===//
 
+#include "Config/dpctl_config.h"
 #include "dpctl_sycl_context_interface.h"
 #include "dpctl_sycl_kernel_interface.h"
 #include "dpctl_sycl_program_interface.h"
 #include "dpctl_sycl_queue_interface.h"
 #include "dpctl_sycl_queue_manager.h"
-#include "Config/dpctl_config.h"
-#include <array>
-#include <fstream>
-#include <filesystem>
-#include <gtest/gtest.h>
 #include <CL/sycl.hpp>
+#include <array>
+#include <filesystem>
+#include <fstream>
+#include <gtest/gtest.h>
 
 using namespace cl::sycl;
 
@@ -42,7 +42,7 @@ namespace
 {
 const int SIZE = 1024;
 
-void add_kernel_checker (queue *syclQueue, DPCTLSyclKernelRef AddKernel)
+void add_kernel_checker(queue *syclQueue, DPCTLSyclKernelRef AddKernel)
 {
     range<1> a_size{SIZE};
     std::array<int, SIZE> a, b, c;
@@ -58,23 +58,23 @@ void add_kernel_checker (queue *syclQueue, DPCTLSyclKernelRef AddKernel)
         buffer<int, 1> b_device(b.data(), a_size);
         buffer<int, 1> c_device(c.data(), a_size);
         buffer<int, 1> buffs[3] = {a_device, b_device, c_device};
-        syclQueue->submit([&](handler& cgh) {
+        syclQueue->submit([&](handler &cgh) {
             for (auto buff : buffs) {
                 auto arg = buff.get_access<access::mode::read_write>(cgh);
                 cgh.set_args(arg);
             }
-            auto syclKernel = reinterpret_cast<kernel*>(AddKernel);
+            auto syclKernel = reinterpret_cast<kernel *>(AddKernel);
             cgh.parallel_for(range<1>{SIZE}, *syclKernel);
         });
     }
 
     // Validate the data
-    for(int i = 0; i < SIZE; ++i) {
+    for (int i = 0; i < SIZE; ++i) {
         EXPECT_EQ(c[i], i + i);
     }
 }
 
-void axpy_kernel_checker (queue *syclQueue, DPCTLSyclKernelRef AxpyKernel)
+void axpy_kernel_checker(queue *syclQueue, DPCTLSyclKernelRef AxpyKernel)
 {
     range<1> a_size{SIZE};
     std::array<int, SIZE> a, b, c;
@@ -90,20 +90,20 @@ void axpy_kernel_checker (queue *syclQueue, DPCTLSyclKernelRef AxpyKernel)
         buffer<int, 1> b_device(b.data(), a_size);
         buffer<int, 1> c_device(c.data(), a_size);
         buffer<int, 1> buffs[3] = {a_device, b_device, c_device};
-        syclQueue->submit([&](handler& cgh) {
+        syclQueue->submit([&](handler &cgh) {
             for (auto i = 0ul; i < 3; ++i) {
                 auto arg = buffs[i].get_access<access::mode::read_write>(cgh);
                 cgh.set_arg(i, arg);
             }
             cgh.set_arg(3, d);
-            auto syclKernel = reinterpret_cast<kernel*>(AxpyKernel);
+            auto syclKernel = reinterpret_cast<kernel *>(AxpyKernel);
             cgh.parallel_for(range<1>{SIZE}, *syclKernel);
         });
     }
 
     // Validate the data
-    for(int i = 0; i < SIZE; ++i) {
-        EXPECT_EQ(c[i], i + d*i);
+    for (int i = 0; i < SIZE; ++i) {
+        EXPECT_EQ(c[i], i + d * i);
     }
 }
 
@@ -122,37 +122,37 @@ struct TestDPCTLSyclProgramInterface : public ::testing::Test
             c[index] = a[index] + d*b[index];
         }
     )CLC";
-    const char *CompileOpts ="-cl-fast-relaxed-math";
+    const char *CompileOpts = "-cl-fast-relaxed-math";
     std::ifstream spirvFile;
     size_t spirvFileSize = 0;
     std::vector<char> spirvBuffer;
     size_t nOpenCLGpuQ = 0;
 
-    TestDPCTLSyclProgramInterface () :
-        spirvFile{"./multi_kernel.spv", std::ios::binary | std::ios::ate},
-        spirvFileSize(std::filesystem::file_size("./multi_kernel.spv")),
-        spirvBuffer(spirvFileSize),
-        nOpenCLGpuQ(DPCTLQueueMgr_GetNumQueues(DPCTL_OPENCL, DPCTL_GPU))
+    TestDPCTLSyclProgramInterface()
+        : spirvFile{"./multi_kernel.spv", std::ios::binary | std::ios::ate},
+          spirvFileSize(std::filesystem::file_size("./multi_kernel.spv")),
+          spirvBuffer(spirvFileSize),
+          nOpenCLGpuQ(DPCTLQueueMgr_GetNumQueues(DPCTL_OPENCL, DPCTL_GPU))
     {
         spirvFile.seekg(0, std::ios::beg);
         spirvFile.read(spirvBuffer.data(), spirvFileSize);
     }
 
-    ~TestDPCTLSyclProgramInterface ()
+    ~TestDPCTLSyclProgramInterface()
     {
         spirvFile.close();
     }
 };
 
-TEST_F (TestDPCTLSyclProgramInterface, CheckCreateFromOCLSource)
+TEST_F(TestDPCTLSyclProgramInterface, CheckCreateFromOCLSource)
 {
-    if(!nOpenCLGpuQ)
+    if (!nOpenCLGpuQ)
         GTEST_SKIP_("Skipping as no OpenCL GPU device found.\n");
 
     auto QueueRef = DPCTLQueueMgr_GetQueue(DPCTL_OPENCL, DPCTL_GPU, 0);
     auto CtxRef = DPCTLQueue_GetContext(QueueRef);
-    auto PRef = DPCTLProgram_CreateFromOCLSource(CtxRef, CLProgramStr,
-                                                 CompileOpts);
+    auto PRef =
+        DPCTLProgram_CreateFromOCLSource(CtxRef, CLProgramStr, CompileOpts);
     ASSERT_TRUE(PRef != nullptr);
     ASSERT_TRUE(DPCTLProgram_HasKernel(PRef, "add"));
     ASSERT_TRUE(DPCTLProgram_HasKernel(PRef, "axpy"));
@@ -162,16 +162,15 @@ TEST_F (TestDPCTLSyclProgramInterface, CheckCreateFromOCLSource)
     DPCTLProgram_Delete(PRef);
 }
 
-TEST_F (TestDPCTLSyclProgramInterface, CheckCreateFromSpirvOCL)
+TEST_F(TestDPCTLSyclProgramInterface, CheckCreateFromSpirvOCL)
 {
-    if(!nOpenCLGpuQ)
+    if (!nOpenCLGpuQ)
         GTEST_SKIP_("Skipping as no OpenCL GPU device found.\n");
 
     auto QueueRef = DPCTLQueueMgr_GetQueue(DPCTL_OPENCL, DPCTL_GPU, 0);
     auto CtxRef = DPCTLQueue_GetContext(QueueRef);
     auto PRef = DPCTLProgram_CreateFromSpirv(CtxRef, spirvBuffer.data(),
-                                             spirvFileSize,
-                                             nullptr);
+                                             spirvFileSize, nullptr);
     ASSERT_TRUE(PRef != nullptr);
     ASSERT_TRUE(DPCTLProgram_HasKernel(PRef, "add"));
     ASSERT_TRUE(DPCTLProgram_HasKernel(PRef, "axpy"));
@@ -182,17 +181,16 @@ TEST_F (TestDPCTLSyclProgramInterface, CheckCreateFromSpirvOCL)
 }
 
 #ifdef DPCTL_ENABLE_LO_PROGRAM_CREATION
-TEST_F (TestDPCTLSyclProgramInterface, CheckCreateFromSpirvL0)
+TEST_F(TestDPCTLSyclProgramInterface, CheckCreateFromSpirvL0)
 {
     auto nL0GpuQ = DPCTLQueueMgr_GetNumQueues(DPCTL_LEVEL_ZERO, DPCTL_GPU);
-    if(!nL0GpuQ)
+    if (!nL0GpuQ)
         GTEST_SKIP_("Skipping as no OpenCL GPU device found.\n");
 
     auto QueueRef = DPCTLQueueMgr_GetQueue(DPCTL_LEVEL_ZERO, DPCTL_GPU, 0);
     auto CtxRef = DPCTLQueue_GetContext(QueueRef);
     auto PRef = DPCTLProgram_CreateFromSpirv(CtxRef, spirvBuffer.data(),
-                                             spirvFileSize,
-                                             nullptr);
+                                             spirvFileSize, nullptr);
     ASSERT_TRUE(PRef != nullptr);
     ASSERT_TRUE(DPCTLProgram_HasKernel(PRef, "add"));
     ASSERT_TRUE(DPCTLProgram_HasKernel(PRef, "axpy"));
@@ -203,22 +201,22 @@ TEST_F (TestDPCTLSyclProgramInterface, CheckCreateFromSpirvL0)
 }
 #endif
 
-TEST_F (TestDPCTLSyclProgramInterface, CheckGetKernelOCLSource)
+TEST_F(TestDPCTLSyclProgramInterface, CheckGetKernelOCLSource)
 {
-    if(!nOpenCLGpuQ)
+    if (!nOpenCLGpuQ)
         GTEST_SKIP_("Skipping as no OpenCL GPU device found.\n");
 
     auto QueueRef = DPCTLQueueMgr_GetQueue(DPCTL_OPENCL, DPCTL_GPU, 0);
     auto CtxRef = DPCTLQueue_GetContext(QueueRef);
-    auto PRef = DPCTLProgram_CreateFromOCLSource(CtxRef, CLProgramStr,
-                                                CompileOpts);
+    auto PRef =
+        DPCTLProgram_CreateFromOCLSource(CtxRef, CLProgramStr, CompileOpts);
     auto AddKernel = DPCTLProgram_GetKernel(PRef, "add");
     auto AxpyKernel = DPCTLProgram_GetKernel(PRef, "axpy");
 
     ASSERT_TRUE(AddKernel != nullptr);
     ASSERT_TRUE(AxpyKernel != nullptr);
 
-    auto syclQueue = reinterpret_cast<queue*>(QueueRef);
+    auto syclQueue = reinterpret_cast<queue *>(QueueRef);
 
     add_kernel_checker(syclQueue, AddKernel);
     axpy_kernel_checker(syclQueue, AxpyKernel);
@@ -230,9 +228,9 @@ TEST_F (TestDPCTLSyclProgramInterface, CheckGetKernelOCLSource)
     DPCTLProgram_Delete(PRef);
 }
 
-TEST_F (TestDPCTLSyclProgramInterface, CheckGetKernelSpirv)
+TEST_F(TestDPCTLSyclProgramInterface, CheckGetKernelSpirv)
 {
-    if(!nOpenCLGpuQ)
+    if (!nOpenCLGpuQ)
         GTEST_SKIP_("Skipping as no OpenCL GPU device found.\n");
 
     auto QueueRef = DPCTLQueueMgr_GetQueue(DPCTL_OPENCL, DPCTL_GPU, 0);
@@ -245,7 +243,7 @@ TEST_F (TestDPCTLSyclProgramInterface, CheckGetKernelSpirv)
     ASSERT_TRUE(AddKernel != nullptr);
     ASSERT_TRUE(AxpyKernel != nullptr);
 
-    auto syclQueue = reinterpret_cast<queue*>(QueueRef);
+    auto syclQueue = reinterpret_cast<queue *>(QueueRef);
 
     add_kernel_checker(syclQueue, AddKernel);
     axpy_kernel_checker(syclQueue, AxpyKernel);
@@ -256,4 +254,3 @@ TEST_F (TestDPCTLSyclProgramInterface, CheckGetKernelSpirv)
     DPCTLContext_Delete(CtxRef);
     DPCTLProgram_Delete(PRef);
 }
-

--- a/dpctl-capi/tests/test_sycl_queue_interface.cpp
+++ b/dpctl-capi/tests/test_sycl_queue_interface.cpp
@@ -24,6 +24,7 @@
 ///
 //===----------------------------------------------------------------------===//
 
+#include "Support/CBindingWrapping.h"
 #include "dpctl_sycl_context_interface.h"
 #include "dpctl_sycl_event_interface.h"
 #include "dpctl_sycl_kernel_interface.h"
@@ -31,7 +32,6 @@
 #include "dpctl_sycl_queue_interface.h"
 #include "dpctl_sycl_queue_manager.h"
 #include "dpctl_sycl_usm_interface.h"
-#include "Support/CBindingWrapping.h"
 #include <CL/sycl.hpp>
 #include <gtest/gtest.h>
 
@@ -43,29 +43,31 @@ constexpr size_t SIZE = 1024;
 
 DEFINE_SIMPLE_CONVERSION_FUNCTIONS(void, DPCTLSyclUSMRef);
 
-void add_kernel_checker (const float *a, const float *b, const float *c)
+void add_kernel_checker(const float *a, const float *b, const float *c)
 {
     // Validate the data
-    for(auto i = 0ul; i < SIZE; ++i) {
+    for (auto i = 0ul; i < SIZE; ++i) {
         EXPECT_EQ(c[i], a[i] + b[i]);
     }
 }
 
-void axpy_kernel_checker (const float *a, const float *b, const float *c,
-                            float d)
+void axpy_kernel_checker(const float *a,
+                         const float *b,
+                         const float *c,
+                         float d)
 {
-    for(auto i = 0ul; i < SIZE; ++i) {
-        EXPECT_EQ(c[i], a[i] + d*b[i]);
+    for (auto i = 0ul; i < SIZE; ++i) {
+        EXPECT_EQ(c[i], a[i] + d * b[i]);
     }
 }
 
-bool has_devices ()
+bool has_devices()
 {
     bool ret = false;
     for (auto &p : platform::get_platforms()) {
         if (p.is_host())
             continue;
-        if(!p.get_devices().empty()) {
+        if (!p.get_devices().empty()) {
             ret = true;
             break;
         }
@@ -73,7 +75,7 @@ bool has_devices ()
     return ret;
 }
 
-}
+} // namespace
 
 struct TestDPCTLSyclQueueInterface : public ::testing::Test
 {
@@ -94,23 +96,21 @@ struct TestDPCTLSyclQueueInterface : public ::testing::Test
             c[index] = a[index] + d*b[index];
         }
     )CLC";
-    const char *CompileOpts ="-cl-fast-relaxed-math";
+    const char *CompileOpts = "-cl-fast-relaxed-math";
 
-    TestDPCTLSyclQueueInterface ()
-    {  }
+    TestDPCTLSyclQueueInterface() {}
 
-    ~TestDPCTLSyclQueueInterface ()
-    {  }
+    ~TestDPCTLSyclQueueInterface() {}
 };
 
-TEST_F (TestDPCTLSyclQueueInterface, CheckAreEq)
+TEST_F(TestDPCTLSyclQueueInterface, CheckAreEq)
 {
-    if(!has_devices())
+    if (!has_devices())
         GTEST_SKIP_("Skipping: No Sycl devices.\n");
 
-    auto nOclGPU = DPCTLQueueMgr_GetNumQueues(DPCTLSyclBackendType::DPCTL_OPENCL,
-                                             DPCTLSyclDeviceType::DPCTL_GPU);
-    if(!nOclGPU)
+    auto nOclGPU = DPCTLQueueMgr_GetNumQueues(
+        DPCTLSyclBackendType::DPCTL_OPENCL, DPCTLSyclDeviceType::DPCTL_GPU);
+    if (!nOclGPU)
         GTEST_SKIP_("Skipping: No OpenCL GPUs available.\n");
 
     auto Q1 = DPCTLQueueMgr_GetCurrentQueue();
@@ -118,20 +118,11 @@ TEST_F (TestDPCTLSyclQueueInterface, CheckAreEq)
     EXPECT_TRUE(DPCTLQueue_AreEq(Q1, Q2));
 
     auto Def_Q = DPCTLQueueMgr_SetAsDefaultQueue(
-                    DPCTLSyclBackendType::DPCTL_OPENCL,
-                    DPCTLSyclDeviceType::DPCTL_GPU,
-                    0
-                 );
-    auto OclGPU_Q0 = DPCTLQueueMgr_PushQueue(
-                        DPCTLSyclBackendType::DPCTL_OPENCL,
-                        DPCTLSyclDeviceType::DPCTL_GPU,
-                        0
-                    );
-    auto OclGPU_Q1 = DPCTLQueueMgr_PushQueue(
-                        DPCTLSyclBackendType::DPCTL_OPENCL,
-                        DPCTLSyclDeviceType::DPCTL_GPU,
-                        0
-                    );
+        DPCTLSyclBackendType::DPCTL_OPENCL, DPCTLSyclDeviceType::DPCTL_GPU, 0);
+    auto OclGPU_Q0 = DPCTLQueueMgr_PushQueue(DPCTLSyclBackendType::DPCTL_OPENCL,
+                                             DPCTLSyclDeviceType::DPCTL_GPU, 0);
+    auto OclGPU_Q1 = DPCTLQueueMgr_PushQueue(DPCTLSyclBackendType::DPCTL_OPENCL,
+                                             DPCTLSyclDeviceType::DPCTL_GPU, 0);
     EXPECT_TRUE(DPCTLQueue_AreEq(Def_Q, OclGPU_Q0));
     EXPECT_TRUE(DPCTLQueue_AreEq(Def_Q, OclGPU_Q1));
     EXPECT_TRUE(DPCTLQueue_AreEq(OclGPU_Q0, OclGPU_Q1));
@@ -142,58 +133,49 @@ TEST_F (TestDPCTLSyclQueueInterface, CheckAreEq)
     DPCTLQueueMgr_PopQueue();
 }
 
-TEST_F (TestDPCTLSyclQueueInterface, CheckAreEq2)
+TEST_F(TestDPCTLSyclQueueInterface, CheckAreEq2)
 {
-    if(!has_devices())
+    if (!has_devices())
         GTEST_SKIP_("Skipping: No Sycl devices.\n");
 
-    auto nOclGPU = DPCTLQueueMgr_GetNumQueues(DPCTLSyclBackendType::DPCTL_OPENCL,
-                                             DPCTLSyclDeviceType::DPCTL_GPU);
-    auto nOclCPU = DPCTLQueueMgr_GetNumQueues(DPCTLSyclBackendType::DPCTL_OPENCL,
-                                             DPCTLSyclDeviceType::DPCTL_CPU);
-    if(!nOclGPU || !nOclCPU)
+    auto nOclGPU = DPCTLQueueMgr_GetNumQueues(
+        DPCTLSyclBackendType::DPCTL_OPENCL, DPCTLSyclDeviceType::DPCTL_GPU);
+    auto nOclCPU = DPCTLQueueMgr_GetNumQueues(
+        DPCTLSyclBackendType::DPCTL_OPENCL, DPCTLSyclDeviceType::DPCTL_CPU);
+    if (!nOclGPU || !nOclCPU)
         GTEST_SKIP_("OpenCL GPUs and CPU not available.\n");
-    auto GPU_Q = DPCTLQueueMgr_PushQueue(
-                    DPCTLSyclBackendType::DPCTL_OPENCL,
-                    DPCTLSyclDeviceType::DPCTL_GPU,
-                    0
-                );
-    auto CPU_Q = DPCTLQueueMgr_PushQueue(
-                    DPCTLSyclBackendType::DPCTL_OPENCL,
-                    DPCTLSyclDeviceType::DPCTL_CPU,
-                    0
-                );
+    auto GPU_Q = DPCTLQueueMgr_PushQueue(DPCTLSyclBackendType::DPCTL_OPENCL,
+                                         DPCTLSyclDeviceType::DPCTL_GPU, 0);
+    auto CPU_Q = DPCTLQueueMgr_PushQueue(DPCTLSyclBackendType::DPCTL_OPENCL,
+                                         DPCTLSyclDeviceType::DPCTL_CPU, 0);
     EXPECT_FALSE(DPCTLQueue_AreEq(GPU_Q, CPU_Q));
     DPCTLQueueMgr_PopQueue();
     DPCTLQueueMgr_PopQueue();
 }
 
-TEST_F (TestDPCTLSyclQueueInterface, CheckGetBackend)
+TEST_F(TestDPCTLSyclQueueInterface, CheckGetBackend)
 {
-    if(!has_devices())
+    if (!has_devices())
         GTEST_SKIP_("Skipping: No Sycl devices.\n");
 
     auto Q1 = DPCTLQueueMgr_GetCurrentQueue();
     auto BE = DPCTLQueue_GetBackend(Q1);
-    EXPECT_TRUE((BE == DPCTL_OPENCL) ||
-                (BE == DPCTL_LEVEL_ZERO) ||
-                (BE == DPCTL_CUDA) ||
-                (BE == DPCTL_HOST)
-    );
+    EXPECT_TRUE((BE == DPCTL_OPENCL) || (BE == DPCTL_LEVEL_ZERO) ||
+                (BE == DPCTL_CUDA) || (BE == DPCTL_HOST));
     DPCTLQueue_Delete(Q1);
-    if(DPCTLQueueMgr_GetNumQueues(DPCTL_OPENCL, DPCTL_GPU)) {
+    if (DPCTLQueueMgr_GetNumQueues(DPCTL_OPENCL, DPCTL_GPU)) {
         auto Q = DPCTLQueueMgr_PushQueue(DPCTL_OPENCL, DPCTL_GPU, 0);
         EXPECT_TRUE(DPCTLQueue_GetBackend(Q) == DPCTL_OPENCL);
         DPCTLQueue_Delete(Q);
         DPCTLQueueMgr_PopQueue();
     }
-    if(DPCTLQueueMgr_GetNumQueues(DPCTL_OPENCL, DPCTL_CPU)) {
+    if (DPCTLQueueMgr_GetNumQueues(DPCTL_OPENCL, DPCTL_CPU)) {
         auto Q = DPCTLQueueMgr_PushQueue(DPCTL_OPENCL, DPCTL_CPU, 0);
         EXPECT_TRUE(DPCTLQueue_GetBackend(Q) == DPCTL_OPENCL);
         DPCTLQueue_Delete(Q);
         DPCTLQueueMgr_PopQueue();
     }
-    if(DPCTLQueueMgr_GetNumQueues(DPCTL_LEVEL_ZERO, DPCTL_GPU)) {
+    if (DPCTLQueueMgr_GetNumQueues(DPCTL_LEVEL_ZERO, DPCTL_GPU)) {
         auto Q = DPCTLQueueMgr_PushQueue(DPCTL_LEVEL_ZERO, DPCTL_GPU, 0);
         EXPECT_TRUE(DPCTLQueue_GetBackend(Q) == DPCTL_LEVEL_ZERO);
         DPCTLQueue_Delete(Q);
@@ -201,9 +183,9 @@ TEST_F (TestDPCTLSyclQueueInterface, CheckGetBackend)
     }
 }
 
-TEST_F (TestDPCTLSyclQueueInterface, CheckGetContext)
+TEST_F(TestDPCTLSyclQueueInterface, CheckGetContext)
 {
-    if(!has_devices())
+    if (!has_devices())
         GTEST_SKIP_("Skipping: No Sycl devices.\n");
 
     auto Q1 = DPCTLQueueMgr_GetCurrentQueue();
@@ -212,7 +194,7 @@ TEST_F (TestDPCTLSyclQueueInterface, CheckGetContext)
     DPCTLQueue_Delete(Q1);
     DPCTLContext_Delete(Ctx);
 
-    if(DPCTLQueueMgr_GetNumQueues(DPCTL_OPENCL, DPCTL_GPU)) {
+    if (DPCTLQueueMgr_GetNumQueues(DPCTL_OPENCL, DPCTL_GPU)) {
         auto Q = DPCTLQueueMgr_PushQueue(DPCTL_OPENCL, DPCTL_GPU, 0);
         auto OclGpuCtx = DPCTLQueue_GetContext(Q);
         ASSERT_TRUE(OclGpuCtx != nullptr);
@@ -220,7 +202,7 @@ TEST_F (TestDPCTLSyclQueueInterface, CheckGetContext)
         DPCTLContext_Delete(OclGpuCtx);
         DPCTLQueueMgr_PopQueue();
     }
-    if(DPCTLQueueMgr_GetNumQueues(DPCTL_OPENCL, DPCTL_CPU)) {
+    if (DPCTLQueueMgr_GetNumQueues(DPCTL_OPENCL, DPCTL_CPU)) {
         auto Q = DPCTLQueueMgr_PushQueue(DPCTL_OPENCL, DPCTL_CPU, 0);
         auto OclCpuCtx = DPCTLQueue_GetContext(Q);
         ASSERT_TRUE(OclCpuCtx != nullptr);
@@ -228,7 +210,7 @@ TEST_F (TestDPCTLSyclQueueInterface, CheckGetContext)
         DPCTLContext_Delete(OclCpuCtx);
         DPCTLQueueMgr_PopQueue();
     }
-    if(DPCTLQueueMgr_GetNumQueues(DPCTL_LEVEL_ZERO, DPCTL_GPU)) {
+    if (DPCTLQueueMgr_GetNumQueues(DPCTL_LEVEL_ZERO, DPCTL_GPU)) {
         auto Q = DPCTLQueueMgr_PushQueue(DPCTL_LEVEL_ZERO, DPCTL_GPU, 0);
         auto L0Ctx = DPCTLQueue_GetContext(Q);
         ASSERT_TRUE(Ctx != nullptr);
@@ -238,9 +220,9 @@ TEST_F (TestDPCTLSyclQueueInterface, CheckGetContext)
     }
 }
 
-TEST_F (TestDPCTLSyclQueueInterface, CheckGetDevice)
+TEST_F(TestDPCTLSyclQueueInterface, CheckGetDevice)
 {
-    if(!has_devices())
+    if (!has_devices())
         GTEST_SKIP_("Skipping: No Sycl devices.\n");
 
     auto Q1 = DPCTLQueueMgr_GetCurrentQueue();
@@ -249,7 +231,7 @@ TEST_F (TestDPCTLSyclQueueInterface, CheckGetDevice)
     DPCTLQueue_Delete(Q1);
     DPCTLDevice_Delete(D);
 
-    if(DPCTLQueueMgr_GetNumQueues(DPCTL_OPENCL, DPCTL_GPU)) {
+    if (DPCTLQueueMgr_GetNumQueues(DPCTL_OPENCL, DPCTL_GPU)) {
         auto Q = DPCTLQueueMgr_PushQueue(DPCTL_OPENCL, DPCTL_GPU, 0);
         auto OCLGPU_D = DPCTLQueue_GetDevice(Q);
         ASSERT_TRUE(OCLGPU_D != nullptr);
@@ -258,7 +240,7 @@ TEST_F (TestDPCTLSyclQueueInterface, CheckGetDevice)
         DPCTLDevice_Delete(OCLGPU_D);
         DPCTLQueueMgr_PopQueue();
     }
-    if(DPCTLQueueMgr_GetNumQueues(DPCTL_OPENCL, DPCTL_CPU)) {
+    if (DPCTLQueueMgr_GetNumQueues(DPCTL_OPENCL, DPCTL_CPU)) {
         auto Q = DPCTLQueueMgr_PushQueue(DPCTL_OPENCL, DPCTL_CPU, 0);
         auto OCLCPU_D = DPCTLQueue_GetDevice(Q);
         ASSERT_TRUE(OCLCPU_D != nullptr);
@@ -267,7 +249,7 @@ TEST_F (TestDPCTLSyclQueueInterface, CheckGetDevice)
         DPCTLDevice_Delete(OCLCPU_D);
         DPCTLQueueMgr_PopQueue();
     }
-    if(DPCTLQueueMgr_GetNumQueues(DPCTL_LEVEL_ZERO, DPCTL_GPU)) {
+    if (DPCTLQueueMgr_GetNumQueues(DPCTL_LEVEL_ZERO, DPCTL_GPU)) {
         auto Q = DPCTLQueueMgr_PushQueue(DPCTL_LEVEL_ZERO, DPCTL_GPU, 0);
         auto L0GPU_D = DPCTLQueue_GetDevice(Q);
         ASSERT_TRUE(L0GPU_D != nullptr);
@@ -278,27 +260,27 @@ TEST_F (TestDPCTLSyclQueueInterface, CheckGetDevice)
     }
 }
 
-TEST_F (TestDPCTLSyclQueueInterface, CheckSubmit)
+TEST_F(TestDPCTLSyclQueueInterface, CheckSubmit)
 {
-    if(!has_devices())
+    if (!has_devices())
         GTEST_SKIP_("Skipping: No Sycl devices.\n");
 
     auto nOpenCLGpuQ = DPCTLQueueMgr_GetNumQueues(DPCTL_OPENCL, DPCTL_GPU);
 
-    if(!nOpenCLGpuQ)
+    if (!nOpenCLGpuQ)
         GTEST_SKIP_("Skipping: No OpenCL GPU device.\n");
 
-    auto Queue  = DPCTLQueueMgr_GetQueue(DPCTL_OPENCL, DPCTL_GPU, 0);
+    auto Queue = DPCTLQueueMgr_GetQueue(DPCTL_OPENCL, DPCTL_GPU, 0);
     auto CtxRef = DPCTLQueue_GetContext(Queue);
-    auto PRef   = DPCTLProgram_CreateFromOCLSource(CtxRef, CLProgramStr,
-                                                  CompileOpts);
+    auto PRef =
+        DPCTLProgram_CreateFromOCLSource(CtxRef, CLProgramStr, CompileOpts);
     ASSERT_TRUE(PRef != nullptr);
     ASSERT_TRUE(DPCTLProgram_HasKernel(PRef, "init_arr"));
     ASSERT_TRUE(DPCTLProgram_HasKernel(PRef, "add"));
     ASSERT_TRUE(DPCTLProgram_HasKernel(PRef, "axpy"));
 
     auto InitKernel = DPCTLProgram_GetKernel(PRef, "init_arr");
-    auto AddKernel  = DPCTLProgram_GetKernel(PRef, "add");
+    auto AddKernel = DPCTLProgram_GetKernel(PRef, "add");
     auto AxpyKernel = DPCTLProgram_GetKernel(PRef, "axpy");
 
     // Create the input args
@@ -312,51 +294,43 @@ TEST_F (TestDPCTLSyclQueueInterface, CheckSubmit)
     // Initialize a,b
     DPCTLKernelArgType argTypes[] = {DPCTL_VOID_PTR};
     size_t Range[] = {SIZE};
-    void *arg1[1] = { unwrap(a) };
-    void *arg2[1] = { unwrap(b) };
+    void *arg1[1] = {unwrap(a)};
+    void *arg2[1] = {unwrap(b)};
 
     auto E1 = DPCTLQueue_SubmitRange(InitKernel, Queue, arg1, argTypes, 1,
-                                    Range, 1, nullptr, 0);
+                                     Range, 1, nullptr, 0);
     auto E2 = DPCTLQueue_SubmitRange(InitKernel, Queue, arg2, argTypes, 1,
-                                    Range, 1, nullptr, 0);
+                                     Range, 1, nullptr, 0);
     ASSERT_TRUE(E1 != nullptr);
     ASSERT_TRUE(E2 != nullptr);
 
     DPCTLQueue_Wait(Queue);
 
     // Submit the add kernel
-    void *args[3] = { unwrap(a), unwrap(b), unwrap(c) };
-    DPCTLKernelArgType addKernelArgTypes[] = {
-                                              DPCTL_VOID_PTR,
-                                              DPCTL_VOID_PTR,
-                                              DPCTL_VOID_PTR
-                                            };
+    void *args[3] = {unwrap(a), unwrap(b), unwrap(c)};
+    DPCTLKernelArgType addKernelArgTypes[] = {DPCTL_VOID_PTR, DPCTL_VOID_PTR,
+                                              DPCTL_VOID_PTR};
 
-    auto E3 = DPCTLQueue_SubmitRange(AddKernel, Queue, args,
-                                    addKernelArgTypes, 3, Range, 1, nullptr, 0);
+    auto E3 = DPCTLQueue_SubmitRange(AddKernel, Queue, args, addKernelArgTypes,
+                                     3, Range, 1, nullptr, 0);
     ASSERT_TRUE(E3 != nullptr);
     DPCTLQueue_Wait(Queue);
 
     // Verify the result of "add"
-    add_kernel_checker((float*)a, (float*)b, (float*)c);
+    add_kernel_checker((float *)a, (float *)b, (float *)c);
 
     // Create kernel args for axpy
     float d = 10.0;
-    void *args2[4] = { unwrap(a), unwrap(b), unwrap(c) , (void*)&d };
-    DPCTLKernelArgType addKernelArgTypes2[] = {
-                                               DPCTL_VOID_PTR,
-                                               DPCTL_VOID_PTR,
-                                               DPCTL_VOID_PTR,
-                                               DPCTL_FLOAT
-                                             };
-    auto E4 = DPCTLQueue_SubmitRange(AxpyKernel, Queue, args2,
-                                    addKernelArgTypes2, 4, Range, 1,
-                                    nullptr, 0);
+    void *args2[4] = {unwrap(a), unwrap(b), unwrap(c), (void *)&d};
+    DPCTLKernelArgType addKernelArgTypes2[] = {DPCTL_VOID_PTR, DPCTL_VOID_PTR,
+                                               DPCTL_VOID_PTR, DPCTL_FLOAT};
+    auto E4 = DPCTLQueue_SubmitRange(
+        AxpyKernel, Queue, args2, addKernelArgTypes2, 4, Range, 1, nullptr, 0);
     ASSERT_TRUE(E4 != nullptr);
     DPCTLQueue_Wait(Queue);
 
     // Verify the result of "axpy"
-    axpy_kernel_checker((float*)a, (float*)b, (float*)c, d);
+    axpy_kernel_checker((float *)a, (float *)b, (float *)c, d);
 
     // clean ups
     DPCTLEvent_Delete(E1);
@@ -376,4 +350,3 @@ TEST_F (TestDPCTLSyclQueueInterface, CheckSubmit)
     DPCTLContext_Delete(CtxRef);
     DPCTLProgram_Delete(PRef);
 }
-

--- a/dpctl-capi/tests/test_sycl_queue_manager.cpp
+++ b/dpctl-capi/tests/test_sycl_queue_manager.cpp
@@ -37,7 +37,7 @@ using namespace cl::sycl;
 
 namespace
 {
-void foo (size_t & num)
+void foo(size_t &num)
 {
     auto q1 = DPCTLQueueMgr_PushQueue(DPCTL_OPENCL, DPCTL_CPU, 0);
     auto q2 = DPCTLQueueMgr_PushQueue(DPCTL_OPENCL, DPCTL_GPU, 0);
@@ -49,7 +49,7 @@ void foo (size_t & num)
     DPCTLQueue_Delete(q2);
 }
 
-void bar (size_t & num)
+void bar(size_t &num)
 {
     auto q1 = DPCTLQueueMgr_PushQueue(DPCTL_OPENCL, DPCTL_GPU, 0);
     // Capture the number of active queues in second
@@ -58,13 +58,13 @@ void bar (size_t & num)
     DPCTLQueue_Delete(q1);
 }
 
-bool has_devices ()
+bool has_devices()
 {
     bool ret = false;
     for (auto &p : platform::get_platforms()) {
         if (p.is_host())
             continue;
-        if(!p.get_devices().empty()) {
+        if (!p.get_devices().empty()) {
             ret = true;
             break;
         }
@@ -72,15 +72,15 @@ bool has_devices ()
     return ret;
 }
 
-}
+} // namespace
 
 struct TestDPCTLSyclQueueManager : public ::testing::Test
-{ };
-
-
-TEST_F (TestDPCTLSyclQueueManager, CheckDPCTLGetCurrentQueue)
 {
-    if(!has_devices())
+};
+
+TEST_F(TestDPCTLSyclQueueManager, CheckDPCTLGetCurrentQueue)
+{
+    if (!has_devices())
         GTEST_SKIP_("Skipping: No Sycl devices.\n");
 
     DPCTLSyclQueueRef q = nullptr;
@@ -88,19 +88,18 @@ TEST_F (TestDPCTLSyclQueueManager, CheckDPCTLGetCurrentQueue)
     ASSERT_TRUE(q != nullptr);
 }
 
-
-TEST_F (TestDPCTLSyclQueueManager, CheckDPCTLGetOpenCLCpuQ)
+TEST_F(TestDPCTLSyclQueueManager, CheckDPCTLGetOpenCLCpuQ)
 {
-    if(!has_devices())
+    if (!has_devices())
         GTEST_SKIP_("Skipping: No Sycl devices.\n");
 
     auto nOpenCLCpuQ = DPCTLQueueMgr_GetNumQueues(DPCTL_OPENCL, DPCTL_CPU);
-    if(!nOpenCLCpuQ)
+    if (!nOpenCLCpuQ)
         GTEST_SKIP_("Skipping: No OpenCL CPU device found.");
 
     auto q = DPCTLQueueMgr_GetQueue(DPCTL_OPENCL, DPCTL_CPU, 0);
     EXPECT_TRUE(q != nullptr);
-    auto sycl_q = reinterpret_cast<queue*>(q);
+    auto sycl_q = reinterpret_cast<queue *>(q);
     auto be = sycl_q->get_context().get_platform().get_backend();
     EXPECT_EQ(be, backend::opencl);
     auto devty = sycl_q->get_device().get_info<info::device::device_type>();
@@ -109,22 +108,22 @@ TEST_F (TestDPCTLSyclQueueManager, CheckDPCTLGetOpenCLCpuQ)
     auto non_existent_device_num = nOpenCLCpuQ + 1;
     // Non-existent device number should return nullptr
     auto null_q = DPCTLQueueMgr_GetQueue(DPCTL_OPENCL, DPCTL_CPU,
-                                        non_existent_device_num);
+                                         non_existent_device_num);
     ASSERT_TRUE(null_q == nullptr);
 }
 
-TEST_F (TestDPCTLSyclQueueManager, CheckDPCTLGetOpenCLGpuQ)
+TEST_F(TestDPCTLSyclQueueManager, CheckDPCTLGetOpenCLGpuQ)
 {
-    if(!has_devices())
+    if (!has_devices())
         GTEST_SKIP_("Skipping: No Sycl devices.\n");
 
     auto nOpenCLGpuQ = DPCTLQueueMgr_GetNumQueues(DPCTL_OPENCL, DPCTL_GPU);
-    if(!nOpenCLGpuQ)
+    if (!nOpenCLGpuQ)
         GTEST_SKIP_("Skipping: No OpenCL GPU device found.\n");
 
     auto q = DPCTLQueueMgr_GetQueue(DPCTL_OPENCL, DPCTL_GPU, 0);
     EXPECT_TRUE(q != nullptr);
-    auto sycl_q = reinterpret_cast<queue*>(q);
+    auto sycl_q = reinterpret_cast<queue *>(q);
     auto be = sycl_q->get_context().get_platform().get_backend();
     EXPECT_EQ(be, backend::opencl);
     auto devty = sycl_q->get_device().get_info<info::device::device_type>();
@@ -133,22 +132,22 @@ TEST_F (TestDPCTLSyclQueueManager, CheckDPCTLGetOpenCLGpuQ)
     auto non_existent_device_num = nOpenCLGpuQ + 1;
     // Non-existent device number should return nullptr
     auto null_q = DPCTLQueueMgr_GetQueue(DPCTL_OPENCL, DPCTL_GPU,
-                                        non_existent_device_num);
+                                         non_existent_device_num);
     ASSERT_TRUE(null_q == nullptr);
 }
 
-TEST_F (TestDPCTLSyclQueueManager, CheckDPCTLGetLevel0GpuQ)
+TEST_F(TestDPCTLSyclQueueManager, CheckDPCTLGetLevel0GpuQ)
 {
-    if(!has_devices())
+    if (!has_devices())
         GTEST_SKIP_("Skipping: No Sycl devices.\n");
 
     auto nL0GpuQ = DPCTLQueueMgr_GetNumQueues(DPCTL_LEVEL_ZERO, DPCTL_GPU);
-    if(!nL0GpuQ)
+    if (!nL0GpuQ)
         GTEST_SKIP_("Skipping: No OpenCL GPU device found.\n");
 
     auto q = DPCTLQueueMgr_GetQueue(DPCTL_LEVEL_ZERO, DPCTL_GPU, 0);
     EXPECT_TRUE(q != nullptr);
-    auto sycl_q = reinterpret_cast<queue*>(q);
+    auto sycl_q = reinterpret_cast<queue *>(q);
     auto be = sycl_q->get_context().get_platform().get_backend();
     EXPECT_EQ(be, backend::level_zero);
     auto devty = sycl_q->get_device().get_info<info::device::device_type>();
@@ -157,13 +156,13 @@ TEST_F (TestDPCTLSyclQueueManager, CheckDPCTLGetLevel0GpuQ)
     auto non_existent_device_num = nL0GpuQ + 1;
     // Non-existent device number should return nullptr
     auto null_q = DPCTLQueueMgr_GetQueue(DPCTL_LEVEL_ZERO, DPCTL_GPU,
-                                          non_existent_device_num);
+                                         non_existent_device_num);
     ASSERT_TRUE(null_q == nullptr);
 }
 
-TEST_F (TestDPCTLSyclQueueManager, CheckGetNumActivatedQueues)
+TEST_F(TestDPCTLSyclQueueManager, CheckGetNumActivatedQueues)
 {
-    if(!has_devices())
+    if (!has_devices())
         GTEST_SKIP_("Skipping: No Sycl devices.\n");
 
     size_t num0, num1, num2, num4;
@@ -172,13 +171,13 @@ TEST_F (TestDPCTLSyclQueueManager, CheckGetNumActivatedQueues)
     auto nOpenCLGpuQ = DPCTLQueueMgr_GetNumQueues(DPCTL_OPENCL, DPCTL_GPU);
 
     // Add a queue to main thread
-    if(!nOpenCLCpuQ || !nOpenCLGpuQ)
+    if (!nOpenCLCpuQ || !nOpenCLGpuQ)
         GTEST_SKIP_("Skipping as no OpenCL GPU device found.\n");
 
     auto q = DPCTLQueueMgr_PushQueue(DPCTL_OPENCL, DPCTL_CPU, 0);
 
-    std::thread first (foo, std::ref(num1));
-    std::thread second (bar, std::ref(num2));
+    std::thread first(foo, std::ref(num1));
+    std::thread second(bar, std::ref(num2));
 
     // synchronize threads:
     first.join();
@@ -199,20 +198,20 @@ TEST_F (TestDPCTLSyclQueueManager, CheckGetNumActivatedQueues)
     DPCTLQueue_Delete(q);
 }
 
-TEST_F (TestDPCTLSyclQueueManager, CheckDPCTLDumpDeviceInfo)
+TEST_F(TestDPCTLSyclQueueManager, CheckDPCTLDumpDeviceInfo)
 {
-    if(!has_devices())
+    if (!has_devices())
         GTEST_SKIP_("Skipping: No Sycl devices.\n");
     auto q = DPCTLQueueMgr_GetCurrentQueue();
     EXPECT_NO_FATAL_FAILURE(DPCTLDevice_DumpInfo(DPCTLQueue_GetDevice(q)));
     EXPECT_NO_FATAL_FAILURE(DPCTLQueue_Delete(q));
 }
 
-TEST_F (TestDPCTLSyclQueueManager, CheckIsCurrentQueue)
+TEST_F(TestDPCTLSyclQueueManager, CheckIsCurrentQueue)
 {
-    if(!has_devices())
+    if (!has_devices())
         GTEST_SKIP_("Skipping: No Sycl devices.\n");
-    if(!DPCTLQueueMgr_GetNumQueues(DPCTL_OPENCL, DPCTL_GPU))
+    if (!DPCTLQueueMgr_GetNumQueues(DPCTL_OPENCL, DPCTL_GPU))
         GTEST_SKIP_("Skipping: No OpenCL GPU.\n");
 
     auto Q0 = DPCTLQueueMgr_GetCurrentQueue();
@@ -225,10 +224,10 @@ TEST_F (TestDPCTLSyclQueueManager, CheckIsCurrentQueue)
     DPCTLQueue_Delete(Q0);
 }
 
-TEST_F (TestDPCTLSyclQueueManager, CheckIsCurrentQueue2)
+TEST_F(TestDPCTLSyclQueueManager, CheckIsCurrentQueue2)
 {
-    if(!DPCTLQueueMgr_GetNumQueues(DPCTL_OPENCL, DPCTL_CPU) ||
-       !DPCTLQueueMgr_GetNumQueues(DPCTL_OPENCL, DPCTL_GPU))
+    if (!DPCTLQueueMgr_GetNumQueues(DPCTL_OPENCL, DPCTL_CPU) ||
+        !DPCTLQueueMgr_GetNumQueues(DPCTL_OPENCL, DPCTL_GPU))
         GTEST_SKIP_("Skipping: No OpenCL GPU and OpenCL CPU.\n");
 
     auto Q1 = DPCTLQueueMgr_PushQueue(DPCTL_OPENCL, DPCTL_GPU, 0);
@@ -243,7 +242,7 @@ TEST_F (TestDPCTLSyclQueueManager, CheckIsCurrentQueue2)
     DPCTLQueueMgr_PopQueue();
 }
 
-TEST_F (TestDPCTLSyclQueueManager, CreateQueueFromDeviceAndContext)
+TEST_F(TestDPCTLSyclQueueManager, CreateQueueFromDeviceAndContext)
 {
     auto Q = DPCTLQueueMgr_GetCurrentQueue();
     auto D = DPCTLQueue_GetDevice(Q);
@@ -259,4 +258,3 @@ TEST_F (TestDPCTLSyclQueueManager, CreateQueueFromDeviceAndContext)
     DPCTLQueue_Delete(Q2);
     DPCTLQueue_Delete(Q);
 }
-

--- a/dpctl-capi/tests/test_sycl_usm_interface.cpp
+++ b/dpctl-capi/tests/test_sycl_usm_interface.cpp
@@ -24,13 +24,13 @@
 ///
 //===----------------------------------------------------------------------===//
 
+#include "Support/CBindingWrapping.h"
 #include "dpctl_sycl_context_interface.h"
 #include "dpctl_sycl_device_interface.h"
 #include "dpctl_sycl_event_interface.h"
 #include "dpctl_sycl_queue_interface.h"
 #include "dpctl_sycl_queue_manager.h"
 #include "dpctl_sycl_usm_interface.h"
-#include "Support/CBindingWrapping.h"
 #include <CL/sycl.hpp>
 #include <gtest/gtest.h>
 
@@ -42,13 +42,13 @@ constexpr size_t SIZE = 1024;
 
 DEFINE_SIMPLE_CONVERSION_FUNCTIONS(void, DPCTLSyclUSMRef);
 
-bool has_devices ()
+bool has_devices()
 {
     bool ret = false;
     for (auto &p : platform::get_platforms()) {
         if (p.is_host())
             continue;
-        if(!p.get_devices().empty()) {
+        if (!p.get_devices().empty()) {
             ret = true;
             break;
         }
@@ -56,9 +56,10 @@ bool has_devices ()
     return ret;
 }
 
-void
-common_test_body (size_t nbytes, const DPCTLSyclUSMRef Ptr,
-		  const DPCTLSyclQueueRef Q, const char *expected)
+void common_test_body(size_t nbytes,
+                      const DPCTLSyclUSMRef Ptr,
+                      const DPCTLSyclQueueRef Q,
+                      const char *expected)
 {
     auto Ctx = DPCTLQueue_GetContext(Q);
 
@@ -81,17 +82,15 @@ common_test_body (size_t nbytes, const DPCTLSyclUSMRef Ptr,
 struct TestDPCTLSyclUSMInterface : public ::testing::Test
 {
 
-    TestDPCTLSyclUSMInterface ()
-    {  }
+    TestDPCTLSyclUSMInterface() {}
 
-    ~TestDPCTLSyclUSMInterface ()
-    {  }
+    ~TestDPCTLSyclUSMInterface() {}
 };
 
-TEST_F (TestDPCTLSyclUSMInterface, MallocShared)
+TEST_F(TestDPCTLSyclUSMInterface, MallocShared)
 {
     if (!has_devices())
-	GTEST_SKIP_("Skipping: No Sycl Devices.\n");
+        GTEST_SKIP_("Skipping: No Sycl Devices.\n");
 
     auto Q = DPCTLQueueMgr_GetCurrentQueue();
     const size_t nbytes = SIZE;
@@ -104,10 +103,10 @@ TEST_F (TestDPCTLSyclUSMInterface, MallocShared)
     DPCTLQueue_Delete(Q);
 }
 
-TEST_F (TestDPCTLSyclUSMInterface, MallocDevice)
+TEST_F(TestDPCTLSyclUSMInterface, MallocDevice)
 {
     if (!has_devices())
-	GTEST_SKIP_("Skipping: No Sycl Devices.\n");
+        GTEST_SKIP_("Skipping: No Sycl Devices.\n");
 
     auto Q = DPCTLQueueMgr_GetCurrentQueue();
     const size_t nbytes = SIZE;
@@ -120,10 +119,10 @@ TEST_F (TestDPCTLSyclUSMInterface, MallocDevice)
     DPCTLQueue_Delete(Q);
 }
 
-TEST_F (TestDPCTLSyclUSMInterface, MallocHost)
+TEST_F(TestDPCTLSyclUSMInterface, MallocHost)
 {
     if (!has_devices())
-	GTEST_SKIP_("Skipping: No Sycl Devices.\n");
+        GTEST_SKIP_("Skipping: No Sycl Devices.\n");
 
     auto Q = DPCTLQueueMgr_GetCurrentQueue();
     const size_t nbytes = SIZE;
@@ -136,10 +135,10 @@ TEST_F (TestDPCTLSyclUSMInterface, MallocHost)
     DPCTLQueue_Delete(Q);
 }
 
-TEST_F (TestDPCTLSyclUSMInterface, AlignedAllocShared)
+TEST_F(TestDPCTLSyclUSMInterface, AlignedAllocShared)
 {
     if (!has_devices())
-	GTEST_SKIP_("Skipping: No Sycl Devices.\n");
+        GTEST_SKIP_("Skipping: No Sycl Devices.\n");
 
     auto Q = DPCTLQueueMgr_GetCurrentQueue();
     const size_t nbytes = SIZE;
@@ -152,10 +151,10 @@ TEST_F (TestDPCTLSyclUSMInterface, AlignedAllocShared)
     DPCTLQueue_Delete(Q);
 }
 
-TEST_F (TestDPCTLSyclUSMInterface, AlignedAllocDevice)
+TEST_F(TestDPCTLSyclUSMInterface, AlignedAllocDevice)
 {
     if (!has_devices())
-	GTEST_SKIP_("Skipping: No Sycl Devices.\n");
+        GTEST_SKIP_("Skipping: No Sycl Devices.\n");
 
     auto Q = DPCTLQueueMgr_GetCurrentQueue();
     const size_t nbytes = SIZE;
@@ -168,10 +167,10 @@ TEST_F (TestDPCTLSyclUSMInterface, AlignedAllocDevice)
     DPCTLQueue_Delete(Q);
 }
 
-TEST_F (TestDPCTLSyclUSMInterface, AlignedAllocHost)
+TEST_F(TestDPCTLSyclUSMInterface, AlignedAllocHost)
 {
     if (!has_devices())
-	GTEST_SKIP_("Skipping: No Sycl Devices.\n");
+        GTEST_SKIP_("Skipping: No Sycl Devices.\n");
 
     auto Q = DPCTLQueueMgr_GetCurrentQueue();
     const size_t nbytes = SIZE;
@@ -182,4 +181,3 @@ TEST_F (TestDPCTLSyclUSMInterface, AlignedAllocHost)
     common_test_body(nbytes, Ptr, Q, "host");
     DPCTLfree_with_queue(Ptr, Q);
 }
-


### PR DESCRIPTION
The PR reformatted all C API files using `clang-format` and adds a workflow to check format compliance for C API sources henceforth. Supersedes https://github.com/IntelPython/dpctl/pull/134 