### PR TITLE
Implemented support for constructing MemoryUSM* from object with __sycl_usm_array_interface__ when array-info is not contiguous

### DIFF
--- a/dpctl/memory/_memory.pxd
+++ b/dpctl/memory/_memory.pxd
@@ -51,18 +51,22 @@ cdef public class _Memory [object Py_MemoryObject, type Py_MemoryType]:
     cpdef bytes tobytes(self)
 
     @staticmethod
-    cdef public SyclDevice get_pointer_device(DPCTLSyclUSMRef p, SyclContext ctx)
+    cdef public SyclDevice get_pointer_device(
+        DPCTLSyclUSMRef p, SyclContext ctx)
     @staticmethod
     cdef public bytes get_pointer_type(DPCTLSyclUSMRef p, SyclContext ctx)
 
 
-cdef public class MemoryUSMShared(_Memory) [object PyMemoryUSMSharedObject, type PyMemoryUSMSharedType]:
+cdef public class MemoryUSMShared(_Memory) [object PyMemoryUSMSharedObject,
+                                            type PyMemoryUSMSharedType]:
     pass
 
 
-cdef public class MemoryUSMHost(_Memory) [object PyMemoryUSMHostObject, type PyMemoryUSMHostType]:
+cdef public class MemoryUSMHost(_Memory) [object PyMemoryUSMHostObject,
+                                          type PyMemoryUSMHostType]:
     pass
 
 
-cdef public class MemoryUSMDevice(_Memory) [object PyMemoryUSMDeviceObject, type PyMemoryUSMDeviceType]:
+cdef public class MemoryUSMDevice(_Memory) [object PyMemoryUSMDeviceObject,
+                                            type PyMemoryUSMDeviceType]:
     pass

--- a/dpctl/memory/_sycl_usm_array_interface_utils.pxi
+++ b/dpctl/memory/_sycl_usm_array_interface_utils.pxi
@@ -1,0 +1,200 @@
+
+
+cdef bint _valid_usm_ptr_and_context(DPCTLSyclUSMRef ptr, SyclContext ctx):
+    usm_type = _Memory.get_pointer_type(ptr, ctx)
+    return usm_type in (b'shared', b'device', b'host')
+
+
+cdef DPCTLSyclQueueRef _queue_ref_copy_from_SyclQueue(
+    DPCTLSyclUSMRef ptr, SyclQueue q):
+    """ Check that USM ptr is consistent with SYCL context in the queue,
+    and return a copy of QueueRef if so, or NULL otherwise.
+    """
+    cdef SyclContext ctx = q.get_sycl_context()
+    if (_valid_usm_ptr_and_context(ptr, ctx)):
+        return DPCTLQueue_Copy(q.get_queue_ref())
+    else:
+        return NULL
+
+
+cdef DPCTLSyclQueueRef _queue_ref_copy_from_USMRef_and_SyclContext(
+    DPCTLSyclUSMRef ptr, SyclContext ctx):
+    """ Obtain device from pointer and sycl context, use
+        context and device to create a queue from which this memory
+        can be accessible.
+    """
+    cdef SyclDevice dev = _Memory.get_pointer_device(ptr, ctx)
+    cdef DPCTLSyclContextRef CRef = ctx.get_context_ref()
+    cdef DPCTLSyclDeviceRef DRef = dev.get_device_ref()
+    return DPCTLQueue_Create(CRef, DRef, NULL, 0)
+
+
+cdef DPCTLSyclQueueRef get_queue_ref_from_ptr_and_syclobj(
+    DPCTLSyclUSMRef ptr, object syclobj):
+    """ Constructs queue from pointer and syclobject from
+        __sycl_usm_array_interface__
+    """
+    cdef SyclContext ctx
+    if type(syclobj) is SyclQueue:
+        return _queue_ref_copy_from_SyclQueue(ptr, <SyclQueue> syclobj)
+    elif type(syclobj) is SyclContext:
+        ctx = <SyclContext>syclobj
+        return _queue_ref_copy_from_USMRef_and_SyclContext(ptr, ctx)
+    elif type(syclobj) is str:
+        q = SyclQueue(syclobj)
+        return _queue_ref_copy_from_SyclQueue(ptr, <SyclQueue> q)
+    elif pycapsule.PyCapsule_IsValid(syclobj, "SyclQueueRef"):
+        q = SyclQueue(syclobj)
+        return _queue_ref_copy_from_SyclQueue(ptr, <SyclQueue> q)
+    elif pycapsule.PyCapsule_IsValid(syclobj, "SyclContextRef"):
+        ctx = <SyclContext>SyclContext(syclobj)
+        return _queue_ref_copy_from_USMRef_and_SyclContext(ptr, ctx)
+    elif hasattr(syclobj, '_get_capsule'):
+        cap = syclobj._get_capsule()
+        if pycapsule.PyCapsule_IsValid(cap, "SyclQueueRef"):
+            q = SyclQueue(cap)
+            return _queue_ref_copy_from_SyclQueue(ptr, <SyclQueue> q)
+        elif pycapsule.PyCapsule_IsValid(cap, "SyclContexRef"):
+            ctx = <SyclContext>SyclContext(cap)
+            return _queue_ref_copy_from_USMRef_and_SyclContext(ptr, ctx)
+        else:
+            return NULL
+    else:
+        return NULL
+
+
+cdef object _pointers_from_shape_and_stride(
+    int nd, object ary_shape, Py_ssize_t itemsize, Py_ssize_t ary_offset,
+    object ary_strides):
+    """
+    Internal utility: for given array data about shape/layout/element
+    compute left-most displacement when enumerating all elements of the array
+    and the number of bytes of memory between the left-most and right-most
+    displacements.
+
+    Returns: tuple(min_disp, nbytes)
+    """
+    if (nd > 0):
+        if (ary_strides is None):
+            nelems = 1
+            for si in ary_shape:
+                sh_i = int(si)
+                if (sh_i <= 0):
+                    raise ValueError("Array shape elements need to be positive")
+                nelems = nelems * sh_i
+            return (ary_offset, nelems * itemsize)
+        else:
+            min_disp = ary_offset
+            max_disp = ary_offset
+            for i in range(nd):
+                str_i = int(ary_strides[i])
+                sh_i = int(ary_shape[i])
+                if (str_i > 0):
+                    max_disp += str_i * (sh_i - 1)
+                else:
+                    min_disp += str_i * (sh_i - 1);
+            return (min_disp, (max_disp - min_disp + 1) * itemsize)
+    elif (nd == 0):
+        return (ary_offset, itemsize)
+    else:
+        raise ValueError("Array dimensions can not be negative")
+
+
+cdef class _USMBufferData:
+    """
+    Internal data struct populated from parsing
+    `__sycl_usm_array_interface__` dictionary
+    """
+    cdef DPCTLSyclUSMRef p
+    cdef int writeable
+    cdef object dt
+    cdef Py_ssize_t itemsize
+    cdef Py_ssize_t nbytes
+    cdef SyclQueue queue
+
+    @staticmethod
+    cdef _USMBufferData from_sycl_usm_ary_iface(dict ary_iface):
+        cdef object ary_data_tuple = ary_iface.get('data', None)
+        cdef object ary_typestr = ary_iface.get('typestr', None)
+        cdef object ary_shape = ary_iface.get('shape', None)
+        cdef object ary_strides = ary_iface.get('strides', None)
+        cdef object ary_syclobj = ary_iface.get('syclobj', None)
+        cdef Py_ssize_t ary_offset = ary_iface.get('offset', 0)
+        cdef int ary_version = ary_iface.get('version', 0)
+        cdef Py_ssize_t arr_data_ptr = 0
+        cdef DPCTLSyclUSMRef memRef = NULL
+        cdef Py_ssize_t itemsize = -1
+        cdef int writeable = -1
+        cdef int nd = -1
+        cdef DPCTLSyclQueueRef QRef = NULL
+        cdef object dt
+        cdef _USMBufferData buf
+        cdef SyclDevice dev
+        cdef SyclContext ctx
+
+        if ary_version != 1:
+            raise ValueError(("__sycl_usm_array_interface__ is malformed:"
+                              " dict('version': {}) is unexpected."
+                              " The only recognized version is 1.").format(
+                                  ary_version))
+        if not ary_data_tuple or len(ary_data_tuple) != 2:
+            raise ValueError("__sycl_usm_array_interface__ is malformed:"
+                             " 'data' field is required, and must be a tuple"
+                             " (usm_pointer, is_writeable_boolean).")
+        arr_data_ptr = <Py_ssize_t>ary_data_tuple[0]
+        writeable = 1 if ary_data_tuple[1] else 0
+        # Check that memory and syclobj are consistent:
+        # (USM pointer is bound to this sycl context)
+        memRef = <DPCTLSyclUSMRef>arr_data_ptr
+        QRef = get_queue_ref_from_ptr_and_syclobj(memRef, ary_syclobj)
+        if (QRef is NULL):
+            raise ValueError("__sycl_usm_array_interface__ is malformed:"
+                             " 'data' field is not consistent with 'syclobj'"
+                             " field, the pointer {} is not bound to"
+                             " SyclContext derived from"
+                             " dict('syclobj': {}).".format(
+                                 hex(arr_data_ptr), ary_syclobj))
+        # shape must be present
+        if ary_shape is None or not (
+                isinstance(ary_shape, collections.abc.Sized) and
+                isinstance(ary_shape, collections.abc.Iterable)):
+            DPCTLQueue_Delete(QRef)
+            raise ValueError("Shape entry is a required element of "
+                             "`__sycl_usm_array_interface__` dictionary")
+        nd = len(ary_shape)
+        try:
+            dt = np.dtype(ary_typestr)
+            if (dt.hasobject or not (np.issubdtype(dt.type, np.integer) or
+                                     np.issubdtype(dt.type, np.inexact))):
+                DPCTLQueue_Delete(QRef)
+                raise TypeError("Only integer types, floating and complex "
+                                "floating types are supported.")
+            itemsize = <Py_ssize_t> (dt.itemsize)
+        except TypeError as e:
+            raise ValueError(
+                "__sycl_usm_array_interface__ is malformed:"
+                " dict('typestr': {}) is unexpected. ".format(ary_typestr)
+            ) from e
+
+        if (ary_strides is None or (
+                isinstance(ary_strides, collections.abc.Sized) and
+                isinstance(ary_strides, collections.abc.Iterable) and
+                len(ary_strides) == nd)):
+            min_disp, nbytes = _pointers_from_shape_and_stride(
+                nd, ary_shape, itemsize, ary_offset, ary_strides)
+        else:
+            DPCTLQueue_Delete(QRef)
+            raise ValueError("__sycl_usm_array_interface__ is malformed: "
+                             "'strides' must be a tuple or "
+                             "list of the same length as shape")
+
+        buf = _USMBufferData.__new__(_USMBufferData)
+        buf.p = <DPCTLSyclUSMRef>(
+            arr_data_ptr + (<Py_ssize_t>min_disp) * itemsize)
+        buf.writeable = writeable
+        buf.itemsize = itemsize
+        buf.nbytes = <Py_ssize_t> nbytes
+
+        buf.queue = SyclQueue._create(QRef)
+
+        return buf

--- a/dpctl/tests/test_sycl_usm.py
+++ b/dpctl/tests/test_sycl_usm.py
@@ -243,5 +243,82 @@ class TestMemoryUSMDevice(_TestMemoryUSMBase, unittest.TestCase):
         self.usm_type = "device"
 
 
+class View:
+    def __init__(self, buf, shape, strides, offset):
+        self.buffer = buf
+        self.shape = shape
+        self.strides = strides
+        self.offset = offset
+
+    @property
+    def __sycl_usm_array_interface__(self):
+        sua_iface = self.buffer.__sycl_usm_array_interface__
+        sua_iface["offset"] = self.offset
+        sua_iface["shape"] = self.shape
+        sua_iface["strides"] = self.strides
+        return sua_iface
+
+
+class TestMemoryWithView(unittest.TestCase):
+    def test_suai_non_contig_1D(self):
+        """ Test of zero-copy using sycl_usm_array_interface with non-contiguous data """
+
+        MemoryUSMClass = MemoryUSMShared
+        try:
+            buf = MemoryUSMClass(32)
+        except:
+            self.skipTest("MemoryUSMShared could not be allocated")
+        host_canary = np.full((buf.nbytes,), 77, dtype="|u1")
+        buf.copy_from_host(host_canary)
+        n1d = 10
+        step_1d = 2
+        offset = 8
+        v = View(buf, shape=(n1d,), strides=(step_1d,), offset=offset)
+        buf2 = MemoryUSMClass(v)
+        expected_nbytes = (
+            np.flip(host_canary[offset : offset + n1d * step_1d : step_1d]).ctypes.data
+            + 1
+            - host_canary[offset:].ctypes.data
+        )
+        self.assertEqual(buf2.nbytes, expected_nbytes)
+        inset_canary = np.arange(0, buf2.nbytes, dtype="|u1")
+        buf2.copy_from_host(inset_canary)
+        res = buf.copy_to_host()
+        del buf
+        del buf2
+        expected_res = host_canary.copy()
+        expected_res[offset : offset + (n1d - 1) * step_1d + 1] = inset_canary
+        self.assertTrue(np.array_equal(res, expected_res))
+
+    def test_suai_non_contig_2D(self):
+        MemoryUSMClass = MemoryUSMDevice
+        try:
+            buf = MemoryUSMClass(20)
+        except:
+            self.skipTest("MemoryUSMShared could not be allocated")
+        host_canary = np.arange(20, dtype="|u1")
+        buf.copy_from_host(host_canary)
+        shape_2d = (2, 2)
+        strides_2d = (10, -2)
+        offset = 9
+        idx = []
+        for i0 in range(shape_2d[0]):
+            for i1 in range(shape_2d[1]):
+                idx.append(offset + i0 * strides_2d[0] + i1 * strides_2d[1])
+        idx.sort()
+        v = View(buf, shape=shape_2d, strides=strides_2d, offset=offset)
+        buf2 = MemoryUSMClass(v)
+        expected_nbytes = idx[-1] - idx[0] + 1
+        self.assertEqual(buf2.nbytes, expected_nbytes)
+        inset_canary = np.full((buf2.nbytes), 255, dtype="|u1")
+        buf2.copy_from_host(inset_canary)
+        res = buf.copy_to_host()
+        del buf
+        del buf2
+        expected_res = host_canary.copy()
+        expected_res[idx[0] : idx[-1] + 1] = inset_canary
+        self.assertTrue(np.array_equal(res, expected_res))
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Closes #396 

This PR permits constructor calls like `dpctl.memory.MemoryUSMShared( obj_with_suai )` to work with Python object whose `__sycl_usm_array_interface__` dictionary specifies non-contiguous strides, and non-byte-size type-string, used to address elements of a contiguous  block of memory. 

I.e. index tuple `(i0, i1, ...)` would address element `offset + strides[0]*i0 + strides[1]*i1 + ...`  in C-array of dimension `shape[0]*shape[1]*...`.

In this case type-less USM memory buffer created addresses memory from the minimal index to maxima index (inclusive) generated by enumeration of all  displacements  `offset + strides[0]*i0 + strides[1]*i1 + ...`  when iterating over all possible tuple of indexes in determined by the `shape`.

Example:

```python
import numpy as np
import dpctl
import dpctl.memory as dpmem

class View:
    def __init__(self, buffer, shape, strides, offset):
        self.buffer=buffer
        self.shape=shape
        self.strides=strides
        self.offset = offset

    @property
    def __sycl_usm_array_interface__(self):
        sua_iface = self.buffer.__sycl_usm_array_interface__
        sua_iface['offset'] = self.offset
        sua_iface['shape'] = self.shape
        sua_iface['strides'] = self.strides
        return sua_iface

# Allocate 32 bytes, and fill them with canary numbers
buf = dpmem.MemoryUSMShared(32)
buf.copy_from_host(np.full((32,), 77, dtype='|u1'))

# View of 10 bytes, starting with byte 8, and going every other byte
v = View(buf, (10,), strides=(2,), offset=8)

# Create USMShared buffer from the view 
# spanning from the lowest byte, offset=8 to highest byte, offset=8 +(10-1)*2
buf2 = dpmem.MemoryUSMShared(v)
# That is total of 19 bytes, (counting the last one too)
assert buf2.nbytes == 19
# populate this buffer with different values
buf2.copy_from_host(np.full((19,), 1, dtype="|u1"))
# copy content of the parent buffer to host
res = buf.copy_to_host()
del buf
del buf2
print(res)
```

Executing this prints

```
[77 77 77 77 77 77 77 77  1  1  1  1  1  1  1  1  1  1  1  1  1  1  1  1
  1  1  1 77 77 77 77 77]
```