### PR TITLE
Feature/device selectors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Documentation improvements
 - Cmake improvements and Coverage for C API, Cython and Python
-- Add support for Level Zero
+- Added support for Level Zero devices and queues
+- Added support for SYCL standard device_selector classes
+- SyclDevice instances can now be constructed using filter selector strings
 - Code of conduct
 
 ### Fixed

--- a/docs/dpCtl_api.rst
+++ b/docs/dpCtl_api.rst
@@ -15,6 +15,7 @@ Classes
 
 .. autoclass:: dpctl.SyclDevice
     :members:
+    :inherited-members:
     :undoc-members:
 
 .. autoclass:: dpctl.SyclEvent

--- a/dpctl-capi/CMakeLists.txt
+++ b/dpctl-capi/CMakeLists.txt
@@ -61,20 +61,17 @@ else()
     message(FATAL_ERROR "Unsupported system.")
 endif()
 
-add_library(
-  DPCTLSyclInterface
-  SHARED
-  source/dpctl_sycl_context_interface.cpp
-  source/dpctl_sycl_device_interface.cpp
-  source/dpctl_sycl_event_interface.cpp
-  source/dpctl_sycl_kernel_interface.cpp
-  source/dpctl_sycl_platform_interface.cpp
-  source/dpctl_sycl_program_interface.cpp
-  source/dpctl_sycl_queue_interface.cpp
-  source/dpctl_sycl_queue_manager.cpp
-  source/dpctl_sycl_usm_interface.cpp
-  source/dpctl_utils.cpp
-  helper/source/dpctl_utils_helper.cpp
+file(GLOB_RECURSE sources
+    ${CMAKE_CURRENT_SOURCE_DIR}/source/*.cpp
+)
+file(GLOB_RECURSE helper_sources
+    ${CMAKE_CURRENT_SOURCE_DIR}/helper/source/*.cpp
+)
+
+add_library(DPCTLSyclInterface
+    SHARED
+    ${sources}
+    ${helper_sources}
 )
 
 target_include_directories(DPCTLSyclInterface
@@ -83,6 +80,7 @@ target_include_directories(DPCTLSyclInterface
     ${CMAKE_SOURCE_DIR}/helper/include/
     ${DPCPP_SYCL_INCLUDE_DIR}
 )
+
 target_link_libraries(DPCTLSyclInterface
     PRIVATE ${DPCPP_SYCL_LIBRARY}
     PRIVATE ${DPCPP_OPENCL_LIBRARY}

--- a/dpctl-capi/include/dpctl_sycl_device_interface.h
+++ b/dpctl-capi/include/dpctl_sycl_device_interface.h
@@ -37,6 +37,17 @@
 DPCTL_C_EXTERN_C_BEGIN
 
 /*!
+ * @brief Returns a copy of the DPCTLSyclDeviceRef object.
+ *
+ * @param    DRef           DPCTLSyclDeviceRef object to be copied.
+ * @return   A new DPCTLSyclDeviceRef created by copying the passed in
+ * DPCTLSyclDeviceRef object.
+ */
+DPCTL_API
+__dpctl_give DPCTLSyclDeviceRef
+DPCTLDevice_Copy(__dpctl_keep const DPCTLSyclDeviceRef DRef);
+
+/*!
  * @brief Returns a new DPCTLSyclDeviceRef opaque object wrapping a SYCL device
  * instance as a host device.
  *

--- a/dpctl-capi/include/dpctl_sycl_device_interface.h
+++ b/dpctl-capi/include/dpctl_sycl_device_interface.h
@@ -37,6 +37,28 @@
 DPCTL_C_EXTERN_C_BEGIN
 
 /*!
+ * @brief Returns a new DPCTLSyclDeviceRef opaque object wrapping a SYCL device
+ * instance as a host device.
+ *
+ * @return   An opaque pointer to the host SYCL device.
+ */
+DPCTL_API
+__dpctl_give DPCTLSyclDeviceRef DPCTLDevice_Create();
+
+/*!
+ * @brief Returns a new DPCTLSyclDeviceRef opaque object created using the
+ * provided device_selector.
+ *
+ * @param    DSRef          An opaque pointer to a SYCL device_selector.
+ * @return   Returns an opaque pointer to a SYCL device created using the
+ *           device_selector, if the requested device could not be created a
+ *           nullptr is returned.
+ */
+DPCTL_API
+__dpctl_give DPCTLSyclDeviceRef DPCTLDevice_CreateFromSelector(
+    __dpctl_keep const DPCTLSyclDeviceSelectorRef DSRef);
+
+/*!
  * @brief Prints out some of the info::deivice attributes for the device.
  *
  * @param    DRef           A DPCTLSyclDeviceRef pointer.

--- a/dpctl-capi/include/dpctl_sycl_device_selector_interface.h
+++ b/dpctl-capi/include/dpctl_sycl_device_selector_interface.h
@@ -1,0 +1,108 @@
+//=== dpctl_sycl_device_selector_interface.h - device_selector C API -*-C++-*-//
+//
+//                      Data Parallel Control (dpCtl)
+//
+// Copyright 2020-2021 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// This header declares C contructors for the various SYCL device_selector
+/// classes.
+///
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "Support/DllExport.h"
+#include "Support/ExternC.h"
+#include "Support/MemOwnershipAttrs.h"
+#include "dpctl_sycl_types.h"
+
+DPCTL_C_EXTERN_C_BEGIN
+
+/**
+ * \defgroup DeviceSelectors C API for SYCL Device Selectors
+ */
+
+/*!
+ * @brief Returns an opaque wrapper for sycl::accelerator_selector object.
+ *
+ * @return An opaque pointer to a sycl::accelerator_selector object.
+ * @ingroup DeviceSelectors
+ */
+DPCTL_API
+__dpctl_give DPCTLSyclDeviceSelectorRef DPCTLAcceleratorSelector_Create();
+
+/*!
+ * @brief Returns an opaque wrapper for sycl::default_selector object.
+ *
+ * @return An opaque pointer to a sycl::default_selector object.
+ */
+DPCTL_API
+__dpctl_give DPCTLSyclDeviceSelectorRef DPCTLDefaultSelector_Create();
+
+/*!
+ * @brief Returns an opaque wrapper for sycl::cpu_selector object.
+ *
+ * @return An opaque pointer to a sycl::cpu_selector object.
+ * @ingroup DeviceSelectors
+ */
+DPCTL_API
+__dpctl_give DPCTLSyclDeviceSelectorRef DPCTLCPUSelector_Create();
+
+/*!
+ * @brief Returns an opaque wrapper for sycl::ONEAPI::filter_selector object
+ * based on the passed in filter string.
+ *
+ * @param    filter_str     A C string providing a filter based on which to
+ *                          create a device_selector.
+ * @return   An opaque pointer to a sycl::ONEAPI::filter_selector object.
+ * @ingroup DeviceSelectors
+ */
+DPCTL_API
+__dpctl_give DPCTLSyclDeviceSelectorRef
+DPCTLFilterSelector_Create(__dpctl_keep const char *filter_str);
+
+/*!
+ * @brief Returns an opaque wrapper for sycl::gpu_selector object.
+ *
+ * @return An opaque pointer to a sycl::gpu_selector object.
+ * @ingroup DeviceSelectors
+ */
+DPCTL_API
+__dpctl_give DPCTLSyclDeviceSelectorRef DPCTLGPUSelector_Create();
+
+/*!
+ * @brief Returns an opaque wrapper for sycl::host_selector object.
+ *
+ * @return An opaque pointer to a sycl::host_selector object.
+ * @ingroup DeviceSelectors
+ */
+DPCTL_API
+__dpctl_give DPCTLSyclDeviceSelectorRef DPCTLHostSelector_Create();
+
+/*!
+ * @brief Deletes the DPCTLSyclDeviceSelectorRef after casting it to a
+ * sycl::device_selector.
+ *
+ * @param    DSRef An opaque DPCTLSyclDeviceSelectorRef pointer that would be
+ *                 freed.
+ * @ingroup DeviceSelectors
+ */
+DPCTL_API
+void DPCTLDeviceSelector_Delete(__dpctl_take DPCTLSyclDeviceSelectorRef DSRef);
+
+DPCTL_C_EXTERN_C_END

--- a/dpctl-capi/include/dpctl_sycl_types.h
+++ b/dpctl-capi/include/dpctl_sycl_types.h
@@ -42,6 +42,12 @@ typedef struct DPCTLOpaqueSyclContext *DPCTLSyclContextRef;
 typedef struct DPCTLOpaqueSyclDevice *DPCTLSyclDeviceRef;
 
 /*!
+ * @brief Opaque pointer to a sycl::device_selector
+ *
+ */
+typedef struct DPCTLOpaqueSyclDeviceSelector *DPCTLSyclDeviceSelectorRef;
+
+/*!
  * @brief Opaque pointer to a sycl::event
  *
  */

--- a/dpctl-capi/source/dpctl_sycl_device_interface.cpp
+++ b/dpctl-capi/source/dpctl_sycl_device_interface.cpp
@@ -38,6 +38,7 @@ namespace
 {
 // Create wrappers for C Binding types (see CBindingWrapping.h).
 DEFINE_SIMPLE_CONVERSION_FUNCTIONS(device, DPCTLSyclDeviceRef)
+DEFINE_SIMPLE_CONVERSION_FUNCTIONS(device_selector, DPCTLSyclDeviceSelectorRef)
 
 /*!
  * @brief Helper function to print the metadata for a sycl::device.
@@ -65,6 +66,43 @@ void dump_device_info(const device &Device)
 }
 
 } /* end of anonymous namespace */
+
+__dpctl_give DPCTLSyclDeviceRef DPCTLDevice_Create()
+{
+    try {
+        auto Device = new device();
+        return wrap(Device);
+    } catch (std::bad_alloc const &ba) {
+        // \todo log error
+        std::cerr << ba.what() << '\n';
+        return nullptr;
+    } catch (runtime_error const &re) {
+        // \todo log error
+        std::cerr << re.what() << '\n';
+        return nullptr;
+    }
+}
+
+__dpctl_give DPCTLSyclDeviceRef DPCTLDevice_CreateFromSelector(
+    __dpctl_keep const DPCTLSyclDeviceSelectorRef DSRef)
+{
+    auto Selector = unwrap(DSRef);
+    if (!Selector)
+        // \todo : Log error
+        return nullptr;
+    try {
+        auto Device = new device(*Selector);
+        return wrap(Device);
+    } catch (std::bad_alloc const &ba) {
+        // \todo log error
+        std::cerr << ba.what() << '\n';
+        return nullptr;
+    } catch (runtime_error const &re) {
+        // \todo log error
+        std::cerr << re.what() << '\n';
+        return nullptr;
+    }
+}
 
 /*!
  * Prints some of the device info metadata for the device corresponding to the

--- a/dpctl-capi/source/dpctl_sycl_device_interface.cpp
+++ b/dpctl-capi/source/dpctl_sycl_device_interface.cpp
@@ -160,21 +160,34 @@ bool DPCTLDevice_IsHost(__dpctl_keep const DPCTLSyclDeviceRef DRef)
 uint32_t
 DPCTLDevice_GetMaxComputeUnits(__dpctl_keep const DPCTLSyclDeviceRef DRef)
 {
+    uint32_t nComputeUnits = 0;
     auto D = unwrap(DRef);
     if (D) {
-        return D->get_info<info::device::max_compute_units>();
+        try {
+            nComputeUnits = D->get_info<info::device::max_compute_units>();
+        } catch (runtime_error const &re) {
+            // \todo log error
+            std::cerr << re.what() << '\n';
+        }
     }
-    return 0;
+    return nComputeUnits;
 }
 
 uint32_t
 DPCTLDevice_GetMaxWorkItemDims(__dpctl_keep const DPCTLSyclDeviceRef DRef)
 {
+    uint32_t maxWorkItemDims = 0;
     auto D = unwrap(DRef);
     if (D) {
-        return D->get_info<info::device::max_work_item_dimensions>();
+        try {
+            maxWorkItemDims =
+                D->get_info<info::device::max_work_item_dimensions>();
+        } catch (runtime_error const &re) {
+            // \todo log error
+            std::cerr << re.what() << '\n';
+        }
     }
-    return 0;
+    return maxWorkItemDims;
 }
 
 __dpctl_keep size_t *
@@ -183,10 +196,18 @@ DPCTLDevice_GetMaxWorkItemSizes(__dpctl_keep const DPCTLSyclDeviceRef DRef)
     size_t *sizes = nullptr;
     auto D = unwrap(DRef);
     if (D) {
-        auto id_sizes = D->get_info<info::device::max_work_item_sizes>();
-        sizes = new size_t[3];
-        for (auto i = 0ul; i < 3; ++i) {
-            sizes[i] = id_sizes[i];
+        try {
+            auto id_sizes = D->get_info<info::device::max_work_item_sizes>();
+            sizes = new size_t[3];
+            for (auto i = 0ul; i < 3; ++i) {
+                sizes[i] = id_sizes[i];
+            }
+        } catch (std::bad_alloc const &ba) {
+            // \todo log error
+            std::cerr << ba.what() << '\n';
+        } catch (runtime_error const &re) {
+            // \todo log error
+            std::cerr << re.what() << '\n';
         }
     }
     return sizes;
@@ -195,103 +216,157 @@ DPCTLDevice_GetMaxWorkItemSizes(__dpctl_keep const DPCTLSyclDeviceRef DRef)
 size_t
 DPCTLDevice_GetMaxWorkGroupSize(__dpctl_keep const DPCTLSyclDeviceRef DRef)
 {
+    size_t max_wg_size = 0;
     auto D = unwrap(DRef);
     if (D) {
-        return D->get_info<info::device::max_work_group_size>();
+        try {
+            max_wg_size = D->get_info<info::device::max_work_group_size>();
+        } catch (runtime_error const &re) {
+            // \todo log error
+            std::cerr << re.what() << '\n';
+        }
     }
-    return 0;
+    return max_wg_size;
 }
 
 uint32_t
 DPCTLDevice_GetMaxNumSubGroups(__dpctl_keep const DPCTLSyclDeviceRef DRef)
 {
+    size_t max_nsubgroups = 0;
     auto D = unwrap(DRef);
     if (D) {
-        return D->get_info<info::device::max_num_sub_groups>();
+        try {
+            max_nsubgroups = D->get_info<info::device::max_num_sub_groups>();
+        } catch (runtime_error const &re) {
+            // \todo log error
+            std::cerr << re.what() << '\n';
+        }
     }
-    return 0;
+    return max_nsubgroups;
 }
 
 bool DPCTLDevice_HasInt64BaseAtomics(__dpctl_keep const DPCTLSyclDeviceRef DRef)
 {
+    bool hasBaseAtomics = false;
     auto D = unwrap(DRef);
     if (D) {
-        return D->has(aspect::int64_base_atomics);
+        try {
+            hasBaseAtomics = D->has(aspect::int64_base_atomics);
+        } catch (runtime_error const &re) {
+            // \todo log error
+            std::cerr << re.what() << '\n';
+        }
     }
-    return false;
+    return hasBaseAtomics;
 }
 
 bool DPCTLDevice_HasInt64ExtendedAtomics(
     __dpctl_keep const DPCTLSyclDeviceRef DRef)
 {
+    bool hasExtendedAtomics = false;
     auto D = unwrap(DRef);
     if (D) {
-        return D->has(aspect::int64_extended_atomics);
+        try {
+            hasExtendedAtomics = D->has(aspect::int64_extended_atomics);
+        } catch (runtime_error const &re) {
+            // \todo log error
+            std::cerr << re.what() << '\n';
+        }
     }
-    return false;
+    return hasExtendedAtomics;
 }
 
 __dpctl_give const char *
 DPCTLDevice_GetName(__dpctl_keep const DPCTLSyclDeviceRef DRef)
 {
+    char *cstr_name = nullptr;
     auto D = unwrap(DRef);
     if (D) {
-        auto name = D->get_info<info::device::name>();
-        auto cstr_len = name.length() + 1;
-        auto cstr_name = new char[cstr_len];
+        try {
+            auto name = D->get_info<info::device::name>();
+            auto cstr_len = name.length() + 1;
+            cstr_name = new char[cstr_len];
 #ifdef _WIN32
-        strncpy_s(cstr_name, cstr_len, name.c_str(), cstr_len);
+            strncpy_s(cstr_name, cstr_len, name.c_str(), cstr_len);
 #else
-        std::strncpy(cstr_name, name.c_str(), cstr_len);
+            std::strncpy(cstr_name, name.c_str(), cstr_len);
 #endif
-        return cstr_name;
+        } catch (std::bad_alloc const &ba) {
+            // \todo log error
+            std::cerr << ba.what() << '\n';
+        } catch (runtime_error const &re) {
+            // \todo log error
+            std::cerr << re.what() << '\n';
+        }
     }
-    return nullptr;
+    return cstr_name;
 }
 
 __dpctl_give const char *
 DPCTLDevice_GetVendorName(__dpctl_keep const DPCTLSyclDeviceRef DRef)
 {
+    char *cstr_vendor = nullptr;
     auto D = unwrap(DRef);
     if (D) {
-        auto vendor = D->get_info<info::device::vendor>();
-        auto cstr_len = vendor.length() + 1;
-        auto cstr_vendor = new char[cstr_len];
+        try {
+            auto vendor = D->get_info<info::device::vendor>();
+            auto cstr_len = vendor.length() + 1;
+            cstr_vendor = new char[cstr_len];
 #ifdef _WIN32
-        strncpy_s(cstr_vendor, cstr_len, vendor.c_str(), cstr_len);
+            strncpy_s(cstr_vendor, cstr_len, vendor.c_str(), cstr_len);
 #else
-        std::strncpy(cstr_vendor, vendor.c_str(), cstr_len);
+            std::strncpy(cstr_vendor, vendor.c_str(), cstr_len);
 #endif
-        return cstr_vendor;
+        } catch (std::bad_alloc const &ba) {
+            // \todo log error
+            std::cerr << ba.what() << '\n';
+        } catch (runtime_error const &re) {
+            // \todo log error
+            std::cerr << re.what() << '\n';
+        }
     }
-    return nullptr;
+    return cstr_vendor;
 }
 
 __dpctl_give const char *
 DPCTLDevice_GetDriverInfo(__dpctl_keep const DPCTLSyclDeviceRef DRef)
 {
+    char *cstr_driver = nullptr;
     auto D = unwrap(DRef);
     if (D) {
-        auto driver = D->get_info<info::device::driver_version>();
-        auto cstr_len = driver.length() + 1;
-        auto cstr_driver = new char[cstr_len];
+        try {
+            auto driver = D->get_info<info::device::driver_version>();
+            auto cstr_len = driver.length() + 1;
+            cstr_driver = new char[cstr_len];
 #ifdef _WIN32
-        strncpy_s(cstr_driver, cstr_len, driver.c_str(), cstr_len);
+            strncpy_s(cstr_driver, cstr_len, driver.c_str(), cstr_len);
 #else
-        std::strncpy(cstr_driver, driver.c_str(), cstr_len);
+            std::strncpy(cstr_driver, driver.c_str(), cstr_len);
 #endif
-        return cstr_driver;
+        } catch (std::bad_alloc const &ba) {
+            // \todo log error
+            std::cerr << ba.what() << '\n';
+        } catch (runtime_error const &re) {
+            // \todo log error
+            std::cerr << re.what() << '\n';
+        }
     }
-    return nullptr;
+    return cstr_driver;
 }
 
 bool DPCTLDevice_IsHostUnifiedMemory(__dpctl_keep const DPCTLSyclDeviceRef DRef)
 {
+    bool ret = false;
     auto D = unwrap(DRef);
     if (D) {
-        return D->get_info<info::device::host_unified_memory>();
+        try {
+            ret = D->get_info<info::device::host_unified_memory>();
+        } catch (runtime_error const &re) {
+            // \todo log error
+            std::cerr << re.what() << '\n';
+        }
     }
-    return false;
+    return ret;
 }
 
 bool DPCTLDevice_AreEq(__dpctl_keep const DPCTLSyclDeviceRef DevRef1,

--- a/dpctl-capi/source/dpctl_sycl_device_interface.cpp
+++ b/dpctl-capi/source/dpctl_sycl_device_interface.cpp
@@ -67,6 +67,24 @@ void dump_device_info(const device &Device)
 
 } /* end of anonymous namespace */
 
+__dpctl_give DPCTLSyclDeviceRef
+DPCTLDevice_Copy(__dpctl_keep const DPCTLSyclDeviceRef DRef)
+{
+    auto Device = unwrap(DRef);
+    if (!Device) {
+        std::cerr << "Cannot copy DPCTLSyclDeviceRef as input is a nullptr\n";
+        return nullptr;
+    }
+    try {
+        auto CopiedDevice = new device(*Device);
+        return wrap(CopiedDevice);
+    } catch (std::bad_alloc const &ba) {
+        // \todo log error
+        std::cerr << ba.what() << '\n';
+        return nullptr;
+    }
+}
+
 __dpctl_give DPCTLSyclDeviceRef DPCTLDevice_Create()
 {
     try {

--- a/dpctl-capi/source/dpctl_sycl_device_selector_interface.cpp
+++ b/dpctl-capi/source/dpctl_sycl_device_selector_interface.cpp
@@ -1,0 +1,128 @@
+//=== dpctl_sycl_device_selector_interface.cpp -  device_selector C API    ===//
+//
+//                      Data Parallel Control (dpCtl)
+//
+// Copyright 2020-2021 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// Implements constructors for SYCL's device selector classes.
+///
+//===----------------------------------------------------------------------===//
+
+#include "dpctl_sycl_device_selector_interface.h"
+#include "Support/CBindingWrapping.h"
+#include <CL/sycl.hpp> /* SYCL headers   */
+
+using namespace cl::sycl;
+
+namespace
+{
+// Create wrappers for C Binding types (see CBindingWrapping.h).
+DEFINE_SIMPLE_CONVERSION_FUNCTIONS(device_selector, DPCTLSyclDeviceSelectorRef)
+
+} /* end of anonymous namespace */
+
+__dpctl_give DPCTLSyclDeviceSelectorRef DPCTLAcceleratorSelector_Create()
+{
+    try {
+        auto Selector = new accelerator_selector();
+        return wrap(Selector);
+    } catch (std::bad_alloc const &ba) {
+        std::cerr << ba.what() << '\n';
+        return nullptr;
+    } catch (runtime_error const &re) {
+        std::cerr << re.what() << '\n';
+        return nullptr;
+    }
+}
+
+__dpctl_give DPCTLSyclDeviceSelectorRef DPCTLDefaultSelector_Create()
+{
+    try {
+        auto Selector = new default_selector();
+        return wrap(Selector);
+    } catch (std::bad_alloc const &ba) {
+        std::cerr << ba.what() << '\n';
+        return nullptr;
+    } catch (runtime_error const &re) {
+        std::cerr << re.what() << '\n';
+        return nullptr;
+    }
+}
+
+__dpctl_give DPCTLSyclDeviceSelectorRef DPCTLCPUSelector_Create()
+{
+    try {
+        auto Selector = new cpu_selector();
+        return wrap(Selector);
+    } catch (std::bad_alloc const &ba) {
+        std::cerr << ba.what() << '\n';
+        return nullptr;
+    } catch (runtime_error const &re) {
+        std::cerr << re.what() << '\n';
+        return nullptr;
+    }
+}
+
+__dpctl_give DPCTLSyclDeviceSelectorRef
+DPCTLFilterSelector_Create(__dpctl_keep const char *filter_str)
+{
+    try {
+        auto Selector = new ONEAPI::filter_selector(filter_str);
+        return wrap(Selector);
+    } catch (std::bad_alloc &ba) {
+        std::cerr << ba.what() << '\n';
+        return nullptr;
+    } catch (runtime_error &re) {
+        std::cerr << "Device: " << filter_str << " " << re.what() << '\n';
+        return nullptr;
+    }
+}
+
+__dpctl_give DPCTLSyclDeviceSelectorRef DPCTLGPUSelector_Create()
+{
+    try {
+        auto Selector = new gpu_selector();
+        return wrap(Selector);
+    } catch (std::bad_alloc const &ba) {
+        std::cerr << ba.what() << '\n';
+        return nullptr;
+    } catch (runtime_error const &re) {
+        std::cerr << re.what() << '\n';
+        return nullptr;
+    }
+}
+
+__dpctl_give DPCTLSyclDeviceSelectorRef DPCTLHostSelector_Create()
+{
+    try {
+        auto Selector = new host_selector();
+        return wrap(Selector);
+    } catch (std::bad_alloc const &ba) {
+        std::cerr << ba.what() << '\n';
+        return nullptr;
+    } catch (runtime_error const &re) {
+        std::cerr << re.what() << '\n';
+        return nullptr;
+    }
+}
+
+void DPCTLDeviceSelector_Delete(__dpctl_take DPCTLSyclDeviceSelectorRef DSRef)
+{
+    auto Selector = unwrap(DSRef);
+    delete Selector;
+}

--- a/dpctl-capi/tests/test_sycl_device_selector_interface.cpp
+++ b/dpctl-capi/tests/test_sycl_device_selector_interface.cpp
@@ -200,4 +200,4 @@ INSTANTIATE_TEST_SUITE_P(FilterSelectorCreation,
 INSTANTIATE_TEST_SUITE_P(
     NegativeFilterSelectorCreation,
     TestUnsupportedFilters,
-    ::testing::Values("host", "0", "-1", "opencl:gpu:1", "level_zero:cpu:0"));
+    ::testing::Values("abc", "-1", "opencl:gpu:1", "level_zero:cpu:0"));

--- a/dpctl-capi/tests/test_sycl_device_selector_interface.cpp
+++ b/dpctl-capi/tests/test_sycl_device_selector_interface.cpp
@@ -1,0 +1,203 @@
+//===--- test_sycl_device_selector_interface.cpp - Device selector tests   ===//
+//
+//                      Data Parallel Control (dpCtl)
+//
+// Copyright 2020-2021 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// This file has unit test cases for functions defined in
+/// dpctl_sycl_device_selector_interface.h.
+///
+//===----------------------------------------------------------------------===//
+
+#include "Support/CBindingWrapping.h"
+#include "dpctl_sycl_device_interface.h"
+#include "dpctl_sycl_device_selector_interface.h"
+#include <CL/sycl.hpp>
+#include <gtest/gtest.h>
+
+using namespace cl::sycl;
+
+namespace
+{
+DEFINE_SIMPLE_CONVERSION_FUNCTIONS(device, DPCTLSyclDeviceRef)
+DEFINE_SIMPLE_CONVERSION_FUNCTIONS(device_selector, DPCTLSyclDeviceSelectorRef)
+} // namespace
+
+struct TestDeviceSelectorInterface : public ::testing::Test
+{
+};
+
+struct TestFilterSelector : public ::testing::TestWithParam<const char *>
+{
+    DPCTLSyclDeviceSelectorRef DSRef = nullptr;
+
+    TestFilterSelector()
+    {
+        EXPECT_NO_FATAL_FAILURE(DSRef = DPCTLFilterSelector_Create(GetParam()));
+    }
+
+    void SetUp()
+    {
+        if (!DSRef) {
+            auto message = "Skipping as no device of type " +
+                           std::string(GetParam()) + ".";
+            GTEST_SKIP_(message.c_str());
+        }
+    }
+
+    ~TestFilterSelector()
+    {
+        EXPECT_NO_FATAL_FAILURE(DPCTLDeviceSelector_Delete(DSRef));
+    }
+};
+
+struct TestUnsupportedFilters : public ::testing::TestWithParam<const char *>
+{
+    DPCTLSyclDeviceSelectorRef DSRef = nullptr;
+
+    TestUnsupportedFilters()
+    {
+        EXPECT_NO_FATAL_FAILURE(DSRef = DPCTLFilterSelector_Create(GetParam()));
+    }
+
+    void SetUp()
+    {
+        if (!DSRef) {
+            auto message = "Skipping as no device of type " +
+                           std::string(GetParam()) + ".";
+            GTEST_SKIP_(message.c_str());
+        }
+    }
+
+    ~TestUnsupportedFilters()
+    {
+        EXPECT_NO_FATAL_FAILURE(DPCTLDeviceSelector_Delete(DSRef));
+    }
+};
+
+TEST_F(TestDeviceSelectorInterface, Chk_DPCTLAcceleratorSelector_Create)
+{
+    DPCTLSyclDeviceSelectorRef DSRef = nullptr;
+    EXPECT_NO_FATAL_FAILURE(DSRef = DPCTLAcceleratorSelector_Create());
+    if (DSRef) {
+        DPCTLSyclDeviceRef DRef = nullptr;
+        EXPECT_NO_FATAL_FAILURE(DRef = DPCTLDevice_CreateFromSelector(DSRef));
+        ASSERT_TRUE(DRef != nullptr);
+        EXPECT_NO_FATAL_FAILURE(DPCTLDevice_DumpInfo(DRef));
+        EXPECT_TRUE(DPCTLDevice_IsAccelerator(DRef));
+        EXPECT_NO_FATAL_FAILURE(DPCTLDevice_Delete(DRef));
+    }
+    EXPECT_NO_FATAL_FAILURE(DPCTLDeviceSelector_Delete(DSRef));
+}
+
+TEST_F(TestDeviceSelectorInterface, Chk_DPCTLDefaultSelector_Create)
+{
+    DPCTLSyclDeviceSelectorRef DSRef = nullptr;
+    EXPECT_NO_FATAL_FAILURE(DSRef = DPCTLDefaultSelector_Create());
+    if (DSRef) {
+        DPCTLSyclDeviceRef DRef = nullptr;
+        EXPECT_NO_FATAL_FAILURE(DRef = DPCTLDevice_CreateFromSelector(DSRef));
+        ASSERT_TRUE(DRef != nullptr);
+        EXPECT_NO_FATAL_FAILURE(DPCTLDevice_DumpInfo(DRef));
+        EXPECT_NO_FATAL_FAILURE(DPCTLDevice_Delete(DRef));
+    }
+    EXPECT_NO_FATAL_FAILURE(DPCTLDeviceSelector_Delete(DSRef));
+}
+
+TEST_F(TestDeviceSelectorInterface, Chk_DPCTLCPUSelector_Create)
+{
+    DPCTLSyclDeviceSelectorRef DSRef = nullptr;
+    EXPECT_NO_FATAL_FAILURE(DSRef = DPCTLCPUSelector_Create());
+    if (DSRef) {
+        DPCTLSyclDeviceRef DRef = nullptr;
+        EXPECT_NO_FATAL_FAILURE(DRef = DPCTLDevice_CreateFromSelector(DSRef));
+        ASSERT_TRUE(DRef != nullptr);
+        EXPECT_NO_FATAL_FAILURE(DPCTLDevice_DumpInfo(DRef));
+        EXPECT_TRUE(DPCTLDevice_IsCPU(DRef));
+        EXPECT_NO_FATAL_FAILURE(DPCTLDevice_Delete(DRef));
+    }
+    EXPECT_NO_FATAL_FAILURE(DPCTLDeviceSelector_Delete(DSRef));
+}
+
+TEST_F(TestDeviceSelectorInterface, Chk_DPCTLGPUSelector_Create)
+{
+    DPCTLSyclDeviceSelectorRef DSRef = nullptr;
+    EXPECT_NO_FATAL_FAILURE(DSRef = DPCTLGPUSelector_Create());
+    if (DSRef) {
+        DPCTLSyclDeviceRef DRef = nullptr;
+        EXPECT_NO_FATAL_FAILURE(DRef = DPCTLDevice_CreateFromSelector(DSRef));
+        ASSERT_TRUE(DRef != nullptr);
+        EXPECT_NO_FATAL_FAILURE(DPCTLDevice_DumpInfo(DRef));
+        EXPECT_TRUE(DPCTLDevice_IsGPU(DRef));
+        EXPECT_NO_FATAL_FAILURE(DPCTLDevice_Delete(DRef));
+    }
+    EXPECT_NO_FATAL_FAILURE(DPCTLDeviceSelector_Delete(DSRef));
+}
+
+TEST_F(TestDeviceSelectorInterface, Chk_DPCTLHostSelector_Create)
+{
+    DPCTLSyclDeviceSelectorRef DSRef = nullptr;
+    EXPECT_NO_FATAL_FAILURE(DSRef = DPCTLHostSelector_Create());
+    if (DSRef) {
+        DPCTLSyclDeviceRef DRef = nullptr;
+        EXPECT_NO_FATAL_FAILURE(DRef = DPCTLDevice_CreateFromSelector(DSRef));
+        ASSERT_TRUE(DRef != nullptr);
+        EXPECT_NO_FATAL_FAILURE(DPCTLDevice_DumpInfo(DRef));
+        // FIXME: DPCPP's host_selector returns a CPU device for some reason.
+        // EXPECT_TRUE(DPCTLDevice_IsHost(DRef));
+        EXPECT_NO_FATAL_FAILURE(DPCTLDevice_Delete(DRef));
+    }
+    EXPECT_NO_FATAL_FAILURE(DPCTLDeviceSelector_Delete(DSRef));
+}
+
+TEST_P(TestFilterSelector, Chk_DPCTLFilterSelector_Create)
+{
+    DPCTLSyclDeviceRef DRef = nullptr;
+    EXPECT_NO_FATAL_FAILURE(DRef = DPCTLDevice_CreateFromSelector(DSRef));
+    ASSERT_TRUE(DRef != nullptr);
+    EXPECT_NO_FATAL_FAILURE(DPCTLDevice_Delete(DRef));
+}
+
+TEST_P(TestUnsupportedFilters, Chk_DPCTLFilterSelector_Create)
+{
+    DPCTLSyclDeviceRef DRef = nullptr;
+    EXPECT_NO_FATAL_FAILURE(DRef = DPCTLDevice_CreateFromSelector(DSRef));
+    ASSERT_TRUE(DRef == nullptr);
+    EXPECT_NO_FATAL_FAILURE(DPCTLDevice_Delete(DRef));
+}
+
+INSTANTIATE_TEST_SUITE_P(FilterSelectorCreation,
+                         TestFilterSelector,
+                         ::testing::Values("opencl",
+                                           "opencl:gpu",
+                                           "opencl:cpu",
+                                           "opencl:gpu:0",
+                                           "gpu",
+                                           "cpu",
+                                           "level_zero",
+                                           "level_zero:gpu",
+                                           "opencl:cpu:0",
+                                           "level_zero:gpu:0",
+                                           "gpu:0",
+                                           "gpu:1",
+                                           "1"));
+
+INSTANTIATE_TEST_SUITE_P(
+    NegativeFilterSelectorCreation,
+    TestUnsupportedFilters,
+    ::testing::Values("host", "0", "-1", "opencl:gpu:1", "level_zero:cpu:0"));

--- a/dpctl/_backend.pxd
+++ b/dpctl/_backend.pxd
@@ -72,6 +72,7 @@ cdef extern from "dpctl_sycl_enum_types.h":
 cdef extern from "dpctl_sycl_types.h":
     cdef struct DPCTLOpaqueSyclContext
     cdef struct DPCTLOpaqueSyclDevice
+    cdef struct DPCTLOpaqueSyclDeviceSelector
     cdef struct DPCTLOpaqueSyclEvent
     cdef struct DPCTLOpaqueSyclKernel
     cdef struct DPCTLOpaqueSyclProgram
@@ -80,6 +81,7 @@ cdef extern from "dpctl_sycl_types.h":
 
     ctypedef DPCTLOpaqueSyclContext        *DPCTLSyclContextRef
     ctypedef DPCTLOpaqueSyclDevice         *DPCTLSyclDeviceRef
+    ctypedef DPCTLOpaqueSyclDeviceSelector *DPCTLSyclDeviceSelectorRef
     ctypedef DPCTLOpaqueSyclEvent          *DPCTLSyclEventRef
     ctypedef DPCTLOpaqueSyclKernel         *DPCTLSyclKernelRef
     ctypedef DPCTLOpaqueSyclProgram        *DPCTLSyclProgramRef
@@ -88,6 +90,9 @@ cdef extern from "dpctl_sycl_types.h":
 
 
 cdef extern from "dpctl_sycl_device_interface.h":
+    cdef DPCTLSyclDeviceRef DPCTLDevice_Create()
+    cdef DPCTLSyclDeviceRef DPCTLDevice_CreateFromSelector(
+        const DPCTLSyclDeviceSelectorRef DSRef)
     cdef void DPCTLDevice_DumpInfo(const DPCTLSyclDeviceRef DRef)
     cdef void DPCTLDevice_Delete(DPCTLSyclDeviceRef DRef)
     cdef void DPCTLDevice_DumpInfo(const DPCTLSyclDeviceRef DRef)
@@ -107,6 +112,17 @@ cdef extern from "dpctl_sycl_device_interface.h":
     cpdef bool DPCTLDevice_HasInt64BaseAtomics(const DPCTLSyclDeviceRef DRef)
     cpdef bool DPCTLDevice_HasInt64ExtendedAtomics(
         const DPCTLSyclDeviceRef DRef)
+
+
+cdef extern from "dpctl_sycl_device_selector_interface.h":
+    DPCTLSyclDeviceSelectorRef DPCTLAcceleratorSelector_Create()
+    DPCTLSyclDeviceSelectorRef DPCTLDefaultSelector_Create()
+    DPCTLSyclDeviceSelectorRef DPCTLCPUSelector_Create()
+    DPCTLSyclDeviceSelectorRef DPCTLFilterSelector_Create(
+        const char *filter_str)
+    DPCTLSyclDeviceSelectorRef DPCTLGPUSelector_Create()
+    DPCTLSyclDeviceSelectorRef DPCTLHostSelector_Create()
+    void DPCTLDeviceSelector_Delete(DPCTLSyclDeviceSelectorRef DSRef)
 
 
 cdef extern from "dpctl_sycl_event_interface.h":

--- a/dpctl/_backend.pxd
+++ b/dpctl/_backend.pxd
@@ -90,6 +90,7 @@ cdef extern from "dpctl_sycl_types.h":
 
 
 cdef extern from "dpctl_sycl_device_interface.h":
+    cdef DPCTLSyclDeviceRef DPCTLDevice_Copy(const DPCTLSyclDeviceRef DRef)
     cdef DPCTLSyclDeviceRef DPCTLDevice_Create()
     cdef DPCTLSyclDeviceRef DPCTLDevice_CreateFromSelector(
         const DPCTLSyclDeviceSelectorRef DSRef)

--- a/dpctl/_sycl_device.pxd
+++ b/dpctl/_sycl_device.pxd
@@ -23,7 +23,8 @@
 from libcpp cimport bool
 from libc.stdint cimport uint32_t
 from ._backend cimport (
-    DPCTLSyclDeviceRef
+    DPCTLSyclDeviceRef,
+    DPCTLSyclDeviceSelectorRef,
 )
 
 
@@ -70,7 +71,8 @@ cdef class SyclDevice(_SyclDevice):
     cdef SyclDevice _create(DPCTLSyclDeviceRef dref)
     @staticmethod
     cdef void _init_helper(SyclDevice device, DPCTLSyclDeviceRef DRef)
-
+    cdef void _init_from__SyclDevice(self, _SyclDevice other)
+    cdef int _init_from_selector(self, DPCTLSyclDeviceSelectorRef DSRef)
 
 cpdef select_accelerator_device()
 cpdef select_cpu_device()

--- a/dpctl/_sycl_device.pxd
+++ b/dpctl/_sycl_device.pxd
@@ -20,7 +20,11 @@
 """ This file declares the SyclDevice extension type.
 """
 
-from ._backend cimport *
+from libcpp cimport bool
+from libc.stdint cimport uint32_t
+from ._backend cimport (
+    DPCTLSyclDeviceRef
+)
 
 
 cdef class SyclDevice:
@@ -52,3 +56,10 @@ cdef class SyclDevice:
     cpdef get_max_num_sub_groups (self)
     cpdef has_int64_base_atomics (self)
     cpdef has_int64_extended_atomics (self)
+
+
+cpdef select_accelerator_device()
+cpdef select_cpu_device()
+cpdef select_default_device()
+cpdef select_gpu_device()
+cpdef select_host_device()

--- a/dpctl/_sycl_device.pxd
+++ b/dpctl/_sycl_device.pxd
@@ -27,7 +27,7 @@ from ._backend cimport (
 )
 
 
-cdef class SyclDevice:
+cdef class _SyclDevice:
     ''' Wrapper class for a Sycl Device
     '''
     cdef DPCTLSyclDeviceRef _device_ref
@@ -41,21 +41,25 @@ cdef class SyclDevice:
     cdef uint32_t _max_num_sub_groups
     cdef bool _int64_base_atomics
     cdef bool _int64_extended_atomics
+    cdef DPCTLSyclDeviceRef get_device_ref(self)
+    cpdef get_device_name(self)
+    cpdef get_device_type(self)
+    cpdef get_vendor_name(self)
+    cpdef get_driver_version(self)
+    cpdef get_max_compute_units(self)
+    cpdef get_max_work_item_dims(self)
+    cpdef get_max_work_item_sizes(self)
+    cpdef get_max_work_group_size(self)
+    cpdef get_max_num_sub_groups(self)
+    cpdef has_int64_base_atomics(self)
+    cpdef has_int64_extended_atomics(self)
 
+
+cdef class SyclDevice(_SyclDevice):
     @staticmethod
-    cdef SyclDevice _create (DPCTLSyclDeviceRef dref)
-    cdef DPCTLSyclDeviceRef get_device_ref (self)
-    cpdef get_device_name (self)
-    cpdef get_device_type (self)
-    cpdef get_vendor_name (self)
-    cpdef get_driver_version (self)
-    cpdef get_max_compute_units (self)
-    cpdef get_max_work_item_dims (self)
-    cpdef get_max_work_item_sizes (self)
-    cpdef get_max_work_group_size (self)
-    cpdef get_max_num_sub_groups (self)
-    cpdef has_int64_base_atomics (self)
-    cpdef has_int64_extended_atomics (self)
+    cdef SyclDevice _create(DPCTLSyclDeviceRef dref)
+    @staticmethod
+    cdef void _init_helper(SyclDevice device, DPCTLSyclDeviceRef DRef)
 
 
 cpdef select_accelerator_device()

--- a/dpctl/_sycl_device.pxd
+++ b/dpctl/_sycl_device.pxd
@@ -31,6 +31,10 @@ cdef class _SyclDevice:
     ''' Wrapper class for a Sycl Device
     '''
     cdef DPCTLSyclDeviceRef _device_ref
+    cdef bool _accelerator_device
+    cdef bool _cpu_device
+    cdef bool _gpu_device
+    cdef bool _host_device
     cdef const char *_vendor_name
     cdef const char *_device_name
     cdef const char *_driver_version
@@ -41,6 +45,8 @@ cdef class _SyclDevice:
     cdef uint32_t _max_num_sub_groups
     cdef bool _int64_base_atomics
     cdef bool _int64_extended_atomics
+
+
     cdef DPCTLSyclDeviceRef get_device_ref(self)
     cpdef get_device_name(self)
     cpdef get_device_type(self)
@@ -53,6 +59,10 @@ cdef class _SyclDevice:
     cpdef get_max_num_sub_groups(self)
     cpdef has_int64_base_atomics(self)
     cpdef has_int64_extended_atomics(self)
+    cpdef is_accelerator(self)
+    cpdef is_cpu(self)
+    cpdef is_gpu(self)
+    cpdef is_host(self)
 
 
 cdef class SyclDevice(_SyclDevice):

--- a/dpctl/_sycl_device.pyx
+++ b/dpctl/_sycl_device.pyx
@@ -45,6 +45,7 @@ from ._backend cimport (
     DPCTLDeviceSelector_Delete,
     DPCTLSize_t_Array_Delete,
     DPCTLSyclDeviceRef,
+    DPCTLSyclDeviceSelectorRef,
 )
 from . import device_type
 

--- a/dpctl/_sycl_device.pyx
+++ b/dpctl/_sycl_device.pyx
@@ -20,11 +20,41 @@
 """ Implements SyclDevice Cython extension type.
 """
 
-from ._backend cimport *
+from ._backend cimport (
+    DPCTLAcceleratorSelector_Create,
+    DPCTLCPUSelector_Create,
+    DPCTLDefaultSelector_Create,
+    DPCTLGPUSelector_Create,
+    DPCTLHostSelector_Create,
+    DPCTLCString_Delete,
+    DPCTLDevice_CreateFromSelector,
+    DPCTLDevice_Delete,
+    DPCTLDevice_DumpInfo,
+    DPCTLDevice_GetVendorName,
+    DPCTLDevice_GetName,
+    DPCTLDevice_GetDriverInfo,
+    DPCTLDevice_GetMaxComputeUnits,
+    DPCTLDevice_GetMaxWorkItemDims,
+    DPCTLDevice_GetMaxWorkItemSizes,
+    DPCTLDevice_GetMaxWorkGroupSize,
+    DPCTLDevice_GetMaxNumSubGroups,
+    DPCTLDevice_HasInt64BaseAtomics,
+    DPCTLDevice_HasInt64ExtendedAtomics,
+    DPCTLDevice_IsGPU,
+    DPCTLDevice_IsCPU,
+    DPCTLDeviceSelector_Delete,
+    DPCTLSize_t_Array_Delete,
+    DPCTLSyclDeviceRef,
+)
 from . import device_type
 
 __all__ = [
     "SyclDevice",
+    "select_accelerator_device",
+    "select_cpu_device",
+    "select_default_device",
+    "select_gpu_device",
+    "select_host_device",
 ]
 
 
@@ -33,7 +63,7 @@ cdef class SyclDevice:
     """
 
     @staticmethod
-    cdef SyclDevice _create (DPCTLSyclDeviceRef dref):
+    cdef SyclDevice _create(DPCTLSyclDeviceRef dref):
         cdef SyclDevice ret = SyclDevice.__new__(SyclDevice)
         ret._device_ref = dref
         ret._vendor_name = DPCTLDevice_GetVendorName(dref)
@@ -48,24 +78,28 @@ cdef class SyclDevice:
         ret._int64_extended_atomics = DPCTLDevice_HasInt64ExtendedAtomics(dref)
         return ret
 
-    def __dealloc__ (self):
+
+    def __dealloc__(self):
         DPCTLDevice_Delete(self._device_ref)
         DPCTLCString_Delete(self._device_name)
         DPCTLCString_Delete(self._vendor_name)
         DPCTLCString_Delete(self._driver_version)
         DPCTLSize_t_Array_Delete(self._max_work_item_sizes)
 
-    def dump_device_info (self):
+
+    def dump_device_info(self):
         """ Print information about the SYCL device.
         """
         DPCTLDevice_DumpInfo(self._device_ref)
 
-    cpdef get_device_name (self):
+
+    cpdef get_device_name(self):
         """ Returns the name of the device as a string
         """
         return self._device_name.decode()
 
-    cpdef get_device_type (self):
+
+    cpdef get_device_type(self):
         """ Returns the type of the device as a `device_type` enum
         """
         if DPCTLDevice_IsGPU(self._device_ref):
@@ -75,12 +109,14 @@ cdef class SyclDevice:
         else:
             raise ValueError("Unknown device type.")
 
-    cpdef get_vendor_name (self):
+
+    cpdef get_vendor_name(self):
         """ Returns the device vendor name as a string
         """
         return self._vendor_name.decode()
 
-    cpdef get_driver_version (self):
+
+    cpdef get_driver_version(self):
         """ Returns the OpenCL software driver version as a string
             in the form: major number.minor number, if this SYCL
             device is an OpenCL device. Returns a string class
@@ -88,23 +124,27 @@ cdef class SyclDevice:
         """
         return self._driver_version.decode()
 
-    cpdef has_int64_base_atomics (self):
+
+    cpdef has_int64_base_atomics(self):
         """ Returns true if device has int64_base_atomics else returns false.
         """
         return self._int64_base_atomics
 
-    cpdef has_int64_extended_atomics (self):
+
+    cpdef has_int64_extended_atomics(self):
         """ Returns true if device has int64_extended_atomics else returns false.
         """
         return self._int64_extended_atomics
 
-    cpdef get_max_compute_units (self):
+
+    cpdef get_max_compute_units(self):
         """ Returns the number of parallel compute units
             available to the device. The minimum value is 1.
         """
         return self._max_compute_units
 
-    cpdef get_max_work_item_dims (self):
+
+    cpdef get_max_work_item_dims(self):
         """ Returns the maximum dimensions that specify
             the global and local work-item IDs used by the
             data parallel execution model. The minimum
@@ -113,7 +153,8 @@ cdef class SyclDevice:
         """
         return self._max_work_item_dims
 
-    cpdef get_max_work_item_sizes (self):
+
+    cpdef get_max_work_item_sizes(self):
         """ Returns the maximum number of work-items
             that are permitted in each dimension of the
             work-group of the nd_range. The minimum
@@ -125,7 +166,8 @@ cdef class SyclDevice:
             max_work_item_sizes.append(self._max_work_item_sizes[n])
         return tuple(max_work_item_sizes)
 
-    cpdef get_max_work_group_size (self):
+
+    cpdef get_max_work_group_size(self):
         """ Returns the maximum number of work-items
             that are permitted in a work-group executing a
             kernel on a single compute unit. The minimum
@@ -133,19 +175,22 @@ cdef class SyclDevice:
         """
         return self._max_work_group_size
 
-    cpdef get_max_num_sub_groups (self):
+
+    cpdef get_max_num_sub_groups(self):
         """ Returns the maximum number of sub-groups
             in a work-group for any kernel executed on the
             device. The minimum value is 1.
         """
         return self._max_num_sub_groups
 
+
     cdef DPCTLSyclDeviceRef get_device_ref (self):
         """ Returns the DPCTLSyclDeviceRef pointer for this class.
         """
         return self._device_ref
 
-    def addressof_ref (self):
+
+    def addressof_ref(self):
         """
         Returns the address of the DPCTLSyclDeviceRef pointer as a size_t.
 
@@ -154,3 +199,98 @@ cdef class SyclDevice:
             SyclDevice cast to a size_t.
         """
         return int(<size_t>self._device_ref)
+
+
+cpdef select_accelerator_device():
+    """ A wrapper for SYCL's `accelerator_selector` device_selector class.
+
+    Returns:
+        A new SyclDevice object containing the SYCL device returned by the
+        `accelerator_selector`.
+    Raises:
+        A ValueError is raised if the SYCL `accelerator_selector` is unable to
+        select a device.
+    """
+    cdef DPCTLSyclDeviceSelectorRef DSRef = DPCTLAcceleratorSelector_Create()
+    cdef DPCTLSyclDeviceRef DRef = DPCTLDevice_CreateFromSelector(DSRef)
+    DPCTLDeviceSelector_Delete(DSRef)
+    if DRef is NULL:
+        raise ValueError("Device unavailable.")
+    Device = SyclDevice._create(DRef)
+    return Device
+
+
+cpdef select_cpu_device():
+    """ A wrapper for SYCL's `cpu_selector` device_selector class.
+
+    Returns:
+        A new SyclDevice object containing the SYCL device returned by the
+        `cpu_selector`.
+    Raises:
+        A ValueError is raised if the SYCL `cpu_seector` is unable to select a
+        device.
+    """
+    cdef DPCTLSyclDeviceSelectorRef DSRef = DPCTLCPUSelector_Create()
+    cdef DPCTLSyclDeviceRef DRef = DPCTLDevice_CreateFromSelector(DSRef)
+    DPCTLDeviceSelector_Delete(DSRef)
+    if DRef is NULL:
+        raise ValueError("Device unavailable.")
+    Device = SyclDevice._create(DRef)
+    return Device
+
+
+cpdef select_default_device():
+    """ A wrapper for SYCL's `default_selector` device_selector class.
+
+    Returns:
+        A new SyclDevice object containing the SYCL device returned by the
+        `default_selector`.
+    Raises:
+        A ValueError is raised if the SYCL `default_seector` is unable to
+        select a device.
+    """
+    cdef DPCTLSyclDeviceSelectorRef DSRef = DPCTLDefaultSelector_Create()
+    cdef DPCTLSyclDeviceRef DRef = DPCTLDevice_CreateFromSelector(DSRef)
+    DPCTLDeviceSelector_Delete(DSRef)
+    if DRef is NULL:
+        raise ValueError("Device unavailable.")
+    Device = SyclDevice._create(DRef)
+    return Device
+
+
+cpdef select_gpu_device():
+    """ A wrapper for SYCL's `gpu_selector` device_selector class.
+
+    Returns:
+        A new SyclDevice object containing the SYCL device returned by the
+        `gpu_selector`.
+    Raises:
+        A ValueError is raised if the SYCL `gpu_seector` is unable to select a
+        device.
+    """
+    cdef DPCTLSyclDeviceSelectorRef DSRef = DPCTLGPUSelector_Create()
+    cdef DPCTLSyclDeviceRef DRef = DPCTLDevice_CreateFromSelector(DSRef)
+    DPCTLDeviceSelector_Delete(DSRef)
+    if DRef is NULL:
+        raise ValueError("Device unavailable.")
+    Device = SyclDevice._create(DRef)
+    return Device
+
+
+cpdef select_host_device():
+    """ A wrapper for SYCL's `host_selector` device_selector class.
+
+    Returns:
+        A new SyclDevice object containing the SYCL device returned by the
+        `host_selector`.
+    Raises:
+        A ValueError is raised if the SYCL `host_seector` is unable to select a
+        device.
+    """
+    cdef DPCTLSyclDeviceSelectorRef DSRef = DPCTLHostSelector_Create()
+    cdef DPCTLSyclDeviceRef DRef = DPCTLDevice_CreateFromSelector(DSRef)
+    DPCTLDeviceSelector_Delete(DSRef)
+    if DRef is NULL:
+        raise ValueError("Device unavailable.")
+    Device = SyclDevice._create(DRef)
+    return Device

--- a/dpctl/_sycl_device.pyx
+++ b/dpctl/_sycl_device.pyx
@@ -74,18 +74,15 @@ cdef class _SyclDevice:
         DPCTLCString_Delete(self._driver_version)
         DPCTLSize_t_Array_Delete(self._max_work_item_sizes)
 
-
     def dump_device_info(self):
         """ Print information about the SYCL device.
         """
         DPCTLDevice_DumpInfo(self._device_ref)
 
-
     cpdef get_device_name(self):
         """ Returns the name of the device as a string
         """
         return self._device_name.decode()
-
 
     cpdef get_device_type(self):
         """ Returns the type of the device as a `device_type` enum
@@ -97,12 +94,10 @@ cdef class _SyclDevice:
         else:
             raise ValueError("Unknown device type.")
 
-
     cpdef get_vendor_name(self):
         """ Returns the device vendor name as a string
         """
         return self._vendor_name.decode()
-
 
     cpdef get_driver_version(self):
         """ Returns the OpenCL software driver version as a string
@@ -112,25 +107,21 @@ cdef class _SyclDevice:
         """
         return self._driver_version.decode()
 
-
     cpdef has_int64_base_atomics(self):
         """ Returns true if device has int64_base_atomics else returns false.
         """
         return self._int64_base_atomics
-
 
     cpdef has_int64_extended_atomics(self):
         """ Returns true if device has int64_extended_atomics else returns false.
         """
         return self._int64_extended_atomics
 
-
     cpdef get_max_compute_units(self):
         """ Returns the number of parallel compute units
             available to the device. The minimum value is 1.
         """
         return self._max_compute_units
-
 
     cpdef get_max_work_item_dims(self):
         """ Returns the maximum dimensions that specify
@@ -140,7 +131,6 @@ cdef class _SyclDevice:
             type ``info::device_type::custom``.
         """
         return self._max_work_item_dims
-
 
     cpdef get_max_work_item_sizes(self):
         """ Returns the maximum number of work-items
@@ -154,7 +144,6 @@ cdef class _SyclDevice:
             max_work_item_sizes.append(self._max_work_item_sizes[n])
         return tuple(max_work_item_sizes)
 
-
     cpdef get_max_work_group_size(self):
         """ Returns the maximum number of work-items
             that are permitted in a work-group executing a
@@ -163,14 +152,12 @@ cdef class _SyclDevice:
         """
         return self._max_work_group_size
 
-
     cpdef get_max_num_sub_groups(self):
         """ Returns the maximum number of sub-groups
             in a work-group for any kernel executed on the
             device. The minimum value is 1.
         """
         return self._max_num_sub_groups
-
 
     cpdef is_accelerator(self):
         """ Returns True if the SyclDevice instance is a SYCL accelerator
@@ -182,7 +169,6 @@ cdef class _SyclDevice:
         """
         return self._accelerator_device
 
-
     cpdef is_cpu(self):
         """ Returns True if the SyclDevice instance is a SYCL CPU device.
 
@@ -190,7 +176,6 @@ cdef class _SyclDevice:
             bool: True if the SyclDevice is a SYCL CPU device, else False.
         """
         return self._cpu_device
-
 
     cpdef is_gpu(self):
         """ Returns True if the SyclDevice instance is a SYCL GPU device.
@@ -200,7 +185,6 @@ cdef class _SyclDevice:
         """
         return self._gpu_device
 
-
     cpdef is_host(self):
         """ Returns True if the SyclDevice instance is a SYCL host device.
 
@@ -209,13 +193,10 @@ cdef class _SyclDevice:
         """
         return self._host_device
 
-
-
     cdef DPCTLSyclDeviceRef get_device_ref (self):
         """ Returns the DPCTLSyclDeviceRef pointer for this class.
         """
         return self._device_ref
-
 
     def addressof_ref(self):
         """
@@ -227,9 +208,8 @@ cdef class _SyclDevice:
         """
         return int(<size_t>self._device_ref)
 
-
     @property
-    def __name__:
+    def __name__():
         return "SyclDevice"
 
 
@@ -361,11 +341,9 @@ cdef class SyclDevice(_SyclDevice):
                 "a SYCL filter selector string."
             )
 
-
     @property
     def __name__(self):
         return "SyclDevice"
-
 
     def __repr__(self):
         return "<dpctl." + self.__name__ + " at {}>".format(hex(id(self)))

--- a/dpctl/_sycl_device.pyx
+++ b/dpctl/_sycl_device.pyx
@@ -232,32 +232,40 @@ cdef class SyclDevice(_SyclDevice):
     """ Python equivalent for cl::sycl::device class.
 
     There are two ways of creating a SyclDevice instance:
-        - by directly passing in a string to the class constructor.
+
+        - by directly passing in a filter string to the class constructor. The
+        filter string needs to conform to the the `DPC++ filter selector SYCL
+        extension <https://bit.ly/37kqANT>`_.
 
         :Example:
-
             .. code-block:: python
 
-            import dpctl
+                import dpctl
 
-            l0gpu = dpctl.SyclDevice("level0:gpu:0"):
-            l0gpu.dump_device_info()
+                # Create a SyclDevice with an explicit filter string, in
+                # this case the first level_zero gpu device.
+                level_zero_gpu = dpctl.SyclDevice("level_zero:gpu:0"):
+                level_zero_gpu.dump_device_info()
 
         - by calling one of the device selector helper functions:
-          :py:meth:`~dpctl.select_accelerator_device`,
-          :py:meth:`~dpctl.select_cpu_device`,
-          :py:meth:`~dpctl.select_default_device`,
-          :py:meth:`~dpctl.select_gpu_device`,
-          :py:meth:`~dpctl.select_host_device`.
+
+          :func:`dpctl.select_accelerator_device()`,
+          :func:`dpctl.select_cpu_device()`,
+          :func:`dpctl.select_default_device()`,
+          :func:`dpctl.select_gpu_device()`,
+          :func:`dpctl.select_host_device()`.
+
 
         :Example:
-
             .. code-block:: python
 
-            import dpctl
+                import dpctl
 
-            gpu = dpctl.select_gpu_device():
-            gpu.dump_device_info()
+                # Create a SyclDevice of type GPU based on whatever is returned
+                # by the SYCL `gpu_selector` device selector class.
+                gpu = dpctl.select_gpu_device():
+                gpu.dump_device_info()
+
     """
 
     @staticmethod

--- a/dpctl/_sycl_device.pyx
+++ b/dpctl/_sycl_device.pyx
@@ -209,8 +209,11 @@ cdef class _SyclDevice:
         return int(<size_t>self._device_ref)
 
     @property
-    def __name__():
+    def __name__(self):
         return "SyclDevice"
+
+    def __repr__(self):
+        return "<dpctl." + self.__name__ + " at {}>".format(hex(id(self)))
 
 
 cdef class SyclDevice(_SyclDevice):

--- a/dpctl/tests/test_sycl_device.py
+++ b/dpctl/tests/test_sycl_device.py
@@ -57,14 +57,17 @@ def check_get_max_compute_units(device):
     max_compute_units = device.get_max_compute_units()
     assert max_compute_units > 0
 
+
 def check_get_max_work_item_dims(device):
     max_work_item_dims = device.get_max_work_item_dims()
     assert max_work_item_dims > 0
+
 
 def check_get_max_work_item_sizes(device):
     max_work_item_sizes = device.get_max_work_item_sizes()
     for size in max_work_item_sizes:
         assert size is not None
+
 
 def check_get_max_work_group_size(device):
     max_work_group_size = device.get_max_work_group_size()
@@ -74,6 +77,7 @@ def check_get_max_work_group_size(device):
     else:
         assert max_work_group_size > 0
 
+
 def check_get_max_num_sub_groups(device):
     max_num_sub_groups = device.get_max_num_sub_groups()
     # Special case for FPGA simulator
@@ -82,11 +86,13 @@ def check_get_max_num_sub_groups(device):
     else:
         assert max_num_sub_groups > 0
 
+
 def check_has_int64_base_atomics(device):
     try:
         device.has_int64_base_atomics()
     except Exception:
         pytest.fail("has_int64_base_atomics call failed")
+
 
 def check_has_int64_extended_atomics(device):
     try:
@@ -94,11 +100,13 @@ def check_has_int64_extended_atomics(device):
     except Exception:
         pytest.fail("has_int64_extended_atomics call failed")
 
+
 def check_is_accelerator(device):
     try:
         device.is_accelerator()
     except Exception:
         pytest.fail("is_accelerator call failed")
+
 
 def check_is_cpu(device):
     try:
@@ -106,11 +114,13 @@ def check_is_cpu(device):
     except Exception:
         pytest.fail("is_cpu call failed")
 
+
 def check_is_gpu(device):
     try:
         device.is_gpu()
     except Exception:
         pytest.fail("is_gpu call failed")
+
 
 def check_is_host(device):
     try:
@@ -118,19 +128,21 @@ def check_is_host(device):
     except Exception:
         pytest.fail("is_hostcall failed")
 
+
 list_of_checks = [
-check_get_max_compute_units,
-check_get_max_work_item_dims,
-check_get_max_work_item_sizes,
-check_get_max_work_group_size,
-check_get_max_num_sub_groups,
-check_has_int64_base_atomics,
-check_has_int64_extended_atomics,
-check_is_accelerator,
-check_is_cpu,
-check_is_gpu,
-check_is_host,
+    check_get_max_compute_units,
+    check_get_max_work_item_dims,
+    check_get_max_work_item_sizes,
+    check_get_max_work_group_size,
+    check_get_max_num_sub_groups,
+    check_has_int64_base_atomics,
+    check_has_int64_extended_atomics,
+    check_is_accelerator,
+    check_is_cpu,
+    check_is_gpu,
+    check_is_host,
 ]
+
 
 @pytest.fixture(params=list_of_valid_filter_selectors)
 def valid_filter(request):
@@ -145,6 +157,7 @@ def invalid_filter(request):
 @pytest.fixture(params=list_of_standard_selectors)
 def device_selector(request):
     return request.param
+
 
 @pytest.fixture(params=list_of_checks)
 def check(request):

--- a/dpctl/tests/test_sycl_device.py
+++ b/dpctl/tests/test_sycl_device.py
@@ -52,6 +52,85 @@ list_of_invalid_filter_selectors = [
     "level_zero:cpu:0",
 ]
 
+# Unit test cases that will be run for every device
+def check_get_max_compute_units(device):
+    max_compute_units = device.get_max_compute_units()
+    assert max_compute_units > 0
+
+def check_get_max_work_item_dims(device):
+    max_work_item_dims = device.get_max_work_item_dims()
+    assert max_work_item_dims > 0
+
+def check_get_max_work_item_sizes(device):
+    max_work_item_sizes = device.get_max_work_item_sizes()
+    for size in max_work_item_sizes:
+        assert size is not None
+
+def check_get_max_work_group_size(device):
+    max_work_group_size = device.get_max_work_group_size()
+    # Special case for FPGA simulator
+    if device.is_accelerator():
+        assert max_work_group_size >= 0
+    else:
+        assert max_work_group_size > 0
+
+def check_get_max_num_sub_groups(device):
+    max_num_sub_groups = device.get_max_num_sub_groups()
+    # Special case for FPGA simulator
+    if device.is_accelerator():
+        assert max_num_sub_groups >= 0
+    else:
+        assert max_num_sub_groups > 0
+
+def check_has_int64_base_atomics(device):
+    try:
+        device.has_int64_base_atomics()
+    except Exception:
+        pytest.fail("has_int64_base_atomics call failed")
+
+def check_has_int64_extended_atomics(device):
+    try:
+        device.has_int64_extended_atomics()
+    except Exception:
+        pytest.fail("has_int64_extended_atomics call failed")
+
+def check_is_accelerator(device):
+    try:
+        device.is_accelerator()
+    except Exception:
+        pytest.fail("is_accelerator call failed")
+
+def check_is_cpu(device):
+    try:
+        device.is_cpu()
+    except Exception:
+        pytest.fail("is_cpu call failed")
+
+def check_is_gpu(device):
+    try:
+        device.is_gpu()
+    except Exception:
+        pytest.fail("is_gpu call failed")
+
+def check_is_host(device):
+    try:
+        device.is_host()
+    except Exception:
+        pytest.fail("is_hostcall failed")
+
+list_of_checks = [
+check_get_max_compute_units,
+check_get_max_work_item_dims,
+check_get_max_work_item_sizes,
+check_get_max_work_group_size,
+check_get_max_num_sub_groups,
+check_has_int64_base_atomics,
+check_has_int64_extended_atomics,
+check_is_accelerator,
+check_is_cpu,
+check_is_gpu,
+check_is_host,
+]
 
 @pytest.fixture(params=list_of_valid_filter_selectors)
 def valid_filter(request):
@@ -67,109 +146,37 @@ def invalid_filter(request):
 def device_selector(request):
     return request.param
 
-
-class DeviceTestFunctions:
-    def __init__(self, device):
-        self.check_get_max_compute_units(device)
-        self.check_get_max_work_item_dims(device)
-        self.check_get_max_work_item_sizes(device)
-        self.check_get_max_work_group_size(device)
-        self.check_get_max_num_sub_groups(device)
-        self.check_has_int64_base_atomics(device)
-        self.check_has_int64_extended_atomics(device)
-
-    def check_get_max_compute_units(self, device):
-        max_compute_units = device.get_max_compute_units()
-        assert max_compute_units > 0
-
-    def check_get_max_work_item_dims(self, device):
-        max_work_item_dims = device.get_max_work_item_dims()
-        assert max_work_item_dims > 0
-
-    def check_get_max_work_item_sizes(self, device):
-        max_work_item_sizes = device.get_max_work_item_sizes()
-        for size in max_work_item_sizes:
-            assert size is not None
-
-    def check_get_max_work_group_size(self, device):
-        max_work_group_size = device.get_max_work_group_size()
-        # Special case for FPGA simulator
-        if device.is_accelerator():
-            assert max_work_group_size >= 0
-        else:
-            assert max_work_group_size > 0
-
-    def check_get_max_num_sub_groups(self, device):
-        max_num_sub_groups = device.get_max_num_sub_groups()
-        # Special case for FPGA simulator
-        if device.is_accelerator():
-            assert max_num_sub_groups >= 0
-        else:
-            assert max_num_sub_groups > 0
-
-    def check_has_int64_base_atomics(self, device):
-        try:
-            device.has_int64_base_atomics()
-        except Exception:
-            pytest.fail("has_int64_base_atomics call failed")
-
-    def check_has_int64_extended_atomics(self, device):
-        try:
-            device.has_int64_extended_atomics()
-        except Exception:
-            pytest.fail("has_int64_extended_atomics call failed")
-
-    def check_is_accelerator(self, device):
-        try:
-            device.is_accelerator()
-        except Exception:
-            pytest.fail("is_accelerator call failed")
-
-    def check_is_cpu(self, device):
-        try:
-            device.is_cpu()
-        except Exception:
-            pytest.fail("is_cpu call failed")
-
-    def check_is_gpu(self, device):
-        try:
-            device.is_gpu()
-        except Exception:
-            pytest.fail("is_gpu call failed")
-
-    def check_is_host(self, device):
-        try:
-            device.is_host()
-        except Exception:
-            pytest.fail("is_hostcall failed")
+@pytest.fixture(params=list_of_checks)
+def check(request):
+    return request.param
 
 
-def test_standard_selectors(device_selector):
+def test_standard_selectors(device_selector, check):
     """Tests if the standard SYCL device_selectors are able to select a
     device.
     """
     try:
         device = device_selector()
-        DeviceTestFunctions(device)
+        check(device)
     except ValueError:
         pytest.skip()
 
 
-def test_current_device():
+def test_current_device(check):
     """Test is the device for the current queue is valid."""
     try:
         q = dpctl.get_current_queue()
     except Exception:
         pytest.fail("Encountered an exception inside get_current_queue().")
     device = q.get_sycl_device()
-    DeviceTestFunctions(device)
+    check(device)
 
 
-def test_valid_filter_selectors(valid_filter):
+def test_valid_filter_selectors(valid_filter, check):
     """Tests if we can create a SyclDevice using a supported filter selector string."""
     try:
         device = dpctl.SyclDevice(valid_filter)
-        DeviceTestFunctions(device)
+        check(device)
     except ValueError:
         pytest.fail("Failed to create device with supported filter")
 

--- a/dpctl/tests/test_sycl_device.py
+++ b/dpctl/tests/test_sycl_device.py
@@ -187,11 +187,12 @@ def test_current_device(check):
 
 def test_valid_filter_selectors(valid_filter, check):
     """Tests if we can create a SyclDevice using a supported filter selector string."""
+    device = None
     try:
         device = dpctl.SyclDevice(valid_filter)
-        check(device)
     except ValueError:
-        pytest.fail("Failed to create device with supported filter")
+        pytest.skip("Failed to create device with supported filter")
+    check(device)
 
 
 def test_invalid_filter_selectors(invalid_filter):

--- a/dpctl/tests/test_sycl_device.py
+++ b/dpctl/tests/test_sycl_device.py
@@ -45,11 +45,10 @@ list_of_valid_filter_selectors = [
 ]
 
 list_of_invalid_filter_selectors = [
-    "host",
-    "0",
     "-1",
-    "opencl:gpu:1",
+    "opencl:gpu:-1",
     "level_zero:cpu:0",
+    "abc",
 ]
 
 # Unit test cases that will be run for every device

--- a/dpctl/tests/test_sycl_device.py
+++ b/dpctl/tests/test_sycl_device.py
@@ -93,11 +93,19 @@ class DeviceTestFunctions:
 
     def check_get_max_work_group_size(self, device):
         max_work_group_size = device.get_max_work_group_size()
-        assert max_work_group_size > 0
+        # Special case for FPGA simulator
+        if device.is_accelerator():
+            assert max_work_group_size >= 0
+        else:
+            assert max_work_group_size > 0
 
     def check_get_max_num_sub_groups(self, device):
         max_num_sub_groups = device.get_max_num_sub_groups()
-        assert max_num_sub_groups > 0
+        # Special case for FPGA simulator
+        if device.is_accelerator():
+            assert max_num_sub_groups >= 0
+        else:
+            assert max_num_sub_groups > 0
 
     def check_has_int64_base_atomics(self, device):
         try:
@@ -110,6 +118,30 @@ class DeviceTestFunctions:
             device.has_int64_extended_atomics()
         except Exception:
             pytest.fail("has_int64_extended_atomics call failed")
+
+    def check_is_accelerator(self, device):
+        try:
+            device.is_accelerator()
+        except Exception:
+            pytest.fail("is_accelerator call failed")
+
+    def check_is_cpu(self, device):
+        try:
+            device.is_cpu()
+        except Exception:
+            pytest.fail("is_cpu call failed")
+
+    def check_is_gpu(self, device):
+        try:
+            device.is_gpu()
+        except Exception:
+            pytest.fail("is_gpu call failed")
+
+    def check_is_host(self, device):
+        try:
+            device.is_host()
+        except Exception:
+            pytest.fail("is_hostcall failed")
 
 
 def test_standard_selectors(device_selector):


### PR DESCRIPTION
This PR is extracted out of #271 and only adds the device selector classes to C API and Python API. 

- A `SyclDevice` can now be created out of SYCL's standard device selector classes. 
- A `SyclDevice` can also be constructed using a filter selector string.
