### PR TITLE
Fix CI for release0.6

### DIFF
--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -5,9 +5,8 @@ name: black
 # Controls when the action will run. Triggers the workflow on push or pull request
 # events but only for the master branch
 on:
-  push:
-    branches: [master]
   pull_request:
+  push:
     branches: [master]
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel

--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -5,9 +5,8 @@ name: clang-format Check
 # Controls when the action will run. Triggers the workflow on push or pull request
 # events but only for the master branch
 on:
-  push:
-    branches: [master]
   pull_request:
+  push:
     branches: [master]
 
 jobs:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.1] - 2021-03-01
+### Fixed
+- Do not use POP_FRONT in FindDPCPP.cmake so that we can use a cmake version older that 3.15.
+
 ## [0.6.0] - 2021-03-01
 ### Added
 - Documentation improvements.

--- a/dpctl-capi/cmake/modules/FindDPCPP.cmake
+++ b/dpctl-capi/cmake/modules/FindDPCPP.cmake
@@ -54,7 +54,7 @@ execute_process(
     OUTPUT_VARIABLE dpcpp_ver
 )
 
-# If dpcpp is found then set then set the package variables
+# If dpcpp is found then set the package variables
 if(${dpcpp_result} MATCHES "0")
     string(REPLACE "\n" ";" DPCPP_VERSION_LIST "${dpcpp_ver}")
     list(GET DPCPP_VERSION_LIST 0 dpcpp_ver_line)
@@ -89,7 +89,7 @@ if(${dpcpp_result} MATCHES "0")
 
     # set package-level variables
     set(DPCPP_ROOT ${DPCPP_INSTALL_DIR})
-    list(POP_FRONT DPCPP_VERSION_LIST DPCPP_VERSION)
+    list(GET DPCPP_VERSION_LIST 0 DPCPP_VERSION)
     set(DPCPP_INCLUDE_DIR ${DPCPP_INSTALL_DIR}/include)
     set(DPCPP_SYCL_INCLUDE_DIR ${DPCPP_INSTALL_DIR}/include/sycl)
     set(DPCPP_LIBRARY_DIR ${DPCPP_INSTALL_DIR}/lib)


### PR DESCRIPTION
* Do not use POP_FRONT in FindDPCPP.cmake so that we can use a cmake version older that 3.15.