### PR TITLE
Fixed missing variable assignment

### DIFF
--- a/dpctl/_sycl_context.pyx
+++ b/dpctl/_sycl_context.pyx
@@ -141,7 +141,7 @@ cdef class SyclContext(_SyclContext):
             PyMem_Free(elems)
         else:
             return -2
-        DPCTLContext_CreateFromDevices(DVRef, eh_callback, props)
+        CRef = DPCTLContext_CreateFromDevices(DVRef, eh_callback, props)
         DPCTLDeviceVector_Delete(DVRef)
         if (CRef is NULL):
             return -1


### PR DESCRIPTION
The example for multi-device context creation now works as expected:

```python
Python 3.7.9 (default, Mar 10 2021, 05:18:00)
Type 'copyright', 'credits' or 'license' for more information
IPython 7.22.0 -- An enhanced Interactive Python. Type '?' for help.

In [1]: import dpctl

In [2]: cpu_d = dpctl.SyclDevice("cpu")

In [3]: d0, d1, d2 = cpu_d.create_sub_devices(partition=(4,4,4))

In [4]: ctx = dpctl.SyclContext((d0, d1, d2))

In [5]: ctx
Out[5]: <dpctl.SyclContext for 3 devices at 0x7ffb7a82c350>

In [6]: q = dpctl.SyclQueue(ctx, d0)

In [7]: import dpctl.memory as dpmem

In [8]: dpmem.MemoryUSMShared(1024, queue=q)
Out[8]: <Intel(R) USM allocated memory block of 1024 bytes at 0x55e2e6bf4300>
```