### PR TITLE
Cleanup/tests

### DIFF
--- a/dpctl-capi/tests/test_sycl_context_interface.cpp
+++ b/dpctl-capi/tests/test_sycl_context_interface.cpp
@@ -69,7 +69,7 @@ struct TestDPCTLContextInterface : public ::testing::TestWithParam<const char *>
     }
 };
 
-TEST_P(TestDPCTLContextInterface, Chk_Create)
+TEST_P(TestDPCTLContextInterface, ChkCreate)
 {
     DPCTLSyclContextRef CRef = nullptr;
     EXPECT_NO_FATAL_FAILURE(CRef = DPCTLContext_Create(DRef, nullptr, 0));
@@ -77,7 +77,7 @@ TEST_P(TestDPCTLContextInterface, Chk_Create)
     EXPECT_NO_FATAL_FAILURE(DPCTLContext_Delete(CRef));
 }
 
-TEST_P(TestDPCTLContextInterface, Chk_CreateWithDevices)
+TEST_P(TestDPCTLContextInterface, ChkCreateWithDevices)
 {
     size_t nCUs = 0;
     DPCTLSyclContextRef CRef = nullptr;
@@ -107,7 +107,7 @@ TEST_P(TestDPCTLContextInterface, Chk_CreateWithDevices)
     EXPECT_NO_FATAL_FAILURE(DPCTLContext_Delete(CRef));
 }
 
-TEST_P(TestDPCTLContextInterface, Chk_CreateWithDevices_GetDevices)
+TEST_P(TestDPCTLContextInterface, ChkCreateWithDevicesGetDevices)
 {
     size_t nCUs = 0;
     DPCTLSyclContextRef CRef = nullptr;
@@ -146,7 +146,7 @@ TEST_P(TestDPCTLContextInterface, Chk_CreateWithDevices_GetDevices)
     EXPECT_NO_FATAL_FAILURE(DPCTLDeviceVector_Delete(Res_DVRef));
 }
 
-TEST_P(TestDPCTLContextInterface, Chk_GetDevices)
+TEST_P(TestDPCTLContextInterface, ChkGetDevices)
 {
     DPCTLSyclContextRef CRef = nullptr;
     DPCTLDeviceVectorRef DVRef = nullptr;
@@ -159,7 +159,7 @@ TEST_P(TestDPCTLContextInterface, Chk_GetDevices)
     EXPECT_NO_FATAL_FAILURE(DPCTLDeviceVector_Delete(DVRef));
 }
 
-TEST_P(TestDPCTLContextInterface, Chk_AreEq)
+TEST_P(TestDPCTLContextInterface, ChkAreEq)
 {
     DPCTLSyclContextRef CRef1 = nullptr, CRef2 = nullptr, CRef3 = nullptr;
     bool are_eq = true, are_not_eq = false;
@@ -183,7 +183,7 @@ TEST_P(TestDPCTLContextInterface, Chk_AreEq)
     EXPECT_NO_FATAL_FAILURE(DPCTLContext_Delete(CRef3));
 }
 
-TEST_P(TestDPCTLContextInterface, Chk_IsHost)
+TEST_P(TestDPCTLContextInterface, ChkIsHost)
 {
     DPCTLSyclContextRef CRef = nullptr;
     bool is_host_device = false, is_host_context = false;
@@ -198,7 +198,7 @@ TEST_P(TestDPCTLContextInterface, Chk_IsHost)
     EXPECT_NO_FATAL_FAILURE(DPCTLContext_Delete(CRef));
 }
 
-TEST_P(TestDPCTLContextInterface, Chk_GetBackend)
+TEST_P(TestDPCTLContextInterface, ChkGetBackend)
 {
     DPCTLSyclContextRef CRef = nullptr;
     DPCTLSyclBackendType context_backend = DPCTL_UNKNOWN_BACKEND,

--- a/dpctl-capi/tests/test_sycl_device_aspects.cpp
+++ b/dpctl-capi/tests/test_sycl_device_aspects.cpp
@@ -152,7 +152,7 @@ struct TestDPCTLSyclDeviceInterfaceAspects
     }
 };
 
-TEST_P(TestDPCTLSyclDeviceInterfaceAspects, Chk_HasAspect)
+TEST_P(TestDPCTLSyclDeviceInterfaceAspects, ChkHasAspect)
 {
     bool actual = false;
     auto dpctlAspect = DPCTL_StrToAspectType(GetParam().second.first);

--- a/dpctl-capi/tests/test_sycl_device_interface.cpp
+++ b/dpctl-capi/tests/test_sycl_device_interface.cpp
@@ -63,7 +63,7 @@ struct TestDPCTLSyclDeviceInterface
     }
 };
 
-TEST_P(TestDPCTLSyclDeviceInterface, Chk_Copy)
+TEST_P(TestDPCTLSyclDeviceInterface, ChkCopy)
 {
     DPCTLSyclDeviceRef Copied_DRef = nullptr;
     EXPECT_NO_FATAL_FAILURE(Copied_DRef = DPCTLDevice_Copy(DRef));
@@ -71,7 +71,7 @@ TEST_P(TestDPCTLSyclDeviceInterface, Chk_Copy)
     EXPECT_NO_FATAL_FAILURE(DPCTLDevice_Delete(Copied_DRef));
 }
 
-TEST_P(TestDPCTLSyclDeviceInterface, Chk_GetBackend)
+TEST_P(TestDPCTLSyclDeviceInterface, ChkGetBackend)
 {
     DPCTLSyclBackendType BTy = DPCTLSyclBackendType::DPCTL_UNKNOWN_BACKEND;
     EXPECT_NO_FATAL_FAILURE(BTy = DPCTLDevice_GetBackend(DRef));
@@ -91,7 +91,7 @@ TEST_P(TestDPCTLSyclDeviceInterface, Chk_GetBackend)
     }());
 }
 
-TEST_P(TestDPCTLSyclDeviceInterface, Chk_GetDeviceType)
+TEST_P(TestDPCTLSyclDeviceInterface, ChkGetDeviceType)
 {
     DPCTLSyclDeviceType DTy = DPCTLSyclDeviceType::DPCTL_UNKNOWN_DEVICE;
     EXPECT_NO_FATAL_FAILURE(DTy = DPCTLDevice_GetDeviceType(DRef));
@@ -99,7 +99,7 @@ TEST_P(TestDPCTLSyclDeviceInterface, Chk_GetDeviceType)
     EXPECT_TRUE(DTy != DPCTLSyclDeviceType::DPCTL_ALL);
 }
 
-TEST_P(TestDPCTLSyclDeviceInterface, Chk_GetDriverInfo)
+TEST_P(TestDPCTLSyclDeviceInterface, ChkGetDriverInfo)
 {
     const char *DriverInfo = nullptr;
     EXPECT_NO_FATAL_FAILURE(DriverInfo = DPCTLDevice_GetDriverInfo(DRef));
@@ -107,7 +107,7 @@ TEST_P(TestDPCTLSyclDeviceInterface, Chk_GetDriverInfo)
     EXPECT_NO_FATAL_FAILURE(DPCTLCString_Delete(DriverInfo));
 }
 
-TEST_P(TestDPCTLSyclDeviceInterface, Chk_GetName)
+TEST_P(TestDPCTLSyclDeviceInterface, ChkGetName)
 {
     const char *Name = nullptr;
     EXPECT_NO_FATAL_FAILURE(Name = DPCTLDevice_GetName(DRef));
@@ -115,7 +115,7 @@ TEST_P(TestDPCTLSyclDeviceInterface, Chk_GetName)
     EXPECT_NO_FATAL_FAILURE(DPCTLCString_Delete(Name));
 }
 
-TEST_P(TestDPCTLSyclDeviceInterface, Chk_GetVendorName)
+TEST_P(TestDPCTLSyclDeviceInterface, ChkGetVendorName)
 {
     const char *VendorName = nullptr;
     EXPECT_NO_FATAL_FAILURE(VendorName = DPCTLDevice_GetVendorName(DRef));
@@ -123,21 +123,21 @@ TEST_P(TestDPCTLSyclDeviceInterface, Chk_GetVendorName)
     EXPECT_NO_FATAL_FAILURE(DPCTLCString_Delete(VendorName));
 }
 
-TEST_P(TestDPCTLSyclDeviceInterface, Chk_GetMaxComputeUnits)
+TEST_P(TestDPCTLSyclDeviceInterface, ChkGetMaxComputeUnits)
 {
     size_t n = 0;
     EXPECT_NO_FATAL_FAILURE(n = DPCTLDevice_GetMaxComputeUnits(DRef));
     EXPECT_TRUE(n > 0);
 }
 
-TEST_P(TestDPCTLSyclDeviceInterface, Chk_GetMaxWorkItemDims)
+TEST_P(TestDPCTLSyclDeviceInterface, ChkGetMaxWorkItemDims)
 {
     size_t n = 0;
     EXPECT_NO_FATAL_FAILURE(n = DPCTLDevice_GetMaxWorkItemDims(DRef));
     EXPECT_TRUE(n > 0);
 }
 
-TEST_P(TestDPCTLSyclDeviceInterface, Chk_GetMaxWorkItemSizes)
+TEST_P(TestDPCTLSyclDeviceInterface, ChkGetMaxWorkItemSizes)
 {
     size_t *sizes = nullptr;
     EXPECT_NO_FATAL_FAILURE(sizes = DPCTLDevice_GetMaxWorkItemSizes(DRef));
@@ -145,7 +145,7 @@ TEST_P(TestDPCTLSyclDeviceInterface, Chk_GetMaxWorkItemSizes)
     EXPECT_NO_FATAL_FAILURE(DPCTLSize_t_Array_Delete(sizes));
 }
 
-TEST_P(TestDPCTLSyclDeviceInterface, Chk_GetMaxWorkGroupSize)
+TEST_P(TestDPCTLSyclDeviceInterface, ChkGetMaxWorkGroupSize)
 {
     size_t n = 0;
     EXPECT_NO_FATAL_FAILURE(n = DPCTLDevice_GetMaxWorkGroupSize(DRef));
@@ -155,7 +155,7 @@ TEST_P(TestDPCTLSyclDeviceInterface, Chk_GetMaxWorkGroupSize)
         EXPECT_TRUE(n > 0);
 }
 
-TEST_P(TestDPCTLSyclDeviceInterface, Chk_GetMaxNumSubGroups)
+TEST_P(TestDPCTLSyclDeviceInterface, ChkGetMaxNumSubGroups)
 {
     size_t n = 0;
     EXPECT_NO_FATAL_FAILURE(n = DPCTLDevice_GetMaxNumSubGroups(DRef));
@@ -165,7 +165,7 @@ TEST_P(TestDPCTLSyclDeviceInterface, Chk_GetMaxNumSubGroups)
         EXPECT_TRUE(n > 0);
 }
 
-TEST_P(TestDPCTLSyclDeviceInterface, Chk_GetPlatform)
+TEST_P(TestDPCTLSyclDeviceInterface, ChkGetPlatform)
 {
     DPCTLSyclPlatformRef PRef = nullptr;
     EXPECT_NO_FATAL_FAILURE(PRef = DPCTLDevice_GetPlatform(DRef));
@@ -173,27 +173,27 @@ TEST_P(TestDPCTLSyclDeviceInterface, Chk_GetPlatform)
     EXPECT_NO_FATAL_FAILURE(DPCTLPlatform_Delete(PRef));
 }
 
-TEST_P(TestDPCTLSyclDeviceInterface, Chk_IsAccelerator)
+TEST_P(TestDPCTLSyclDeviceInterface, ChkIsAccelerator)
 {
     EXPECT_NO_FATAL_FAILURE(DPCTLDevice_IsAccelerator(DRef));
 }
 
-TEST_P(TestDPCTLSyclDeviceInterface, Chk_IsCPU)
+TEST_P(TestDPCTLSyclDeviceInterface, ChkIsCPU)
 {
     EXPECT_NO_FATAL_FAILURE(DPCTLDevice_IsCPU(DRef));
 }
 
-TEST_P(TestDPCTLSyclDeviceInterface, Chk_IsGPU)
+TEST_P(TestDPCTLSyclDeviceInterface, ChkIsGPU)
 {
     EXPECT_NO_FATAL_FAILURE(DPCTLDevice_IsGPU(DRef));
 }
 
-TEST_P(TestDPCTLSyclDeviceInterface, Chk_IsHost)
+TEST_P(TestDPCTLSyclDeviceInterface, ChkIsHost)
 {
     EXPECT_NO_FATAL_FAILURE(DPCTLDevice_IsHost(DRef));
 }
 
-TEST_P(TestDPCTLSyclDeviceInterface, Chk_GetSubGroupIndependentForwardProgress)
+TEST_P(TestDPCTLSyclDeviceInterface, ChkGetSubGroupIndependentForwardProgress)
 {
     bool sub_group_progress = 0;
     EXPECT_NO_FATAL_FAILURE(
@@ -205,7 +205,7 @@ TEST_P(TestDPCTLSyclDeviceInterface, Chk_GetSubGroupIndependentForwardProgress)
     EXPECT_TRUE(get_sub_group_progress == sub_group_progress);
 }
 
-TEST_P(TestDPCTLSyclDeviceInterface, Chk_GetPreferredVectorWidthChar)
+TEST_P(TestDPCTLSyclDeviceInterface, ChkGetPreferredVectorWidthChar)
 {
     size_t vector_width_char = 0;
     EXPECT_NO_FATAL_FAILURE(vector_width_char =
@@ -213,7 +213,7 @@ TEST_P(TestDPCTLSyclDeviceInterface, Chk_GetPreferredVectorWidthChar)
     EXPECT_TRUE(vector_width_char != 0);
 }
 
-TEST_P(TestDPCTLSyclDeviceInterface, Chk_GetPreferredVectorWidthShort)
+TEST_P(TestDPCTLSyclDeviceInterface, ChkGetPreferredVectorWidthShort)
 {
     size_t vector_width_short = 0;
     EXPECT_NO_FATAL_FAILURE(vector_width_short =
@@ -221,7 +221,7 @@ TEST_P(TestDPCTLSyclDeviceInterface, Chk_GetPreferredVectorWidthShort)
     EXPECT_TRUE(vector_width_short != 0);
 }
 
-TEST_P(TestDPCTLSyclDeviceInterface, Chk_GetPreferredVectorWidthInt)
+TEST_P(TestDPCTLSyclDeviceInterface, ChkGetPreferredVectorWidthInt)
 {
     size_t vector_width_int = 0;
     EXPECT_NO_FATAL_FAILURE(vector_width_int =
@@ -229,7 +229,7 @@ TEST_P(TestDPCTLSyclDeviceInterface, Chk_GetPreferredVectorWidthInt)
     EXPECT_TRUE(vector_width_int != 0);
 }
 
-TEST_P(TestDPCTLSyclDeviceInterface, Chk_GetPreferredVectorWidthLong)
+TEST_P(TestDPCTLSyclDeviceInterface, ChkGetPreferredVectorWidthLong)
 {
     size_t vector_width_long = 0;
     EXPECT_NO_FATAL_FAILURE(vector_width_long =
@@ -237,7 +237,7 @@ TEST_P(TestDPCTLSyclDeviceInterface, Chk_GetPreferredVectorWidthLong)
     EXPECT_TRUE(vector_width_long != 0);
 }
 
-TEST_P(TestDPCTLSyclDeviceInterface, Chk_GetPreferredVectorWidthFloat)
+TEST_P(TestDPCTLSyclDeviceInterface, ChkGetPreferredVectorWidthFloat)
 {
     size_t vector_width_float = 0;
     EXPECT_NO_FATAL_FAILURE(vector_width_float =
@@ -245,7 +245,7 @@ TEST_P(TestDPCTLSyclDeviceInterface, Chk_GetPreferredVectorWidthFloat)
     EXPECT_TRUE(vector_width_float != 0);
 }
 
-TEST_P(TestDPCTLSyclDeviceInterface, Chk_GetPreferredVectorWidthDouble)
+TEST_P(TestDPCTLSyclDeviceInterface, ChkGetPreferredVectorWidthDouble)
 {
     size_t vector_width_double = 0;
     EXPECT_NO_FATAL_FAILURE(
@@ -260,7 +260,7 @@ TEST_P(TestDPCTLSyclDeviceInterface, Chk_GetPreferredVectorWidthDouble)
     }
 }
 
-TEST_P(TestDPCTLSyclDeviceInterface, Chk_GetPreferredVectorWidthHalf)
+TEST_P(TestDPCTLSyclDeviceInterface, ChkGetPreferredVectorWidthHalf)
 {
     size_t vector_width_half = 0;
     EXPECT_NO_FATAL_FAILURE(vector_width_half =
@@ -275,7 +275,7 @@ TEST_P(TestDPCTLSyclDeviceInterface, Chk_GetPreferredVectorWidthHalf)
     }
 }
 
-TEST_P(TestDPCTLSyclDeviceInterface, Chk_GetImage2dMaxWidth)
+TEST_P(TestDPCTLSyclDeviceInterface, ChkGetImage2dMaxWidth)
 {
     size_t image_2d_max_width = 0;
     EXPECT_NO_FATAL_FAILURE(image_2d_max_width =
@@ -286,7 +286,7 @@ TEST_P(TestDPCTLSyclDeviceInterface, Chk_GetImage2dMaxWidth)
         EXPECT_TRUE(image_2d_max_width >= min_val);
 }
 
-TEST_P(TestDPCTLSyclDeviceInterface, Chk_GetImage2dMaxHeight)
+TEST_P(TestDPCTLSyclDeviceInterface, ChkGetImage2dMaxHeight)
 {
     size_t image_2d_max_height = 0;
     EXPECT_NO_FATAL_FAILURE(image_2d_max_height =
@@ -297,7 +297,7 @@ TEST_P(TestDPCTLSyclDeviceInterface, Chk_GetImage2dMaxHeight)
         EXPECT_TRUE(image_2d_max_height >= min_val);
 }
 
-TEST_P(TestDPCTLSyclDeviceInterface, Chk_GetImage3dMaxWidth)
+TEST_P(TestDPCTLSyclDeviceInterface, ChkGetImage3dMaxWidth)
 {
     size_t image_3d_max_width = 0;
     EXPECT_NO_FATAL_FAILURE(image_3d_max_width =
@@ -308,7 +308,7 @@ TEST_P(TestDPCTLSyclDeviceInterface, Chk_GetImage3dMaxWidth)
         EXPECT_TRUE(image_3d_max_width >= min_val);
 }
 
-TEST_P(TestDPCTLSyclDeviceInterface, Chk_GetImage3dMaxHeight)
+TEST_P(TestDPCTLSyclDeviceInterface, ChkGetImage3dMaxHeight)
 {
     size_t image_3d_max_height = 0;
     EXPECT_NO_FATAL_FAILURE(image_3d_max_height =
@@ -319,7 +319,7 @@ TEST_P(TestDPCTLSyclDeviceInterface, Chk_GetImage3dMaxHeight)
         EXPECT_TRUE(image_3d_max_height >= min_val);
 }
 
-TEST_P(TestDPCTLSyclDeviceInterface, Chk_GetImage3dMaxDepth)
+TEST_P(TestDPCTLSyclDeviceInterface, ChkGetImage3dMaxDepth)
 {
     size_t image_3d_max_depth = 0;
     EXPECT_NO_FATAL_FAILURE(image_3d_max_depth =
@@ -330,14 +330,14 @@ TEST_P(TestDPCTLSyclDeviceInterface, Chk_GetImage3dMaxDepth)
         EXPECT_TRUE(image_3d_max_depth >= min_val);
 }
 
-TEST_P(TestDPCTLSyclDeviceInterface, Chk_GetParentDevice)
+TEST_P(TestDPCTLSyclDeviceInterface, ChkGetParentDevice)
 {
     DPCTLSyclDeviceRef pDRef = nullptr;
     EXPECT_NO_FATAL_FAILURE(pDRef = DPCTLDevice_GetParentDevice(DRef));
     EXPECT_TRUE(pDRef == nullptr);
 }
 
-INSTANTIATE_TEST_SUITE_P(DPCTLDevice_Fns,
+INSTANTIATE_TEST_SUITE_P(DPCTLDeviceFns,
                          TestDPCTLSyclDeviceInterface,
                          ::testing::Values("opencl",
                                            "opencl:gpu",

--- a/dpctl-capi/tests/test_sycl_device_invalid_filters.cpp
+++ b/dpctl-capi/tests/test_sycl_device_invalid_filters.cpp
@@ -53,7 +53,7 @@ struct TestUnsupportedFilters : public ::testing::TestWithParam<const char *>
     }
 };
 
-TEST_P(TestUnsupportedFilters, Chk_DPCTLDevice_CreateFromSelector)
+TEST_P(TestUnsupportedFilters, ChkDPCTLDeviceCreateFromSelector)
 {
     DPCTLSyclDeviceRef DRef = nullptr;
     EXPECT_NO_FATAL_FAILURE(DRef = DPCTLDevice_CreateFromSelector(DSRef));

--- a/dpctl-capi/tests/test_sycl_device_manager.cpp
+++ b/dpctl-capi/tests/test_sycl_device_manager.cpp
@@ -56,19 +56,19 @@ struct TestDPCTLDeviceManager : public ::testing::TestWithParam<const char *>
     }
 };
 
-TEST_P(TestDPCTLDeviceManager, Chk_GetRelativeId)
+TEST_P(TestDPCTLDeviceManager, ChkGetRelativeId)
 {
     int64_t rel_id = -1;
     EXPECT_NO_FATAL_FAILURE(rel_id = DPCTLDeviceMgr_GetRelativeId(DRef));
     EXPECT_FALSE(rel_id == -1);
 }
 
-TEST_P(TestDPCTLDeviceManager, Chk_PrintDeviceInfo)
+TEST_P(TestDPCTLDeviceManager, ChkPrintDeviceInfo)
 {
     EXPECT_NO_FATAL_FAILURE(DPCTLDeviceMgr_PrintDeviceInfo(DRef));
 }
 
-TEST_P(TestDPCTLDeviceManager, Chk_GetCachedContext)
+TEST_P(TestDPCTLDeviceManager, ChkGetCachedContext)
 {
     DPCTLSyclContextRef CRef = nullptr;
     EXPECT_NO_FATAL_FAILURE(CRef = DPCTLDeviceMgr_GetCachedContext(DRef));
@@ -107,7 +107,7 @@ struct TestDPCTLDeviceVector : public ::testing::TestWithParam<int>
     }
 };
 
-TEST_P(TestDPCTLDeviceVector, Chk_GetAt)
+TEST_P(TestDPCTLDeviceVector, ChkGetAt)
 {
     for (auto i = 0ul; i < nDevices; ++i) {
         DPCTLSyclDeviceRef DRef = nullptr;
@@ -125,7 +125,7 @@ INSTANTIATE_TEST_SUITE_P(
                       DPCTLSyclBackendType::DPCTL_OPENCL |
                           DPCTLSyclDeviceType::DPCTL_GPU));
 
-TEST(TestDPCTLDeviceVector, Chk_DPCTLDeviceVector_Create)
+TEST(TestDPCTLDeviceVector, ChkDPCTLDeviceVectorCreate)
 {
     DPCTLDeviceVectorRef DVRef = nullptr;
     size_t nDevices = 0;

--- a/dpctl-capi/tests/test_sycl_device_selector_interface.cpp
+++ b/dpctl-capi/tests/test_sycl_device_selector_interface.cpp
@@ -85,7 +85,7 @@ struct TestUnsupportedFilters : public ::testing::TestWithParam<const char *>
     }
 };
 
-TEST_F(TestDeviceSelectorInterface, Chk_DPCTLAcceleratorSelector_Create)
+TEST_F(TestDeviceSelectorInterface, ChkDPCTLAcceleratorSelectorCreate)
 {
     DPCTLSyclDeviceSelectorRef DSRef = nullptr;
     DPCTLSyclDeviceRef DRef = nullptr;
@@ -105,7 +105,7 @@ TEST_F(TestDeviceSelectorInterface, Chk_DPCTLAcceleratorSelector_Create)
     EXPECT_NO_FATAL_FAILURE(DPCTLDevice_Delete(DRef));
 }
 
-TEST_F(TestDeviceSelectorInterface, Chk_DPCTLDefaultSelector_Create)
+TEST_F(TestDeviceSelectorInterface, ChkDPCTLDefaultSelectorCreate)
 {
     DPCTLSyclDeviceSelectorRef DSRef = nullptr;
     DPCTLSyclDeviceRef DRef = nullptr;
@@ -125,7 +125,7 @@ TEST_F(TestDeviceSelectorInterface, Chk_DPCTLDefaultSelector_Create)
     EXPECT_NO_FATAL_FAILURE(DPCTLDevice_Delete(DRef));
 }
 
-TEST_F(TestDeviceSelectorInterface, Chk_DPCTLCPUSelector_Create)
+TEST_F(TestDeviceSelectorInterface, ChkDPCTLCPUSelectorCreate)
 {
     DPCTLSyclDeviceSelectorRef DSRef = nullptr;
     DPCTLSyclDeviceRef DRef = nullptr;
@@ -145,7 +145,7 @@ TEST_F(TestDeviceSelectorInterface, Chk_DPCTLCPUSelector_Create)
     EXPECT_NO_FATAL_FAILURE(DPCTLDevice_Delete(DRef));
 }
 
-TEST_F(TestDeviceSelectorInterface, Chk_DPCTLGPUSelector_Create)
+TEST_F(TestDeviceSelectorInterface, ChkDPCTLGPUSelectorCreate)
 {
     DPCTLSyclDeviceSelectorRef DSRef = nullptr;
     DPCTLSyclDeviceRef DRef = nullptr;
@@ -165,7 +165,7 @@ TEST_F(TestDeviceSelectorInterface, Chk_DPCTLGPUSelector_Create)
     EXPECT_NO_FATAL_FAILURE(DPCTLDevice_Delete(DRef));
 }
 
-TEST_F(TestDeviceSelectorInterface, Chk_DPCTLHostSelector_Create)
+TEST_F(TestDeviceSelectorInterface, ChkDPCTLHostSelectorCreate)
 {
     DPCTLSyclDeviceSelectorRef DSRef = nullptr;
     DPCTLSyclDeviceRef DRef = nullptr;
@@ -186,12 +186,12 @@ TEST_F(TestDeviceSelectorInterface, Chk_DPCTLHostSelector_Create)
     EXPECT_NO_FATAL_FAILURE(DPCTLDevice_Delete(DRef));
 }
 
-TEST_P(TestFilterSelector, Chk_DPCTLFilterSelector_Create)
+TEST_P(TestFilterSelector, ChkDPCTLFilterSelectorCreate)
 {
     ASSERT_TRUE(DRef != nullptr);
 }
 
-TEST_P(TestUnsupportedFilters, Chk_DPCTLFilterSelector_Create)
+TEST_P(TestUnsupportedFilters, ChkDPCTLFilterSelectorCreate)
 {
     DPCTLSyclDeviceRef DRef = nullptr;
     EXPECT_NO_FATAL_FAILURE(DRef = DPCTLDevice_CreateFromSelector(DSRef));
@@ -199,7 +199,7 @@ TEST_P(TestUnsupportedFilters, Chk_DPCTLFilterSelector_Create)
     EXPECT_NO_FATAL_FAILURE(DPCTLDevice_Delete(DRef));
 }
 
-TEST_F(TestDeviceSelectorInterface, Chk_DPCTLGPUSelector_Score)
+TEST_F(TestDeviceSelectorInterface, ChkDPCTLGPUSelectorScore)
 {
     DPCTLSyclDeviceSelectorRef DSRef_GPU = nullptr;
     DPCTLSyclDeviceSelectorRef DSRef_CPU = nullptr;

--- a/dpctl-capi/tests/test_sycl_device_subdevices.cpp
+++ b/dpctl-capi/tests/test_sycl_device_subdevices.cpp
@@ -1,3 +1,4 @@
+
 //===--- test_sycl_device_interface.cpp - Test cases for device interface  ===//
 //
 //                      Data Parallel Control (dpCtl)
@@ -70,7 +71,7 @@ struct TestDPCTLSyclDeviceInterface
     }
 };
 
-TEST_P(TestDPCTLSyclDeviceInterface, Chk_CreateSubDevicesEqually)
+TEST_P(TestDPCTLSyclDeviceInterface, ChkCreateSubDevicesEqually)
 {
     DPCTLDeviceVectorRef DVRef = nullptr;
     uint32_t maxCUs = 0;
@@ -94,7 +95,7 @@ TEST_P(TestDPCTLSyclDeviceInterface, Chk_CreateSubDevicesEqually)
     }
 }
 
-TEST_P(TestDPCTLSyclDeviceInterface, Chk_CreateSubDevicesByCounts)
+TEST_P(TestDPCTLSyclDeviceInterface, ChkCreateSubDevicesByCounts)
 {
     DPCTLDeviceVectorRef DVRef = nullptr;
     uint32_t maxCUs = 0;
@@ -117,8 +118,7 @@ TEST_P(TestDPCTLSyclDeviceInterface, Chk_CreateSubDevicesByCounts)
     }
 }
 
-TEST_P(TestDPCTLSyclDeviceInterface,
-       Chk_CreateSubDevicesByAffinityNotApplicable)
+TEST_P(TestDPCTLSyclDeviceInterface, ChkCreateSubDevicesByAffinityNotApplicable)
 {
     DPCTLDeviceVectorRef DVRef = nullptr;
 
@@ -146,7 +146,7 @@ TEST_P(TestDPCTLSyclDeviceInterface,
     }
 }
 
-TEST_P(TestDPCTLSyclDeviceInterface, Chk_CreateSubDevicesByAffinityNuma)
+TEST_P(TestDPCTLSyclDeviceInterface, ChkCreateSubDevicesByAffinityNuma)
 {
     DPCTLDeviceVectorRef DVRef = nullptr;
 
@@ -182,7 +182,7 @@ TEST_P(TestDPCTLSyclDeviceInterface, Chk_CreateSubDevicesByAffinityNuma)
     }
 }
 
-TEST_P(TestDPCTLSyclDeviceInterface, Chk_CreateSubDevicesByAffinityL4Cache)
+TEST_P(TestDPCTLSyclDeviceInterface, ChkCreateSubDevicesByAffinityL4Cache)
 {
     DPCTLDeviceVectorRef DVRef = nullptr;
 
@@ -218,7 +218,7 @@ TEST_P(TestDPCTLSyclDeviceInterface, Chk_CreateSubDevicesByAffinityL4Cache)
     }
 }
 
-TEST_P(TestDPCTLSyclDeviceInterface, Chk_CreateSubDevicesByAffinityL3Cache)
+TEST_P(TestDPCTLSyclDeviceInterface, ChkCreateSubDevicesByAffinityL3Cache)
 {
     DPCTLDeviceVectorRef DVRef = nullptr;
 
@@ -254,7 +254,7 @@ TEST_P(TestDPCTLSyclDeviceInterface, Chk_CreateSubDevicesByAffinityL3Cache)
     }
 }
 
-TEST_P(TestDPCTLSyclDeviceInterface, Chk_CreateSubDevicesByAffinityL2Cache)
+TEST_P(TestDPCTLSyclDeviceInterface, ChkCreateSubDevicesByAffinityL2Cache)
 {
     DPCTLDeviceVectorRef DVRef = nullptr;
 
@@ -290,7 +290,7 @@ TEST_P(TestDPCTLSyclDeviceInterface, Chk_CreateSubDevicesByAffinityL2Cache)
     }
 }
 
-TEST_P(TestDPCTLSyclDeviceInterface, Chk_CreateSubDevicesByAffinityL1Cache)
+TEST_P(TestDPCTLSyclDeviceInterface, ChkCreateSubDevicesByAffinityL1Cache)
 {
     DPCTLDeviceVectorRef DVRef = nullptr;
 
@@ -327,7 +327,7 @@ TEST_P(TestDPCTLSyclDeviceInterface, Chk_CreateSubDevicesByAffinityL1Cache)
 }
 
 TEST_P(TestDPCTLSyclDeviceInterface,
-       Chk_CreateSubDevicesByAffinityNextPartitionable)
+       ChkCreateSubDevicesByAffinityNextPartitionable)
 {
     DPCTLDeviceVectorRef DVRef = nullptr;
 
@@ -363,7 +363,7 @@ TEST_P(TestDPCTLSyclDeviceInterface,
     }
 }
 
-INSTANTIATE_TEST_SUITE_P(DPCTLDevice_Fns,
+INSTANTIATE_TEST_SUITE_P(DPCTLDeviceFns,
                          TestDPCTLSyclDeviceInterface,
                          ::testing::Values("opencl",
                                            "opencl:gpu",

--- a/dpctl-capi/tests/test_sycl_platform_interface.cpp
+++ b/dpctl-capi/tests/test_sycl_platform_interface.cpp
@@ -136,27 +136,27 @@ struct TestDPCTLSyclDefaultPlatform : public ::testing::Test
     }
 };
 
-TEST_P(TestDPCTLSyclPlatformInterface, Chk_GetName)
+TEST_P(TestDPCTLSyclPlatformInterface, ChkGetName)
 {
     check_platform_name(PRef);
 }
 
-TEST_P(TestDPCTLSyclPlatformInterface, Chk_GetVendor)
+TEST_P(TestDPCTLSyclPlatformInterface, ChkGetVendor)
 {
     check_platform_vendor(PRef);
 }
 
-TEST_P(TestDPCTLSyclPlatformInterface, Chk_GetVersion)
+TEST_P(TestDPCTLSyclPlatformInterface, ChkGetVersion)
 {
     check_platform_version(PRef);
 }
 
-TEST_P(TestDPCTLSyclPlatformInterface, Chk_GetBackend)
+TEST_P(TestDPCTLSyclPlatformInterface, ChkGetBackend)
 {
     check_platform_backend(PRef);
 }
 
-TEST_P(TestDPCTLSyclPlatformInterface, Chk_Copy)
+TEST_P(TestDPCTLSyclPlatformInterface, ChkCopy)
 {
     DPCTLSyclPlatformRef Copied_PRef = nullptr;
     EXPECT_NO_FATAL_FAILURE(Copied_PRef = DPCTLPlatform_Copy(PRef));
@@ -164,32 +164,32 @@ TEST_P(TestDPCTLSyclPlatformInterface, Chk_Copy)
     EXPECT_NO_FATAL_FAILURE(DPCTLPlatform_Delete(Copied_PRef));
 }
 
-TEST_P(TestDPCTLSyclPlatformInterface, Chk_PrintInfo)
+TEST_P(TestDPCTLSyclPlatformInterface, ChkPrintInfo)
 {
     EXPECT_NO_FATAL_FAILURE(DPCTLPlatformMgr_PrintInfo(PRef));
 }
 
-TEST_F(TestDPCTLSyclDefaultPlatform, Chk_GetName)
+TEST_F(TestDPCTLSyclDefaultPlatform, ChkGetName)
 {
     check_platform_name(PRef);
 }
 
-TEST_F(TestDPCTLSyclDefaultPlatform, Chk_GetVendor)
+TEST_F(TestDPCTLSyclDefaultPlatform, ChkGetVendor)
 {
     check_platform_vendor(PRef);
 }
 
-TEST_F(TestDPCTLSyclDefaultPlatform, Chk_GetVersion)
+TEST_F(TestDPCTLSyclDefaultPlatform, ChkGetVersion)
 {
     check_platform_version(PRef);
 }
 
-TEST_F(TestDPCTLSyclDefaultPlatform, Chk_GetBackend)
+TEST_F(TestDPCTLSyclDefaultPlatform, ChkGetBackend)
 {
     check_platform_backend(PRef);
 }
 
-TEST_F(TestDPCTLSyclDefaultPlatform, Chk_PrintInfo)
+TEST_F(TestDPCTLSyclDefaultPlatform, ChkPrintInfo)
 {
     EXPECT_NO_FATAL_FAILURE(DPCTLPlatformMgr_PrintInfo(PRef));
 }
@@ -213,7 +213,7 @@ TEST(TestGetPlatforms, Chk)
     EXPECT_NO_FATAL_FAILURE(DPCTLPlatformVector_Delete(PVRef));
 }
 
-INSTANTIATE_TEST_SUITE_P(DPCTLPlatform_Tests,
+INSTANTIATE_TEST_SUITE_P(DPCTLPlatformTests,
                          TestDPCTLSyclPlatformInterface,
                          ::testing::Values("opencl",
                                            "opencl:gpu",

--- a/dpctl-capi/tests/test_sycl_platform_invalid_filters.cpp
+++ b/dpctl-capi/tests/test_sycl_platform_invalid_filters.cpp
@@ -54,7 +54,7 @@ struct TestUnsupportedFilters : public ::testing::TestWithParam<const char *>
     }
 };
 
-TEST_P(TestUnsupportedFilters, Chk_DPCTLPlatform_CreateFromSelector)
+TEST_P(TestUnsupportedFilters, ChkDPCTLPlatformCreateFromSelector)
 {
     DPCTLSyclPlatformRef PRef = nullptr;
     EXPECT_NO_FATAL_FAILURE(PRef = DPCTLPlatform_CreateFromSelector(DSRef));

--- a/dpctl-capi/tests/test_sycl_program_interface.cpp
+++ b/dpctl-capi/tests/test_sycl_program_interface.cpp
@@ -92,7 +92,7 @@ struct TestDPCTLSyclProgramInterface
     }
 };
 
-TEST_P(TestDPCTLSyclProgramInterface, Chk_CreateFromSpirv)
+TEST_P(TestDPCTLSyclProgramInterface, ChkCreateFromSpirv)
 {
 
     ASSERT_TRUE(PRef != nullptr);
@@ -100,7 +100,7 @@ TEST_P(TestDPCTLSyclProgramInterface, Chk_CreateFromSpirv)
     ASSERT_TRUE(DPCTLProgram_HasKernel(PRef, "axpy"));
 }
 
-TEST_P(TestDPCTLSyclProgramInterface, Chk_GetKernel)
+TEST_P(TestDPCTLSyclProgramInterface, ChkGetKernel)
 {
     auto AddKernel = DPCTLProgram_GetKernel(PRef, "add");
     auto AxpyKernel = DPCTLProgram_GetKernel(PRef, "axpy");

--- a/dpctl-capi/tests/test_sycl_queue_interface.cpp
+++ b/dpctl-capi/tests/test_sycl_queue_interface.cpp
@@ -126,7 +126,7 @@ protected:
     }
 };
 
-TEST_F(TestDPCTLSyclQueueInterface, Check_CreateForDevice)
+TEST_F(TestDPCTLSyclQueueInterface, CheckCreateForDevice)
 {
     /* We are testing that we do not crash even when input is garbage. */
     DPCTLSyclQueueRef QRef = nullptr;
@@ -136,7 +136,7 @@ TEST_F(TestDPCTLSyclQueueInterface, Check_CreateForDevice)
     ASSERT_TRUE(QRef == nullptr);
 }
 
-TEST_F(TestDPCTLSyclQueueInterface, Check_Copy)
+TEST_F(TestDPCTLSyclQueueInterface, CheckCopy)
 {
     DPCTLSyclQueueRef Q1 = nullptr;
     DPCTLSyclQueueRef Q2 = nullptr;


### PR DESCRIPTION
1. GTest requires test case names and test names to not have underscore. See [Primer](https://chromium.googlesource.com/external/github.com/pwnall/googletest/+/refs/tags/release-1.8.0/googletest/docs/Primer.md).

2.  In `test_sycl_queue_manager` some tests were being register with `TEST( test_case_struct_name, name)`, but `test_case_struct_name` was deriving from a parameterized test, so these tests were never executed.

This PR fixes these two issues.