### PR TITLE
Fix/test cases with pytest

### DIFF
--- a/dpctl/tests/test_sycl_usm.py
+++ b/dpctl/tests/test_sycl_usm.py
@@ -168,8 +168,6 @@ class _TestMemoryUSMBase:
     """ Base tests for MemoryUSM* """
 
     def setUp(self):
-        # self.MemoryUSMClass = None
-        # self.usm_type = None
         pass
 
     @unittest.skipUnless(

--- a/dpctl/tests/test_sycl_usm.py
+++ b/dpctl/tests/test_sycl_usm.py
@@ -168,8 +168,8 @@ class _TestMemoryUSMBase:
     """ Base tests for MemoryUSM* """
 
     def setUp(self):
-        #self.MemoryUSMClass = None
-        #self.usm_type = None
+        # self.MemoryUSMClass = None
+        # self.usm_type = None
         pass
 
     @unittest.skipUnless(

--- a/dpctl/tests/test_sycl_usm.py
+++ b/dpctl/tests/test_sycl_usm.py
@@ -164,11 +164,13 @@ class TestMemory(unittest.TestCase):
         )
 
 
-class TestMemoryUSMBase:
+class _TestMemoryUSMBase:
     """ Base tests for MemoryUSM* """
 
-    MemoryUSMClass = None
-    usm_type = None
+    def setUp(self):
+        #self.MemoryUSMClass = None
+        #self.usm_type = None
+        pass
 
     @unittest.skipUnless(
         dpctl.has_sycl_platforms(), "No SYCL devices except the default host device."
@@ -217,25 +219,28 @@ class TestMemoryUSMBase:
         self.assertTrue(np.array_equal(m.copy_to_host(), hb))
 
 
-class TestMemoryUSMShared(TestMemoryUSMBase, unittest.TestCase):
+class TestMemoryUSMShared(_TestMemoryUSMBase, unittest.TestCase):
     """ Tests for MemoryUSMShared """
 
-    MemoryUSMClass = MemoryUSMShared
-    usm_type = "shared"
+    def setUp(self):
+        self.MemoryUSMClass = MemoryUSMShared
+        self.usm_type = "shared"
 
 
-class TestMemoryUSMHost(TestMemoryUSMBase, unittest.TestCase):
+class TestMemoryUSMHost(_TestMemoryUSMBase, unittest.TestCase):
     """ Tests for MemoryUSMHost """
 
-    MemoryUSMClass = MemoryUSMHost
-    usm_type = "host"
+    def setUp(self):
+        self.MemoryUSMClass = MemoryUSMHost
+        self.usm_type = "host"
 
 
-class TestMemoryUSMDevice(TestMemoryUSMBase, unittest.TestCase):
+class TestMemoryUSMDevice(_TestMemoryUSMBase, unittest.TestCase):
     """ Tests for MemoryUSMDevice """
 
-    MemoryUSMClass = MemoryUSMDevice
-    usm_type = "device"
+    def setUp(self):
+        self.MemoryUSMClass = MemoryUSMDevice
+        self.usm_type = "device"
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes `MemoryUSM` tests to work with both `unittest` and `pytest`.