### PR TITLE
Fix/crashes reported in 345 344

### DIFF
--- a/dpctl-capi/source/dpctl_sycl_platform_interface.cpp
+++ b/dpctl-capi/source/dpctl_sycl_platform_interface.cpp
@@ -84,6 +84,9 @@ __dpctl_give DPCTLSyclPlatformRef DPCTLPlatform_CreateFromSelector(
             PRef = wrap(P);
         } catch (std::bad_alloc const &ba) {
             std::cerr << ba.what() << '\n';
+        } catch (runtime_error const &re) {
+            std::cerr << re.what() << '\n';
+            return nullptr;
         }
     }
     else {

--- a/dpctl-capi/source/dpctl_sycl_queue_manager.cpp
+++ b/dpctl-capi/source/dpctl_sycl_queue_manager.cpp
@@ -64,6 +64,8 @@ struct QueueManager
                 delete unwrap(CRef);
             } catch (std::bad_alloc const &ba) {
                 std::cerr << ba.what() << '\n';
+            } catch (runtime_error const &re) {
+                std::cerr << re.what() << '\n';
             }
 
             return qs;

--- a/dpctl-capi/tests/test_sycl_device_invalid_filters.cpp
+++ b/dpctl-capi/tests/test_sycl_device_invalid_filters.cpp
@@ -1,0 +1,67 @@
+//===--- test_sycl_device_invalid_filters.cpp - -ve tests for device iface ===//
+//
+//                      Data Parallel Control (dpctl)
+//
+// Copyright 2020-2021 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// Negative test cases for SYCL device creation with invalid filter selectors.
+///
+//===----------------------------------------------------------------------===//
+
+#include "dpctl_sycl_device_interface.h"
+#include "dpctl_sycl_device_selector_interface.h"
+#include <CL/sycl.hpp>
+#include <gtest/gtest.h>
+
+using namespace cl::sycl;
+struct TestUnsupportedFilters : public ::testing::TestWithParam<const char *>
+{
+    DPCTLSyclDeviceSelectorRef DSRef = nullptr;
+
+    TestUnsupportedFilters()
+    {
+        EXPECT_NO_FATAL_FAILURE(DSRef = DPCTLFilterSelector_Create(GetParam()));
+    }
+
+    void SetUp()
+    {
+        if (!DSRef) {
+            auto message = "Skipping as no device of type " +
+                           std::string(GetParam()) + ".";
+            GTEST_SKIP_(message.c_str());
+        }
+    }
+
+    ~TestUnsupportedFilters()
+    {
+        EXPECT_NO_FATAL_FAILURE(DPCTLDeviceSelector_Delete(DSRef));
+    }
+};
+
+TEST_P(TestUnsupportedFilters, Chk_DPCTLDevice_CreateFromSelector)
+{
+    DPCTLSyclDeviceRef DRef = nullptr;
+    EXPECT_NO_FATAL_FAILURE(DRef = DPCTLDevice_CreateFromSelector(DSRef));
+    ASSERT_TRUE(DRef == nullptr);
+    EXPECT_NO_FATAL_FAILURE(DPCTLDevice_Delete(DRef));
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    NegativeDeviceCreationTests,
+    TestUnsupportedFilters,
+    ::testing::Values("abc", "-1", "invalid_filter", "cuda:cpu:0"));

--- a/dpctl-capi/tests/test_sycl_device_selector_interface.cpp
+++ b/dpctl-capi/tests/test_sycl_device_selector_interface.cpp
@@ -46,15 +46,17 @@ struct TestDeviceSelectorInterface : public ::testing::Test
 struct TestFilterSelector : public ::testing::TestWithParam<const char *>
 {
     DPCTLSyclDeviceSelectorRef DSRef = nullptr;
+    DPCTLSyclDeviceRef DRef = nullptr;
 
     TestFilterSelector()
     {
         EXPECT_NO_FATAL_FAILURE(DSRef = DPCTLFilterSelector_Create(GetParam()));
+        EXPECT_NO_FATAL_FAILURE(DRef = DPCTLDevice_CreateFromSelector(DSRef));
     }
 
     void SetUp()
     {
-        if (!DSRef) {
+        if (!DRef) {
             auto message = "Skipping as no device of type " +
                            std::string(GetParam()) + ".";
             GTEST_SKIP_(message.c_str());
@@ -64,6 +66,7 @@ struct TestFilterSelector : public ::testing::TestWithParam<const char *>
     ~TestFilterSelector()
     {
         EXPECT_NO_FATAL_FAILURE(DPCTLDeviceSelector_Delete(DSRef));
+        EXPECT_NO_FATAL_FAILURE(DPCTLDevice_Delete(DRef));
     }
 };
 
@@ -76,15 +79,6 @@ struct TestUnsupportedFilters : public ::testing::TestWithParam<const char *>
         EXPECT_NO_FATAL_FAILURE(DSRef = DPCTLFilterSelector_Create(GetParam()));
     }
 
-    void SetUp()
-    {
-        if (!DSRef) {
-            auto message = "Skipping as no device of type " +
-                           std::string(GetParam()) + ".";
-            GTEST_SKIP_(message.c_str());
-        }
-    }
-
     ~TestUnsupportedFilters()
     {
         EXPECT_NO_FATAL_FAILURE(DPCTLDeviceSelector_Delete(DSRef));
@@ -94,84 +88,107 @@ struct TestUnsupportedFilters : public ::testing::TestWithParam<const char *>
 TEST_F(TestDeviceSelectorInterface, Chk_DPCTLAcceleratorSelector_Create)
 {
     DPCTLSyclDeviceSelectorRef DSRef = nullptr;
+    DPCTLSyclDeviceRef DRef = nullptr;
+
     EXPECT_NO_FATAL_FAILURE(DSRef = DPCTLAcceleratorSelector_Create());
-    if (DSRef) {
-        DPCTLSyclDeviceRef DRef = nullptr;
-        EXPECT_NO_FATAL_FAILURE(DRef = DPCTLDevice_CreateFromSelector(DSRef));
-        ASSERT_TRUE(DRef != nullptr);
-        EXPECT_NO_FATAL_FAILURE(DPCTLDeviceMgr_PrintDeviceInfo(DRef));
-        EXPECT_TRUE(DPCTLDevice_IsAccelerator(DRef));
+    EXPECT_NO_FATAL_FAILURE(DRef = DPCTLDevice_CreateFromSelector(DSRef));
+
+    if (!DRef) {
+        EXPECT_NO_FATAL_FAILURE(DPCTLDeviceSelector_Delete(DSRef));
         EXPECT_NO_FATAL_FAILURE(DPCTLDevice_Delete(DRef));
+        GTEST_SKIP_("Device not found. Skip tests.");
     }
+
+    EXPECT_NO_FATAL_FAILURE(DPCTLDeviceMgr_PrintDeviceInfo(DRef));
+    EXPECT_TRUE(DPCTLDevice_IsAccelerator(DRef));
     EXPECT_NO_FATAL_FAILURE(DPCTLDeviceSelector_Delete(DSRef));
+    EXPECT_NO_FATAL_FAILURE(DPCTLDevice_Delete(DRef));
 }
 
 TEST_F(TestDeviceSelectorInterface, Chk_DPCTLDefaultSelector_Create)
 {
     DPCTLSyclDeviceSelectorRef DSRef = nullptr;
+    DPCTLSyclDeviceRef DRef = nullptr;
+
     EXPECT_NO_FATAL_FAILURE(DSRef = DPCTLDefaultSelector_Create());
-    if (DSRef) {
-        DPCTLSyclDeviceRef DRef = nullptr;
-        EXPECT_NO_FATAL_FAILURE(DRef = DPCTLDevice_CreateFromSelector(DSRef));
-        ASSERT_TRUE(DRef != nullptr);
-        EXPECT_NO_FATAL_FAILURE(DPCTLDeviceMgr_PrintDeviceInfo(DRef));
+    EXPECT_NO_FATAL_FAILURE(DRef = DPCTLDevice_CreateFromSelector(DSRef));
+
+    if (!DRef) {
+        EXPECT_NO_FATAL_FAILURE(DPCTLDeviceSelector_Delete(DSRef));
         EXPECT_NO_FATAL_FAILURE(DPCTLDevice_Delete(DRef));
+        GTEST_SKIP_("Device not found. Skip tests.");
     }
+
+    ASSERT_TRUE(DRef != nullptr);
+    EXPECT_NO_FATAL_FAILURE(DPCTLDeviceMgr_PrintDeviceInfo(DRef));
     EXPECT_NO_FATAL_FAILURE(DPCTLDeviceSelector_Delete(DSRef));
+    EXPECT_NO_FATAL_FAILURE(DPCTLDevice_Delete(DRef));
 }
 
 TEST_F(TestDeviceSelectorInterface, Chk_DPCTLCPUSelector_Create)
 {
     DPCTLSyclDeviceSelectorRef DSRef = nullptr;
+    DPCTLSyclDeviceRef DRef = nullptr;
+
     EXPECT_NO_FATAL_FAILURE(DSRef = DPCTLCPUSelector_Create());
-    if (DSRef) {
-        DPCTLSyclDeviceRef DRef = nullptr;
-        EXPECT_NO_FATAL_FAILURE(DRef = DPCTLDevice_CreateFromSelector(DSRef));
-        ASSERT_TRUE(DRef != nullptr);
-        EXPECT_NO_FATAL_FAILURE(DPCTLDeviceMgr_PrintDeviceInfo(DRef));
-        EXPECT_TRUE(DPCTLDevice_IsCPU(DRef));
+    EXPECT_NO_FATAL_FAILURE(DRef = DPCTLDevice_CreateFromSelector(DSRef));
+
+    if (!DRef) {
+        EXPECT_NO_FATAL_FAILURE(DPCTLDeviceSelector_Delete(DSRef));
         EXPECT_NO_FATAL_FAILURE(DPCTLDevice_Delete(DRef));
+        GTEST_SKIP_("Device not found. Skip tests.");
     }
+
+    EXPECT_NO_FATAL_FAILURE(DPCTLDeviceMgr_PrintDeviceInfo(DRef));
+    EXPECT_TRUE(DPCTLDevice_IsCPU(DRef));
     EXPECT_NO_FATAL_FAILURE(DPCTLDeviceSelector_Delete(DSRef));
+    EXPECT_NO_FATAL_FAILURE(DPCTLDevice_Delete(DRef));
 }
 
 TEST_F(TestDeviceSelectorInterface, Chk_DPCTLGPUSelector_Create)
 {
     DPCTLSyclDeviceSelectorRef DSRef = nullptr;
+    DPCTLSyclDeviceRef DRef = nullptr;
+
     EXPECT_NO_FATAL_FAILURE(DSRef = DPCTLGPUSelector_Create());
-    if (DSRef) {
-        DPCTLSyclDeviceRef DRef = nullptr;
-        EXPECT_NO_FATAL_FAILURE(DRef = DPCTLDevice_CreateFromSelector(DSRef));
-        ASSERT_TRUE(DRef != nullptr);
-        EXPECT_NO_FATAL_FAILURE(DPCTLDeviceMgr_PrintDeviceInfo(DRef));
-        EXPECT_TRUE(DPCTLDevice_IsGPU(DRef));
+    EXPECT_NO_FATAL_FAILURE(DRef = DPCTLDevice_CreateFromSelector(DSRef));
+
+    if (!DRef) {
+        EXPECT_NO_FATAL_FAILURE(DPCTLDeviceSelector_Delete(DSRef));
         EXPECT_NO_FATAL_FAILURE(DPCTLDevice_Delete(DRef));
+        GTEST_SKIP_("Device not found. Skip tests.");
     }
+
+    EXPECT_NO_FATAL_FAILURE(DPCTLDeviceMgr_PrintDeviceInfo(DRef));
+    EXPECT_TRUE(DPCTLDevice_IsGPU(DRef));
     EXPECT_NO_FATAL_FAILURE(DPCTLDeviceSelector_Delete(DSRef));
+    EXPECT_NO_FATAL_FAILURE(DPCTLDevice_Delete(DRef));
 }
 
 TEST_F(TestDeviceSelectorInterface, Chk_DPCTLHostSelector_Create)
 {
     DPCTLSyclDeviceSelectorRef DSRef = nullptr;
+    DPCTLSyclDeviceRef DRef = nullptr;
+
     EXPECT_NO_FATAL_FAILURE(DSRef = DPCTLHostSelector_Create());
-    if (DSRef) {
-        DPCTLSyclDeviceRef DRef = nullptr;
-        EXPECT_NO_FATAL_FAILURE(DRef = DPCTLDevice_CreateFromSelector(DSRef));
-        ASSERT_TRUE(DRef != nullptr);
-        EXPECT_NO_FATAL_FAILURE(DPCTLDeviceMgr_PrintDeviceInfo(DRef));
-        // FIXME: DPCPP's host_selector returns a CPU device for some reason.
-        // EXPECT_TRUE(DPCTLDevice_IsHost(DRef));
+    EXPECT_NO_FATAL_FAILURE(DRef = DPCTLDevice_CreateFromSelector(DSRef));
+
+    if (!DRef) {
+        EXPECT_NO_FATAL_FAILURE(DPCTLDeviceSelector_Delete(DSRef));
         EXPECT_NO_FATAL_FAILURE(DPCTLDevice_Delete(DRef));
+        GTEST_SKIP_("Device not found. Skip tests.");
     }
+
+    EXPECT_NO_FATAL_FAILURE(DPCTLDeviceMgr_PrintDeviceInfo(DRef));
+    // FIXME: DPCPP's host_selector returns a CPU device for some reason.
+    // EXPECT_TRUE(DPCTLDevice_IsHost(DRef));
     EXPECT_NO_FATAL_FAILURE(DPCTLDeviceSelector_Delete(DSRef));
+    EXPECT_NO_FATAL_FAILURE(DPCTLDevice_Delete(DRef));
 }
 
 TEST_P(TestFilterSelector, Chk_DPCTLFilterSelector_Create)
 {
-    DPCTLSyclDeviceRef DRef = nullptr;
-    EXPECT_NO_FATAL_FAILURE(DRef = DPCTLDevice_CreateFromSelector(DSRef));
     ASSERT_TRUE(DRef != nullptr);
-    EXPECT_NO_FATAL_FAILURE(DPCTLDevice_Delete(DRef));
 }
 
 TEST_P(TestUnsupportedFilters, Chk_DPCTLFilterSelector_Create)
@@ -186,20 +203,26 @@ TEST_F(TestDeviceSelectorInterface, Chk_DPCTLGPUSelector_Score)
 {
     DPCTLSyclDeviceSelectorRef DSRef_GPU = nullptr;
     DPCTLSyclDeviceSelectorRef DSRef_CPU = nullptr;
+    DPCTLSyclDeviceRef DRef = nullptr;
+
     EXPECT_NO_FATAL_FAILURE(DSRef_GPU = DPCTLGPUSelector_Create());
     EXPECT_NO_FATAL_FAILURE(DSRef_CPU = DPCTLCPUSelector_Create());
-    if (DSRef_CPU && DSRef_GPU) {
-        DPCTLSyclDeviceRef DRef = nullptr;
-        EXPECT_NO_FATAL_FAILURE(DRef =
-                                    DPCTLDevice_CreateFromSelector(DSRef_CPU));
-        ASSERT_TRUE(DRef != nullptr);
-        EXPECT_TRUE(DPCTLDevice_IsCPU(DRef));
-        EXPECT_TRUE(DPCTLDeviceSelector_Score(DSRef_GPU, DRef) < 0);
-        EXPECT_TRUE(DPCTLDeviceSelector_Score(DSRef_CPU, DRef) > 0);
+    EXPECT_NO_FATAL_FAILURE(DRef = DPCTLDevice_CreateFromSelector(DSRef_CPU));
+
+    if (!DRef) {
+        EXPECT_NO_FATAL_FAILURE(DPCTLDeviceSelector_Delete(DSRef_GPU));
+        EXPECT_NO_FATAL_FAILURE(DPCTLDeviceSelector_Delete(DSRef_CPU));
         EXPECT_NO_FATAL_FAILURE(DPCTLDevice_Delete(DRef));
+        GTEST_SKIP_("Device not found. Skip tests.");
     }
+
+    ASSERT_TRUE(DRef != nullptr);
+    EXPECT_TRUE(DPCTLDevice_IsCPU(DRef));
+    EXPECT_TRUE(DPCTLDeviceSelector_Score(DSRef_GPU, DRef) < 0);
+    EXPECT_TRUE(DPCTLDeviceSelector_Score(DSRef_CPU, DRef) > 0);
     EXPECT_NO_FATAL_FAILURE(DPCTLDeviceSelector_Delete(DSRef_GPU));
     EXPECT_NO_FATAL_FAILURE(DPCTLDeviceSelector_Delete(DSRef_CPU));
+    EXPECT_NO_FATAL_FAILURE(DPCTLDevice_Delete(DRef));
 }
 
 INSTANTIATE_TEST_SUITE_P(FilterSelectorCreation,
@@ -216,9 +239,10 @@ INSTANTIATE_TEST_SUITE_P(FilterSelectorCreation,
                                            "level_zero:gpu:0",
                                            "gpu:0",
                                            "gpu:1",
-                                           "1"));
+                                           "1",
+                                           "0",
+                                           "host"));
 
-INSTANTIATE_TEST_SUITE_P(
-    NegativeFilterSelectorCreation,
-    TestUnsupportedFilters,
-    ::testing::Values("abc", "-1", "opencl:gpu:1", "level_zero:cpu:0"));
+INSTANTIATE_TEST_SUITE_P(NegativeFilterSelectorCreation,
+                         TestUnsupportedFilters,
+                         ::testing::Values("abc", "-1", "cuda:cpu:0"));

--- a/dpctl-capi/tests/test_sycl_platform_invalid_filters.cpp
+++ b/dpctl-capi/tests/test_sycl_platform_invalid_filters.cpp
@@ -1,0 +1,68 @@
+//=== test_sycl_platform_invalid_filters.cpp - -ve tests for platform iface ==//
+//
+//                      Data Parallel Control (dpctl)
+//
+// Copyright 2020-2021 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// Negative test cases for SYCL platform creation with invalid filter
+/// selectors.
+///
+//===----------------------------------------------------------------------===//
+
+#include "dpctl_sycl_device_selector_interface.h"
+#include "dpctl_sycl_platform_interface.h"
+#include <CL/sycl.hpp>
+#include <gtest/gtest.h>
+
+using namespace cl::sycl;
+struct TestUnsupportedFilters : public ::testing::TestWithParam<const char *>
+{
+    DPCTLSyclDeviceSelectorRef DSRef = nullptr;
+
+    TestUnsupportedFilters()
+    {
+        EXPECT_NO_FATAL_FAILURE(DSRef = DPCTLFilterSelector_Create(GetParam()));
+    }
+
+    void SetUp()
+    {
+        if (!DSRef) {
+            auto message = "Skipping as no device of type " +
+                           std::string(GetParam()) + ".";
+            GTEST_SKIP_(message.c_str());
+        }
+    }
+
+    ~TestUnsupportedFilters()
+    {
+        EXPECT_NO_FATAL_FAILURE(DPCTLDeviceSelector_Delete(DSRef));
+    }
+};
+
+TEST_P(TestUnsupportedFilters, Chk_DPCTLPlatform_CreateFromSelector)
+{
+    DPCTLSyclPlatformRef PRef = nullptr;
+    EXPECT_NO_FATAL_FAILURE(PRef = DPCTLPlatform_CreateFromSelector(DSRef));
+    ASSERT_TRUE(PRef == nullptr);
+    EXPECT_NO_FATAL_FAILURE(DPCTLPlatform_Delete(PRef));
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    NegativeDeviceCreationTests,
+    TestUnsupportedFilters,
+    ::testing::Values("abc", "-1", "invalid_filter", "cuda:cpu:0"));

--- a/dpctl-capi/tests/test_sycl_program_interface.cpp
+++ b/dpctl-capi/tests/test_sycl_program_interface.cpp
@@ -41,78 +41,78 @@
 
 using namespace cl::sycl;
 
-namespace
+struct TestDPCTLSyclProgramInterface
+    : public ::testing::TestWithParam<const char *>
 {
-const int SIZE = 1024;
+    DPCTLSyclDeviceRef DRef = nullptr;
+    DPCTLSyclContextRef CRef = nullptr;
+    DPCTLSyclQueueRef QRef = nullptr;
+    DPCTLSyclProgramRef PRef = nullptr;
+    std::ifstream spirvFile;
+    size_t spirvFileSize;
+    std::vector<char> spirvBuffer;
 
-void add_kernel_checker(queue *syclQueue, DPCTLSyclKernelRef AddKernel)
-{
-    range<1> a_size{SIZE};
-    std::array<int, SIZE> a, b, c;
-
-    for (int i = 0; i < SIZE; ++i) {
-        a[i] = i;
-        b[i] = i;
-        c[i] = 0;
-    }
-
+    TestDPCTLSyclProgramInterface()
     {
-        buffer<int, 1> a_device(a.data(), a_size);
-        buffer<int, 1> b_device(b.data(), a_size);
-        buffer<int, 1> c_device(c.data(), a_size);
-        buffer<int, 1> buffs[3] = {a_device, b_device, c_device};
-        syclQueue->submit([&](handler &cgh) {
-            for (auto buff : buffs) {
-                auto arg = buff.get_access<access::mode::read_write>(cgh);
-                cgh.set_args(arg);
-            }
-            auto syclKernel = reinterpret_cast<kernel *>(AddKernel);
-            cgh.parallel_for(range<1>{SIZE}, *syclKernel);
-        });
+        auto DS = DPCTLFilterSelector_Create(GetParam());
+        DRef = DPCTLDevice_CreateFromSelector(DS);
+        DPCTLDeviceSelector_Delete(DS);
+        CRef = DPCTLDeviceMgr_GetCachedContext(DRef);
+        QRef = DPCTLQueue_Create(CRef, DRef, nullptr, DPCTL_DEFAULT_PROPERTY);
+
+        if (DRef) {
+            spirvFile.open("./multi_kernel.spv",
+                           std::ios::binary | std::ios::ate);
+            spirvFileSize = std::filesystem::file_size("./multi_kernel.spv");
+            spirvBuffer.reserve(spirvFileSize);
+            spirvFile.seekg(0, std::ios::beg);
+            spirvFile.read(spirvBuffer.data(), spirvFileSize);
+            PRef = DPCTLProgram_CreateFromSpirv(CRef, spirvBuffer.data(),
+                                                spirvFileSize, nullptr);
+        }
     }
 
-    // Validate the data
-    for (int i = 0; i < SIZE; ++i) {
-        EXPECT_EQ(c[i], i + i);
+    void SetUp()
+    {
+        if (!DRef) {
+            auto message = "Skipping as no device of type " +
+                           std::string(GetParam()) + ".";
+            GTEST_SKIP_(message.c_str());
+        }
     }
+
+    ~TestDPCTLSyclProgramInterface()
+    {
+        if (DRef)
+            spirvFile.close();
+        DPCTLDevice_Delete(DRef);
+        DPCTLQueue_Delete(QRef);
+        DPCTLContext_Delete(CRef);
+        DPCTLProgram_Delete(PRef);
+    }
+};
+
+TEST_P(TestDPCTLSyclProgramInterface, Chk_CreateFromSpirv)
+{
+
+    ASSERT_TRUE(PRef != nullptr);
+    ASSERT_TRUE(DPCTLProgram_HasKernel(PRef, "add"));
+    ASSERT_TRUE(DPCTLProgram_HasKernel(PRef, "axpy"));
+    DPCTLProgram_Delete(PRef);
 }
 
-void axpy_kernel_checker(queue *syclQueue, DPCTLSyclKernelRef AxpyKernel)
+TEST_P(TestDPCTLSyclProgramInterface, Chk_GetKernel)
 {
-    range<1> a_size{SIZE};
-    std::array<int, SIZE> a, b, c;
+    auto AddKernel = DPCTLProgram_GetKernel(PRef, "add");
+    auto AxpyKernel = DPCTLProgram_GetKernel(PRef, "axpy");
 
-    for (int i = 0; i < SIZE; ++i) {
-        a[i] = i;
-        b[i] = i;
-        c[i] = 0;
-    }
-    int d = 10;
-    {
-        buffer<int, 1> a_device(a.data(), a_size);
-        buffer<int, 1> b_device(b.data(), a_size);
-        buffer<int, 1> c_device(c.data(), a_size);
-        buffer<int, 1> buffs[3] = {a_device, b_device, c_device};
-        syclQueue->submit([&](handler &cgh) {
-            for (auto i = 0ul; i < 3; ++i) {
-                auto arg = buffs[i].get_access<access::mode::read_write>(cgh);
-                cgh.set_arg(i, arg);
-            }
-            cgh.set_arg(3, d);
-            auto syclKernel = reinterpret_cast<kernel *>(AxpyKernel);
-            cgh.parallel_for(range<1>{SIZE}, *syclKernel);
-        });
-    }
-
-    // Validate the data
-    for (int i = 0; i < SIZE; ++i) {
-        EXPECT_EQ(c[i], i + d * i);
-    }
+    ASSERT_TRUE(AddKernel != nullptr);
+    ASSERT_TRUE(AxpyKernel != nullptr);
+    DPCTLKernel_Delete(AddKernel);
+    DPCTLKernel_Delete(AxpyKernel);
 }
 
-} /* end of anonymous namespace */
-
-struct TestDPCTLSyclProgramInterface : public ::testing::Test
+struct TestOCLProgramFromSource : public ::testing::Test
 {
     const char *CLProgramStr = R"CLC(
         kernel void add(global int* a, global int* b, global int* c) {
@@ -120,155 +120,71 @@ struct TestDPCTLSyclProgramInterface : public ::testing::Test
             c[index] = a[index] + b[index];
         }
 
-        kernel void axpy(global int* a, global int* b, global int* c, int d) {
+        kernel void axpy(global int* a, global int* b, global int* c, int d)
+        {
             size_t index = get_global_id(0);
             c[index] = a[index] + d*b[index];
         }
     )CLC";
     const char *CompileOpts = "-cl-fast-relaxed-math";
-    std::ifstream spirvFile;
-    size_t spirvFileSize = 0;
-    std::vector<char> spirvBuffer;
-    size_t nOpenCLGpuQ = 0;
+    DPCTLSyclDeviceRef DRef = nullptr;
+    DPCTLSyclContextRef CRef = nullptr;
+    DPCTLSyclQueueRef QRef = nullptr;
+    DPCTLSyclProgramRef PRef = nullptr;
 
-    TestDPCTLSyclProgramInterface()
-        : spirvFile{"./multi_kernel.spv", std::ios::binary | std::ios::ate},
-          spirvFileSize(std::filesystem::file_size("./multi_kernel.spv")),
-          spirvBuffer(spirvFileSize),
-          nOpenCLGpuQ(DPCTLDeviceMgr_GetNumDevices(DPCTL_OPENCL | DPCTL_GPU))
+    TestOCLProgramFromSource()
     {
-        spirvFile.seekg(0, std::ios::beg);
-        spirvFile.read(spirvBuffer.data(), spirvFileSize);
+        auto DS = DPCTLFilterSelector_Create("opencl:gpu");
+        DRef = DPCTLDevice_CreateFromSelector(DS);
+        DPCTLDeviceSelector_Delete(DS);
+        CRef = DPCTLDeviceMgr_GetCachedContext(DRef);
+        QRef = DPCTLQueue_Create(CRef, DRef, nullptr, DPCTL_DEFAULT_PROPERTY);
+
+        if (DRef)
+            PRef = DPCTLProgram_CreateFromOCLSource(CRef, CLProgramStr,
+                                                    CompileOpts);
     }
 
-    ~TestDPCTLSyclProgramInterface()
+    ~TestOCLProgramFromSource()
     {
-        spirvFile.close();
+        DPCTLDevice_Delete(DRef);
+        DPCTLQueue_Delete(QRef);
+        DPCTLContext_Delete(CRef);
+        DPCTLProgram_Delete(PRef);
     }
 };
 
-TEST_F(TestDPCTLSyclProgramInterface, CheckCreateFromOCLSource)
+TEST_F(TestOCLProgramFromSource, CheckCreateFromOCLSource)
 {
-    if (!nOpenCLGpuQ)
+    if (!DRef)
         GTEST_SKIP_("Skipping as no OpenCL GPU device found.\n");
-    auto FSRef = DPCTLFilterSelector_Create("opencl:gpu:0");
-    auto DRef = DPCTLDevice_CreateFromSelector(FSRef);
-    auto QueueRef = DPCTLQueue_CreateForDevice(DRef, nullptr, 0);
-    auto CtxRef = DPCTLQueue_GetContext(QueueRef);
-    auto PRef =
-        DPCTLProgram_CreateFromOCLSource(CtxRef, CLProgramStr, CompileOpts);
+
     ASSERT_TRUE(PRef != nullptr);
     ASSERT_TRUE(DPCTLProgram_HasKernel(PRef, "add"));
     ASSERT_TRUE(DPCTLProgram_HasKernel(PRef, "axpy"));
-
-    DPCTLQueue_Delete(QueueRef);
-    DPCTLContext_Delete(CtxRef);
-    DPCTLProgram_Delete(PRef);
-    DPCTLDeviceSelector_Delete(FSRef);
-    DPCTLDevice_Delete(DRef);
 }
 
-TEST_F(TestDPCTLSyclProgramInterface, CheckCreateFromSpirvOCL)
+TEST_F(TestOCLProgramFromSource, CheckGetKernelOCLSource)
 {
-    if (!nOpenCLGpuQ)
+    if (!DRef)
         GTEST_SKIP_("Skipping as no OpenCL GPU device found.\n");
-    auto FSRef = DPCTLFilterSelector_Create("opencl:gpu:0");
-    auto DRef = DPCTLDevice_CreateFromSelector(FSRef);
-    auto QueueRef = DPCTLQueue_CreateForDevice(DRef, nullptr, 0);
-    auto CtxRef = DPCTLQueue_GetContext(QueueRef);
-    auto PRef = DPCTLProgram_CreateFromSpirv(CtxRef, spirvBuffer.data(),
-                                             spirvFileSize, nullptr);
-    ASSERT_TRUE(PRef != nullptr);
-    ASSERT_TRUE(DPCTLProgram_HasKernel(PRef, "add"));
-    ASSERT_TRUE(DPCTLProgram_HasKernel(PRef, "axpy"));
 
-    DPCTLQueue_Delete(QueueRef);
-    DPCTLContext_Delete(CtxRef);
-    DPCTLProgram_Delete(PRef);
-    DPCTLDeviceSelector_Delete(FSRef);
-    DPCTLDevice_Delete(DRef);
+    auto AddKernel = DPCTLProgram_GetKernel(PRef, "add");
+    auto AxpyKernel = DPCTLProgram_GetKernel(PRef, "axpy");
+    ASSERT_TRUE(AddKernel != nullptr);
+    ASSERT_TRUE(AxpyKernel != nullptr);
+    DPCTLKernel_Delete(AddKernel);
+    DPCTLKernel_Delete(AxpyKernel);
 }
 
+INSTANTIATE_TEST_SUITE_P(ProgramCreationFromSpriv,
+                         TestDPCTLSyclProgramInterface,
+                         ::testing::Values("opencl",
+                                           "opencl:gpu",
+                                           "opencl:cpu",
+                                           "opencl:gpu:0",
 #ifdef DPCTL_ENABLE_LO_PROGRAM_CREATION
-TEST_F(TestDPCTLSyclProgramInterface, CheckCreateFromSpirvL0)
-{
-    auto nL0GpuQ = DPCTLDeviceMgr_GetNumDevices(DPCTL_LEVEL_ZERO | DPCTL_GPU);
-    if (!nL0GpuQ)
-        GTEST_SKIP_("Skipping as no OpenCL GPU device found.\n");
-    auto FSRef = DPCTLFilterSelector_Create("level_zero:gpu:0");
-    auto DRef = DPCTLDevice_CreateFromSelector(FSRef);
-    auto QueueRef = DPCTLQueue_CreateForDevice(DRef, nullptr, 0);
-    auto CtxRef = DPCTLQueue_GetContext(QueueRef);
-    auto PRef = DPCTLProgram_CreateFromSpirv(CtxRef, spirvBuffer.data(),
-                                             spirvFileSize, nullptr);
-    ASSERT_TRUE(PRef != nullptr);
-    ASSERT_TRUE(DPCTLProgram_HasKernel(PRef, "add"));
-    ASSERT_TRUE(DPCTLProgram_HasKernel(PRef, "axpy"));
-
-    DPCTLQueue_Delete(QueueRef);
-    DPCTLContext_Delete(CtxRef);
-    DPCTLProgram_Delete(PRef);
-    DPCTLDeviceSelector_Delete(FSRef);
-    DPCTLDevice_Delete(DRef);
-}
+                                           "level_zero",
+                                           "level_zero:gpu",
 #endif
-
-TEST_F(TestDPCTLSyclProgramInterface, CheckGetKernelOCLSource)
-{
-    if (!nOpenCLGpuQ)
-        GTEST_SKIP_("Skipping as no OpenCL GPU device found.\n");
-    auto FSRef = DPCTLFilterSelector_Create("opencl:gpu:0");
-    auto DRef = DPCTLDevice_CreateFromSelector(FSRef);
-    auto QueueRef = DPCTLQueue_CreateForDevice(DRef, nullptr, 0);
-    auto CtxRef = DPCTLQueue_GetContext(QueueRef);
-    auto PRef =
-        DPCTLProgram_CreateFromOCLSource(CtxRef, CLProgramStr, CompileOpts);
-    auto AddKernel = DPCTLProgram_GetKernel(PRef, "add");
-    auto AxpyKernel = DPCTLProgram_GetKernel(PRef, "axpy");
-
-    ASSERT_TRUE(AddKernel != nullptr);
-    ASSERT_TRUE(AxpyKernel != nullptr);
-
-    auto syclQueue = reinterpret_cast<queue *>(QueueRef);
-
-    add_kernel_checker(syclQueue, AddKernel);
-    axpy_kernel_checker(syclQueue, AxpyKernel);
-
-    DPCTLKernel_Delete(AddKernel);
-    DPCTLKernel_Delete(AxpyKernel);
-    DPCTLQueue_Delete(QueueRef);
-    DPCTLContext_Delete(CtxRef);
-    DPCTLProgram_Delete(PRef);
-    DPCTLDeviceSelector_Delete(FSRef);
-    DPCTLDevice_Delete(DRef);
-}
-
-TEST_F(TestDPCTLSyclProgramInterface, CheckGetKernelSpirv)
-{
-    if (!nOpenCLGpuQ)
-        GTEST_SKIP_("Skipping as no OpenCL GPU device found.\n");
-    auto FSRef = DPCTLFilterSelector_Create("opencl:gpu:0");
-    auto DRef = DPCTLDevice_CreateFromSelector(FSRef);
-    auto QueueRef = DPCTLQueue_CreateForDevice(DRef, nullptr, 0);
-    auto CtxRef = DPCTLQueue_GetContext(QueueRef);
-    auto PRef = DPCTLProgram_CreateFromSpirv(CtxRef, spirvBuffer.data(),
-                                             spirvFileSize, nullptr);
-    auto AddKernel = DPCTLProgram_GetKernel(PRef, "add");
-    auto AxpyKernel = DPCTLProgram_GetKernel(PRef, "axpy");
-
-    ASSERT_TRUE(AddKernel != nullptr);
-    ASSERT_TRUE(AxpyKernel != nullptr);
-
-    auto syclQueue = reinterpret_cast<queue *>(QueueRef);
-
-    add_kernel_checker(syclQueue, AddKernel);
-    axpy_kernel_checker(syclQueue, AxpyKernel);
-
-    DPCTLKernel_Delete(AddKernel);
-    DPCTLKernel_Delete(AxpyKernel);
-    DPCTLQueue_Delete(QueueRef);
-    DPCTLContext_Delete(CtxRef);
-    DPCTLProgram_Delete(PRef);
-    DPCTLDeviceSelector_Delete(FSRef);
-    DPCTLDevice_Delete(DRef);
-}
+                                           "opencl:cpu:0"));

--- a/dpctl-capi/tests/test_sycl_queue_interface.cpp
+++ b/dpctl-capi/tests/test_sycl_queue_interface.cpp
@@ -65,20 +65,6 @@ void axpy_kernel_checker(const float *a,
     }
 }
 
-bool has_devices()
-{
-    bool ret = false;
-    for (auto &p : platform::get_platforms()) {
-        if (p.is_host())
-            continue;
-        if (!p.get_devices().empty()) {
-            ret = true;
-            break;
-        }
-    }
-    return ret;
-}
-
 } /* End of anonymous namespace */
 
 struct TestDPCTLSyclQueueInterface : public ::testing::Test
@@ -155,6 +141,7 @@ TEST_F(TestDPCTLSyclQueueInterface, Check_Copy)
     DPCTLSyclQueueRef Q1 = nullptr;
     DPCTLSyclQueueRef Q2 = nullptr;
     EXPECT_NO_FATAL_FAILURE(Q1 = DPCTLQueueMgr_GetCurrentQueue());
+    ASSERT_TRUE(Q1);
     EXPECT_NO_FATAL_FAILURE(Q2 = DPCTLQueue_Copy(Q1));
     EXPECT_TRUE(bool(Q2));
     EXPECT_NO_FATAL_FAILURE(DPCTLQueue_Delete(Q1));
@@ -163,17 +150,22 @@ TEST_F(TestDPCTLSyclQueueInterface, Check_Copy)
 
 TEST_F(TestDPCTLSyclQueueInterface, CheckAreEq)
 {
-    auto nOclGPU = DPCTLDeviceMgr_GetNumDevices(DPCTL_OPENCL | DPCTL_GPU);
-    if (!nOclGPU)
+    auto FSRef = DPCTLFilterSelector_Create("opencl:gpu:0");
+    auto DRef = DPCTLDevice_CreateFromSelector(FSRef);
+    if (!DRef)
         GTEST_SKIP_("Skipping: No OpenCL GPUs available.\n");
 
     auto Q1 = DPCTLQueueMgr_GetCurrentQueue();
     auto Q2 = DPCTLQueueMgr_GetCurrentQueue();
 
-    EXPECT_TRUE(DPCTLQueue_AreEq(Q1, Q2));
+    EXPECT_TRUE(Q1 && Q2);
+    if (!(Q1 && Q2)) {
+        DPCTLDeviceSelector_Delete(FSRef);
+        DPCTLDevice_Delete(DRef);
+        GTEST_SKIP_("No current queue exists. Skip everything else.");
+    }
 
-    auto FSRef = DPCTLFilterSelector_Create("opencl:gpu:0");
-    auto DRef = DPCTLDevice_CreateFromSelector(FSRef);
+    EXPECT_TRUE(DPCTLQueue_AreEq(Q1, Q2));
     auto Q3 = DPCTLQueue_CreateForDevice(DRef, nullptr, 0);
     auto Q4 = DPCTLQueue_CreateForDevice(DRef, nullptr, 0);
 
@@ -198,19 +190,19 @@ TEST_F(TestDPCTLSyclQueueInterface, CheckAreEq)
 
 TEST_F(TestDPCTLSyclQueueInterface, CheckAreEq2)
 {
-    if (!has_devices())
-        GTEST_SKIP_("Skipping: No Sycl devices.\n");
-
-    auto nOclGPU = DPCTLDeviceMgr_GetNumDevices(DPCTL_OPENCL | DPCTL_GPU);
-    auto nOclCPU = DPCTLDeviceMgr_GetNumDevices(
-        DPCTLSyclBackendType::DPCTL_OPENCL | DPCTL_CPU);
-    if (!nOclGPU || !nOclCPU)
-        GTEST_SKIP_("OpenCL GPUs and CPU not available.\n");
-
     auto FSRef = DPCTLFilterSelector_Create("opencl:gpu:0");
     auto DRef = DPCTLDevice_CreateFromSelector(FSRef);
     auto FSRef2 = DPCTLFilterSelector_Create("opencl:cpu:0");
     auto DRef2 = DPCTLDevice_CreateFromSelector(FSRef2);
+
+    if (!(DRef && DRef2)) {
+        DPCTLDeviceSelector_Delete(FSRef);
+        DPCTLDevice_Delete(DRef);
+        DPCTLDeviceSelector_Delete(FSRef2);
+        DPCTLDevice_Delete(DRef2);
+        GTEST_SKIP_("OpenCL GPUs and CPU not available.\n");
+    }
+
     auto GPU_Q =
         DPCTLQueue_CreateForDevice(DRef, nullptr, DPCTL_DEFAULT_PROPERTY);
     auto CPU_Q =
@@ -271,16 +263,13 @@ INSTANTIATE_TEST_SUITE_P(DPCTLQueueMemberFuncTests,
 
 TEST_F(TestDPCTLSyclQueueInterface, CheckSubmit)
 {
-    if (!has_devices())
-        GTEST_SKIP_("Skipping: No Sycl devices.\n");
-
-    auto nOpenCLGpuQ = DPCTLDeviceMgr_GetNumDevices(DPCTL_OPENCL | DPCTL_GPU);
-
-    if (!nOpenCLGpuQ)
-        GTEST_SKIP_("Skipping: No OpenCL GPU device.\n");
-
     auto FSRef = DPCTLFilterSelector_Create("opencl:gpu:0");
     auto DRef = DPCTLDevice_CreateFromSelector(FSRef);
+    if (!DRef) {
+        DPCTLDeviceSelector_Delete(FSRef);
+        DPCTLDevice_Delete(DRef);
+        GTEST_SKIP_("Skipping: No OpenCL GPU device.\n");
+    }
     auto Queue =
         DPCTLQueue_CreateForDevice(DRef, nullptr, DPCTL_DEFAULT_PROPERTY);
     auto CtxRef = DPCTLQueue_GetContext(Queue);

--- a/dpctl-capi/tests/test_sycl_queue_manager.cpp
+++ b/dpctl-capi/tests/test_sycl_queue_manager.cpp
@@ -129,50 +129,73 @@ TEST_P(TestDPCTLSyclQueueManager, CheckIsCurrentQueue)
 
 TEST(TestDPCTLSyclQueueManager, CheckGetNumActivatedQueues)
 {
-    if (!(DPCTLDeviceMgr_GetNumDevices(DPCTL_OPENCL | DPCTL_GPU) &&
-          DPCTLDeviceMgr_GetNumDevices(DPCTL_OPENCL | DPCTL_CPU)))
-        GTEST_SKIP_("Both OpenCL gpu and cpu drivers needed for this test.");
-
     size_t num0, num1, num2, num4;
-    auto DS1 = DPCTLFilterSelector_Create("opencl:gpu");
-    auto D1 = DPCTLDevice_CreateFromSelector(DS1);
-    auto Q1 = DPCTLQueue_CreateForDevice(D1, nullptr, DPCTL_DEFAULT_PROPERTY);
-    DPCTLQueueMgr_PushQueue(Q1);
+    DPCTLSyclDeviceSelectorRef CPU_DSRef = nullptr, GPU_DSRef = nullptr;
+    DPCTLSyclDeviceRef CPU_DRef = nullptr, GPU_DRef = nullptr;
 
-    std::thread first(foo, std::ref(num1));
-    std::thread second(bar, std::ref(num2));
+    GPU_DSRef = DPCTLFilterSelector_Create("opencl:gpu");
+    GPU_DRef = DPCTLDevice_CreateFromSelector(GPU_DSRef);
+    CPU_DSRef = DPCTLFilterSelector_Create("opencl:cpu");
+    CPU_DRef = DPCTLDevice_CreateFromSelector(CPU_DSRef);
 
-    // synchronize threads:
-    first.join();
-    second.join();
+    if (!(CPU_DRef && GPU_DRef)) {
+        DPCTLDeviceSelector_Delete(GPU_DSRef);
+        DPCTLDevice_Delete(GPU_DRef);
+        DPCTLDeviceSelector_Delete(CPU_DSRef);
+        DPCTLDevice_Delete(CPU_DRef);
+        GTEST_SKIP_(
+            "OpenCL GPU and CPU devices are needed, but were not found.");
+    }
+    else {
+        auto Q1 = DPCTLQueue_CreateForDevice(GPU_DRef, nullptr,
+                                             DPCTL_DEFAULT_PROPERTY);
+        DPCTLQueueMgr_PushQueue(Q1);
+        std::thread first(foo, std::ref(num1));
+        std::thread second(bar, std::ref(num2));
 
-    // Capture the number of active queues in first
-    num0 = DPCTLQueueMgr_GetQueueStackSize();
-    DPCTLQueueMgr_PopQueue();
-    num4 = DPCTLQueueMgr_GetQueueStackSize();
+        // synchronize threads:
+        first.join();
+        second.join();
 
-    // Verify what the expected number of activated queues each time a thread
-    // called getNumActivatedQueues.
-    EXPECT_EQ(num0, 1ul);
-    EXPECT_EQ(num1, 2ul);
-    EXPECT_EQ(num2, 1ul);
-    EXPECT_EQ(num4, 0ul);
+        // Capture the number of active queues in first
+        num0 = DPCTLQueueMgr_GetQueueStackSize();
+        DPCTLQueueMgr_PopQueue();
+        num4 = DPCTLQueueMgr_GetQueueStackSize();
 
-    DPCTLQueue_Delete(Q1);
-    DPCTLDeviceSelector_Delete(DS1);
-    DPCTLDevice_Delete(D1);
+        // Verify what the expected number of activated queues each time a
+        // thread called getNumActivatedQueues.
+        EXPECT_EQ(num0, 1ul);
+        EXPECT_EQ(num1, 2ul);
+        EXPECT_EQ(num2, 1ul);
+        EXPECT_EQ(num4, 0ul);
+
+        DPCTLQueue_Delete(Q1);
+        DPCTLDeviceSelector_Delete(GPU_DSRef);
+        DPCTLDevice_Delete(GPU_DRef);
+        DPCTLDeviceSelector_Delete(CPU_DSRef);
+        DPCTLDevice_Delete(CPU_DRef);
+    }
 }
 
 TEST(TestDPCTLSyclQueueManager, CheckIsCurrentQueue2)
 {
-    if (!(DPCTLDeviceMgr_GetNumDevices(DPCTL_OPENCL | DPCTL_GPU) &&
-          DPCTLDeviceMgr_GetNumDevices(DPCTL_OPENCL | DPCTL_CPU)))
-        GTEST_SKIP_("Both OpenCL gpu and cpu drivers needed for this test.");
+    DPCTLSyclDeviceSelectorRef DS1 = nullptr, DS2 = nullptr;
+    DPCTLSyclDeviceRef D1 = nullptr, D2 = nullptr;
 
-    auto DS1 = DPCTLFilterSelector_Create("opencl:gpu");
-    auto DS2 = DPCTLFilterSelector_Create("opencl:cpu");
-    auto D1 = DPCTLDevice_CreateFromSelector(DS1);
-    auto D2 = DPCTLDevice_CreateFromSelector(DS2);
+    DS1 = DPCTLFilterSelector_Create("opencl:gpu");
+    DS2 = DPCTLFilterSelector_Create("opencl:cpu");
+    D1 = DPCTLDevice_CreateFromSelector(DS1);
+    D2 = DPCTLDevice_CreateFromSelector(DS2);
+
+    if (!(D1 && D2)) {
+        DPCTLDeviceSelector_Delete(DS1);
+        DPCTLDeviceSelector_Delete(DS2);
+        DPCTLDevice_Delete(D1);
+        DPCTLDevice_Delete(D2);
+        GTEST_SKIP_(
+            "OpenCL GPU and CPU devices are needed, but were not found.");
+    }
+
     auto Q1 = DPCTLQueue_CreateForDevice(D1, nullptr, DPCTL_DEFAULT_PROPERTY);
     DPCTLQueueMgr_PushQueue(Q1);
     EXPECT_TRUE(DPCTLQueueMgr_IsCurrentQueue(Q1));

--- a/dpctl-capi/tests/test_sycl_usm_interface.cpp
+++ b/dpctl-capi/tests/test_sycl_usm_interface.cpp
@@ -42,20 +42,6 @@ constexpr size_t SIZE = 1024;
 
 DEFINE_SIMPLE_CONVERSION_FUNCTIONS(void, DPCTLSyclUSMRef);
 
-bool has_devices()
-{
-    bool ret = false;
-    for (auto &p : platform::get_platforms()) {
-        if (p.is_host())
-            continue;
-        if (!p.get_devices().empty()) {
-            ret = true;
-            break;
-        }
-    }
-    return ret;
-}
-
 void common_test_body(size_t nbytes,
                       const DPCTLSyclUSMRef Ptr,
                       const DPCTLSyclQueueRef Q,
@@ -89,15 +75,11 @@ struct TestDPCTLSyclUSMInterface : public ::testing::Test
 
 TEST_F(TestDPCTLSyclUSMInterface, MallocShared)
 {
-    if (!has_devices())
-        GTEST_SKIP_("Skipping: No Sycl Devices.\n");
-
     auto Q = DPCTLQueueMgr_GetCurrentQueue();
+    ASSERT_TRUE(Q);
     const size_t nbytes = SIZE;
-
     auto Ptr = DPCTLmalloc_shared(nbytes, Q);
     EXPECT_TRUE(bool(Ptr));
-
     common_test_body(nbytes, Ptr, Q, "shared");
     DPCTLfree_with_queue(Ptr, Q);
     DPCTLQueue_Delete(Q);
@@ -105,15 +87,11 @@ TEST_F(TestDPCTLSyclUSMInterface, MallocShared)
 
 TEST_F(TestDPCTLSyclUSMInterface, MallocDevice)
 {
-    if (!has_devices())
-        GTEST_SKIP_("Skipping: No Sycl Devices.\n");
-
     auto Q = DPCTLQueueMgr_GetCurrentQueue();
+    ASSERT_TRUE(Q);
     const size_t nbytes = SIZE;
-
     auto Ptr = DPCTLmalloc_device(nbytes, Q);
     EXPECT_TRUE(bool(Ptr));
-
     common_test_body(nbytes, Ptr, Q, "device");
     DPCTLfree_with_queue(Ptr, Q);
     DPCTLQueue_Delete(Q);
@@ -121,15 +99,11 @@ TEST_F(TestDPCTLSyclUSMInterface, MallocDevice)
 
 TEST_F(TestDPCTLSyclUSMInterface, MallocHost)
 {
-    if (!has_devices())
-        GTEST_SKIP_("Skipping: No Sycl Devices.\n");
-
     auto Q = DPCTLQueueMgr_GetCurrentQueue();
+    ASSERT_TRUE(Q);
     const size_t nbytes = SIZE;
-
     auto Ptr = DPCTLmalloc_host(nbytes, Q);
     EXPECT_TRUE(bool(Ptr));
-
     common_test_body(nbytes, Ptr, Q, "host");
     DPCTLfree_with_queue(Ptr, Q);
     DPCTLQueue_Delete(Q);
@@ -137,15 +111,11 @@ TEST_F(TestDPCTLSyclUSMInterface, MallocHost)
 
 TEST_F(TestDPCTLSyclUSMInterface, AlignedAllocShared)
 {
-    if (!has_devices())
-        GTEST_SKIP_("Skipping: No Sycl Devices.\n");
-
     auto Q = DPCTLQueueMgr_GetCurrentQueue();
+    ASSERT_TRUE(Q);
     const size_t nbytes = SIZE;
-
     auto Ptr = DPCTLaligned_alloc_shared(64, nbytes, Q);
     EXPECT_TRUE(bool(Ptr));
-
     common_test_body(nbytes, Ptr, Q, "shared");
     DPCTLfree_with_queue(Ptr, Q);
     DPCTLQueue_Delete(Q);
@@ -153,15 +123,11 @@ TEST_F(TestDPCTLSyclUSMInterface, AlignedAllocShared)
 
 TEST_F(TestDPCTLSyclUSMInterface, AlignedAllocDevice)
 {
-    if (!has_devices())
-        GTEST_SKIP_("Skipping: No Sycl Devices.\n");
-
     auto Q = DPCTLQueueMgr_GetCurrentQueue();
+    ASSERT_TRUE(Q);
     const size_t nbytes = SIZE;
-
     auto Ptr = DPCTLaligned_alloc_device(64, nbytes, Q);
     EXPECT_TRUE(bool(Ptr));
-
     common_test_body(nbytes, Ptr, Q, "device");
     DPCTLfree_with_queue(Ptr, Q);
     DPCTLQueue_Delete(Q);
@@ -169,15 +135,11 @@ TEST_F(TestDPCTLSyclUSMInterface, AlignedAllocDevice)
 
 TEST_F(TestDPCTLSyclUSMInterface, AlignedAllocHost)
 {
-    if (!has_devices())
-        GTEST_SKIP_("Skipping: No Sycl Devices.\n");
-
     auto Q = DPCTLQueueMgr_GetCurrentQueue();
+    ASSERT_TRUE(Q);
     const size_t nbytes = SIZE;
-
     auto Ptr = DPCTLaligned_alloc_host(64, nbytes, Q);
     EXPECT_TRUE(bool(Ptr));
-
     common_test_body(nbytes, Ptr, Q, "host");
     DPCTLfree_with_queue(Ptr, Q);
 }

--- a/dpctl/tests/test_sycl_device.py
+++ b/dpctl/tests/test_sycl_device.py
@@ -47,7 +47,7 @@ list_of_valid_filter_selectors = [
 list_of_invalid_filter_selectors = [
     "-1",
     "opencl:gpu:-1",
-    "level_zero:cpu:0",
+    "cuda:cpu:0",
     "abc",
 ]
 

--- a/dpctl/tests/test_sycl_platform.py
+++ b/dpctl/tests/test_sycl_platform.py
@@ -37,6 +37,13 @@ list_of_valid_filter_selectors = [
     "1",
 ]
 
+list_of_invalid_filter_selectors = [
+    "-1",
+    "opencl:gpu:-1",
+    "cuda:cpu:0",
+    "abc",
+]
+
 
 def check_name(platform):
     try:
@@ -87,6 +94,11 @@ def valid_filter(request):
     return request.param
 
 
+@pytest.fixture(params=list_of_invalid_filter_selectors)
+def invalid_filter(request):
+    return request.param
+
+
 @pytest.fixture(params=list_of_checks)
 def check(request):
     return request.param
@@ -102,6 +114,14 @@ def test_platform_creation(valid_filter, check):
     except ValueError:
         pytest.skip("Failed to create platform with supported filter")
     check(platform)
+
+
+def test_invalid_platform_creation(invalid_filter, check):
+    """Tests if we can create a SyclPlatform using a supported filter selector
+    string.
+    """
+    with pytest.raises(ValueError):
+        platform = dpctl.SyclPlatform(invalid_filter)
 
 
 def test_lsplatform():


### PR DESCRIPTION
Closes #345 
Closes #344

- Fixes #345 and #344 by handling exceptions.
- Fixes C API tests that were segfaulting due to same reason. Now we skip if a device is not found.
- Add negative test cases to CAPI and Pytest to make sure we do not crash on getting an invalid filter.

Supersedes #348 

