### PR TITLE
Fix tests which fail if GPU is not available (only CPU is available)

### DIFF
--- a/dpctl/tests/test_sycl_context.py
+++ b/dpctl/tests/test_sycl_context.py
@@ -356,7 +356,7 @@ def test_context_equals():
     try:
         ctx1 = dpctl.SyclContext("gpu")
         ctx0 = dpctl.SyclContext("gpu")
-    except dpctl.SyclQueueCreationError:
+    except ValueError:
         pytest.skip()
     assert ctx0.equals(ctx1)
 
@@ -373,7 +373,10 @@ def test_context_can_be_used_in_queue(valid_filter):
 
 
 def test_context_can_be_used_in_queue2(valid_filter):
-    d = dpctl.SyclDevice(valid_filter)
+    try:
+        d = dpctl.SyclDevice(valid_filter)
+    except ValueError:
+        pytest.skip()
     if d.default_selector_score < 0:
         # skip test for devices rejected by default selector
         pytest.skip()

--- a/dpctl/tests/test_sycl_queue_manager.py
+++ b/dpctl/tests/test_sycl_queue_manager.py
@@ -43,6 +43,7 @@ class TestIsInDeviceContext(unittest.TestCase):
 
 
 @unittest.skipIf(not has_sycl_platforms(), "No SYCL platforms available")
+@unittest.skipUnless(has_gpu(), "No OpenCL GPU queues available")
 class TestGetCurrentDevice(unittest.TestCase):
     def test_get_current_device_type_outside_device_ctxt(self):
         self.assertNotEqual(dpctl.get_current_device_type(), None)


### PR DESCRIPTION
This PR contains several fixes for tests which should be skipped if GPU is not available but they was not skipped.

1. `dpctl.SyclContext("gpu")` raises `ValueError`. It seems that catching `dpctl.SyclQueueCreationError` is copy/past error.
2. In `test_context_can_be_used_in_queue2` exception was not caught.
3. `TestGetCurrentDevice` uses context `opencl:gpu:0` in several tests so it should be skipped if GPU is not available.