### PR TITLE
Added get_queue_ref_from_ptr_and_syclobj

### DIFF
--- a/dpctl/memory/_memory.pxd
+++ b/dpctl/memory/_memory.pxd
@@ -22,11 +22,14 @@ in dpctl.memory._memory.pyx.
 
 """
 
-from .._backend cimport DPCTLSyclUSMRef
+from .._backend cimport DPCTLSyclUSMRef, DPCTLSyclQueueRef
 from .._sycl_context cimport SyclContext
 from .._sycl_device cimport SyclDevice
 from .._sycl_queue cimport SyclQueue
 
+
+cdef DPCTLSyclQueueRef get_queue_ref_from_ptr_and_syclobj(
+    DPCTLSyclUSMRef ptr, object syclobj)
 
 cdef class _Memory:
     cdef DPCTLSyclUSMRef memory_ptr


### PR DESCRIPTION
Implements
```c
   DPCTLSyclQueueRef get_queue_ref_from_ptr_and_syclobj(
      DPCTLSyclUSMRef ptr, object syclobj)
```

This function is to help users of ``__sycl_usm_array_interface__`` to
create a queue from a pointer and a valid `syclobj` entry in the
interface dictionary.

Currently supported variants are:

```
    - filter selector string
          : creates queue for the device created from the selector
    - dpctl.SyclQueue
          : use given queue
    - dpctl.SyclContext
          : find device from ptr and context, create queue from context
	  : and device
    - capsule with SyclQueueRef
          : use this queue
    - capsule with SyclContextRef
          : use this context to recover device and create queue
    - any python object that implements method _get_capsule()
          : use that capsule as outlined above
```