### PR TITLE
Refactor/device properties

### DIFF
--- a/dpctl/_sycl_device.pxd
+++ b/dpctl/_sycl_device.pxd
@@ -20,8 +20,6 @@
 """ This file declares the SyclDevice extension type.
 """
 
-from libcpp cimport bool
-from libc.stdint cimport uint32_t
 from ._backend cimport (
     DPCTLSyclDeviceRef,
     DPCTLSyclDeviceSelectorRef,
@@ -32,18 +30,10 @@ cdef class _SyclDevice:
     ''' Wrapper class for a Sycl Device
     '''
     cdef DPCTLSyclDeviceRef _device_ref
-    cdef bool _accelerator_device
-    cdef bool _cpu_device
-    cdef bool _gpu_device
-    cdef bool _host_device
     cdef const char *_vendor_name
     cdef const char *_device_name
     cdef const char *_driver_version
-    cdef uint32_t _max_compute_units
-    cdef uint32_t _max_work_item_dims
     cdef size_t *_max_work_item_sizes
-    cdef size_t _max_work_group_size
-    cdef uint32_t _max_num_sub_groups
 
 
 cdef class SyclDevice(_SyclDevice):
@@ -54,17 +44,3 @@ cdef class SyclDevice(_SyclDevice):
     cdef int _init_from__SyclDevice(self, _SyclDevice other)
     cdef int _init_from_selector(self, DPCTLSyclDeviceSelectorRef DSRef)
     cdef DPCTLSyclDeviceRef get_device_ref(self)
-    cpdef get_backend(self)
-    cpdef get_device_name(self)
-    cpdef get_device_type(self)
-    cpdef get_vendor_name(self)
-    cpdef get_driver_version(self)
-    cpdef get_max_compute_units(self)
-    cpdef get_max_work_item_dims(self)
-    cpdef get_max_work_item_sizes(self)
-    cpdef get_max_work_group_size(self)
-    cpdef get_max_num_sub_groups(self)
-    cpdef is_accelerator(self)
-    cpdef is_cpu(self)
-    cpdef is_gpu(self)
-    cpdef is_host(self)

--- a/dpctl/_sycl_device.pyx
+++ b/dpctl/_sycl_device.pyx
@@ -418,10 +418,11 @@ cdef class SyclDevice(_SyclDevice):
             value is (1; 1; 1) for devices that are not of
             device type ``info::device_type::custom``.
         """
-        max_work_item_sizes = []
-        for n in range(3):
-            max_work_item_sizes.append(self._max_work_item_sizes[n])
-        return tuple(max_work_item_sizes)
+        return (
+            self._max_work_item_sizes[0],
+            self._max_work_item_sizes[1],
+            self._max_work_item_sizes[2],
+        )
 
     @property
     def max_compute_units(self):

--- a/dpctl/_sycl_device.pyx
+++ b/dpctl/_sycl_device.pyx
@@ -480,5 +480,5 @@ cdef class SyclDevice(_SyclDevice):
 
     def __repr__(self):
         return ("<dpctl." + self.__name__ + " [" +
-                str(self.get_backend()) + ", " + str(self.get_device_type()) +", " +
-                " " + self.get_device_name() + "] at {}>".format(hex(id(self))) )
+                str(self.backend) + ", " + str(self.device_type) +", " +
+                " " + self.device_name + "] at {}>".format(hex(id(self))) )

--- a/dpctl/_sycl_queue_manager.pyx
+++ b/dpctl/_sycl_queue_manager.pyx
@@ -144,7 +144,7 @@ cdef class _SyclQueueManager:
             device_type: The SYCL device type for the currently selected queue.
             Possible values can be gpu, cpu, accelerator, or host.
         """
-        return self.get_current_queue().get_sycl_device().get_device_type()
+        return self.get_current_queue().get_sycl_device().device_type
 
     cpdef SyclQueue get_current_queue(self):
         """

--- a/dpctl/tests/test_dump_functions.py
+++ b/dpctl/tests/test_dump_functions.py
@@ -32,12 +32,12 @@ class TestDumpMethods(unittest.TestCase):
     @unittest.skipUnless(
         dpctl.has_sycl_platforms(), "No SYCL devices except the default host device."
     )
-    def test_dpctl_dump_device_info(self):
+    def test_dpctl_print_device_info(self):
         q = dpctl.get_current_queue()
         try:
-            q.get_sycl_device().dump_device_info()
+            q.get_sycl_device().print_device_info()
         except Exception:
-            self.fail("Encountered an exception inside dump_device_info().")
+            self.fail("Encountered an exception inside print_device_info().")
 
 
 if __name__ == "__main__":

--- a/dpctl/tests/test_sycl_device.py
+++ b/dpctl/tests/test_sycl_device.py
@@ -53,34 +53,34 @@ list_of_invalid_filter_selectors = [
 
 # Unit test cases that will be run for every device
 def check_get_max_compute_units(device):
-    max_compute_units = device.get_max_compute_units()
+    max_compute_units = device.max_compute_units
     assert max_compute_units > 0
 
 
 def check_get_max_work_item_dims(device):
-    max_work_item_dims = device.get_max_work_item_dims()
+    max_work_item_dims = device.max_work_item_dims
     assert max_work_item_dims > 0
 
 
 def check_get_max_work_item_sizes(device):
-    max_work_item_sizes = device.get_max_work_item_sizes()
+    max_work_item_sizes = device.max_work_item_sizes
     for size in max_work_item_sizes:
         assert size is not None
 
 
 def check_get_max_work_group_size(device):
-    max_work_group_size = device.get_max_work_group_size()
+    max_work_group_size = device.max_work_group_size
     # Special case for FPGA simulator
-    if device.is_accelerator():
+    if device.is_accelerator:
         assert max_work_group_size >= 0
     else:
         assert max_work_group_size > 0
 
 
 def check_get_max_num_sub_groups(device):
-    max_num_sub_groups = device.get_max_num_sub_groups()
+    max_num_sub_groups = device.max_num_sub_groups
     # Special case for FPGA simulator
-    if device.is_accelerator() or device.is_host():
+    if device.is_accelerator or device.is_host:
         assert max_num_sub_groups >= 0
     else:
         assert max_num_sub_groups > 0
@@ -214,28 +214,28 @@ def check_has_aspect_usm_system_allocator(device):
 
 def check_is_accelerator(device):
     try:
-        device.is_accelerator()
+        device.is_accelerator
     except Exception:
         pytest.fail("is_accelerator call failed")
 
 
 def check_is_cpu(device):
     try:
-        device.is_cpu()
+        device.is_cpu
     except Exception:
         pytest.fail("is_cpu call failed")
 
 
 def check_is_gpu(device):
     try:
-        device.is_gpu()
+        device.is_gpu
     except Exception:
         pytest.fail("is_gpu call failed")
 
 
 def check_is_host(device):
     try:
-        device.is_host()
+        device.is_host
     except Exception:
         pytest.fail("is_hostcall failed")
 

--- a/dpctl/tests/test_sycl_device_factory.py
+++ b/dpctl/tests/test_sycl_device_factory.py
@@ -102,22 +102,22 @@ def device_type_str(request):
 
 def check_if_device_type_is_valid(devices):
     for d in devices:
-        assert d.get_device_type() in set(item for item in dty)
+        assert d.device_type in set(item for item in dty)
 
 
 def check_if_backend_is_valid(devices):
     for d in devices:
-        assert d.get_backend() in set(item for item in bty)
+        assert d.backend in set(item for item in bty)
 
 
 def check_if_backend_matches(devices, backend):
     for d in devices:
-        assert d.get_backend() == backend
+        assert d.backend == backend
 
 
 def check_if_device_type_matches(devices, device_type):
     for d in devices:
-        assert d.get_device_type() == device_type
+        assert d.device_type == device_type
 
 
 def test_get_devices_with_string_args(str_args):

--- a/dpctl/tests/test_sycl_queue.py
+++ b/dpctl/tests/test_sycl_queue.py
@@ -53,34 +53,34 @@ list_of_invalid_filter_selectors = [
 
 # Unit test cases that will be run for every device
 def check_get_max_compute_units(device):
-    max_compute_units = device.get_max_compute_units()
+    max_compute_units = device.max_compute_units
     assert max_compute_units > 0
 
 
 def check_get_max_work_item_dims(device):
-    max_work_item_dims = device.get_max_work_item_dims()
+    max_work_item_dims = device.max_work_item_dims
     assert max_work_item_dims > 0
 
 
 def check_get_max_work_item_sizes(device):
-    max_work_item_sizes = device.get_max_work_item_sizes()
+    max_work_item_sizes = device.max_work_item_sizes
     for size in max_work_item_sizes:
         assert size is not None
 
 
 def check_get_max_work_group_size(device):
-    max_work_group_size = device.get_max_work_group_size()
+    max_work_group_size = device.max_work_group_size
     # Special case for FPGA simulator
-    if device.is_accelerator():
+    if device.is_accelerator:
         assert max_work_group_size >= 0
     else:
         assert max_work_group_size > 0
 
 
 def check_get_max_num_sub_groups(device):
-    max_num_sub_groups = device.get_max_num_sub_groups()
+    max_num_sub_groups = device.max_num_sub_groups
     # Special case for FPGA simulator
-    if device.is_accelerator() or device.is_host():
+    if device.is_accelerator or device.is_host:
         assert max_num_sub_groups >= 0
     else:
         assert max_num_sub_groups > 0
@@ -214,28 +214,28 @@ def check_has_aspect_usm_system_allocator(device):
 
 def check_is_accelerator(device):
     try:
-        device.is_accelerator()
+        device.is_accelerator
     except Exception:
         pytest.fail("is_accelerator call failed")
 
 
 def check_is_cpu(device):
     try:
-        device.is_cpu()
+        device.is_cpu
     except Exception:
         pytest.fail("is_cpu call failed")
 
 
 def check_is_gpu(device):
     try:
-        device.is_gpu()
+        device.is_gpu
     except Exception:
         pytest.fail("is_gpu call failed")
 
 
 def check_is_host(device):
     try:
-        device.is_host()
+        device.is_host
     except Exception:
         pytest.fail("is_hostcall failed")
 

--- a/dpctl/tests/test_sycl_queue_manager.py
+++ b/dpctl/tests/test_sycl_queue_manager.py
@@ -36,12 +36,12 @@ class TestDumpMethods(unittest.TestCase):
         except Exception:
             self.fail("Encountered an exception inside dump().")
 
-    def test_dpctl_dump_device_info(self):
+    def test_dpctl_print_device_info(self):
         q = dpctl.get_current_queue()
         try:
-            q.get_sycl_device().dump_device_info()
+            q.get_sycl_device().print_device_info()
         except Exception:
-            self.fail("Encountered an exception inside dump_device_info().")
+            self.fail("Encountered an exception inside print_device_info().")
 
 
 @unittest.skipIf(not dpctl.has_sycl_platforms(), "No SYCL platforms available")

--- a/examples/python/create_sycl_queues.py
+++ b/examples/python/create_sycl_queues.py
@@ -43,7 +43,7 @@ with device_context("opencl:cpu:0") as cpu_queue:
     print("========================================")
     print("Current context inside with scope")
     print("========================================")
-    cpu_queue.get_sycl_device().dump_device_info()
+    cpu_queue.get_sycl_device().print_device_info()
 
     # Note the current context can be either directly accessed by using
     # the "cpu_queue" object, or it can be accessed via the runtime's
@@ -51,10 +51,10 @@ with device_context("opencl:cpu:0") as cpu_queue:
     print("========================================")
     print("Looking up current context using runtime")
     print("========================================")
-    rt.get_current_queue().get_sycl_device().dump_device_info()
+    rt.get_current_queue().get_sycl_device().print_device_info()
 
 
 print("========================================")
 print("Current context after exiting with scope")
 print("========================================")
-rt.get_current_queue().get_sycl_device().dump_device_info()
+rt.get_current_queue().get_sycl_device().print_device_info()

--- a/examples/python/usm_memory_allocation.py
+++ b/examples/python/usm_memory_allocation.py
@@ -38,4 +38,4 @@ mdq = dpmem.MemoryUSMDevice(256, queue=mda._queue)
 
 # information about device associate with USM buffer
 print("Allocation performed on device:")
-mda._queue.get_sycl_device().dump_device_info()
+mda._queue.get_sycl_device().print_device_info()


### PR DESCRIPTION
SyclDevice no longer stores attributes related to SYCL device_info types (except for vendor_name, driver_version, device_name, and _max_work_item_sizes). All device_info values are converted to properties. 

Contains everything in #323 and should be merged after #323 is merged.