### PR TITLE
Fixed crash reported in #345

### DIFF
--- a/dpctl-capi/source/dpctl_sycl_queue_manager.cpp
+++ b/dpctl-capi/source/dpctl_sycl_queue_manager.cpp
@@ -64,6 +64,8 @@ struct QueueManager
                 delete unwrap(CRef);
             } catch (std::bad_alloc const &ba) {
                 std::cerr << ba.what() << '\n';
+            } catch (runtime_error const &re) {
+                std::cerr << re.what() << '\n';
             }
 
             return qs;


### PR DESCRIPTION
Closes #345

```
(idp) [20:48:49 ansatnuc04 dpctl]$ SYCL_DEVICE_FILTER=cuda python -c "import dpctl; dpctl.get_current_queue()"
No device of requested type available. Please check https://software.intel.com/content/www/us/en/develop/articles/intel-oneapi-dpcpp-system-requirements.html -1 (CL_DEVICE_NOT_FOUND)
No currently active queues.
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "dpctl/_sycl_queue_manager.pyx", line 174, in dpctl._sycl_queue_manager.get_current_queue
    cpdef SyclQueue get_current_queue():
  File "dpctl/_sycl_queue_manager.pyx", line 188, in dpctl._sycl_queue_manager.get_current_queue
    return _mgr.get_current_queue()
  File "dpctl/_sycl_queue_manager.pyx", line 91, in dpctl._sycl_queue_manager._SyclQueueManager.get_current_queue
    cpdef SyclQueue get_current_queue(self):
  File "dpctl/_sycl_queue_manager.pyx", line 105, in dpctl._sycl_queue_manager._SyclQueueManager.get_current_queue
    return SyclQueue._create(DPCTLQueueMgr_GetCurrentQueue())
  File "dpctl/_sycl_queue.pyx", line 372, in dpctl._sycl_queue.SyclQueue._create
    raise SyclQueueCreationError("Queue creation failed.")
dpctl._sycl_queue.SyclQueueCreationError: Queue creation failed.
```