### PR TITLE
Small changes to examples/cython/usm_memory for BS model

### DIFF
--- a/examples/cython/usm_memory/README.md
+++ b/examples/cython/usm_memory/README.md
@@ -8,7 +8,8 @@ Make sure oneAPI is activated. Environment variable `$ONEAPI_ROOT` must be set.
 
 
 ```
-$ CC=clang CXX=dpcpp LD_SHARED="dpcpp -shared" python setup.py build_ext --inplace
+$ CC=clang CXX=dpcpp LD_SHARED="dpcpp -shared" \
+  CXXFLAGS=-fno-sycl-early-optimizations python setup.py build_ext --inplace
 ```
 
 #2 Running

--- a/examples/cython/usm_memory/blackscholes.pyx
+++ b/examples/cython/usm_memory/blackscholes.pyx
@@ -87,8 +87,8 @@ def populate_params(floating[:, ::1] option_params, pl, ph, sl, sh, tl, th, rl, 
 
     cdef c_dpctl.SyclQueue q
     cdef c_dpctl.DPCTLSyclQueueRef q_ptr
-    cdef double* dp
-    cdef float* fp
+    cdef double* dp = NULL
+    cdef float* fp = NULL
 
     if (n_params != 5):
         raise ValueError((


### PR DESCRIPTION
1. initialized pointers to NULL in declaration in source code
2. Noted in README that `CXXFLAGS=-fno-sycl-early-optimizations` is necessary for compiler issue work-around.