### PR TITLE
Rename dpCtl to dpctl in all comments, license headers, and docs.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,7 @@ We use [clang-format](https://clang.llvm.org/docs/ClangFormat.html) code formatt
 Install: `conda install clang-tools`
 
 - Revision: `10.0.1`
-- See the default configuration used by dpCtl in `.clang-format`.
+- See the default configuration used by dpctl in `.clang-format`.
 
 Run before each commit: `clang-format -style=file -i dpctl-capi/include/*.h dpctl-capi/include/Support/*.h dpctl-capi/source/*.cpp dpctl-capi/tests/*.cpp dpctl-capi/helper/include/*.h dpctl-capi/helper/source/*.cpp`
 
@@ -30,7 +30,7 @@ purpose of the file. The standard header looks like this:
 ```
 //===----- dpctl_sycl_event_interface.h - C API for sycl::event  -*-C++-*- ===//
 //
-//                      Data Parallel Control (dpCtl)
+//                      Data Parallel Control (dpctl)
 //
 // Copyright 2020-2021 Intel Corporation
 //
@@ -69,7 +69,7 @@ Few things to note about this format:
 Every Python and Cython file should only include the following license header:
 
 ```
-#                      Data Parallel Control (dpCtl)
+#                      Data Parallel Control (dpctl)
 #
 # Copyright 2020-2021 Intel Corporation
 #

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ conda install dpctl
 
 Build and Install with setuptools
 =================================
-dpCtl relies on DPC++ runtime. With Intel oneAPI installed you should activate it.
+dpctl relies on DPC++ runtime. With Intel oneAPI installed you should activate it.
 `setup.py` requires environment variable `ONEAPI_ROOT` and following packages
 installed:
 - `cython`
@@ -67,11 +67,11 @@ python setup.py develop
 
 Install Wheel Package from Pypi
 ==================================
-1. Install dpCtl
+1. Install dpctl
 ```cmd
 python -m pip install --index-url https://pypi.anaconda.org/intel/simple -extra-index-url https://pypi.org/simple dpctl
 ```
-Note: dpCtl wheel package is placed on Pypi, but some of its dependencies (like Intel numpy) are in Anaconda Cloud.
+Note: dpctl wheel package is placed on Pypi, but some of its dependencies (like Intel numpy) are in Anaconda Cloud.
 That is why install command requires additional intel Pypi channel from Anaconda Cloud.
 
 2. Set path to Performance Libraries in case of using venv or system Python:
@@ -84,9 +84,9 @@ On Windows:
 set PATH=<path_to_your_env>\bin;<path_to_your_env>\Library\bin;%PATH%
 ```
 
-Using dpCtl
+Using dpctl
 ===========
-dpCtl relies on DPC++ runtime. With Intel oneAPI installed you could activate it.
+dpctl relies on DPC++ runtime. With Intel oneAPI installed you could activate it.
 
 On Windows:
 ```cmd
@@ -97,7 +97,7 @@ On Linux:
 source ${ONEAPI_ROOT}/compiler/latest/env/vars.sh
 ```
 
-When dpCtl is installed via conda package
+When dpctl is installed via conda package
 then it uses DPC++ runtime from `dpcpp_cpp_rt` package
 and it is not necessary to activate oneAPI DPC++ compiler environment.
 
@@ -113,7 +113,7 @@ for script in `ls examples/python/`; do echo "executing ${script}"; python examp
 ```
 
 Examples of building Cython extensions with DPC++ compiler, that interoperate
-with dpCtl can be found in folder `cython`.
+with dpctl can be found in folder `cython`.
 
 Each example in `cython` folder can be built using
 `CC=clang CXX=dpcpp python setup.py build_ext --inplace`.

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -34,7 +34,7 @@ test:
     - pytest
     - pytest-cov
 about:
-    home: https://github.com/IntelPython/dpCtl.git
+    home: https://github.com/IntelPython/dpctl.git
     license: Apache-2.0
     license_file: LICENSE
     summary: 'A lightweight Python wrapper for a subset of OpenCL and SYCL API.'

--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.18 FATAL_ERROR)
-project("Data-parallel Control (dpCtl)")
+project("Data-parallel Control (dpctl)")
 # Add the cmake folder so the FindSphinx module is found
 set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake" ${CMAKE_MODULE_PATH})
 
@@ -9,7 +9,7 @@ find_package (Git)
 
 set(DOC_OUTPUT_DIR ${CMAKE_CURRENT_SOURCE_DIR}/generated_docs)
 if( DPCTL_DOCGEN_PREFIX )
-    message(STATUS "Generating dpCtl documents in " ${DPCTL_DOCGEN_PREFIX})
+    message(STATUS "Generating dpctl documents in " ${DPCTL_DOCGEN_PREFIX})
     set(DOC_OUTPUT_DIR ${DPCTL_DOCGEN_PREFIX})
 endif()
 
@@ -74,7 +74,7 @@ add_custom_command(
     COMMAND
         ${SPHINX_EXECUTABLE} -b html
         # Tell Breathe where to find the Doxygen output
-        -Dbreathe_projects.dpCtl-CAPI=${DOXYGEN_OUTPUT_DIR}/xml
+        -Dbreathe_projects.dpctl-CAPI=${DOXYGEN_OUTPUT_DIR}/xml
         ${SPHINX_SOURCE} ${SPHINX_OUTPUT_DIR}
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
     DEPENDS

--- a/docs/Doxyfile.in
+++ b/docs/Doxyfile.in
@@ -32,7 +32,7 @@ DOXYFILE_ENCODING      = UTF-8
 # title of most generated pages and in a few other places.
 # The default value is: My Project.
 
-PROJECT_NAME           = "Data-parallel Control (dpCtl)"
+PROJECT_NAME           = "Data-parallel Control (dpctl)"
 
 # The PROJECT_NUMBER tag can be used to enter a project or revision number. This
 # could be handy for archiving the generated documentation or if some version

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,7 +1,7 @@
 What?
 =====
 
-Generator scripts for dpCtl API documentation. To run these scripts, follow
+Generator scripts for dpctl API documentation. To run these scripts, follow
 the following steps:
 ```bash
 cd dpctl/docs
@@ -16,7 +16,7 @@ documents in the current source directory in a sub-directory called
 `generated_docs`.
 
 The `make Sphinx` command will generate standalone Doxygen documentation and
-a consolidated Sphinx documentation for both dpCtl Python and C APIs.
+a consolidated Sphinx documentation for both dpctl Python and C APIs.
 
 Prerequisite
 ============

--- a/docs/conf.in
+++ b/docs/conf.in
@@ -38,7 +38,7 @@ extensions = [
 ]
 
 # Breathe Configuration
-breathe_default_project = "dpCtl-CAPI"
+breathe_default_project = "dpctl-CAPI"
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]
@@ -58,8 +58,8 @@ exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 exhale_args = {
     # These arguments are required
     "containmentFolder": "./api",
-    "rootFileName": "dpCtl-CAPI_root.rst",
-    "rootFileTitle": "dpCtl C API",
+    "rootFileName": "dpctl-CAPI_root.rst",
+    "rootFileTitle": "dpctl C API",
     "doxygenStripFromPath": "..",
     "createTreeView": True,
     "exhaleExecutesDoxygen": True,

--- a/docs/dpCtl.dptensor_api.rst
+++ b/docs/dpCtl.dptensor_api.rst
@@ -1,7 +1,7 @@
 .. _dpCtl.dptensor_api:
 
 #########################
-dpCtl dptensor Python API
+dpctl dptensor Python API
 #########################
 
 .. automodule:: dpctl.dptensor

--- a/docs/dpCtl.program_api.rst
+++ b/docs/dpCtl.program_api.rst
@@ -1,7 +1,7 @@
 .. _dpCtl.program_api:
 
 ########################
-dpCtl Program Python API
+dpctl Program Python API
 ########################
 
 .. automodule:: dpctl.program

--- a/docs/dpCtl_api.rst
+++ b/docs/dpCtl_api.rst
@@ -1,7 +1,7 @@
 .. _dpCtl_api:
 
 ################
-dpCtl Python API
+dpctl Python API
 ################
 
 .. automodule:: dpctl

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -3,7 +3,7 @@
    You can adapt this file completely to your liking, but it should at least
    contain the root `toctree` directive.
 
-Welcome to Data-parallel Control (dpCtl)'s documentation!
+Welcome to Data-parallel Control (dpctl)'s documentation!
 =========================================================
 
 .. toctree::

--- a/dpctl-capi/CMakeLists.txt
+++ b/dpctl-capi/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.10 FATAL_ERROR)
-project("dpCtl C API - A C wrapper for a subset of SYCL")
+project("dpctl C API - A C wrapper for a subset of SYCL")
 
 # Option to turn on support for creating Level Zero interoperability programs
 # from a SPIR-V binary file.
@@ -152,7 +152,7 @@ if(DPCTL_GENERATE_COVERAGE)
     endif()
 endif()
 
-# Add sub-directory to build the dpCtl C API test cases
+# Add sub-directory to build the dpctl C API test cases
 if(DPCTL_BUILD_CAPI_TESTS)
     add_subdirectory(tests)
 endif()

--- a/dpctl-capi/cmake/modules/FindDPCPP.cmake
+++ b/dpctl-capi/cmake/modules/FindDPCPP.cmake
@@ -1,4 +1,4 @@
-#                       Data Parallel Control (dpCtl)
+#                       Data Parallel Control (dpctl)
 #
 # Copyright 2020-2021 Intel Corporation
 #

--- a/dpctl-capi/cmake/modules/FindLcov.cmake
+++ b/dpctl-capi/cmake/modules/FindLcov.cmake
@@ -1,4 +1,4 @@
-#                       Data Parallel Control (dpCtl)
+#                       Data Parallel Control (dpctl)
 #
 # Copyright 2020-2021 Intel Corporation
 #

--- a/dpctl-capi/cmake/modules/FindLevelZero.cmake
+++ b/dpctl-capi/cmake/modules/FindLevelZero.cmake
@@ -1,4 +1,4 @@
-#                       Data Parallel Control (dpCtl)
+#                       Data Parallel Control (dpctl)
 #
 # Copyright 2020-2021 Intel Corporation
 #

--- a/dpctl-capi/helper/include/dpctl_async_error_handler.h
+++ b/dpctl-capi/helper/include/dpctl_async_error_handler.h
@@ -1,6 +1,6 @@
 //===-- dpctl_async_error_handler.h - An async error handler     -*-C++-*- ===//
 //
-//                      Data Parallel Control (dpCtl)
+//                      Data Parallel Control (dpctl)
 //
 // Copyright 2020-2021 Intel Corporation
 //

--- a/dpctl-capi/helper/include/dpctl_dynamic_lib_helper.h
+++ b/dpctl-capi/helper/include/dpctl_dynamic_lib_helper.h
@@ -1,6 +1,6 @@
 //===--- dpctl_dynamic_lib_helper.h - Dynamic library helper     -*-C++-*- ===//
 //
-//                      Data Parallel Control (dpCtl)
+//                      Data Parallel Control (dpctl)
 //
 // Copyright 2020-2021 Intel Corporation
 //

--- a/dpctl-capi/helper/include/dpctl_utils_helper.h
+++ b/dpctl-capi/helper/include/dpctl_utils_helper.h
@@ -1,6 +1,6 @@
 //===-- dpctl_utils.h - Enum to string helper functions          -*-C++-*- ===//
 //
-//                      Data Parallel Control (dpCtl)
+//                      Data Parallel Control (dpctl)
 //
 // Copyright 2020-2021 Intel Corporation
 //
@@ -19,7 +19,7 @@
 //===----------------------------------------------------------------------===//
 ///
 /// \file
-/// This file defines common helper functions used in other places in dpCtl.
+/// This file defines common helper functions used in other places in dpctl.
 //===----------------------------------------------------------------------===//
 
 #pragma once

--- a/dpctl-capi/helper/include/dpctl_vector_macros.h
+++ b/dpctl-capi/helper/include/dpctl_vector_macros.h
@@ -1,6 +1,6 @@
 //=== dpctl_vector_macros.h - Macros to help build function sig.    -*-C++-*- //
 //
-//                      Data Parallel Control (dpCtl)
+//                      Data Parallel Control (dpctl)
 //
 // Copyright 2020-2021 Intel Corporation
 //

--- a/dpctl-capi/helper/source/dpctl_async_error_handler.cpp
+++ b/dpctl-capi/helper/source/dpctl_async_error_handler.cpp
@@ -1,6 +1,6 @@
 //===-- dpctl_async_error_handler.h - An async error handler     -*-C++-*- ===//
 //
-//                      Data Parallel Control (dpCtl)
+//                      Data Parallel Control (dpctl)
 //
 // Copyright 2020-2021 Intel Corporation
 //

--- a/dpctl-capi/helper/source/dpctl_utils_helper.cpp
+++ b/dpctl-capi/helper/source/dpctl_utils_helper.cpp
@@ -1,6 +1,6 @@
 //===- dpctl_utils_helper.cpp - Implementation of enum to string helpers   ===//
 //
-//                      Data Parallel Control (dpCtl)
+//                      Data Parallel Control (dpctl)
 //
 // Copyright 2020-2021 Intel Corporation
 //

--- a/dpctl-capi/include/Config/dpctl_config.h.in
+++ b/dpctl-capi/include/Config/dpctl_config.h.in
@@ -1,6 +1,6 @@
-//===--------- dpctl_config.h - Configured options for dpCtl C API         ===//
+//===--------- dpctl_config.h - Configured options for dpctl C API         ===//
 //
-//                      Data Parallel Control (dpCtl)
+//                      Data Parallel Control (dpctl)
 //
 // Copyright 2020-2021 Intel Corporation
 //
@@ -19,14 +19,14 @@
 //===----------------------------------------------------------------------===//
 ///
 /// \file
-/// This file exports a set of dpCtl C API configurations.
+/// This file exports a set of dpctl C API configurations.
 ///
 //===----------------------------------------------------------------------===//
 
 #pragma once
 
-/* Defined when dpCtl was built with level zero program creation enabled. */
+/* Defined when dpctl was built with level zero program creation enabled. */
 #cmakedefine DPCTL_ENABLE_LO_PROGRAM_CREATION @DPCTL_ENABLE_LO_PROGRAM_CREATION@
 
-/* The DPCPP version used to build dpCtl */
+/* The DPCPP version used to build dpctl */
 #define DPCTL_DPCPP_VERSION "@DPCPP_VERSION@"

--- a/dpctl-capi/include/Support/CBindingWrapping.h
+++ b/dpctl-capi/include/Support/CBindingWrapping.h
@@ -1,6 +1,6 @@
 //===- CBindingWrapping.h - Wrappers for casting C pointers      -*-C++-*- ===//
 //
-//                      Data Parallel Control (dpCtl)
+//                      Data Parallel Control (dpctl)
 //
 // Copyright 2020-2021 Intel Corporation
 //
@@ -19,7 +19,7 @@
 //===----------------------------------------------------------------------===//
 ///
 /// \file
-/// This file declares the wrapping macros for the dpCtl C interface.
+/// This file declares the wrapping macros for the dpctl C interface.
 ///
 //===----------------------------------------------------------------------===//
 

--- a/dpctl-capi/include/Support/DllExport.h
+++ b/dpctl-capi/include/Support/DllExport.h
@@ -1,6 +1,6 @@
 //===---------  DllExport.h - Decalres dllexport for Windows     -*-C++-*- ===//
 //
-//                      Data Parallel Control (dpCtl)
+//                      Data Parallel Control (dpctl)
 //
 // Copyright 2020-2021 Intel Corporation
 //

--- a/dpctl-capi/include/Support/ExternC.h
+++ b/dpctl-capi/include/Support/ExternC.h
@@ -1,6 +1,6 @@
 //===----------- ExternC.h - Defines an extern C helper macro    -*-C++-*- ===//
 //
-//                      Data Parallel Control (dpCtl)
+//                      Data Parallel Control (dpctl)
 //
 // Copyright 2020-2021 Intel Corporation
 //

--- a/dpctl-capi/include/Support/MemOwnershipAttrs.h
+++ b/dpctl-capi/include/Support/MemOwnershipAttrs.h
@@ -1,6 +1,6 @@
 //===- MemOwnershipAttrs.h - Defines memory ownership attributes -*-C++-*- ===//
 //
-//                      Data Parallel Control (dpCtl)
+//                      Data Parallel Control (dpctl)
 //
 // Copyright 2020-2021 Intel Corporation
 //
@@ -22,7 +22,7 @@
 /// This file defines a group of macros that serve as attributes indicating the
 /// type of ownership of a pointer. The macros are modeled after similar
 /// attributes defines in Integer Set Library (isl) and serve the purpose of
-/// helping a programmer understand the semantics of a dpCtl function.
+/// helping a programmer understand the semantics of a dpctl function.
 ///
 //===----------------------------------------------------------------------===//
 

--- a/dpctl-capi/include/dpctl_data_types.h
+++ b/dpctl-capi/include/dpctl_data_types.h
@@ -1,6 +1,6 @@
 //===-------------- dpctl_data_types.h - Defines integer types   -*-C++-*- ===//
 //
-//                      Data Parallel Control (dpCtl)
+//                      Data Parallel Control (dpctl)
 //
 // Copyright 2020-2021 Intel Corporation
 //

--- a/dpctl-capi/include/dpctl_error_handler_type.h
+++ b/dpctl-capi/include/dpctl_error_handler_type.h
@@ -1,6 +1,6 @@
 //===--- dpctl_error_handler_types.h - Error handler callbacks   -*-C++-*- ===//
 //
-//                      Data Parallel Control (dpCtl)
+//                      Data Parallel Control (dpctl)
 //
 // Copyright 2020-2021 Intel Corporation
 //

--- a/dpctl-capi/include/dpctl_sycl_context_interface.h
+++ b/dpctl-capi/include/dpctl_sycl_context_interface.h
@@ -1,6 +1,6 @@
 //===-- dpctl_sycl_context_interface.h - C API for sycl::context -*-C++-*- ===//
 //
-//                      Data Parallel Control (dpCtl)
+//                      Data Parallel Control (dpctl)
 //
 // Copyright 2020-2021 Intel Corporation
 //

--- a/dpctl-capi/include/dpctl_sycl_device_interface.h
+++ b/dpctl-capi/include/dpctl_sycl_device_interface.h
@@ -1,6 +1,6 @@
 //===----- dpctl_sycl_device_interface.h - C API for sycl::device -*-C++-*- ==//
 //
-//                      Data Parallel Control (dpCtl)
+//                      Data Parallel Control (dpctl)
 //
 // Copyright 2020-2021 Intel Corporation
 //

--- a/dpctl-capi/include/dpctl_sycl_device_manager.h
+++ b/dpctl-capi/include/dpctl_sycl_device_manager.h
@@ -1,6 +1,6 @@
 //===-- dpctl_sycl_device_manager.h - A manager for sycl devices -*-C++-*- ===//
 //
-//                      Data Parallel Control (dpCtl)
+//                      Data Parallel Control (dpctl)
 //
 // Copyright 2020-2021 Intel Corporation
 //
@@ -108,7 +108,7 @@ size_t DPCTLDeviceMgr_GetNumDevices(int device_identifier);
 
 /*!
  * @brief Prints out the info::deivice attributes for the device that are
- * currently supported by dpCtl.
+ * currently supported by dpctl.
  *
  * @param    DRef           A #DPCTLSyclDeviceRef opaque pointer.
  * @ingroup DeviceManager

--- a/dpctl-capi/include/dpctl_sycl_device_selector_interface.h
+++ b/dpctl-capi/include/dpctl_sycl_device_selector_interface.h
@@ -1,6 +1,6 @@
 //=== dpctl_sycl_device_selector_interface.h - device_selector C API -*-C++-*-//
 //
-//                      Data Parallel Control (dpCtl)
+//                      Data Parallel Control (dpctl)
 //
 // Copyright 2020-2021 Intel Corporation
 //

--- a/dpctl-capi/include/dpctl_sycl_enum_types.h
+++ b/dpctl-capi/include/dpctl_sycl_enum_types.h
@@ -1,6 +1,6 @@
 //===- dpctl_sycl_enum_types.h - C API enums for few sycl enum   -*-C++-*- ===//
 //
-//                      Data Parallel Control (dpCtl)
+//                      Data Parallel Control (dpctl)
 //
 // Copyright 2020-2021 Intel Corporation
 //
@@ -19,7 +19,7 @@
 //===----------------------------------------------------------------------===//
 ///
 /// \file
-/// This header defines dpCtl specficif enum types that wrap corresponding Sycl
+/// This header defines dpctl specific enum types that wrap corresponding Sycl
 /// enum classes. These enums are defined primarily so that Python extensions
 /// that use DPCTL do not have to include Sycl headers directly.
 ///

--- a/dpctl-capi/include/dpctl_sycl_event_interface.h
+++ b/dpctl-capi/include/dpctl_sycl_event_interface.h
@@ -1,6 +1,6 @@
 //===----- dpctl_sycl_event_interface.h - C API for sycl::event  -*-C++-*- ===//
 //
-//                      Data Parallel Control (dpCtl)
+//                      Data Parallel Control (dpctl)
 //
 // Copyright 2020-2021 Intel Corporation
 //

--- a/dpctl-capi/include/dpctl_sycl_kernel_interface.h
+++ b/dpctl-capi/include/dpctl_sycl_kernel_interface.h
@@ -1,6 +1,6 @@
 //===--- dpctl_sycl_kernel_interface.h - C API for sycl::kernel  -*-C++-*- ===//
 //
-//                      Data Parallel Control (dpCtl)
+//                      Data Parallel Control (dpctl)
 //
 // Copyright 2020-2021 Intel Corporation
 //

--- a/dpctl-capi/include/dpctl_sycl_platform_interface.h
+++ b/dpctl-capi/include/dpctl_sycl_platform_interface.h
@@ -1,6 +1,6 @@
 //===-- dpctl_sycl_platform_interface.h - C API for sycl::platform -*-C++-*- =//
 //
-//                      Data Parallel Control (dpCtl)
+//                      Data Parallel Control (dpctl)
 //
 // Copyright 2020-2021 Intel Corporation
 //

--- a/dpctl-capi/include/dpctl_sycl_platform_manager.h
+++ b/dpctl-capi/include/dpctl_sycl_platform_manager.h
@@ -1,6 +1,6 @@
 //===-- dpctl_sycl_platform_manager.h - Helpers for sycl::platform -*-C++-*- =//
 //
-//                      Data Parallel Control (dpCtl)
+//                      Data Parallel Control (dpctl)
 //
 // Copyright 2020-2021 Intel Corporation
 //

--- a/dpctl-capi/include/dpctl_sycl_program_interface.h
+++ b/dpctl-capi/include/dpctl_sycl_program_interface.h
@@ -1,6 +1,6 @@
 //===- dpctl_sycl_program_interface.h - C API for sycl::program  -*-C++-*- ===//
 //
-//                      Data Parallel Control (dpCtl)
+//                      Data Parallel Control (dpctl)
 //
 // Copyright 2020-2021 Intel Corporation
 //

--- a/dpctl-capi/include/dpctl_sycl_queue_interface.h
+++ b/dpctl-capi/include/dpctl_sycl_queue_interface.h
@@ -1,6 +1,6 @@
 //===----- dpctl_sycl_queue_interface.h - C API for sycl::queue  -*-C++-*- ===//
 //
-//                      Data Parallel Control (dpCtl)
+//                      Data Parallel Control (dpctl)
 //
 // Copyright 2020-2021 Intel Corporation
 //

--- a/dpctl-capi/include/dpctl_sycl_queue_manager.h
+++ b/dpctl-capi/include/dpctl_sycl_queue_manager.h
@@ -1,6 +1,6 @@
 //===---- dpctl_sycl_queue_manager.h - A manager for sycl queues -*-C++-*- ===//
 //
-//                      Data Parallel Control (dpCtl)
+//                      Data Parallel Control (dpctl)
 //
 // Copyright 2020-2021 Intel Corporation
 //
@@ -20,7 +20,7 @@
 ///
 /// \file
 /// This header declares a set of functions to support a concept of current
-/// queue for applications using dpCtl.
+/// queue for applications using dpctl.
 ///
 //===----------------------------------------------------------------------===//
 
@@ -41,8 +41,8 @@ DPCTL_C_EXTERN_C_BEGIN
 /*!
  * @brief Get the current sycl::queue for the thread of execution.
  *
- * DpCtl lets an application access a "current queue" as soon as the application
- * loads dpCtl. The initial current queue also termed the global queue is a
+ * Dpctl lets an application access a "current queue" as soon as the application
+ * loads dpctl. The initial current queue also termed the global queue is a
  * queue created using SYCL's default_selector. The current queue is set per
  * thread and can be changed for a specific execution scope using the PushQueue
  * and PopQueue functions in this module. The global queue can also be changed

--- a/dpctl-capi/include/dpctl_sycl_types.h
+++ b/dpctl-capi/include/dpctl_sycl_types.h
@@ -1,6 +1,6 @@
 //===-- dpctl_sycl_types.h - Defines opaque types for SYCL objects -*-C++-*- =//
 //
-//                      Data Parallel Control (dpCtl)
+//                      Data Parallel Control (dpctl)
 //
 // Copyright 2020-2021 Intel Corporation
 //
@@ -19,7 +19,7 @@
 //===----------------------------------------------------------------------===//
 ///
 /// \file
-/// This file defines types used by dpCtl's C interface to SYCL.
+/// This file defines types used by dpctl's C interface to SYCL.
 ///
 //===----------------------------------------------------------------------===//
 

--- a/dpctl-capi/include/dpctl_sycl_usm_interface.h
+++ b/dpctl-capi/include/dpctl_sycl_usm_interface.h
@@ -1,6 +1,6 @@
 //===---- dpctl_sycl_usm_interface.h - C API for USM allocators  -*-C++-*- ===//
 //
-//                      Data Parallel Control (dpCtl)
+//                      Data Parallel Control (dpctl)
 //
 // Copyright 2020-2021 Intel Corporation
 //

--- a/dpctl-capi/include/dpctl_utils.h
+++ b/dpctl-capi/include/dpctl_utils.h
@@ -1,6 +1,6 @@
 //===----------- dpctl_utils.h - Helper functions                -*-C++-*- ===//
 //
-//                      Data Parallel Control (dpCtl)
+//                      Data Parallel Control (dpctl)
 //
 // Copyright 2020-2021 Intel Corporation
 //
@@ -19,7 +19,7 @@
 //===----------------------------------------------------------------------===//
 ///
 /// \file
-/// This file defines common helper functions used in other places in dpCtl.
+/// This file defines common helper functions used in other places in dpctl.
 //===----------------------------------------------------------------------===//
 
 #pragma once

--- a/dpctl-capi/include/dpctl_vector.h
+++ b/dpctl-capi/include/dpctl_vector.h
@@ -1,6 +1,6 @@
 //===-- dpctl_vector.h - Defines macros for opaque vector types    -*-C++-*- =//
 //
-//                      Data Parallel Control (dpCtl)
+//                      Data Parallel Control (dpctl)
 //
 // Copyright 2020-2021 Intel Corporation
 //
@@ -20,7 +20,7 @@
 ///
 /// \file
 /// A set of helper macros are defined here to create opaque lists (implemented
-/// using std::vector) and helper functions of any DPCTL type.
+/// using std::vector) and helper functions of any dpctl type.
 ///
 //===----------------------------------------------------------------------===//
 

--- a/dpctl-capi/source/dpctl_sycl_context_interface.cpp
+++ b/dpctl-capi/source/dpctl_sycl_context_interface.cpp
@@ -1,6 +1,6 @@
 //===- dpctl_sycl_context_interface.cpp - Implements C API for sycl::context =//
 //
-//                      Data Parallel Control (dpCtl)
+//                      Data Parallel Control (dpctl)
 //
 // Copyright 2020-2021 Intel Corporation
 //

--- a/dpctl-capi/source/dpctl_sycl_device_interface.cpp
+++ b/dpctl-capi/source/dpctl_sycl_device_interface.cpp
@@ -1,6 +1,6 @@
 //===--- dpctl_sycl_device_interface.cpp - Implements C API for sycl::device =//
 //
-//                      Data Parallel Control (dpCtl)
+//                      Data Parallel Control (dpctl)
 //
 // Copyright 2020-2021 Intel Corporation
 //

--- a/dpctl-capi/source/dpctl_sycl_device_manager.cpp
+++ b/dpctl-capi/source/dpctl_sycl_device_manager.cpp
@@ -1,6 +1,6 @@
 //===-------- dpctl_sycl_device_manager.cpp - helpers for sycl devices ------=//
 //
-//                      Data Parallel Control (dpCtl)
+//                      Data Parallel Control (dpctl)
 //
 // Copyright 2020-2021 Intel Corporation
 //

--- a/dpctl-capi/source/dpctl_sycl_device_selector_interface.cpp
+++ b/dpctl-capi/source/dpctl_sycl_device_selector_interface.cpp
@@ -1,6 +1,6 @@
 //=== dpctl_sycl_device_selector_interface.cpp -  device_selector C API    ===//
 //
-//                      Data Parallel Control (dpCtl)
+//                      Data Parallel Control (dpctl)
 //
 // Copyright 2020-2021 Intel Corporation
 //

--- a/dpctl-capi/source/dpctl_sycl_event_interface.cpp
+++ b/dpctl-capi/source/dpctl_sycl_event_interface.cpp
@@ -1,6 +1,6 @@
 //===----- dpctl_sycl_event_interface.cpp - Implements C API for sycl::event =//
 //
-//                      Data Parallel Control (dpCtl)
+//                      Data Parallel Control (dpctl)
 //
 // Copyright 2020-2021 Intel Corporation
 //

--- a/dpctl-capi/source/dpctl_sycl_kernel_interface.cpp
+++ b/dpctl-capi/source/dpctl_sycl_kernel_interface.cpp
@@ -1,6 +1,6 @@
 //===--- dpctl_sycl_kernel_interface.cpp - Implements C API for sycl::kernel =//
 //
-//                      Data Parallel Control (dpCtl)
+//                      Data Parallel Control (dpctl)
 //
 // Copyright 2020-2021 Intel Corporation
 //

--- a/dpctl-capi/source/dpctl_sycl_platform_interface.cpp
+++ b/dpctl-capi/source/dpctl_sycl_platform_interface.cpp
@@ -1,6 +1,6 @@
 //=== dpctl_sycl_platform_interface.cpp - Implements C API for sycl::platform //
 //
-//                      Data Parallel Control (dpCtl)
+//                      Data Parallel Control (dpctl)
 //
 // Copyright 2020-2021 Intel Corporation
 //

--- a/dpctl-capi/source/dpctl_sycl_platform_manager.cpp
+++ b/dpctl-capi/source/dpctl_sycl_platform_manager.cpp
@@ -1,6 +1,6 @@
 //=== dpctl_sycl_platform_manager.cpp - Implements helpers for sycl::platform //
 //
-//                      Data Parallel Control (dpCtl)
+//                      Data Parallel Control (dpctl)
 //
 // Copyright 2020-2021 Intel Corporation
 //

--- a/dpctl-capi/source/dpctl_sycl_program_interface.cpp
+++ b/dpctl-capi/source/dpctl_sycl_program_interface.cpp
@@ -1,6 +1,6 @@
 //===- dpctl_sycl_program_interface.cpp - Implements C API for sycl::program =//
 //
-//                      Data Parallel Control (dpCtl)
+//                      Data Parallel Control (dpctl)
 //
 // Copyright 2020-2021 Intel Corporation
 //

--- a/dpctl-capi/source/dpctl_sycl_queue_interface.cpp
+++ b/dpctl-capi/source/dpctl_sycl_queue_interface.cpp
@@ -1,6 +1,6 @@
 //===----- dpctl_sycl_queue_interface.cpp - Implements C API for sycl::queue =//
 //
-//                      Data Parallel Control (dpCtl)
+//                      Data Parallel Control (dpctl)
 //
 // Copyright 2020-2021 Intel Corporation
 //

--- a/dpctl-capi/source/dpctl_sycl_queue_manager.cpp
+++ b/dpctl-capi/source/dpctl_sycl_queue_manager.cpp
@@ -1,6 +1,6 @@
 //===-------- dpctl_sycl_queue_manager.cpp - Implements a SYCL queue manager =//
 //
-//                      Data Parallel Control (dpCtl)
+//                      Data Parallel Control (dpctl)
 //
 // Copyright 2020-2021 Intel Corporation
 //

--- a/dpctl-capi/source/dpctl_sycl_usm_interface.cpp
+++ b/dpctl-capi/source/dpctl_sycl_usm_interface.cpp
@@ -1,6 +1,6 @@
 //===------ dpctl_sycl_usm_interface.cpp - Implements C API for USM ops    ===//
 //
-//                      Data Parallel Control (dpCtl)
+//                      Data Parallel Control (dpctl)
 //
 // Copyright 2020-2021 Intel Corporation
 //

--- a/dpctl-capi/source/dpctl_utils.cpp
+++ b/dpctl-capi/source/dpctl_utils.cpp
@@ -1,6 +1,6 @@
 //===------------- dpctl_utils.cpp - Implements helper functions           ===//
 //
-//                      Data Parallel Control (dpCtl)
+//                      Data Parallel Control (dpctl)
 //
 // Copyright 2020-2021 Intel Corporation
 //

--- a/dpctl-capi/source/dpctl_vector_templ.cpp
+++ b/dpctl-capi/source/dpctl_vector_templ.cpp
@@ -1,6 +1,6 @@
 //===-- dpctl_vector_templ.cpp - Wrapper functions for opaque vector types ===//
 //
-//                      Data Parallel Control (dpCtl)
+//                      Data Parallel Control (dpctl)
 //
 // Copyright 2020-2021 Intel Corporation
 //

--- a/dpctl-capi/tests/test_main.cpp
+++ b/dpctl-capi/tests/test_main.cpp
@@ -1,6 +1,6 @@
 //===-------------------- test_main.cpp - Common test runner               ===//
 //
-//                      Data Parallel Control (dpCtl)
+//                      Data Parallel Control (dpctl)
 //
 // Copyright 2020-2021 Intel Corporation
 //
@@ -19,7 +19,7 @@
 //===----------------------------------------------------------------------===//
 ///
 /// \file
-/// A common test runner for all tests in dpCtl C API.
+/// A common test runner for all tests in dpctl C API.
 ///
 //===----------------------------------------------------------------------===//
 

--- a/dpctl-capi/tests/test_sycl_context_interface.cpp
+++ b/dpctl-capi/tests/test_sycl_context_interface.cpp
@@ -1,6 +1,6 @@
 //===--- test_sycl_context_interface.cpp - Test cases for device interface ===//
 //
-//                      Data Parallel Control (dpCtl)
+//                      Data Parallel Control (dpctl)
 //
 // Copyright 2020-2021 Intel Corporation
 //

--- a/dpctl-capi/tests/test_sycl_device_interface.cpp
+++ b/dpctl-capi/tests/test_sycl_device_interface.cpp
@@ -1,6 +1,6 @@
 //===--- test_sycl_device_interface.cpp - Test cases for device interface  ===//
 //
-//                      Data Parallel Control (dpCtl)
+//                      Data Parallel Control (dpctl)
 //
 // Copyright 2020-2021 Intel Corporation
 //

--- a/dpctl-capi/tests/test_sycl_device_manager.cpp
+++ b/dpctl-capi/tests/test_sycl_device_manager.cpp
@@ -1,6 +1,6 @@
 //===------- test_sycl_device_manager.cpp - Test cases for device manager  ===//
 //
-//                      Data Parallel Control (dpCtl)
+//                      Data Parallel Control (dpctl)
 //
 // Copyright 2020-2021 Intel Corporation
 //

--- a/dpctl-capi/tests/test_sycl_device_selector_interface.cpp
+++ b/dpctl-capi/tests/test_sycl_device_selector_interface.cpp
@@ -1,6 +1,6 @@
 //===--- test_sycl_device_selector_interface.cpp - Device selector tests   ===//
 //
-//                      Data Parallel Control (dpCtl)
+//                      Data Parallel Control (dpctl)
 //
 // Copyright 2020-2021 Intel Corporation
 //

--- a/dpctl-capi/tests/test_sycl_kernel_interface.cpp
+++ b/dpctl-capi/tests/test_sycl_kernel_interface.cpp
@@ -1,6 +1,6 @@
 //===-- test_sycl_program_interface.cpp - Test cases for kernel interface ===//
 //
-//                      Data Parallel Control (dpCtl)
+//                      Data Parallel Control (dpctl)
 //
 // Copyright 2020-2021 Intel Corporation
 //

--- a/dpctl-capi/tests/test_sycl_platform_interface.cpp
+++ b/dpctl-capi/tests/test_sycl_platform_interface.cpp
@@ -1,6 +1,6 @@
 //===-- test_sycl_platform_interface.cpp - Test cases for platform interface =//
 //
-//                      Data Parallel Control (dpCtl)
+//                      Data Parallel Control (dpctl)
 //
 // Copyright 2020-2021 Intel Corporation
 //

--- a/dpctl-capi/tests/test_sycl_program_interface.cpp
+++ b/dpctl-capi/tests/test_sycl_program_interface.cpp
@@ -1,6 +1,6 @@
 //===-- test_sycl_program_interface.cpp - Test cases for module interface -===//
 //
-//                      Data Parallel Control (dpCtl)
+//                      Data Parallel Control (dpctl)
 //
 // Copyright 2020-2021 Intel Corporation
 //

--- a/dpctl-capi/tests/test_sycl_queue_interface.cpp
+++ b/dpctl-capi/tests/test_sycl_queue_interface.cpp
@@ -1,6 +1,6 @@
 //===------ test_sycl_queue_interface.cpp - Test cases for queue interface ===//
 //
-//                      Data Parallel Control (dpCtl)
+//                      Data Parallel Control (dpctl)
 //
 // Copyright 2020-2021 Intel Corporation
 //

--- a/dpctl-capi/tests/test_sycl_queue_manager.cpp
+++ b/dpctl-capi/tests/test_sycl_queue_manager.cpp
@@ -1,6 +1,6 @@
 //===------- test_sycl_queue_manager.cpp - Test cases for queue manager    ===//
 //
-//                      Data Parallel Control (dpCtl)
+//                      Data Parallel Control (dpctl)
 //
 // Copyright 2020-2021 Intel Corporation
 //

--- a/dpctl-capi/tests/test_sycl_usm_interface.cpp
+++ b/dpctl-capi/tests/test_sycl_usm_interface.cpp
@@ -1,6 +1,6 @@
 //===---------- test_sycl_usm_interface.cpp - Test cases for USM interface ===//
 //
-//                      Data Parallel Control (dpCtl)
+//                      Data Parallel Control (dpctl)
 //
 // Copyright 2020-2021 Intel Corporation
 //

--- a/dpctl/__init__.pxd
+++ b/dpctl/__init__.pxd
@@ -1,4 +1,4 @@
-#                      Data Parallel Control (dpCtl)
+#                      Data Parallel Control (dpctl)
 #
 # Copyright 2020-2021 Intel Corporation
 #

--- a/dpctl/__init__.py
+++ b/dpctl/__init__.py
@@ -1,4 +1,4 @@
-#                      Data Parallel Control (dpCtl)
+#                      Data Parallel Control (dpctl)
 #
 # Copyright 2020-2021 Intel Corporation
 #
@@ -15,15 +15,15 @@
 # limitations under the License.
 
 """
-    **Data Parallel Control (dpCtl)**
+    **Data Parallel Control (dpctl)**
 
-    DpCtl provides a lightweight Python wrapper over a subset of
-    DPC++/SYCL's API. The goal of dpCtl is not (yet) to provide a
-    abstraction for every SYCL function. DpCtl is intended to provide
+    Dpctl provides a lightweight Python wrapper over a subset of
+    DPC++/SYCL's API. The goal of dpctl is not (yet) to provide a
+    abstraction for every SYCL function. Dpctl is intended to provide
     a common runtime to manage specific SYCL resources, such as devices
     and USM memory, for SYCL-based Python packages and extension modules.
 
-    The main features presently provided by dpCtl are:
+    The main features presently provided by dpctl are:
 
     * A SYCL queue manager exposed directly inside the top-level `dpctl`
       module.
@@ -65,9 +65,9 @@ __all__ = (
 
 def get_include():
     """
-    Return the directory that contains the dpCtl \*.h header files.
+    Return the directory that contains the dpctl \*.h header files.
 
-    Extension modules that need to be compiled against dpCtl should use
+    Extension modules that need to be compiled against dpctl should use
     this function to locate the appropriate include directory.
     """
     import os.path

--- a/dpctl/_backend.pxd
+++ b/dpctl/_backend.pxd
@@ -1,4 +1,4 @@
-#                      Data Parallel Control (dpCtl)
+#                      Data Parallel Control (dpctl)
 #
 # Copyright 2020-2021 Intel Corporation
 #

--- a/dpctl/_sycl_context.pxd
+++ b/dpctl/_sycl_context.pxd
@@ -1,4 +1,4 @@
-#                      Data Parallel Control (dpCtl)
+#                      Data Parallel Control (dpctl)
 #
 # Copyright 2020-2021 Intel Corporation
 #

--- a/dpctl/_sycl_context.pyx
+++ b/dpctl/_sycl_context.pyx
@@ -1,4 +1,4 @@
-#                      Data Parallel Control (dpCtl)
+#                      Data Parallel Control (dpctl)
 #
 # Copyright 2020-2021 Intel Corporation
 #

--- a/dpctl/_sycl_device.pxd
+++ b/dpctl/_sycl_device.pxd
@@ -1,4 +1,4 @@
-#                      Data Parallel Control (dpCtl)
+#                      Data Parallel Control (dpctl)
 #
 # Copyright 2020-2021 Intel Corporation
 #

--- a/dpctl/_sycl_device.pyx
+++ b/dpctl/_sycl_device.pyx
@@ -1,4 +1,4 @@
-#                      Data Parallel Control (dpCtl)
+#                      Data Parallel Control (dpctl)
 #
 # Copyright 2020-2021 Intel Corporation
 #

--- a/dpctl/_sycl_device_factory.pxd
+++ b/dpctl/_sycl_device_factory.pxd
@@ -1,4 +1,4 @@
-#                      Data Parallel Control (dpCtl)
+#                      Data Parallel Control (dpctl)
 #
 # Copyright 2020-2021 Intel Corporation
 #

--- a/dpctl/_sycl_device_factory.pyx
+++ b/dpctl/_sycl_device_factory.pyx
@@ -1,4 +1,4 @@
-#                      Data Parallel Control (dpCtl)
+#                      Data Parallel Control (dpctl)
 #
 # Copyright 2020-2021 Intel Corporation
 #

--- a/dpctl/_sycl_event.pxd
+++ b/dpctl/_sycl_event.pxd
@@ -1,4 +1,4 @@
-#                      Data Parallel Control (dpCtl)
+#                      Data Parallel Control (dpctl)
 #
 # Copyright 2020-2021 Intel Corporation
 #

--- a/dpctl/_sycl_event.pyx
+++ b/dpctl/_sycl_event.pyx
@@ -1,4 +1,4 @@
-#                      Data Parallel Control (dpCtl)
+#                      Data Parallel Control (dpctl)
 #
 # Copyright 2020-2021 Intel Corporation
 #

--- a/dpctl/_sycl_platform.pxd
+++ b/dpctl/_sycl_platform.pxd
@@ -1,4 +1,4 @@
-#                      Data Parallel Control (dpCtl)
+#                      Data Parallel Control (dpctl)
 #
 # Copyright 2020-2021 Intel Corporation
 #

--- a/dpctl/_sycl_platform.pyx
+++ b/dpctl/_sycl_platform.pyx
@@ -1,4 +1,4 @@
-#                      Data Parallel Control (dpCtl)
+#                      Data Parallel Control (dpctl)
 #
 # Copyright 2020 Intel Corporation
 #

--- a/dpctl/_sycl_queue.pxd
+++ b/dpctl/_sycl_queue.pxd
@@ -1,4 +1,4 @@
-#                      Data Parallel Control (dpCtl)
+#                      Data Parallel Control (dpctl)
 #
 # Copyright 2020-2021 Intel Corporation
 #

--- a/dpctl/_sycl_queue.pyx
+++ b/dpctl/_sycl_queue.pyx
@@ -1,4 +1,4 @@
-#                      Data Parallel Control (dpCtl)
+#                      Data Parallel Control (dpctl)
 #
 # Copyright 2020-2021 Intel Corporation
 #

--- a/dpctl/_sycl_queue_manager.pxd
+++ b/dpctl/_sycl_queue_manager.pxd
@@ -1,4 +1,4 @@
-#                      Data Parallel Control (dpCtl)
+#                      Data Parallel Control (dpctl)
 #
 # Copyright 2020 Intel Corporation
 #

--- a/dpctl/_sycl_queue_manager.pyx
+++ b/dpctl/_sycl_queue_manager.pyx
@@ -1,4 +1,4 @@
-#                      Data Parallel Control (dpCtl)
+#                      Data Parallel Control (dpctl)
 #
 # Copyright 2020 Intel Corporation
 #

--- a/dpctl/dptensor/__init__.py
+++ b/dpctl/dptensor/__init__.py
@@ -1,4 +1,4 @@
-#                      Data Parallel Control (dpCtl)
+#                      Data Parallel Control (dpctl)
 #
 # Copyright 2020-2021 Intel Corporation
 #

--- a/dpctl/dptensor/numpy_usm_shared.py
+++ b/dpctl/dptensor/numpy_usm_shared.py
@@ -1,4 +1,4 @@
-#                       Data Parallel Control (dpCtl)
+#                       Data Parallel Control (dpctl)
 #
 #  Copyright 2020-2021 Intel Corporation
 #

--- a/dpctl/enum_types.py
+++ b/dpctl/enum_types.py
@@ -1,4 +1,4 @@
-#                      Data Parallel Control (dpCtl)
+#                      Data Parallel Control (dpctl)
 #
 # Copyright 2020 Intel Corporation
 #

--- a/dpctl/memory/__init__.pxd
+++ b/dpctl/memory/__init__.pxd
@@ -1,4 +1,4 @@
-#                      Data Parallel Control (dpCtl)
+#                      Data Parallel Control (dpctl)
 #
 # Copyright 2020-2021 Intel Corporation
 #

--- a/dpctl/memory/__init__.py
+++ b/dpctl/memory/__init__.py
@@ -1,4 +1,4 @@
-#                      Data Parallel Control (dpCtl)
+#                      Data Parallel Control (dpctl)
 #
 # Copyright 2020-2021 Intel Corporation
 #

--- a/dpctl/memory/_memory.pxd
+++ b/dpctl/memory/_memory.pxd
@@ -1,4 +1,4 @@
-#                      Data Parallel Control (dpCtl)
+#                      Data Parallel Control (dpctl)
 #
 # Copyright 2020-2021 Intel Corporation
 #

--- a/dpctl/memory/_memory.pyx
+++ b/dpctl/memory/_memory.pyx
@@ -1,4 +1,4 @@
-#                      Data Parallel Control (dpCtl)
+#                      Data Parallel Control (dpctl)
 #
 # Copyright 2020-2021 Intel Corporation
 #

--- a/dpctl/program/__init__.pxd
+++ b/dpctl/program/__init__.pxd
@@ -1,4 +1,4 @@
-#                      Data Parallel Control (dpCtl)
+#                      Data Parallel Control (dpctl)
 #
 # Copyright 2020-2021 Intel Corporation
 #

--- a/dpctl/program/__init__.py
+++ b/dpctl/program/__init__.py
@@ -1,4 +1,4 @@
-#                      Data Parallel Control (dpCtl)
+#                      Data Parallel Control (dpctl)
 #
 # Copyright 2020-2021 Intel Corporation
 #

--- a/dpctl/program/_program.pxd
+++ b/dpctl/program/_program.pxd
@@ -1,4 +1,4 @@
-#                      Data Parallel Control (dpCtl)
+#                      Data Parallel Control (dpctl)
 #
 # Copyright 2020-2021 Intel Corporation
 #

--- a/dpctl/program/_program.pyx
+++ b/dpctl/program/_program.pyx
@@ -1,4 +1,4 @@
-#                      Data Parallel Control (dpCtl)
+#                      Data Parallel Control (dpctl)
 #
 # Copyright 2020-2021 Intel Corporation
 #

--- a/dpctl/tests/__init__.py
+++ b/dpctl/tests/__init__.py
@@ -1,4 +1,4 @@
-#                      Data Parallel Control (dpCtl)
+#                      Data Parallel Control (dpctl)
 #
 # Copyright 2020-2021 Intel Corporation
 #
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Top-level module of all dpCtl Python unit test cases.
+"""Top-level module of all dpctl Python unit test cases.
 """
 
 from .test_dparray import *

--- a/dpctl/tests/test_dparray.py
+++ b/dpctl/tests/test_dparray.py
@@ -1,4 +1,4 @@
-#                       Data Parallel Control (dpCtl)
+#                       Data Parallel Control (dpctl)
 #
 #  Copyright 2020-2021 Intel Corporation
 #

--- a/dpctl/tests/test_sycl_platform.py
+++ b/dpctl/tests/test_sycl_platform.py
@@ -1,4 +1,4 @@
-#                      Data Parallel Control (dpCtl)
+#                      Data Parallel Control (dpctl)
 #
 # Copyright 2020-2021 Intel Corporation
 #

--- a/dpctl/tests/test_sycl_queue_manager.py
+++ b/dpctl/tests/test_sycl_queue_manager.py
@@ -1,4 +1,4 @@
-#                      Data Parallel Control (dpCtl)
+#                      Data Parallel Control (dpctl)
 #
 # Copyright 2020-2021 Intel Corporation
 #

--- a/dpctl/tests/test_sycl_queue_memcpy.py
+++ b/dpctl/tests/test_sycl_queue_memcpy.py
@@ -1,4 +1,4 @@
-#                      Data Parallel Control (dpCtl)
+#                      Data Parallel Control (dpctl)
 #
 # Copyright 2020-2021 Intel Corporation
 #

--- a/dpctl/tests/test_sycl_usm.py
+++ b/dpctl/tests/test_sycl_usm.py
@@ -1,4 +1,4 @@
-#                      Data Parallel Control (dpCtl)
+#                      Data Parallel Control (dpctl)
 #
 # Copyright 2020-2021 Intel Corporation
 #

--- a/examples/cython/sycl_buffer/_buffer_example.pyx
+++ b/examples/cython/sycl_buffer/_buffer_example.pyx
@@ -1,4 +1,4 @@
-#                      Data Parallel Control (dpCtl)
+#                      Data Parallel Control (dpctl)
 #
 # Copyright 2020-2021 Intel Corporation
 #

--- a/examples/cython/sycl_buffer/bench.py
+++ b/examples/cython/sycl_buffer/bench.py
@@ -1,4 +1,4 @@
-#                      Data Parallel Control (dpCtl)
+#                      Data Parallel Control (dpctl)
 #
 # Copyright 2020-2021 Intel Corporation
 #

--- a/examples/cython/sycl_buffer/run.py
+++ b/examples/cython/sycl_buffer/run.py
@@ -1,4 +1,4 @@
-#                      Data Parallel Control (dpCtl)
+#                      Data Parallel Control (dpctl)
 #
 # Copyright 2020-2021 Intel Corporation
 #

--- a/examples/cython/sycl_buffer/setup.py
+++ b/examples/cython/sycl_buffer/setup.py
@@ -1,4 +1,4 @@
-#                      Data Parallel Control (dpCtl)
+#                      Data Parallel Control (dpctl)
 #
 # Copyright 2020-2021 Intel Corporation
 #

--- a/examples/cython/sycl_direct_linkage/README.md
+++ b/examples/cython/sycl_direct_linkage/README.md
@@ -1,6 +1,6 @@
 # Example "sycl_direct_linkage"
 
-This Cython extension does not use dpCtl and links to SYCL directly.
+This Cython extension does not use dpctl and links to SYCL directly.
 
 It exposes `columnwise_total` function that uses oneMKL to compute
 totals for each column of its argument matrix in double precision,
@@ -19,7 +19,7 @@ This extension does not allow one to control the device/queue to
 which execution of kernel is being schedules.
 
 A related example "sycl_buffer" modifies this example in that it uses
-`dpCtl` to retrieve the current queue, allowing a user control the queue,
+`dpctl` to retrieve the current queue, allowing a user control the queue,
 and the avoid the overhead of the queue creation.
 
 To illustrate the queue creation overhead in each call, compare execution of default queue,

--- a/examples/cython/sycl_direct_linkage/_buffer_example.pyx
+++ b/examples/cython/sycl_direct_linkage/_buffer_example.pyx
@@ -1,4 +1,4 @@
-#                      Data Parallel Control (dpCtl)
+#                      Data Parallel Control (dpctl)
 #
 # Copyright 2020-2021 Intel Corporation
 #

--- a/examples/cython/sycl_direct_linkage/bench.py
+++ b/examples/cython/sycl_direct_linkage/bench.py
@@ -1,4 +1,4 @@
-#                      Data Parallel Control (dpCtl)
+#                      Data Parallel Control (dpctl)
 #
 # Copyright 2020-2021 Intel Corporation
 #

--- a/examples/cython/sycl_direct_linkage/run.py
+++ b/examples/cython/sycl_direct_linkage/run.py
@@ -1,4 +1,4 @@
-#                      Data Parallel Control (dpCtl)
+#                      Data Parallel Control (dpctl)
 #
 # Copyright 2020-2021 Intel Corporation
 #

--- a/examples/cython/sycl_direct_linkage/setup.py
+++ b/examples/cython/sycl_direct_linkage/setup.py
@@ -1,4 +1,4 @@
-#                      Data Parallel Control (dpCtl)
+#                      Data Parallel Control (dpctl)
 #
 # Copyright 2020-2021 Intel Corporation
 #

--- a/examples/cython/usm_memory/blackscholes.pyx
+++ b/examples/cython/usm_memory/blackscholes.pyx
@@ -1,4 +1,4 @@
-#                      Data Parallel Control (dpCtl)
+#                      Data Parallel Control (dpctl)
 #
 # Copyright 2020-2021 Intel Corporation
 #

--- a/examples/cython/usm_memory/reference_black_scholes.py
+++ b/examples/cython/usm_memory/reference_black_scholes.py
@@ -1,4 +1,4 @@
-#                      Data Parallel Control (dpCtl)
+#                      Data Parallel Control (dpctl)
 #
 # Copyright 2020-2021 Intel Corporation
 #

--- a/examples/cython/usm_memory/run.py
+++ b/examples/cython/usm_memory/run.py
@@ -1,4 +1,4 @@
-#                      Data Parallel Control (dpCtl)
+#                      Data Parallel Control (dpctl)
 #
 # Copyright 2020-2021 Intel Corporation
 #

--- a/examples/cython/usm_memory/setup.py
+++ b/examples/cython/usm_memory/setup.py
@@ -1,4 +1,4 @@
-#                      Data Parallel Control (dpCtl)
+#                      Data Parallel Control (dpctl)
 #
 # Copyright 2020-2021 Intel Corporation
 #

--- a/examples/python/create_sycl_queues.py
+++ b/examples/python/create_sycl_queues.py
@@ -1,4 +1,4 @@
-#                      Data Parallel Control (dpCtl)
+#                      Data Parallel Control (dpctl)
 #
 # Copyright 2020-2021 Intel Corporation
 #

--- a/examples/python/usm_memory_allocation.py
+++ b/examples/python/usm_memory_allocation.py
@@ -1,4 +1,4 @@
-#                      Data Parallel Control (dpCtl)
+#                      Data Parallel Control (dpctl)
 #
 # Copyright 2020-2021 Intel Corporation
 #

--- a/examples/python/usm_memory_host_access.py
+++ b/examples/python/usm_memory_host_access.py
@@ -1,4 +1,4 @@
-#                      Data Parallel Control (dpCtl)
+#                      Data Parallel Control (dpctl)
 #
 # Copyright 2020-2021 Intel Corporation
 #

--- a/examples/python/usm_memory_operation.py
+++ b/examples/python/usm_memory_operation.py
@@ -1,4 +1,4 @@
-#                      Data Parallel Control (dpCtl)
+#                      Data Parallel Control (dpctl)
 #
 # Copyright 2020-2021 Intel Corporation
 #

--- a/scripts/build_backend.py
+++ b/scripts/build_backend.py
@@ -1,4 +1,4 @@
-#                      Data Parallel Control (dpCtl)
+#                      Data Parallel Control (dpctl)
 #
 # Copyright 2020-2021 Intel Corporation
 #
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Invokes CMake build dpCtl's C API library.
+"""Invokes CMake build dpctl's C API library.
 """
 
 

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-#               Data Parallel Control Library (dpCtl)
+#               Data Parallel Control Library (dpctl)
 #
 # Copyright 2020-2021 Intel Corporation
 #
@@ -270,7 +270,7 @@ setup(
     long_description_content_type="text/markdown",
     license="Apache 2.0",
     author="Intel Corporation",
-    url="https://github.com/IntelPython/dpCtl",
+    url="https://github.com/IntelPython/dpctl",
     packages=find_packages(include=["*"]),
     include_package_data=True,
     ext_modules=extensions(),


### PR DESCRIPTION
`dpCtl` just did not catch on :D so let us use `dpctl` consistently everywhere (refer #330). This PR changes `dpCtl` to `dpctl`in all docstring, license headers, and readme.