### PR TITLE
Fixed signature of SyclDevice._init_helper

### DIFF
--- a/dpctl/_sycl_device.pxd
+++ b/dpctl/_sycl_device.pxd
@@ -40,7 +40,7 @@ cdef class SyclDevice(_SyclDevice):
     @staticmethod
     cdef SyclDevice _create(DPCTLSyclDeviceRef dref)
     @staticmethod
-    cdef void _init_helper(SyclDevice device, DPCTLSyclDeviceRef DRef)
+    cdef void _init_helper(_SyclDevice device, DPCTLSyclDeviceRef DRef)
     cdef int _init_from__SyclDevice(self, _SyclDevice other)
     cdef int _init_from_selector(self, DPCTLSyclDeviceSelectorRef DSRef)
     cdef DPCTLSyclDeviceRef get_device_ref(self)

--- a/dpctl/_sycl_device.pyx
+++ b/dpctl/_sycl_device.pyx
@@ -123,7 +123,7 @@ cdef class SyclDevice(_SyclDevice):
 
     """
     @staticmethod
-    cdef void _init_helper(SyclDevice device, DPCTLSyclDeviceRef DRef):
+    cdef void _init_helper(_SyclDevice device, DPCTLSyclDeviceRef DRef):
         device._device_ref = DRef
         device._device_name = DPCTLDevice_GetName(DRef)
         device._driver_version = DPCTLDevice_GetDriverInfo(DRef)
@@ -132,9 +132,9 @@ cdef class SyclDevice(_SyclDevice):
 
     @staticmethod
     cdef SyclDevice _create(DPCTLSyclDeviceRef dref):
-        cdef SyclDevice ret = <SyclDevice>_SyclDevice.__new__(_SyclDevice)
+        cdef _SyclDevice ret = _SyclDevice.__new__(_SyclDevice)
         # Initialize the attributes of the SyclDevice object
-        SyclDevice._init_helper(ret, dref)
+        SyclDevice._init_helper(<_SyclDevice> ret, dref)
         return SyclDevice(ret)
 
     cdef int _init_from__SyclDevice(self, _SyclDevice other):
@@ -147,6 +147,7 @@ cdef class SyclDevice(_SyclDevice):
             DPCTLDevice_GetMaxWorkItemSizes(self._device_ref)
         )
         self._vendor_name = DPCTLDevice_GetVendorName(self._device_ref)
+        return 0
 
     cdef int _init_from_selector(self, DPCTLSyclDeviceSelectorRef DSRef):
         # Initialize the attributes of the SyclDevice object
@@ -221,7 +222,7 @@ cdef class SyclDevice(_SyclDevice):
             int: The address of the DPCTLSyclDeviceRef object used to create
             this SyclDevice cast to a size_t.
         """
-        return int(<size_t>self._device_ref)
+        return <size_t>self._device_ref
 
     @property
     def backend(self):


### PR DESCRIPTION
From #334, changes to _sycl_device.pyx and .pxd.