### PR TITLE
moved __cinit__ docstring into class docstrings

### DIFF
--- a/dpctl/_sycl_context.pyx
+++ b/dpctl/_sycl_context.pyx
@@ -69,7 +69,12 @@ cdef class _SyclContext:
 
 
 cdef class SyclContext(_SyclContext):
-    """ Python wrapper class for cl::sycl::context.
+    """ Python class representing cl::sycl::context.
+
+        SyclContext() - create a context for a default device
+        SyclContext(filter_selector_string) - create a context for specified device
+        SyclContext(SyclDevice_instance) - create a context for the given device
+        SyclContext((dev1, dev2, ...)) - create a context for given set of device instances
     """
     
     @staticmethod
@@ -176,11 +181,6 @@ cdef class SyclContext(_SyclContext):
             return -128
 
     def __cinit__(self, arg=None):
-        """ SyclContext() - create a context for a default device
-            SyclContext(filter_selector_string) - create a context for specified device
-            SyclContext(SyclDevice_instance) - create a context for the given device
-            SyclContext((dev1, dev2, ...)) - create a context for given set of devices
-        """
         cdef int ret = 0
         if isinstance(arg, _SyclContext):
             ret = self._init_context_from__SyclContext(<_SyclContext> arg)

--- a/dpctl/_sycl_platform.pyx
+++ b/dpctl/_sycl_platform.pyx
@@ -64,7 +64,10 @@ cdef class _SyclPlatform:
 
 
 cdef class SyclPlatform(_SyclPlatform):
-    """ Python equivalent for cl::sycl::platform class.
+    """ Python class representing cl::sycl::platform class.
+
+        SyclPlatform() - create platform selected by sycl::default_selector
+        SyclPlatform(filter_selector) - create platform selected by filter selector
     """
     @staticmethod
     cdef void _init_helper(_SyclPlatform platform, DPCTLSyclPlatformRef PRef):

--- a/dpctl/_sycl_queue.pyx
+++ b/dpctl/_sycl_queue.pyx
@@ -158,20 +158,19 @@ cdef class _SyclQueue:
 
 
 cdef class SyclQueue(_SyclQueue):
-    """ Python wrapper class for cl::sycl::queue.
+    """ Python class representing cl::sycl::queue.
+
+        SyclQueue(*, /, property=None)
+            create SyclQueue from default selector
+        SyclQueue(filter_string, *, /, propery=None)
+            create SyclQueue from filter selector string
+        SyclQueue(SyclDevice, *, /, property=None)
+            create SyclQueue from give SyclDevice automatically
+            finding/creating SyclContext.
+        SyclQueue(SyclContext, SyclDevice, *, /, property=None)
+            create SyclQueue from give SyclContext, SyclDevice
     """
     def __cinit__(self, *args, **kwargs):
-        """
-           SyclQueue(*, /, property=None)
-               create SyclQueue from default selector
-           SyclQueue(filter_string, *, /, propery=None)
-               create SyclQueue from filter selector string
-           SyclQueue(SyclDevice, *, /, property=None)
-               create SyclQueue from give SyclDevice automatically
-               finding/creating SyclContext.
-           SyclQueue(SyclContext, SyclDevice, *, /, property=None)
-               create SyclQueue from give SyclContext, SyclDevice
-        """
         cdef int len_args
         cdef int status = 0
         cdef const char *filter_c_str = NULL


### PR DESCRIPTION
No functional change, but moved docstring content of `__cinit__` method to the class docstring.

Now `help(dpctl.SyclQueue)` displays the relevant help info.