### PR TITLE
Fix the flag in "subprocess.check_call" for Windows

### DIFF
--- a/scripts/build_backend.py
+++ b/scripts/build_backend.py
@@ -109,7 +109,7 @@ if IS_WIN:
         "-DCMAKE_CXX_COMPILER:PATH=" + os.path.join(DPCPP_ROOT, "bin", "dpcpp.exe"),
         backends,
     ]
-    subprocess.check_call(cmake_args, stderr=subprocess.STDOUT, shell=True)
+    subprocess.check_call(cmake_args, stderr=subprocess.STDOUT, shell=False)
     subprocess.check_call(["ninja", "-n"])
     subprocess.check_call(["ninja", "install"])
 


### PR DESCRIPTION
This PR fixes Bandit warning in building script related to `subprocess.check_call(..., shell=True)`.