### PR TITLE
Fix the black action.

### DIFF
--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -24,4 +24,4 @@ jobs:
       - uses: actions/setup-python@v2
 
       # Run black code formatter
-      - uses: psf/black@stable
+      - uses: psf/black@20.8b1

--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -25,3 +25,5 @@ jobs:
 
       # Run black code formatter
       - uses: psf/black@20.8b1
+        with:
+          args: ". --check"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,7 +17,7 @@ Run before each commit: `clang-format -style=file -i dpctl-capi/include/*.h dpct
 
 We use [black](https://black.readthedocs.io/en/stable/) code formatter.
 
-- Revision: `20.8b1` or branch `stable`.
+- Revision: `20.8b1`.
 - See configuration in `pyproject.toml`.
 
 Run before each commit: `black .`


### PR DESCRIPTION
The `stable` branch is no longer there in `github.com/psf/black`. Updated our action to use `20.8b1` tag.