### PR TITLE
Adds new helper functions to convert between DPCTL and SYCL enum values.

### DIFF
--- a/dpctl-capi/helper/include/dpctl_utils_helper.h
+++ b/dpctl-capi/helper/include/dpctl_utils_helper.h
@@ -24,8 +24,74 @@
 
 #pragma once
 
+#include "../include/dpctl_sycl_enum_types.h"
 #include <CL/sycl.hpp>
-using namespace cl::sycl;
 
-std::string DPCTL_DeviceTypeToStr(info::device_type devTy);
-info::device_type DPCTL_StrToDeviceType(std::string devTyStr);
+/*!
+ * @brief Converts a sycl::info::device_type input value to a string.
+ *
+ * @param    devTy          A sycl::info::device_type enum value.
+ * @return   A string representation of a sycl::info::device_type enum.
+ */
+std::string DPCTL_DeviceTypeToStr(sycl::info::device_type devTy);
+
+/*!
+ * @brief Converts a string to sycl::info::device_type enum value.
+ *
+ * Tries to interpret the input string a return a corresponding device_type. If
+ * no conversion is possible, then a runtime_error is thrown.
+ *
+ * @param    devTyStr       Input string for which we search a
+ *                          sycl::info::device_type enum value.
+ * @return   The sycl::info::device_type enum value corresponding to the input
+ * string.
+ * @throws runtime_error
+ */
+sycl::info::device_type DPCTL_StrToDeviceType(const std::string &devTyStr);
+
+/*!
+ * @brief Converts a DPCTLSyclBackendType enum value to its corresponding
+ * sycl::backend enum value. If conversion fails, a runtime_error is thrown.
+ *
+ * @param    BeTy           My Param doc
+ * @return   A sycl::backend enum value for the input
+ * DPCTLSyclDeviceType enum value.
+ * @throws runtime_error
+ */
+sycl::backend DPCTL_DPCTLBackendTypeToSyclBackend(DPCTLSyclBackendType BeTy);
+
+/*!
+ * @brief Converts a sycl::backend enum value to corresponding
+ * DPCTLSyclBackendType enum value.
+ *
+ * @param    B           sycl::backend to be converted to
+ *                       DPCTLSyclBackendType enum.
+ * @return   A DPCTLSyclBackendType enum value for the input
+ * sycl::backend enum value.
+ */
+DPCTLSyclBackendType DPCTL_SyclBackendToDPCTLBackendType(sycl::backend B);
+
+/*!
+ * @brief Converts a DPCTLSyclDeviceType enum value to its corresponding
+ * sycl::info::device_type enum value. If conversion fails, a runtime_error is
+ * thrown.
+ *
+ * @param    DTy           A DPCTLSyclDeviceType enum value
+ * @return   A sycl::info::device_type enum value for the input
+ * DPCTLSyclDeviceType enum value.
+ * @throws runtime_error
+ */
+sycl::info::device_type
+DPCTL_DPCTLDeviceTypeToSyclDeviceType(DPCTLSyclDeviceType DTy);
+
+/*!
+ * @brief Converts a sycl::info::device_type enum value to corresponding
+ * DPCTLSyclDeviceType enum value.
+ *
+ * @param    D           sycl::info::device_type to be converted to
+ *                       DPCTLSyclDeviceType enum.
+ * @return   A DPCTLSyclDeviceType enum value for the input
+ * sycl::info::device_type enum value.
+ */
+DPCTLSyclDeviceType
+DPCTL_SyclDeviceTypeToDPCTLDeviceType(sycl::info::device_type D);

--- a/dpctl-capi/helper/source/dpctl_utils_helper.cpp
+++ b/dpctl-capi/helper/source/dpctl_utils_helper.cpp
@@ -60,7 +60,7 @@ std::string DPCTL_DeviceTypeToStr(info::device_type devTy)
 /*!
  * Transforms string to enum info::device_type.
  */
-info::device_type DPCTL_StrToDeviceType(std::string devTyStr)
+info::device_type DPCTL_StrToDeviceType(const std::string &devTyStr)
 {
     info::device_type devTy;
     if (devTyStr == "cpu") {
@@ -83,4 +83,80 @@ info::device_type DPCTL_StrToDeviceType(std::string devTyStr)
         throw std::runtime_error("Unknown device type.");
     }
     return devTy;
+}
+
+backend DPCTL_DPCTLBackendTypeToSyclBackend(DPCTLSyclBackendType BeTy)
+{
+    switch (BeTy) {
+    case DPCTLSyclBackendType::DPCTL_CUDA:
+        return backend::cuda;
+    case DPCTLSyclBackendType::DPCTL_HOST:
+        return backend::host;
+    case DPCTLSyclBackendType::DPCTL_LEVEL_ZERO:
+        return backend::level_zero;
+    case DPCTLSyclBackendType::DPCTL_OPENCL:
+        return backend::opencl;
+    default:
+        throw runtime_error("Unsupported backend type", -1);
+    }
+}
+
+DPCTLSyclBackendType DPCTL_SyclBackendToDPCTLBackendType(backend B)
+{
+    switch (B) {
+    case backend::cuda:
+        return DPCTLSyclBackendType::DPCTL_CUDA;
+    case backend::host:
+        return DPCTLSyclBackendType::DPCTL_HOST;
+    case backend::level_zero:
+        return DPCTLSyclBackendType::DPCTL_LEVEL_ZERO;
+    case backend::opencl:
+        return DPCTLSyclBackendType::DPCTL_OPENCL;
+    default:
+        return DPCTLSyclBackendType::DPCTL_UNKNOWN_BACKEND;
+    }
+}
+
+info::device_type DPCTL_DPCTLDeviceTypeToSyclDeviceType(DPCTLSyclDeviceType DTy)
+{
+    switch (DTy) {
+    case DPCTLSyclDeviceType::DPCTL_ACCELERATOR:
+        return info::device_type::accelerator;
+    case DPCTLSyclDeviceType::DPCTL_ALL:
+        return info::device_type::all;
+    case DPCTLSyclDeviceType::DPCTL_AUTOMATIC:
+        return info::device_type::automatic;
+    case DPCTLSyclDeviceType::DPCTL_CPU:
+        return info::device_type::cpu;
+    case DPCTLSyclDeviceType::DPCTL_CUSTOM:
+        return info::device_type::custom;
+    case DPCTLSyclDeviceType::DPCTL_GPU:
+        return info::device_type::gpu;
+    case DPCTLSyclDeviceType::DPCTL_HOST_DEVICE:
+        return info::device_type::host;
+    default:
+        throw runtime_error("Unsupported device type", -1);
+    }
+}
+
+DPCTLSyclDeviceType DPCTL_SyclDeviceTypeToDPCTLDeviceType(info::device_type D)
+{
+    switch (D) {
+    case info::device_type::accelerator:
+        return DPCTLSyclDeviceType::DPCTL_ACCELERATOR;
+    case info::device_type::all:
+        return DPCTLSyclDeviceType::DPCTL_ALL;
+    case info::device_type::automatic:
+        return DPCTLSyclDeviceType::DPCTL_AUTOMATIC;
+    case info::device_type::cpu:
+        return DPCTLSyclDeviceType::DPCTL_CPU;
+    case info::device_type::custom:
+        return DPCTLSyclDeviceType::DPCTL_CUSTOM;
+    case info::device_type::gpu:
+        return DPCTLSyclDeviceType::DPCTL_GPU;
+    case info::device_type::host:
+        return DPCTLSyclDeviceType::DPCTL_HOST_DEVICE;
+    default:
+        return DPCTLSyclDeviceType::DPCTL_UNKNOWN_DEVICE;
+    }
 }


### PR DESCRIPTION
- Adds new functions to convert between SYCL and DPCTL enum types. We can not directly cast the values as DPCTL uses bit flags for some of the enum classes. 
- Also added doc strings to old functions.