### PR TITLE
Use size_t instead of Py_ssize_t to fit device USM pointer

### DIFF
--- a/dpctl/memory/_memory.pyx
+++ b/dpctl/memory/_memory.pyx
@@ -228,7 +228,7 @@ cdef class _Memory:
 
     def __repr__(self):
         return "<Intel(R) USM allocated memory block of {} bytes at {}>" \
-            .format(self.nbytes, hex(<object>(<Py_ssize_t>self.memory_ptr)))
+            .format(self.nbytes, hex(<object>(<size_t>self.memory_ptr)))
 
     def __len__(self):
         return self.nbytes
@@ -245,7 +245,7 @@ cdef class _Memory:
     property __sycl_usm_array_interface__:
         def __get__(self):
             cdef dict iface = {
-                "data": (<Py_ssize_t>(<void *>self.memory_ptr),
+                "data": (<size_t>(<void *>self.memory_ptr),
                          True), # bool(self.writeable)),
                 "shape": (self.nbytes,),
                 "strides": None,

--- a/dpctl/memory/_sycl_usm_array_interface_utils.pxi
+++ b/dpctl/memory/_sycl_usm_array_interface_utils.pxi
@@ -121,7 +121,7 @@ cdef class _USMBufferData:
         cdef object ary_syclobj = ary_iface.get('syclobj', None)
         cdef Py_ssize_t ary_offset = ary_iface.get('offset', 0)
         cdef int ary_version = ary_iface.get('version', 0)
-        cdef Py_ssize_t arr_data_ptr = 0
+        cdef size_t arr_data_ptr = 0
         cdef DPCTLSyclUSMRef memRef = NULL
         cdef Py_ssize_t itemsize = -1
         cdef int writeable = -1
@@ -141,7 +141,7 @@ cdef class _USMBufferData:
             raise ValueError("__sycl_usm_array_interface__ is malformed:"
                              " 'data' field is required, and must be a tuple"
                              " (usm_pointer, is_writeable_boolean).")
-        arr_data_ptr = <Py_ssize_t>ary_data_tuple[0]
+        arr_data_ptr = <size_t>ary_data_tuple[0]
         writeable = 1 if ary_data_tuple[1] else 0
         # Check that memory and syclobj are consistent:
         # (USM pointer is bound to this sycl context)


### PR DESCRIPTION
Use `size_t` instead of `Py_ssize_t` to represent USM pointer as Python object. This allows `_USMBufferData` class to understand SUAI with device-pointers.

Also to avoid formatting of the USM-device pointer as a negative hex value, e.g. format `dpctl.memory.MemoryUSMDevice(32)`.

