### PR TITLE
fixed typo in SyclContext code giving a run-time error

### DIFF
--- a/dpctl/_sycl_context.pyx
+++ b/dpctl/_sycl_context.pyx
@@ -189,7 +189,7 @@ cdef class SyclContext(_SyclContext):
         elif pycapsule.PyCapsule_IsValid(arg, "SyclContextRef"):
             status = self._init_context_from_capsule(arg)
         elif isinstance(arg, (list, tuple)) and all([isinstance(argi, SyclDevice) for argi in arg]):
-            ret = self._init_conext_from_devices(arg, 0)
+            ret = self._init_context_from_devices(arg, 0)
         else:
             dev = SyclDevice(arg)
             ret = self._init_context_from_one_device(<SyclDevice> dev, 0)


### PR DESCRIPTION
Simple typo mistake, but can only be discovered at run-time. This is possible now that sub-devices supported has been merged.