### PR TITLE
Feature/sycl context

### DIFF
--- a/dpctl-capi/include/dpctl_sycl_context_interface.h
+++ b/dpctl-capi/include/dpctl_sycl_context_interface.h
@@ -100,6 +100,17 @@ __dpctl_give DPCTLSyclContextRef
 DPCTLContext_Copy(__dpctl_keep const DPCTLSyclContextRef CRef);
 
 /*!
+ * @brief Returns a vector of devices associated with sycl::context referenced
+ * by DPCTLSyclContextRef object.
+ *
+ * @param    CRef           DPCTLSyclContexRef object to query.
+ * @return   A DPCTLDeviceVectorRef with devices associated with given CRef.
+ */
+DPCTL_API
+__dpctl_give DPCTLDeviceVectorRef
+DPCTLContext_GetDevices(__dpctl_keep const DPCTLSyclContextRef CRef);
+
+/*!
  * @brief Returns true if this SYCL context is a host context.
  *
  * @param    CtxRef        An opaque pointer to a sycl::context.

--- a/dpctl-capi/include/dpctl_sycl_context_interface.h
+++ b/dpctl-capi/include/dpctl_sycl_context_interface.h
@@ -100,6 +100,16 @@ __dpctl_give DPCTLSyclContextRef
 DPCTLContext_Copy(__dpctl_keep const DPCTLSyclContextRef CRef);
 
 /*!
+ * @brief Returns the number of devices associated with sycl::context referenced
+ * by DPCTLSyclContextRef object.
+ *
+ * @param    CRef           DPCTLSyclContexRef object to query.
+ * @return   A positive count on success or zero on error.
+ */
+DPCTL_API
+size_t DPCTLContext_DeviceCount(__dpctl_keep const DPCTLSyclContextRef CRef);
+
+/*!
  * @brief Returns a vector of devices associated with sycl::context referenced
  * by DPCTLSyclContextRef object.
  *

--- a/dpctl-capi/include/dpctl_vector.h
+++ b/dpctl-capi/include/dpctl_vector.h
@@ -42,7 +42,7 @@ DPCTL_C_EXTERN_C_BEGIN
                                                                                \
     DPCTL_API                                                                  \
     __dpctl_give DPCTL##EL##VectorRef DPCTL##EL##Vector_CreateFromArray(       \
-	size_t len, DPCTLSycl##EL##Ref *elems);	 	                       \
+        size_t len, DPCTLSycl##EL##Ref *elems);                                \
                                                                                \
     DPCTL_API                                                                  \
     void DPCTL##EL##Vector_Delete(__dpctl_take DPCTL##EL##VectorRef Ref);      \

--- a/dpctl-capi/include/dpctl_vector.h
+++ b/dpctl-capi/include/dpctl_vector.h
@@ -41,6 +41,10 @@ DPCTL_C_EXTERN_C_BEGIN
     __dpctl_give DPCTL##EL##VectorRef DPCTL##EL##Vector_Create();              \
                                                                                \
     DPCTL_API                                                                  \
+    __dpctl_give DPCTL##EL##VectorRef DPCTL##EL##Vector_CreateFromArray(       \
+	size_t len, DPCTLSycl##EL##Ref *elems);	 	                       \
+                                                                               \
+    DPCTL_API                                                                  \
     void DPCTL##EL##Vector_Delete(__dpctl_take DPCTL##EL##VectorRef Ref);      \
                                                                                \
     DPCTL_API                                                                  \

--- a/dpctl-capi/include/dpctl_vector.h
+++ b/dpctl-capi/include/dpctl_vector.h
@@ -42,7 +42,7 @@ DPCTL_C_EXTERN_C_BEGIN
                                                                                \
     DPCTL_API                                                                  \
     __dpctl_give DPCTL##EL##VectorRef DPCTL##EL##Vector_CreateFromArray(       \
-        size_t len, DPCTLSycl##EL##Ref *elems);                                \
+        size_t len, __dpctl_keep DPCTLSycl##EL##Ref *elems);                   \
                                                                                \
     DPCTL_API                                                                  \
     void DPCTL##EL##Vector_Delete(__dpctl_take DPCTL##EL##VectorRef Ref);      \

--- a/dpctl-capi/source/dpctl_sycl_context_interface.cpp
+++ b/dpctl-capi/source/dpctl_sycl_context_interface.cpp
@@ -144,6 +144,10 @@ DPCTLContext_GetDevices(__dpctl_keep const DPCTLSyclContextRef CRef)
         // \todo log error
         std::cerr << ba.what() << '\n';
         return nullptr;
+    } catch (const runtime_error &re) {
+        // \todo log error
+        std::cerr << re.what() << '\n';
+        return nullptr;
     }
 }
 

--- a/dpctl-capi/source/dpctl_sycl_context_interface.cpp
+++ b/dpctl-capi/source/dpctl_sycl_context_interface.cpp
@@ -116,6 +116,36 @@ DPCTLContext_Copy(__dpctl_keep const DPCTLSyclContextRef CRef)
     }
 }
 
+__dpctl_give DPCTLDeviceVectorRef
+DPCTLContext_GetDevices(__dpctl_keep const DPCTLSyclContextRef CRef)
+{
+    auto Context = unwrap(CRef);
+    if (!Context) {
+	std::cerr << "Can not retrieve devices from DPCTLSyclContextRef as input is a nullptr\n";
+	return nullptr;
+    }
+    vector_class<DPCTLSyclDeviceRef> *DevicesVectorPtr = nullptr;
+    try {
+        DevicesVectorPtr = new vector_class<DPCTLSyclDeviceRef>();
+    } catch (std::bad_alloc const &ba) {
+        // \todo log error
+        std::cerr << ba.what() << '\n';
+        return nullptr;
+    }
+    try {
+	auto Devices = Context->get_devices();
+	DevicesVectorPtr->reserve(Devices.size());
+	for(const auto &Dev : Devices) {
+	    DevicesVectorPtr->emplace_back(wrap(new device(Dev)));
+	}
+	return wrap(DevicesVectorPtr);
+    } catch (std::bad_alloc const &ba) {
+        // \todo log error
+        std::cerr << ba.what() << '\n';
+        return nullptr;
+    }
+}
+
 bool DPCTLContext_IsHost(__dpctl_keep const DPCTLSyclContextRef CtxRef)
 {
     auto Ctx = unwrap(CtxRef);

--- a/dpctl-capi/source/dpctl_sycl_context_interface.cpp
+++ b/dpctl-capi/source/dpctl_sycl_context_interface.cpp
@@ -159,14 +159,8 @@ size_t DPCTLContext_DeviceCount(__dpctl_keep const DPCTLSyclContextRef CRef)
                      "input is a nullptr\n";
         return 0;
     }
-    try {
-        auto Devices = Context->get_devices();
-        return Devices.size();
-    } catch (std::bad_alloc const &ba) {
-        // \todo log error
-        std::cerr << ba.what() << '\n';
-        return 0;
-    }
+    const auto Devices = Context->get_devices();
+    return Devices.size();
 }
 
 bool DPCTLContext_IsHost(__dpctl_keep const DPCTLSyclContextRef CtxRef)

--- a/dpctl-capi/source/dpctl_sycl_context_interface.cpp
+++ b/dpctl-capi/source/dpctl_sycl_context_interface.cpp
@@ -121,8 +121,9 @@ DPCTLContext_GetDevices(__dpctl_keep const DPCTLSyclContextRef CRef)
 {
     auto Context = unwrap(CRef);
     if (!Context) {
-	std::cerr << "Can not retrieve devices from DPCTLSyclContextRef as input is a nullptr\n";
-	return nullptr;
+        std::cerr << "Can not retrieve devices from DPCTLSyclContextRef as "
+                     "input is a nullptr\n";
+        return nullptr;
     }
     vector_class<DPCTLSyclDeviceRef> *DevicesVectorPtr = nullptr;
     try {
@@ -133,12 +134,12 @@ DPCTLContext_GetDevices(__dpctl_keep const DPCTLSyclContextRef CRef)
         return nullptr;
     }
     try {
-	auto Devices = Context->get_devices();
-	DevicesVectorPtr->reserve(Devices.size());
-	for(const auto &Dev : Devices) {
-	    DevicesVectorPtr->emplace_back(wrap(new device(Dev)));
-	}
-	return wrap(DevicesVectorPtr);
+        auto Devices = Context->get_devices();
+        DevicesVectorPtr->reserve(Devices.size());
+        for (const auto &Dev : Devices) {
+            DevicesVectorPtr->emplace_back(wrap(new device(Dev)));
+        }
+        return wrap(DevicesVectorPtr);
     } catch (std::bad_alloc const &ba) {
         // \todo log error
         std::cerr << ba.what() << '\n';

--- a/dpctl-capi/source/dpctl_sycl_context_interface.cpp
+++ b/dpctl-capi/source/dpctl_sycl_context_interface.cpp
@@ -147,6 +147,24 @@ DPCTLContext_GetDevices(__dpctl_keep const DPCTLSyclContextRef CRef)
     }
 }
 
+size_t DPCTLContext_DeviceCount(__dpctl_keep const DPCTLSyclContextRef CRef)
+{
+    auto Context = unwrap(CRef);
+    if (!Context) {
+        std::cerr << "Can not retrieve devices from DPCTLSyclContextRef as "
+                     "input is a nullptr\n";
+        return 0;
+    }
+    try {
+        auto Devices = Context->get_devices();
+        return Devices.size();
+    } catch (std::bad_alloc const &ba) {
+        // \todo log error
+        std::cerr << ba.what() << '\n';
+        return 0;
+    }
+}
+
 bool DPCTLContext_IsHost(__dpctl_keep const DPCTLSyclContextRef CtxRef)
 {
     auto Ctx = unwrap(CtxRef);

--- a/dpctl-capi/source/dpctl_vector_templ.cpp
+++ b/dpctl-capi/source/dpctl_vector_templ.cpp
@@ -49,7 +49,7 @@ __dpctl_give VECTOR(EL) FN(EL, Create)()
 
 /*!
  * @brief Creates a new std::vector of the opaque SYCL pointer types from given
- * C array.
+ * C array with deep copy.
  *
  * @return   A new dynamically allocated std::vector of opaque pointer types.
  */
@@ -57,8 +57,12 @@ __dpctl_give VECTOR(EL)
     FN(EL, CreateFromArray)(size_t n, __dpctl_keep SYCLREF(EL) * elems)
 {
     try {
-        auto Vec = new vector_class<SYCLREF(EL)>(n);
-        Vec->assign(elems, elems + n);
+        auto Vec = new vector_class<SYCLREF(EL)>();
+        for (size_t i = 0; i < n; ++i) {
+            auto Ref = unwrap(elems[i]);
+            Vec->emplace_back(
+                wrap(new std::remove_pointer<decltype(Ref)>::type(*Ref)));
+        }
         return wrap(Vec);
     } catch (std::bad_alloc const &ba) {
         return nullptr;

--- a/dpctl-capi/source/dpctl_vector_templ.cpp
+++ b/dpctl-capi/source/dpctl_vector_templ.cpp
@@ -48,15 +48,17 @@ __dpctl_give VECTOR(EL) FN(EL, Create)()
 }
 
 /*!
- * @brief Creates a new std::vector of the opaque SYCL pointer types from given C array.
+ * @brief Creates a new std::vector of the opaque SYCL pointer types from given
+ * C array.
  *
  * @return   A new dynamically allocated std::vector of opaque pointer types.
  */
-__dpctl_give VECTOR(EL) FN(EL, CreateFromArray)(size_t n, __dpctl_keep SYCLREF(EL) *elems)
+__dpctl_give VECTOR(EL)
+    FN(EL, CreateFromArray)(size_t n, __dpctl_keep SYCLREF(EL) * elems)
 {
     try {
         auto Vec = new vector_class<SYCLREF(EL)>(n);
-	Vec->assign(elems, elems + n);
+        Vec->assign(elems, elems + n);
         return wrap(Vec);
     } catch (std::bad_alloc const &ba) {
         return nullptr;

--- a/dpctl-capi/source/dpctl_vector_templ.cpp
+++ b/dpctl-capi/source/dpctl_vector_templ.cpp
@@ -48,6 +48,22 @@ __dpctl_give VECTOR(EL) FN(EL, Create)()
 }
 
 /*!
+ * @brief Creates a new std::vector of the opaque SYCL pointer types from given C array.
+ *
+ * @return   A new dynamically allocated std::vector of opaque pointer types.
+ */
+__dpctl_give VECTOR(EL) FN(EL, CreateFromArray)(size_t n, __dpctl_keep SYCLREF(EL) *elems)
+{
+    try {
+        auto Vec = new vector_class<SYCLREF(EL)>(n);
+	Vec->assign(elems, elems + n);
+        return wrap(Vec);
+    } catch (std::bad_alloc const &ba) {
+        return nullptr;
+    }
+}
+
+/*!
  * @brief Frees all the elements of the passed in std::vector and then frees the
  * std::vector pointer.
  *

--- a/dpctl-capi/tests/test_sycl_context_interface.cpp
+++ b/dpctl-capi/tests/test_sycl_context_interface.cpp
@@ -113,12 +113,13 @@ TEST_P(TestDPCTLContextInterface, Chk_CreateWithDevices)
     EXPECT_NO_FATAL_FAILURE(DPCTLContext_Delete(CRef));
 }
 
-TEST_P(TestDPCTLContextInterface, Chk_CreateWithDevices2)
+TEST_P(TestDPCTLContextInterface, Chk_CreateWithDevices_GetDevices)
 {
     size_t nCUs = 0;
     DPCTLSyclContextRef CRef = nullptr;
     DPCTLSyclDeviceRef DRef = nullptr;
     DPCTLDeviceVectorRef DVRef = nullptr;
+    DPCTLDeviceVectorRef Res_DVRef = nullptr;
     EXPECT_NO_FATAL_FAILURE(DRef = DPCTLDevice_CreateFromSelector(DSRef));
     if (!DRef)
         GTEST_SKIP_("Device not found");
@@ -141,6 +142,9 @@ TEST_P(TestDPCTLContextInterface, Chk_CreateWithDevices2)
             EXPECT_NO_FATAL_FAILURE(
                 CRef = DPCTLContext_CreateFromDevices(DVRef, nullptr, 0));
             ASSERT_TRUE(CRef);
+	    EXPECT_NO_FATAL_FAILURE(
+		Res_DVRef = DPCTLContext_GetDevices(CRef));
+	    ASSERT_TRUE(DPCTLDeviceVector_Size(Res_DVRef) == len);
 	    delete[] ar;
         } catch (feature_not_supported const &fnse) {
             GTEST_SKIP_("Skipping creating context for sub-devices");
@@ -149,6 +153,26 @@ TEST_P(TestDPCTLContextInterface, Chk_CreateWithDevices2)
     EXPECT_NO_FATAL_FAILURE(DPCTLDevice_Delete(DRef));
     EXPECT_NO_FATAL_FAILURE(DPCTLDeviceVector_Delete(DVRef));
     EXPECT_NO_FATAL_FAILURE(DPCTLContext_Delete(CRef));
+    EXPECT_NO_FATAL_FAILURE(DPCTLDeviceVector_Delete(Res_DVRef));
+}
+
+TEST_P(TestDPCTLContextInterface, Chk_GetDevices)
+{
+    DPCTLSyclContextRef CRef = nullptr;
+    DPCTLSyclDeviceRef DRef = nullptr;
+    DPCTLDeviceVectorRef DVRef = nullptr;
+    EXPECT_NO_FATAL_FAILURE(DRef = DPCTLDevice_CreateFromSelector(DSRef));
+    if (!DRef)
+        GTEST_SKIP_("Device not found");
+    EXPECT_NO_FATAL_FAILURE(CRef = DPCTLContext_Create(DRef, nullptr, 0));
+    ASSERT_TRUE(CRef);
+    EXPECT_NO_FATAL_FAILURE(
+	DVRef = DPCTLContext_GetDevices(CRef));
+    ASSERT_TRUE(DVRef);
+    EXPECT_TRUE(DPCTLDeviceVector_Size(DVRef) == 1);
+    EXPECT_NO_FATAL_FAILURE(DPCTLDevice_Delete(DRef));
+    EXPECT_NO_FATAL_FAILURE(DPCTLContext_Delete(CRef));
+    EXPECT_NO_FATAL_FAILURE(DPCTLDeviceVector_Delete(DVRef));
 }
 
 TEST_P(TestDPCTLContextInterface, Chk_AreEq)

--- a/dpctl-capi/tests/test_sycl_context_interface.cpp
+++ b/dpctl-capi/tests/test_sycl_context_interface.cpp
@@ -133,19 +133,19 @@ TEST_P(TestDPCTLContextInterface, Chk_CreateWithDevices_GetDevices)
         try {
             auto subDevices = D->create_sub_devices<
                 info::partition_property::partition_equally>(nCUs / 2);
-	    const size_t len = subDevices.size();
-	    auto ar = new DPCTLSyclDeviceRef[len];
-	    for(size_t i=0; i < len; ++i) {
-		ar[i] = wrap(new device(subDevices.at(i)));
-	    }
-            EXPECT_NO_FATAL_FAILURE(DVRef = DPCTLDeviceVector_CreateFromArray(len, ar));
+            const size_t len = subDevices.size();
+            auto ar = new DPCTLSyclDeviceRef[len];
+            for (size_t i = 0; i < len; ++i) {
+                ar[i] = wrap(new device(subDevices.at(i)));
+            }
+            EXPECT_NO_FATAL_FAILURE(
+                DVRef = DPCTLDeviceVector_CreateFromArray(len, ar));
             EXPECT_NO_FATAL_FAILURE(
                 CRef = DPCTLContext_CreateFromDevices(DVRef, nullptr, 0));
             ASSERT_TRUE(CRef);
-	    EXPECT_NO_FATAL_FAILURE(
-		Res_DVRef = DPCTLContext_GetDevices(CRef));
-	    ASSERT_TRUE(DPCTLDeviceVector_Size(Res_DVRef) == len);
-	    delete[] ar;
+            EXPECT_NO_FATAL_FAILURE(Res_DVRef = DPCTLContext_GetDevices(CRef));
+            ASSERT_TRUE(DPCTLDeviceVector_Size(Res_DVRef) == len);
+            delete[] ar;
         } catch (feature_not_supported const &fnse) {
             GTEST_SKIP_("Skipping creating context for sub-devices");
         }
@@ -166,8 +166,7 @@ TEST_P(TestDPCTLContextInterface, Chk_GetDevices)
         GTEST_SKIP_("Device not found");
     EXPECT_NO_FATAL_FAILURE(CRef = DPCTLContext_Create(DRef, nullptr, 0));
     ASSERT_TRUE(CRef);
-    EXPECT_NO_FATAL_FAILURE(
-	DVRef = DPCTLContext_GetDevices(CRef));
+    EXPECT_NO_FATAL_FAILURE(DVRef = DPCTLContext_GetDevices(CRef));
     ASSERT_TRUE(DVRef);
     EXPECT_TRUE(DPCTLDeviceVector_Size(DVRef) == 1);
     EXPECT_NO_FATAL_FAILURE(DPCTLDevice_Delete(DRef));

--- a/dpctl-capi/tests/test_sycl_context_interface.cpp
+++ b/dpctl-capi/tests/test_sycl_context_interface.cpp
@@ -143,6 +143,7 @@ TEST_P(TestDPCTLContextInterface, Chk_CreateWithDevices_GetDevices)
             EXPECT_NO_FATAL_FAILURE(
                 CRef = DPCTLContext_CreateFromDevices(DVRef, nullptr, 0));
             ASSERT_TRUE(CRef);
+            ASSERT_TRUE(DPCTLContext_DeviceCount(CRef) == len);
             EXPECT_NO_FATAL_FAILURE(Res_DVRef = DPCTLContext_GetDevices(CRef));
             ASSERT_TRUE(DPCTLDeviceVector_Size(Res_DVRef) == len);
             delete[] ar;

--- a/dpctl-capi/tests/test_sycl_context_interface.cpp
+++ b/dpctl-capi/tests/test_sycl_context_interface.cpp
@@ -126,7 +126,7 @@ TEST_P(TestDPCTLContextInterface, Chk_CreateWithDevices_GetDevices)
             const size_t len = subDevices.size();
             auto ar = new DPCTLSyclDeviceRef[len];
             for (size_t i = 0; i < len; ++i) {
-                ar[i] = wrap(new device(subDevices.at(i)));
+                ar[i] = wrap(&subDevices.at(i));
             }
             EXPECT_NO_FATAL_FAILURE(
                 DVRef = DPCTLDeviceVector_CreateFromArray(len, ar));

--- a/dpctl/_backend.pxd
+++ b/dpctl/_backend.pxd
@@ -244,6 +244,8 @@ cdef extern from "dpctl_sycl_context_interface.h":
         int properties)
     cdef DPCTLSyclContextRef DPCTLContext_Copy(
         const DPCTLSyclContextRef CRef)
+    cdef DPCTLDeviceVectorRef DPCTLContext_GetDevices(
+        const DPCTLSyclContextRef CRef)
     cdef bool DPCTLContext_AreEq(const DPCTLSyclContextRef CtxRef1,
                                  const DPCTLSyclContextRef CtxRef2)
     cdef DPCTLSyclBackendType DPCTLContext_GetBackend(

--- a/dpctl/_backend.pxd
+++ b/dpctl/_backend.pxd
@@ -246,6 +246,7 @@ cdef extern from "dpctl_sycl_context_interface.h":
         const DPCTLSyclContextRef CRef)
     cdef DPCTLDeviceVectorRef DPCTLContext_GetDevices(
         const DPCTLSyclContextRef CRef)
+    cdef size_t DPCTLContext_DeviceCount(const DPCTLSyclContextRef CRef)
     cdef bool DPCTLContext_AreEq(const DPCTLSyclContextRef CtxRef1,
                                  const DPCTLSyclContextRef CtxRef2)
     cdef DPCTLSyclBackendType DPCTLContext_GetBackend(

--- a/dpctl/_backend.pxd
+++ b/dpctl/_backend.pxd
@@ -168,6 +168,9 @@ cdef extern from "dpctl_sycl_device_interface.h":
 cdef extern from "dpctl_sycl_device_manager.h":
     cdef struct DPCTLDeviceVector
     ctypedef DPCTLDeviceVector *DPCTLDeviceVectorRef
+    cdef DPCTLDeviceVectorRef DPCTLDeviceVector_CreateFromArray(
+        size_t nelems,
+        DPCTLSyclDeviceRef *elems)
     cdef void DPCTLDeviceVector_Delete(DPCTLDeviceVectorRef DVRef)
     cdef void DPCTLDeviceVector_Clear(DPCTLDeviceVectorRef DVRef)
     cdef size_t DPCTLDeviceVector_Size(DPCTLDeviceVectorRef DVRef)
@@ -231,6 +234,16 @@ cdef extern from "dpctl_sycl_platform_interface.h":
 
 
 cdef extern from "dpctl_sycl_context_interface.h":
+    cdef DPCTLSyclContextRef DPCTLContext_Create(
+        const DPCTLSyclDeviceRef DRef,
+        error_handler_callback *error_handler,
+        int properties)
+    cdef DPCTLSyclContextRef DPCTLContext_CreateFromDevices(
+        const DPCTLDeviceVectorRef DVRef,
+        error_handler_callback *error_handler,
+        int properties)
+    cdef DPCTLSyclContextRef DPCTLContext_Copy(
+        const DPCTLSyclContextRef CRef)
     cdef bool DPCTLContext_AreEq(const DPCTLSyclContextRef CtxRef1,
                                  const DPCTLSyclContextRef CtxRef2)
     cdef DPCTLSyclBackendType DPCTLContext_GetBackend(

--- a/dpctl/_sycl_context.pxd
+++ b/dpctl/_sycl_context.pxd
@@ -21,15 +21,25 @@
 """
 
 from ._backend cimport DPCTLSyclContextRef
+from ._sycl_device cimport SyclDevice
 from libcpp cimport bool
 
-
-cdef class SyclContext:
-    ''' Wrapper class for a Sycl Context
-    '''
+cdef class _SyclContext:
+    """ Data owner for SyclContext
+    """
     cdef DPCTLSyclContextRef _ctxt_ref
 
+
+cdef class SyclContext(_SyclContext):
+    ''' Wrapper class for a Sycl Context
+    '''
+
     @staticmethod
-    cdef SyclContext _create (DPCTLSyclContextRef ctxt)
+    cdef SyclContext _create (DPCTLSyclContextRef CRef)
+    @staticmethod
+    cdef void _init_helper(_SyclContext self, DPCTLSyclContextRef CRef)
+    cdef int _init_from__SyclContext(self, _SyclContext other)
+    cdef int _init_from_one_device(self, SyclDevice device, int props)
+    cdef int _init_from_devices(self, object devices, int props)
     cpdef bool equals (self, SyclContext ctxt)
     cdef DPCTLSyclContextRef get_context_ref (self)

--- a/dpctl/_sycl_context.pyx
+++ b/dpctl/_sycl_context.pyx
@@ -104,7 +104,7 @@ cdef class SyclContext(_SyclContext):
         cdef int i = 0
         cdef int j
         cdef size_t num_bytes
-        cdef DPCTLDeviceVectorRef DVRef
+        cdef DPCTLDeviceVectorRef DVRef = NULL
         cdef error_handler_callback * eh_callback = \
             <error_handler_callback *>&default_async_error_handler
         cdef DPCTLSyclContextRef CRef = NULL

--- a/dpctl/_sycl_context.pyx
+++ b/dpctl/_sycl_context.pyx
@@ -207,10 +207,11 @@ cdef class SyclContext(_SyclContext):
             devices.append(SyclDevice._create(DRef))
         DPCTLDeviceVector_Delete(DVRef)
         return devices
-
+    
+    @property
     def device_count (self):
         """
-        Returns the number of sycl devices associated with SyclContext instance.
+        The number of sycl devices associated with SyclContext instance.
         """
         cdef size_t num_devs = DPCTLContext_DeviceCount(self.get_context_ref())
         if num_devs:
@@ -224,7 +225,7 @@ cdef class SyclContext(_SyclContext):
         return "SyclContext"
 
     def __repr__(self):
-        cdef size_t n = self.device_count()
+        cdef size_t n = self.device_count
         if n == 1:
             return ("<dpctl." + self.__name__ + " at {}>".format(hex(id(self))))
         else:

--- a/dpctl/_sycl_context.pyx
+++ b/dpctl/_sycl_context.pyx
@@ -24,9 +24,22 @@ from __future__ import print_function
 import logging
 from ._backend cimport (
     DPCTLSyclContextRef,
+    DPCTLSyclDeviceRef,
+    DPCTLContext_Create,
+    DPCTLContext_CreateFromDevices,
+    DPCTLContext_Copy,
     DPCTLContext_Delete,
     DPCTLContext_AreEq,
+    DPCTLDevice_Delete,
+    DPCTLDevice_Copy,
+    DPCTLDeviceVectorRef,
+    DPCTLDeviceVector_CreateFromArray,
+    DPCTLDeviceVector_Delete,
+    error_handler_callback
 )
+from ._sycl_queue cimport default_async_error_handler
+from ._sycl_device cimport SyclDevice
+from cpython.mem cimport PyMem_Malloc, PyMem_Free
 
 __all__ = [
     "SyclContext",
@@ -34,18 +47,105 @@ __all__ = [
 
 _logger = logging.getLogger(__name__)
 
+cdef class _SyclContext:
+    """ Data owner for SyclContext
+    """
 
-cdef class SyclContext:
+    def __dealloc__(self):
+        DPCTLContext_Delete(self._ctxt_ref)
+
+
+cdef class SyclContext(_SyclContext):
     """ Python wrapper class for cl::sycl::context.
     """
+    
+    @staticmethod
+    cdef void _init_helper(_SyclContext context, DPCTLSyclContextRef CRef):
+         context._ctxt_ref = CRef
+    
     @staticmethod
     cdef SyclContext _create (DPCTLSyclContextRef ctxt):
-        cdef SyclContext ret = SyclContext.__new__(SyclContext)
-        ret._ctxt_ref = ctxt
-        return ret
+        cdef _SyclContext ret = <_SyclContext>_SyclContext.__new__(_SyclContext)
+        SyclContext._init_helper(ret, ctxt)
+        return SyclContext(ret)
 
-    def __dealloc__ (self):
-        DPCTLContext_Delete(self._ctxt_ref)
+    cdef int _init_from__SyclContext(self, _SyclContext other):
+        self._ctxt_ref = DPCTLContext_Copy(other._ctxt_ref)
+        if (self._ctxt_ref is NULL):
+            return -1
+        return 0
+
+    cdef int _init_from_one_device(self, SyclDevice device, int props):
+        cdef DPCTLSyclDeviceRef DRef = device.get_device_ref()
+        cdef error_handler_callback * eh_callback = \
+            <error_handler_callback *>&default_async_error_handler
+        cdef DPCTLSyclContextRef CRef = DPCTLContext_Create(DRef, eh_callback, props)
+        if (CRef is NULL):
+            return -1
+        SyclContext._init_helper(<_SyclContext> self, CRef)
+        return 0
+
+    cdef int _init_from_devices(self, object devices, int props):
+        cdef int num_devices = len(devices)
+        cdef int i = 0
+        cdef int j
+        cdef size_t num_bytes
+        cdef DPCTLDeviceVectorRef DVRef
+        cdef error_handler_callback * eh_callback = \
+            <error_handler_callback *>&default_async_error_handler
+        cdef DPCTLSyclContextRef CRef = NULL
+        cdef DPCTLSyclDeviceRef *elems
+
+        if num_devices > 0:
+            num_bytes = num_devices * sizeof(DPCTLSyclDeviceRef *)
+            elems = <DPCTLSyclDeviceRef *>PyMem_Malloc(num_bytes)
+            if (elems is NULL):
+                return -3
+            for dev in devices:
+                if not isinstance(dev, SyclDevice):
+                    elems[i] = NULL
+                else:
+                    elems[i] = DPCTLDevice_Copy((<SyclDevice>dev).get_device_ref())
+                if (elems[i] is NULL):
+                    for j in range(0, i):
+                        DPCTLDevice_Delete(elems[j])
+                    PyMem_Free(elems)
+                    return -4
+                i = i + 1
+            DVRef = DPCTLDeviceVector_CreateFromArray(num_devices, elems)
+            if (DVRef is NULL):
+                for j in range(num_devices):
+                    DPCTLDevice_Delete(elems[j])
+                PyMem_Free(elems)
+                return -5
+            PyMem_Free(elems)
+        else:
+            return -2
+        DPCTLContext_CreateFromDevices(DVRef, eh_callback, props)
+        DPCTLDeviceVector_Delete(DVRef)
+        if (CRef is NULL):
+            return -1
+        SyclContext._init_helper(<_SyclContext> self, CRef)
+        return 0
+
+    def __cinit__(self, arg=None):
+        """ SyclContext() - create a context for a default device
+            SyclContext(filter_selector_string) - create a context for specified device
+            SyclContext(SyclDevice_instance) - create a context for the given device
+            SyclContext((dev1, dev2, ...)) - create a context for given set of devices
+        """
+        cdef int ret = 0
+        if isinstance(arg, _SyclContext):
+            ret = self._init_from__SyclContext(<_SyclContext> arg)
+        elif isinstance(arg, SyclDevice):
+            ret = self._init_from_one_device(<SyclDevice> arg, 0)
+        elif isinstance(arg, (list, tuple)) and all([isinstance(argi, SyclDevice) for argi in arg]):
+            ret = self._init_from_devices(arg, 0)
+        else:
+            dev = SyclDevice(arg)
+            ret = self._init_from_one_device(<SyclDevice> dev, 0)
+        if (ret < 0):
+            raise ValueError(ret)
 
     cpdef bool equals (self, SyclContext ctxt):
         """ Returns true if the SyclContext argument has the same _context_ref

--- a/dpctl/_sycl_context.pyx
+++ b/dpctl/_sycl_context.pyx
@@ -159,7 +159,17 @@ cdef class SyclContext(_SyclContext):
             dev = SyclDevice(arg)
             ret = self._init_from_one_device(<SyclDevice> dev, 0)
         if (ret < 0):
-            raise ValueError(ret)
+            if (ret == -1):
+                raise ValueError("Context failed to be created.")
+            if (ret == -2):
+                raise TypeError("List of devices to create context from must be non-empty.")
+            if (ret == -3):
+                raise MemoryError("Could not allocate necessary temporary memory.")
+            if (ret == -4):
+                raise ValueError("Internal Error: Could not create a copy of a sycl device.")
+            if (ret == -5):
+                raise ValueError("Internal Error: Creation of DeviceVector failed.")
+            raise ValueError("Unrecognized error code ({}) encountered.".format(ret))
 
     cpdef bool equals (self, SyclContext ctxt):
         """ Returns true if the SyclContext argument has the same _context_ref

--- a/dpctl/_sycl_context.pyx
+++ b/dpctl/_sycl_context.pyx
@@ -88,8 +88,8 @@ cdef class SyclContext(_SyclContext):
     cdef int _init_from_one_device(self, SyclDevice device, int props):
         cdef DPCTLSyclDeviceRef DRef = device.get_device_ref()
         cdef DPCTLSyclContextRef CRef = NULL
-        cdef error_handler_callback * eh_callback = \
-            <error_handler_callback *>&default_async_error_handler
+        cdef error_handler_callback * eh_callback = (
+            <error_handler_callback *>&default_async_error_handler)
         # look up cached contexts for root devices first
         CRef = DPCTLDeviceMgr_GetCachedContext(DRef)
         if (CRef is NULL):
@@ -103,11 +103,11 @@ cdef class SyclContext(_SyclContext):
     cdef int _init_from_devices(self, object devices, int props):
         cdef int num_devices = len(devices)
         cdef int i = 0
-        cdef int j
+        cdef int j = 0
         cdef size_t num_bytes
         cdef DPCTLDeviceVectorRef DVRef = NULL
-        cdef error_handler_callback * eh_callback = \
-            <error_handler_callback *>&default_async_error_handler
+        cdef error_handler_callback * eh_callback = (
+            <error_handler_callback *>&default_async_error_handler)
         cdef DPCTLSyclContextRef CRef = NULL
         cdef DPCTLSyclDeviceRef *elems
 
@@ -120,17 +120,14 @@ cdef class SyclContext(_SyclContext):
                 if not isinstance(dev, SyclDevice):
                     elems[i] = NULL
                 else:
-                    elems[i] = DPCTLDevice_Copy((<SyclDevice>dev).get_device_ref())
+                    elems[i] = (<SyclDevice>dev).get_device_ref()
                 if (elems[i] is NULL):
-                    for j in range(0, i):
-                        DPCTLDevice_Delete(elems[j])
                     PyMem_Free(elems)
                     return -4
                 i = i + 1
+            # CreateFromArray will make copies of devices referenced by elems
             DVRef = DPCTLDeviceVector_CreateFromArray(num_devices, elems)
             if (DVRef is NULL):
-                for j in range(num_devices):
-                    DPCTLDevice_Delete(elems[j])
                 PyMem_Free(elems)
                 return -5
             PyMem_Free(elems)

--- a/dpctl/_sycl_context.pyx
+++ b/dpctl/_sycl_context.pyx
@@ -27,6 +27,7 @@ from ._backend cimport (
     DPCTLSyclDeviceRef,
     DPCTLContext_Create,
     DPCTLContext_CreateFromDevices,
+    DPCTLContext_DeviceCount,
     DPCTLContext_GetDevices,
     DPCTLContext_Copy,
     DPCTLContext_Delete,
@@ -191,15 +192,12 @@ cdef class SyclContext(_SyclContext):
         """
         Returns the number of sycl devices associated with SyclContext instance.
         """
-        cdef DPCTLDeviceVectorRef DVRef = DPCTLContext_GetDevices(self.get_context_ref())
-        cdef size_t num_devs
-        cdef size_t i
-        cdef DPCTLSyclDeviceRef DRef
-        if (DVRef is NULL):
-            raise ValueError("Internal error: NULL device vector encountered")
-        num_devs = DPCTLDeviceVector_Size(DVRef)
-        DPCTLDeviceVector_Delete(DVRef)
-        return num_devs
+        cdef size_t num_devs = DPCTLContext_DeviceCount(self.get_context_ref())
+        if num_devs:
+            return num_devs
+        else:
+            raise ValueError("An error was encountered quering the number of devices "
+                             "associated with this context")
 
     @property
     def __name__(self):

--- a/dpctl/_sycl_context.pyx
+++ b/dpctl/_sycl_context.pyx
@@ -27,6 +27,7 @@ from ._backend cimport (
     DPCTLSyclDeviceRef,
     DPCTLContext_Create,
     DPCTLContext_CreateFromDevices,
+    DPCTLContext_GetDevices,
     DPCTLContext_Copy,
     DPCTLContext_Delete,
     DPCTLContext_AreEq,
@@ -34,6 +35,8 @@ from ._backend cimport (
     DPCTLDevice_Copy,
     DPCTLDeviceVectorRef,
     DPCTLDeviceVector_CreateFromArray,
+    DPCTLDeviceVector_GetAt,
+    DPCTLDeviceVector_Size,
     DPCTLDeviceVector_Delete,
     error_handler_callback
 )
@@ -165,3 +168,17 @@ cdef class SyclContext(_SyclContext):
             SyclContext cast to a size_t.
         """
         return int(<size_t>self._ctx_ref)
+
+    def get_devices (self):
+        cdef DPCTLDeviceVectorRef DVRef = DPCTLContext_GetDevices(self.get_context_ref())
+        cdef size_t num_devs
+        cdef size_t i
+        cdef DPCTLSyclDeviceRef DRef
+        if (DVRef is NULL):
+            raise ValueError("Internal error: NULL device vector encountered")
+        num_devs = DPCTLDeviceVector_Size(DVRef)
+        devices = []
+        for i in range(num_devs):
+            DRef = DPCTLDeviceVector_GetAt(DVRef, i)
+            devices.append(SyclDevice._create(DRef))
+        return devices

--- a/dpctl/_sycl_platform.pyx
+++ b/dpctl/_sycl_platform.pyx
@@ -75,6 +75,12 @@ cdef class SyclPlatform(_SyclPlatform):
 
     @staticmethod
     cdef SyclPlatform _create(DPCTLSyclPlatformRef pref):
+        """
+        This function calls DPCTLPlatform_Delete(pref).
+
+        The user of this function must pass a copy to keep the
+        pref argument alive.
+        """
         cdef _SyclPlatform p = _SyclPlatform.__new__(_SyclPlatform)
         # Initialize the attributes of the SyclPlatform object
         SyclPlatform._init_helper(<_SyclPlatform>p, pref)
@@ -92,13 +98,12 @@ cdef class SyclPlatform(_SyclPlatform):
         cdef DPCTLSyclDeviceSelectorRef DSRef = NULL
         DSRef = DPCTLFilterSelector_Create(string)
         ret = self._init_from_selector(DSRef)
-        # Free up the device selector
-        DPCTLDeviceSelector_Delete(DSRef)
         return ret
 
     cdef int _init_from_selector(self, DPCTLSyclDeviceSelectorRef DSRef):
         # Initialize the SyclPlatform from a DPCTLSyclDeviceSelectorRef
         cdef DPCTLSyclPlatformRef PRef = DPCTLPlatform_CreateFromSelector(DSRef)
+        DPCTLDeviceSelector_Delete(DSRef)
         if PRef is NULL:
             return -1
         else:

--- a/dpctl/_sycl_queue.pyx
+++ b/dpctl/_sycl_queue.pyx
@@ -292,7 +292,7 @@ cdef class SyclQueue:
         Creates device from device selector, then calls helper function above.
 
         Returns:
-            0 : normal execution
+             0 : normal execution
             -1 : filter selector could not be created (malformed?)
             -2 : Device could not be created from filter selector
             -3 : Context creation/look-up failed
@@ -363,12 +363,18 @@ cdef class SyclQueue:
 
     @staticmethod
     cdef SyclQueue _create(DPCTLSyclQueueRef qref):
+        """
+        This function calls DPCTLQueue_Delete(qref).
+        The user of this function must pass a copy to keep the
+        qref argument alive.
+        """
         if qref is NULL:
             raise SyclQueueCreationError("Queue creation failed.")
         cdef _SyclQueue ret = _SyclQueue.__new__(_SyclQueue)
         ret._context = SyclContext._create(DPCTLQueue_GetContext(qref))
         ret._device = SyclDevice._create(DPCTLQueue_GetDevice(qref))
         ret._queue_ref = qref
+        # ret is a temporary, and will call DPCTLQueue_Delete(qref)
         return SyclQueue(ret)
 
     @staticmethod

--- a/dpctl/_sycl_queue.pyx
+++ b/dpctl/_sycl_queue.pyx
@@ -25,6 +25,7 @@ from ._backend cimport (
     _arg_data_type,
     _backend_type,
     _queue_property_type,
+    DPCTLContext_Create,
     DPCTLContext_Delete,
     DPCTLDefaultSelector_Create,
     DPCTLDevice_CreateFromSelector,
@@ -262,8 +263,12 @@ cdef class SyclQueue:
 
         CRef = DPCTLDeviceMgr_GetCachedContext(DRef)
         if (CRef is NULL):
-            DPCTLDevice_Delete(DRef)
-            return -3
+            # look-up failed (was not a root device?)
+            # create a new context
+            CRef = DPCTLContext_Create(DRef, NULL, 0)
+            if (CRef is NULL):
+                DPCTLDevice_Delete(DRef)
+                return -3
         QRef = DPCTLQueue_Create(
             CRef,
             DRef,

--- a/dpctl/tests/__init__.py
+++ b/dpctl/tests/__init__.py
@@ -19,6 +19,7 @@
 
 from .test_dparray import *
 from .test_sycl_device import *
+from .test_sycl_context import *
 from .test_sycl_kernel_submit import *
 from .test_sycl_platform import *
 from .test_sycl_program import *

--- a/dpctl/tests/test_sycl_context.py
+++ b/dpctl/tests/test_sycl_context.py
@@ -372,7 +372,6 @@ def test_context_can_be_used_in_queue(valid_filter):
         q = dpctl.SyclQueue(ctx, d)
 
 
-@pytest.mark.xfail(reason="DPC++ bug in device equality")
 def test_context_can_be_used_in_queue2(valid_filter):
     d = dpctl.SyclDevice(valid_filter)
     if d.default_selector_score < 0:

--- a/dpctl/tests/test_sycl_context.py
+++ b/dpctl/tests/test_sycl_context.py
@@ -1,0 +1,360 @@
+#                      Data Parallel Control (dpctl)
+#
+# Copyright 2020-2021 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+""" Defines unit test cases for the SyclQueue class.
+"""
+
+import dpctl
+import pytest
+
+list_of_standard_selectors = [
+    dpctl.select_accelerator_device,
+    dpctl.select_cpu_device,
+    dpctl.select_default_device,
+    dpctl.select_gpu_device,
+    dpctl.select_host_device,
+]
+
+list_of_valid_filter_selectors = [
+    "opencl",
+    "opencl:gpu",
+    "opencl:cpu",
+    "opencl:gpu:0",
+    "gpu",
+    "cpu",
+    "level_zero",
+    "level_zero:gpu",
+    "opencl:cpu:0",
+    "level_zero:gpu:0",
+    "gpu:0",
+    "gpu:1",
+    "1",
+]
+
+list_of_invalid_filter_selectors = [
+    "-1",
+    "opencl:gpu:-1",
+    "level_zero:cpu:0",
+    "abc",
+]
+
+# Unit test cases that will be run for every device
+def check_get_max_compute_units(device):
+    max_compute_units = device.max_compute_units
+    assert max_compute_units > 0
+
+
+def check_get_max_work_item_dims(device):
+    max_work_item_dims = device.max_work_item_dims
+    assert max_work_item_dims > 0
+
+
+def check_get_max_work_item_sizes(device):
+    max_work_item_sizes = device.max_work_item_sizes
+    for size in max_work_item_sizes:
+        assert size is not None
+
+
+def check_get_max_work_group_size(device):
+    max_work_group_size = device.max_work_group_size
+    # Special case for FPGA simulator
+    if device.is_accelerator:
+        assert max_work_group_size >= 0
+    else:
+        assert max_work_group_size > 0
+
+
+def check_get_max_num_sub_groups(device):
+    max_num_sub_groups = device.max_num_sub_groups
+    # Special case for FPGA simulator
+    if device.is_accelerator or device.is_host:
+        assert max_num_sub_groups >= 0
+    else:
+        assert max_num_sub_groups > 0
+
+
+def check_has_aspect_host(device):
+    try:
+        device.has_aspect_host
+    except Exception:
+        pytest.fail("has_aspect_host call failed")
+
+
+def check_has_aspect_cpu(device):
+    try:
+        device.has_aspect_cpu
+    except Exception:
+        pytest.fail("has_aspect_cpu call failed")
+
+
+def check_has_aspect_gpu(device):
+    try:
+        device.has_aspect_gpu
+    except Exception:
+        pytest.fail("has_aspect_gpu call failed")
+
+
+def check_has_aspect_accelerator(device):
+    try:
+        device.has_aspect_accelerator
+    except Exception:
+        pytest.fail("has_aspect_accelerator call failed")
+
+
+def check_has_aspect_custom(device):
+    try:
+        device.has_aspect_custom
+    except Exception:
+        pytest.fail("has_aspect_custom call failed")
+
+
+def check_has_aspect_fp16(device):
+    try:
+        device.has_aspect_fp16
+    except Exception:
+        pytest.fail("has_aspect_fp16 call failed")
+
+
+def check_has_aspect_fp64(device):
+    try:
+        device.has_aspect_fp64
+    except Exception:
+        pytest.fail("has_aspect_fp64 call failed")
+
+
+def check_has_aspect_int64_base_atomics(device):
+    try:
+        device.has_aspect_int64_base_atomics
+    except Exception:
+        pytest.fail("has_aspect_int64_base_atomics call failed")
+
+
+def check_has_aspect_int64_extended_atomics(device):
+    try:
+        device.has_aspect_int64_extended_atomics
+    except Exception:
+        pytest.fail("has_aspect_int64_extended_atomics call failed")
+
+
+def check_has_aspect_image(device):
+    try:
+        device.has_aspect_image
+    except Exception:
+        pytest.fail("has_aspect_image call failed")
+
+
+def check_has_aspect_online_compiler(device):
+    try:
+        device.has_aspect_online_compiler
+    except Exception:
+        pytest.fail("has_aspect_online_compiler call failed")
+
+
+def check_has_aspect_online_linker(device):
+    try:
+        device.has_aspect_online_linker
+    except Exception:
+        pytest.fail("has_aspect_online_linker call failed")
+
+
+def check_has_aspect_queue_profiling(device):
+    try:
+        device.has_aspect_queue_profiling
+    except Exception:
+        pytest.fail("has_aspect_queue_profiling call failed")
+
+
+def check_has_aspect_usm_device_allocations(device):
+    try:
+        device.has_aspect_usm_device_allocations
+    except Exception:
+        pytest.fail("has_aspect_usm_device_allocations call failed")
+
+
+def check_has_aspect_usm_host_allocations(device):
+    try:
+        device.has_aspect_usm_host_allocations
+    except Exception:
+        pytest.fail("has_aspect_usm_host_allocations call failed")
+
+
+def check_has_aspect_usm_shared_allocations(device):
+    try:
+        device.has_aspect_usm_shared_allocations
+    except Exception:
+        pytest.fail("has_aspect_usm_shared_allocations call failed")
+
+
+def check_has_aspect_usm_restricted_shared_allocations(device):
+    try:
+        device.has_aspect_usm_restricted_shared_allocations
+    except Exception:
+        pytest.fail("has_aspect_usm_restricted_shared_allocations call failed")
+
+
+def check_has_aspect_usm_system_allocator(device):
+    try:
+        device.has_aspect_usm_system_allocator
+    except Exception:
+        pytest.fail("has_aspect_usm_system_allocator call failed")
+
+
+def check_is_accelerator(device):
+    try:
+        device.is_accelerator
+    except Exception:
+        pytest.fail("is_accelerator call failed")
+
+
+def check_is_cpu(device):
+    try:
+        device.is_cpu
+    except Exception:
+        pytest.fail("is_cpu call failed")
+
+
+def check_is_gpu(device):
+    try:
+        device.is_gpu
+    except Exception:
+        pytest.fail("is_gpu call failed")
+
+
+def check_is_host(device):
+    try:
+        device.is_host
+    except Exception:
+        pytest.fail("is_hostcall failed")
+
+
+list_of_checks = [
+    check_get_max_compute_units,
+    check_get_max_work_item_dims,
+    check_get_max_work_item_sizes,
+    check_get_max_work_group_size,
+    check_get_max_num_sub_groups,
+    check_is_accelerator,
+    check_is_cpu,
+    check_is_gpu,
+    check_is_host,
+    check_has_aspect_host,
+    check_has_aspect_cpu,
+    check_has_aspect_gpu,
+    check_has_aspect_accelerator,
+    check_has_aspect_custom,
+    check_has_aspect_fp16,
+    check_has_aspect_fp64,
+    check_has_aspect_int64_base_atomics,
+    check_has_aspect_int64_extended_atomics,
+    check_has_aspect_image,
+    check_has_aspect_online_compiler,
+    check_has_aspect_online_linker,
+    check_has_aspect_queue_profiling,
+    check_has_aspect_usm_device_allocations,
+    check_has_aspect_usm_host_allocations,
+    check_has_aspect_usm_shared_allocations,
+    check_has_aspect_usm_restricted_shared_allocations,
+    check_has_aspect_usm_system_allocator,
+]
+
+
+@pytest.fixture(params=list_of_valid_filter_selectors)
+def valid_filter(request):
+    return request.param
+
+
+@pytest.fixture(params=list_of_invalid_filter_selectors)
+def invalid_filter(request):
+    return request.param
+
+
+@pytest.fixture(params=list_of_standard_selectors)
+def device_selector(request):
+    return request.param
+
+
+@pytest.fixture(params=list_of_checks)
+def check(request):
+    return request.param
+
+
+def test_standard_selectors(device_selector, check):
+    """Tests if the standard SYCL device_selectors are able to select a
+    device.
+    """
+    try:
+        device = device_selector()
+        if device.default_selector_score < 0:
+            pytest.skip()
+        ctx = dpctl.SyclContext(device)
+        devs = ctx.get_devices()
+        assert len(devs) == 1
+        check(devs[0])
+    except ValueError:
+        pytest.skip()
+
+
+def test_current_device(check):
+    """Test is the device for the current queue is valid."""
+    try:
+        q = dpctl.get_current_queue()
+    except Exception:
+        pytest.fail("Encountered an exception inside get_current_queue().")
+    device = q.get_sycl_device()
+    ctx = q.get_sycl_context()
+    devs = ctx.get_devices()
+    # add check that device is among devs
+    check(devs[0])
+
+
+def test_valid_filter_selectors(valid_filter, check):
+    """Tests if we can create a SyclDevice using a supported filter selector string."""
+    device = None
+    try:
+        ctx = dpctl.SyclContext(valid_filter)
+        device = ctx.get_devices()
+    except ValueError:
+        pytest.skip("Failed to create context with supported filter")
+    check(device[0])
+
+
+def test_invalid_filter_selectors(invalid_filter):
+    """An invalid filter string should always be caught and a SyclQueueCreationError
+    raised.
+    """
+    with pytest.raises(ValueError):
+        q = dpctl.SyclContext(invalid_filter)
+
+
+def test_context_not_equals():
+    try:
+        ctx_gpu = dpctl.SyclContext("gpu")
+    except ValueError:
+        pytest.skip()
+    try:
+        ctx_cpu = dpctl.SyclContext("cpu")
+    except ValueError:
+        pytest.skip()
+    assert not ctx_cpu.equals(ctx_gpu)
+
+
+def test_context_equals():
+    try:
+        ctx1 = dpctl.SyclContext("gpu")
+        ctx0 = dpctl.SyclContext("gpu")
+    except dpctl.SyclQueueCreationError:
+        pytest.skip()
+    assert ctx0.equals(ctx1)


### PR DESCRIPTION
@diptorupd This is a WIP to add SyclContext constructors, including those multi-device context.

```
In [1]: import dpctl

In [2]: dpctl.SyclContext() # default device context
Out[2]: <dpctl._sycl_context.SyclContext at 0x7f987c330770>

In [3]: Out[2].get_devices()
Out[3]: [<dpctl.SyclDevice [backend_type.level_zero, device_type.gpu,  Intel(R) Graphics [0x9bca]] at 0x7f986c81b0b0>]

In [4]: dpctl.SyclContext("opencl:cpu")
Out[4]: <dpctl._sycl_context.SyclContext at 0x7f986c84e630>

In [5]: Out[4].get_devices()
Out[5]: [<dpctl.SyclDevice [backend_type.opencl, device_type.cpu,  Intel(R) Core(TM) i7-10710U CPU @ 1.10GHz] at 0x7f986c8157b0>]
```

This works

```
In [6]: d = dpctl.SyclDevice("opencl:cpu")

In [7]: ctx = dpctl.SyclContext(d)

In [9]: q = dpctl.SyclQueue(ctx, d)

In [10]: q
Out[10]: <dpctl.SyclQueue at 0x7f985b58ac30>

In [11]: ctx
Out[11]: <dpctl._sycl_context.SyclContext at 0x7f986c84e330>

In [12]: q.get_sycl_context()
Out[12]: <dpctl._sycl_context.SyclContext at 0x7f986c84e330>

In [13]: q.get_sycl_device()
Out[13]: <dpctl.SyclDevice [backend_type.opencl, device_type.cpu,  Intel(R) Core(TM) i7-10710U CPU @ 1.10GHz] at 0x7f986c7fcfb0>

In [14]: ctx.get_devices()
Out[14]: [<dpctl.SyclDevice [backend_type.opencl, device_type.cpu,  Intel(R) Core(TM) i7-10710U CPU @ 1.10GHz] at 0x7f984806bcf0>]

In [15]: d
Out[15]: <dpctl.SyclDevice [backend_type.opencl, device_type.cpu,  Intel(R) Core(TM) i7-10710U CPU @ 1.10GHz] at 0x7f986c7fcfb0>
```

However, when using different instances of device, it does not work:

```
In [16]: dpctl.SyclQueue( dpctl.SyclContext(dpctl.select_cpu_device()), dpctl.select_cpu_device())
Queue cannot be constructed with the given context and device as the context does not contain the given device. -33 (CL_INVALID_DEVICE)
---------------------------------------------------------------------------
SyclQueueCreationError                    Traceback (most recent call last)
<ipython-input-16-9313ae43729f> in <module>()
----> 1 dpctl.SyclQueue( dpctl.SyclContext(dpctl.select_cpu_device()), dpctl.select_cpu_device())

~/work/dpctl/dpctl/_sycl_queue.pyx in dpctl._sycl_queue.SyclQueue.__cinit__()
    230                 if len_args == 2:
    231                     arg = args
--> 232                 raise SyclQueueCreationError(
    233                     "SYCL Queue failed to be created from '{}'.".format(arg)
    234                 )

SyclQueueCreationError: SYCL Queue failed to be created from '(<dpctl._sycl_context.SyclContext object at 0x7f986c84ee10>, <dpctl.SyclDevice [backend_type.opencl, device_type.cpu,  Intel(R) Core(TM) i7-10710U CPU @ 1.10GHz] at 0x7f9848071eb0>)'.
```