### PR TITLE
Update .gitignore (#288)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,3 +83,6 @@ target/
 
 # generated Cython files
 _dpctl_bindings*
+
+# generated C API coverage reports
+dpctl-c-api-coverage


### PR DESCRIPTION
Ignore the generated coverage reports.