### PR TITLE
Feature/sycl queue in order

### DIFF
--- a/dpctl-capi/include/dpctl_sycl_queue_interface.h
+++ b/dpctl-capi/include/dpctl_sycl_queue_interface.h
@@ -312,4 +312,14 @@ void DPCTLQueue_MemAdvise(__dpctl_keep DPCTLSyclQueueRef QRef,
                           size_t Count,
                           int Advice);
 
+/*!
+ * @brief C-API wrapper for sycl::queue::is_in_order that indicates whether
+ * the referenced queue is in-order or out-of-order.
+ *
+ * @param    QRef         An opaque pointer to the sycl queue.
+ * @ingroup QueueInterface
+ */
+DPCTL_API
+bool DPCTLQueue_IsInOrder(__dpctl_keep const DPCTLSyclQueueRef QRef);
+
 DPCTL_C_EXTERN_C_END

--- a/dpctl-capi/source/dpctl_sycl_queue_interface.cpp
+++ b/dpctl-capi/source/dpctl_sycl_queue_interface.cpp
@@ -119,14 +119,16 @@ bool set_kernel_arg(handler &cgh,
 std::unique_ptr<property_list> create_property_list(int properties)
 {
     std::unique_ptr<property_list> propList;
-    if (properties & (DPCTL_ENABLE_PROFILING | DPCTL_IN_ORDER)) {
-        propList = std::make_unique<property_list>(
-            sycl::property::queue::enable_profiling(),
-            sycl::property::queue::in_order());
-    }
-    else if (properties & DPCTL_ENABLE_PROFILING) {
-        propList = std::make_unique<property_list>(
-            sycl::property::queue::enable_profiling());
+    if (properties & DPCTL_ENABLE_PROFILING) {
+        if (properties & DPCTL_IN_ORDER) {
+            propList = std::make_unique<property_list>(
+                sycl::property::queue::enable_profiling(),
+                sycl::property::queue::in_order());
+        }
+        else {
+            propList = std::make_unique<property_list>(
+                sycl::property::queue::enable_profiling());
+        }
     }
     else if (properties & DPCTL_IN_ORDER) {
         propList =

--- a/dpctl-capi/source/dpctl_sycl_queue_interface.cpp
+++ b/dpctl-capi/source/dpctl_sycl_queue_interface.cpp
@@ -450,7 +450,8 @@ void DPCTLQueue_Wait(__dpctl_keep DPCTLSyclQueueRef QRef)
     // \todo what happens if the QRef is null or a pointer to a valid sycl
     // queue
     auto SyclQueue = unwrap(QRef);
-    SyclQueue->wait();
+    if (SyclQueue)
+        SyclQueue->wait();
 }
 
 void DPCTLQueue_Memcpy(__dpctl_keep const DPCTLSyclQueueRef QRef,
@@ -459,8 +460,10 @@ void DPCTLQueue_Memcpy(__dpctl_keep const DPCTLSyclQueueRef QRef,
                        size_t Count)
 {
     auto Q = unwrap(QRef);
-    auto event = Q->memcpy(Dest, Src, Count);
-    event.wait();
+    if (Q) {
+        auto event = Q->memcpy(Dest, Src, Count);
+        event.wait();
+    }
 }
 
 void DPCTLQueue_Prefetch(__dpctl_keep DPCTLSyclQueueRef QRef,
@@ -468,8 +471,10 @@ void DPCTLQueue_Prefetch(__dpctl_keep DPCTLSyclQueueRef QRef,
                          size_t Count)
 {
     auto Q = unwrap(QRef);
-    auto event = Q->prefetch(Ptr, Count);
-    event.wait();
+    if (Q) {
+        auto event = Q->prefetch(Ptr, Count);
+        event.wait();
+    }
 }
 
 void DPCTLQueue_MemAdvise(__dpctl_keep DPCTLSyclQueueRef QRef,
@@ -478,6 +483,19 @@ void DPCTLQueue_MemAdvise(__dpctl_keep DPCTLSyclQueueRef QRef,
                           int Advice)
 {
     auto Q = unwrap(QRef);
-    auto event = Q->mem_advise(Ptr, Count, static_cast<pi_mem_advice>(Advice));
-    event.wait();
+    if (Q) {
+        auto event =
+            Q->mem_advise(Ptr, Count, static_cast<pi_mem_advice>(Advice));
+        event.wait();
+    }
+}
+
+bool DPCTLQueue_IsInOrder(__dpctl_keep const DPCTLSyclQueueRef QRef)
+{
+    auto Q = unwrap(QRef);
+    if (Q) {
+        return Q->is_in_order();
+    }
+    else
+        return false;
 }

--- a/dpctl-capi/tests/test_sycl_queue_interface.cpp
+++ b/dpctl-capi/tests/test_sycl_queue_interface.cpp
@@ -255,6 +255,22 @@ TEST_P(TestDPCTLQueueMemberFunctions, CheckGetDevice)
     DPCTLDevice_Delete(D);
 }
 
+TEST_P(TestDPCTLQueueMemberFunctions, CheckIsInOrder)
+{
+    bool ioq = true;
+
+    EXPECT_NO_FATAL_FAILURE(ioq = DPCTLQueue_IsInOrder(QRef));
+    EXPECT_FALSE(ioq);
+
+    DPCTLSyclQueueRef QRef_ioq = nullptr;
+    EXPECT_NO_FATAL_FAILURE(
+        QRef_ioq = DPCTLQueue_CreateForDevice(DRef, nullptr, DPCTL_IN_ORDER));
+    EXPECT_TRUE(QRef_ioq);
+    EXPECT_NO_FATAL_FAILURE(ioq = DPCTLQueue_IsInOrder(QRef_ioq));
+    EXPECT_TRUE(ioq);
+    EXPECT_NO_FATAL_FAILURE(DPCTLQueue_Delete(QRef_ioq));
+}
+
 INSTANTIATE_TEST_SUITE_P(DPCTLQueueMemberFuncTests,
                          TestDPCTLQueueMemberFunctions,
                          ::testing::Values("opencl:gpu:0",

--- a/dpctl/_backend.pxd
+++ b/dpctl/_backend.pxd
@@ -347,6 +347,7 @@ cdef extern from "dpctl_sycl_queue_interface.h":
         const void *Src,
         size_t Count,
         int Advice)
+    cdef bool DPCTLQueue_IsInOrder(const DPCTLSyclQueueRef QRef)
 
 
 cdef extern from "dpctl_sycl_queue_manager.h":

--- a/dpctl/_sycl_queue.pyx
+++ b/dpctl/_sycl_queue.pyx
@@ -132,7 +132,9 @@ cdef int _parse_queue_properties(object prop) except *:
             elif (p == "default"):
                 res = res | _queue_property_type._DEFAULT_PROPERTY
             else:
-                raise ValueError("queue property '{}' is not understood.".format(prop))
+                raise ValueError(("queue property '{}' is not understood, "
+                                 "expecting 'in_order', 'enable_profiling', or 'default'"
+                                  ).format(prop))
         else:
             raise ValueError("queue property '{}' is not understood.".format(prop))
     return res
@@ -164,7 +166,7 @@ cdef class SyclQueue(_SyclQueue):
                create SyclQueue from default selector
            SyclQueue(filter_string, *, /, propery=None)
                create SyclQueue from filter selector string
-           SyclQueue(SyclDevice, *, / property=None)
+           SyclQueue(SyclDevice, *, /, property=None)
                create SyclQueue from give SyclDevice automatically
                finding/creating SyclContext.
            SyclQueue(SyclContext, SyclDevice, *, /, property=None)

--- a/dpctl/_sycl_queue.pyx
+++ b/dpctl/_sycl_queue.pyx
@@ -47,6 +47,7 @@ from ._backend cimport (
     DPCTLQueue_SubmitNDRange,
     DPCTLQueue_SubmitRange,
     DPCTLQueue_Wait,
+    DPCTLQueue_IsInOrder,
     DPCTLSyclBackendType,
     DPCTLSyclContextRef,
     DPCTLSyclDeviceSelectorRef,
@@ -730,11 +731,20 @@ cdef class SyclQueue(_SyclQueue):
        DPCTLQueue_MemAdvise(self._queue_ref, ptr, count, advice)
 
     @property
+    def is_in_order(self):
+        """True if SyclQueue is in-order, False if it is out-of-order."""
+        return DPCTLQueue_IsInOrder(self._queue_ref)
+
+    @property
     def __name__(self):
         return "SyclQueue"
 
     def __repr__(self):
-        return "<dpctl." + self.__name__ + " at {}>".format(hex(id(self)))
+        cdef cpp_bool in_order = DPCTLQueue_IsInOrder(self._queue_ref)
+        if in_order:
+            return "<dpctl." + self.__name__ + " at {}, property=in_order>".format(hex(id(self)))
+        else:
+            return "<dpctl." + self.__name__ + " at {}>".format(hex(id(self)))
 
     def _get_capsule(self):
         cdef DPCTLSyclQueueRef QRef = NULL

--- a/dpctl/tests/test_sycl_queue.py
+++ b/dpctl/tests/test_sycl_queue.py
@@ -321,6 +321,10 @@ def test_valid_filter_selectors(valid_filter, check):
     try:
         q = dpctl.SyclQueue(valid_filter)
         device = q.get_sycl_device()
+        assert q.is_in_order is False
+        q2 = dpctl.SyclQueue(valid_filter, property="in_order")
+        # assert device == q2.get_sycl_device()
+        assert q2.is_in_order is True
     except dpctl.SyclQueueCreationError:
         pytest.skip("Failed to create device with supported filter")
     check(device)


### PR DESCRIPTION
```
Python 3.7.9 (default, Mar 10 2021, 05:18:00)
Type 'copyright', 'credits' or 'license' for more information
IPython 7.22.0 -- An enhanced Interactive Python. Type '?' for help.

In [1]: import dpctl

In [2]: q = dpctl.SyclQueue("gpu", property=("enable_profiling", "in_order"))

In [3]: q
Out[3]: <dpctl.SyclQueue at 0x7f2084fc0500, property=in_order>

In [4]: q.sycl_device
Out[4]: <dpctl.SyclDevice [backend_type.level_zero, device_type.gpu,  Intel(R) UHD Graphics [0x9bca]] at 0x7f20858ece30>

In [5]: q.is_in_order
Out[5]: True

```