### PR TITLE
Update Python coverage to use pytest-cov

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -2,4 +2,4 @@
 plugins = Cython.Coverage
 branch = True
 source = dpctl
-omit = dpctl/tests/*, *__init__.py
+omit = dpctl/tests/*, dpctl/_version.py

--- a/conda-recipe/run_test.sh
+++ b/conda-recipe/run_test.sh
@@ -6,4 +6,4 @@ set -e
 source ${ONEAPI_ROOT}/compiler/latest/env/vars.sh || true
 
 ${PYTHON} -c "import dpctl"
-pytest -q -ra --disable-warnings --pyargs dpctl -vv
+pytest -q -ra --disable-warnings --cov dpctl --cov-report term-missing --pyargs dpctl -vv


### PR DESCRIPTION
Blocked by [SAT-3964](https://jira.devtools.intel.com/browse/SAT-3964). Waiting for coverage package on internal CI.
Closes #280.
Implemented coverage only on Linux. On Windows tests run without coverage.