### PR TITLE
Fix deprecation warning

### DIFF
--- a/dpctl/__init__.py
+++ b/dpctl/__init__.py
@@ -56,7 +56,7 @@ __all__ = (
 
 
 def get_include():
-    """
+    r"""
     Return the directory that contains the dpctl \*.h header files.
 
     Extension modules that need to be compiled against dpctl should use


### PR DESCRIPTION
In this PR:

Fixed deprecation warnings by using `r"""string with backslashes"""` as per  [PEP-257](https://www.python.org/dev/peps/pep-0257/).