### PR TITLE
Print the backend as part of print_device_info.

### DIFF
--- a/dpctl-capi/helper/include/dpctl_utils_helper.h
+++ b/dpctl-capi/helper/include/dpctl_utils_helper.h
@@ -178,3 +178,21 @@ DPCTL_DPCTLPartitionAffinityDomainTypeToSycl(
 DPCTL_API
 DPCTLPartitionAffinityDomainType DPCTL_SyclPartitionAffinityDomainToDPCTLType(
     sycl::info::partition_affinity_domain PartitionAffinityDomain);
+
+/*!
+ * @brief Gives the index of the given device with respective to all the other
+ * devices of the same type in the device's platform.
+ *
+ * The relative device id of a device (Device) is computed by looking up the
+ * position of Device in the ``std::vector`` returned by calling the
+ * ``get_devices(Device.get_info<sycl::info::device::device_type>())`` function
+ * for Device's platform. A relative device id of -1 indicates that the relative
+ * id could not be computed.
+ *
+ * @param    Device         A ``sycl::device`` object whose relative id is to be
+ *                          computed.
+ * @return   A relative id corresponding to the device, -1 indicates that a
+ * relative id value could not be computed.
+ */
+DPCTL_API
+int64_t DPCTL_GetRelativeDeviceId(const sycl::device &Device);

--- a/dpctl-capi/helper/source/dpctl_utils_helper.cpp
+++ b/dpctl-capi/helper/source/dpctl_utils_helper.cpp
@@ -37,22 +37,22 @@ std::string DPCTL_DeviceTypeToStr(info::device_type devTy)
     std::stringstream ss;
     switch (devTy) {
     case info::device_type::cpu:
-        ss << "cpu" << '\n';
+        ss << "cpu";
         break;
     case info::device_type::gpu:
-        ss << "gpu" << '\n';
+        ss << "gpu";
         break;
     case info::device_type::accelerator:
-        ss << "accelerator" << '\n';
+        ss << "accelerator";
         break;
     case info::device_type::custom:
-        ss << "custom" << '\n';
+        ss << "custom";
         break;
     case info::device_type::host:
-        ss << "host" << '\n';
+        ss << "host";
         break;
     default:
-        ss << "unknown" << '\n';
+        ss << "unknown";
     }
     return ss.str();
 }
@@ -169,58 +169,58 @@ std::string DPCTL_AspectToStr(aspect aspectTy)
     std::stringstream ss;
     switch (aspectTy) {
     case aspect::host:
-        ss << "host" << '\n';
+        ss << "host";
         break;
     case aspect::cpu:
-        ss << "cpu" << '\n';
+        ss << "cpu";
         break;
     case aspect::gpu:
-        ss << "gpu" << '\n';
+        ss << "gpu";
         break;
     case aspect::accelerator:
-        ss << "accelerator" << '\n';
+        ss << "accelerator";
         break;
     case aspect::custom:
-        ss << "custom" << '\n';
+        ss << "custom";
         break;
     case aspect::fp16:
-        ss << "fp16" << '\n';
+        ss << "fp16";
         break;
     case aspect::fp64:
-        ss << "fp64" << '\n';
+        ss << "fp64";
         break;
     case aspect::int64_base_atomics:
-        ss << "int64_base_atomics" << '\n';
+        ss << "int64_base_atomics";
         break;
     case aspect::int64_extended_atomics:
-        ss << "int64_extended_atomics" << '\n';
+        ss << "int64_extended_atomics";
         break;
     case aspect::image:
-        ss << "image" << '\n';
+        ss << "image";
         break;
     case aspect::online_compiler:
-        ss << "online_compiler" << '\n';
+        ss << "online_compiler";
         break;
     case aspect::online_linker:
-        ss << "online_linker" << '\n';
+        ss << "online_linker";
         break;
     case aspect::queue_profiling:
-        ss << "queue_profiling" << '\n';
+        ss << "queue_profiling";
         break;
     case aspect::usm_device_allocations:
-        ss << "usm_device_allocations" << '\n';
+        ss << "usm_device_allocations";
         break;
     case aspect::usm_host_allocations:
-        ss << "usm_host_allocations" << '\n';
+        ss << "usm_host_allocations";
         break;
     case aspect::usm_shared_allocations:
-        ss << "usm_shared_allocations" << '\n';
+        ss << "usm_shared_allocations";
         break;
     case aspect::usm_restricted_shared_allocations:
-        ss << "usm_restricted_shared_allocations" << '\n';
+        ss << "usm_restricted_shared_allocations";
         break;
     case aspect::usm_system_allocator:
-        ss << "usm_system_allocator" << '\n';
+        ss << "usm_system_allocator";
         break;
     default:
         throw runtime_error("Unsupported aspect type", -1);
@@ -427,4 +427,19 @@ DPCTLPartitionAffinityDomainType DPCTL_SyclPartitionAffinityDomainToDPCTLType(
     default:
         throw runtime_error("Unsupported partition_affinity_domain type", -1);
     }
+}
+
+int64_t DPCTL_GetRelativeDeviceId(const device &Device)
+{
+    auto relid = -1;
+    auto p = Device.get_platform();
+    auto dt = Device.get_info<sycl::info::device::device_type>();
+    auto dev_vec = p.get_devices(dt);
+    int64_t id = 0;
+    for (const auto &d_i : dev_vec) {
+        if (Device == d_i)
+            relid = id;
+        ++id;
+    }
+    return relid;
 }

--- a/dpctl-capi/include/dpctl_sycl_device_manager.h
+++ b/dpctl-capi/include/dpctl_sycl_device_manager.h
@@ -116,10 +116,18 @@ DPCTL_API
 void DPCTLDeviceMgr_PrintDeviceInfo(__dpctl_keep const DPCTLSyclDeviceRef DRef);
 
 /*!
- * @brief Gives the index of the given device in the vector returned get_devices
- * for the platform associated with DRef for the device type of DRef.
+ * @brief Gives the index of the given device with respective to all the other
+ * devices of the same type in the device's platform.
+ *
+ * The relative device id of a device (Device) is computed by looking up the
+ * position of Device in the ``std::vector`` returned by calling the
+ * ``get_devices(Device.get_info<sycl::info::device::device_type>())`` function
+ * for Device's platform. A relative device id of -1 indicates that the relative
+ * id could not be computed.
  *
  * @param    DRef           A #DPCTLSyclDeviceRef opaque pointer.
+ * @return  A relative id corresponding to the device, -1 indicates that a
+ * relative id value could not be computed.
  * @ingroup DeviceManager
  */
 DPCTL_API

--- a/dpctl-capi/include/dpctl_sycl_platform_manager.h
+++ b/dpctl-capi/include/dpctl_sycl_platform_manager.h
@@ -45,10 +45,24 @@ DPCTL_DECLARE_VECTOR(Platform)
 
 /*!
  * @brief Prints out information about the sycl::platform argument.
+ *
+ * The helper function is used to print metadata about a given platform. The
+ * amount of information printed out is controlled by the verbosity level.
+ *
+ * Verbosity level 0: Prints only the name of the platform.
+ * Verbosity level 1: Prints the name, version, vendor, backend, number of
+ *                    devices in the platform.
+ * Verbosity level 2: Prints everything in level 1 and also prints the name,
+ *                    version, and filter string for each device in the
+ *                    platform.
+ *
  * @param    PRef           A #DPCTLSyclPlatformRef opaque pointer.
+ * @param    verbosity      Verbosilty level to control how much information is
+ *                          printed out.
  */
 DPCTL_API
-void DPCTLPlatformMgr_PrintInfo(__dpctl_keep const DPCTLSyclPlatformRef PRef);
+void DPCTLPlatformMgr_PrintInfo(__dpctl_keep const DPCTLSyclPlatformRef PRef,
+                                size_t verbosity);
 
 /*! @} */
 

--- a/dpctl-capi/tests/test_sycl_platform_interface.cpp
+++ b/dpctl-capi/tests/test_sycl_platform_interface.cpp
@@ -166,7 +166,7 @@ TEST_P(TestDPCTLSyclPlatformInterface, ChkCopy)
 
 TEST_P(TestDPCTLSyclPlatformInterface, ChkPrintInfo)
 {
-    EXPECT_NO_FATAL_FAILURE(DPCTLPlatformMgr_PrintInfo(PRef));
+    EXPECT_NO_FATAL_FAILURE(DPCTLPlatformMgr_PrintInfo(PRef, 0));
 }
 
 TEST_F(TestDPCTLSyclDefaultPlatform, ChkGetName)
@@ -189,9 +189,24 @@ TEST_F(TestDPCTLSyclDefaultPlatform, ChkGetBackend)
     check_platform_backend(PRef);
 }
 
-TEST_F(TestDPCTLSyclDefaultPlatform, ChkPrintInfo)
+TEST_F(TestDPCTLSyclDefaultPlatform, ChkPrintInfo0)
 {
-    EXPECT_NO_FATAL_FAILURE(DPCTLPlatformMgr_PrintInfo(PRef));
+    EXPECT_NO_FATAL_FAILURE(DPCTLPlatformMgr_PrintInfo(PRef, 0));
+}
+
+TEST_F(TestDPCTLSyclDefaultPlatform, ChkPrintInfo1)
+{
+    EXPECT_NO_FATAL_FAILURE(DPCTLPlatformMgr_PrintInfo(PRef, 1));
+}
+
+TEST_F(TestDPCTLSyclDefaultPlatform, ChkPrintInfo2)
+{
+    EXPECT_NO_FATAL_FAILURE(DPCTLPlatformMgr_PrintInfo(PRef, 2));
+}
+
+TEST_F(TestDPCTLSyclDefaultPlatform, ChkPrintInfo3)
+{
+    EXPECT_NO_FATAL_FAILURE(DPCTLPlatformMgr_PrintInfo(PRef, 3));
 }
 
 TEST(TestGetPlatforms, Chk)

--- a/dpctl/_backend.pxd
+++ b/dpctl/_backend.pxd
@@ -247,7 +247,7 @@ cdef extern from "dpctl_sycl_platform_manager.h":
     cdef DPCTLSyclPlatformRef DPCTLPlatformVector_GetAt(
         DPCTLPlatformVectorRef,
         size_t index)
-    cdef void DPCTLPlatformMgr_PrintInfo(const DPCTLSyclPlatformRef)
+    cdef void DPCTLPlatformMgr_PrintInfo(const DPCTLSyclPlatformRef, size_t)
 
 
 cdef extern from "dpctl_sycl_platform_interface.h":

--- a/dpctl/_sycl_platform.pyx
+++ b/dpctl/_sycl_platform.pyx
@@ -175,10 +175,43 @@ cdef class SyclPlatform(_SyclPlatform):
                 "a SYCL filter selector string."
             )
 
-    def print_platform_info(self):
+    def print_platform_info(self, verbosity=0):
         """ Print information about the SYCL platform.
+
+        The level of information printed out by the function can be controlled
+        by the optional ``vebosity`` setting.
+
+            - **Verbosity level 0**: Prints out the list of platforms and their
+              names.
+            - **Verbosity level 1**: Prints out the name, version, vendor,
+              backend, number of devices for each platform.
+            - **Verbosity level 2**: At the highest level of verbosity
+              everything in the previous levels along with the name, version,
+              and filter string for each device is printed.
+
+        Args:
+            verbosity (optional): Defaults to 0.
+                The verbosity controls how much information is printed by the
+                function. 0 is the lowest level set by default and 2 is the
+                highest level to print the most verbose output.
+
         """
-        DPCTLPlatformMgr_PrintInfo(self._platform_ref)
+        cdef size_t v = 0
+
+        if not isinstance(verbosity, int):
+            print(
+                "Illegal verbosity level. Accepted values are 0, 1, or 2. "
+                "Using the default verbosity level of 0."
+            )
+        else:
+            v = <size_t>(verbosity)
+            if v > 2:
+                print(
+                    "Illegal verbosity level. Accepted values are 0, 1, or 2. "
+                    "Using the default verbosity level of 0."
+                )
+                v = 0
+        DPCTLPlatformMgr_PrintInfo(self._platform_ref, v)
 
     @property
     def vendor(self):
@@ -220,13 +253,22 @@ cdef class SyclPlatform(_SyclPlatform):
             raise ValueError("Unknown backend type.")
 
 
-def lsplatform():
+def lsplatform(verbosity=0):
     """
-    Prints out the list of available SYCL platforms and various information
-    about each platform.
+    Prints out the list of available SYCL platforms, and optionally extra
+    metadata about each platform.
 
-    Currently, this function prints a list of all SYCL platforms that
-    are available on the system and the list of devices for each platform.
+    The level of information printed out by the function can be controlled by
+    the optional ``vebosity`` setting.
+
+    - **Verbosity level 0**: Prints out the list of platforms and their names.
+    - **Verbosity level 1**: Prints out the name, version, vendor, backend,
+      number of devices for each platform.
+    - **Verbosity level 2**: At the highest level of verbosity everything in the
+      previous levels along with the name, version, and filter string for each
+      device is printed.
+
+    At verbosity level 2 (highest level) the following output is generated.
 
     :Example:
         On a system with an OpenCL CPU driver, OpenCL GPU driver,
@@ -270,19 +312,40 @@ def lsplatform():
                     Driver version  1.0.18513
                     Device type     gpu
 
+    Args:
+        verbosity (optional): Defaults to 0.
+            The verbosity controls how much information is printed by the
+            function. 0 is the lowest level set by default and 2 is the highest
+            level to print the most verbose output.
     """
     cdef DPCTLPlatformVectorRef PVRef = NULL
+    cdef size_t v = 0
     cdef size_t size = 0
     cdef DPCTLSyclPlatformRef PRef = NULL
+
+    if not isinstance(verbosity, int):
+        print(
+            "Illegal verbosity level. Accepted values are 0, 1, or 2. "
+            "Using the default verbosity level of 0."
+        )
+    else:
+        v = <size_t>(verbosity)
+        if v > 2:
+            print(
+                "Illegal verbosity level. Accepted values are 0, 1, or 2. "
+                "Using the default verbosity level of 0."
+            )
+            v = 0
 
     PVRef = DPCTLPlatform_GetPlatforms()
 
     if PVRef is not NULL:
         size = DPCTLPlatformVector_Size(PVRef)
         for i in range(size):
-            print("Platform ", i, "::")
+            if v != 0:
+                print("Platform ", i, "::")
             PRef = DPCTLPlatformVector_GetAt(PVRef, i)
-            DPCTLPlatformMgr_PrintInfo(PRef)
+            DPCTLPlatformMgr_PrintInfo(PRef, v)
             DPCTLPlatform_Delete(PRef)
     DPCTLPlatformVector_Delete(PVRef)
 

--- a/dpctl/_sycl_platform.pyx
+++ b/dpctl/_sycl_platform.pyx
@@ -46,6 +46,8 @@ from ._backend cimport (  # noqa: E211
     _backend_type,
 )
 
+import warnings
+
 from .enum_types import backend_type
 
 __all__ = [
@@ -199,14 +201,14 @@ cdef class SyclPlatform(_SyclPlatform):
         cdef size_t v = 0
 
         if not isinstance(verbosity, int):
-            print(
+            warnings.warn(
                 "Illegal verbosity level. Accepted values are 0, 1, or 2. "
                 "Using the default verbosity level of 0."
             )
         else:
             v = <size_t>(verbosity)
             if v > 2:
-                print(
+                warnings.warn(
                     "Illegal verbosity level. Accepted values are 0, 1, or 2. "
                     "Using the default verbosity level of 0."
                 )
@@ -331,7 +333,7 @@ def lsplatform(verbosity=0):
     else:
         v = <size_t>(verbosity)
         if v > 2:
-            print(
+            warnings.warn(
                 "Illegal verbosity level. Accepted values are 0, 1, or 2. "
                 "Using the default verbosity level of 0."
             )

--- a/dpctl/tests/test_sycl_platform.py
+++ b/dpctl/tests/test_sycl_platform.py
@@ -133,6 +133,34 @@ def test_lsplatform():
         pytest.fail("Encountered an exception inside lsplatform().")
 
 
+def test_lsplatform0():
+    try:
+        dpctl.lsplatform(0)
+    except Exception:
+        pytest.fail("Encountered an exception inside lsplatform().")
+
+
+def test_lsplatform1():
+    try:
+        dpctl.lsplatform(1)
+    except Exception:
+        pytest.fail("Encountered an exception inside lsplatform().")
+
+
+def test_lsplatform2():
+    try:
+        dpctl.lsplatform(2)
+    except Exception:
+        pytest.fail("Encountered an exception inside lsplatform().")
+
+
+def test_lsplatform3():
+    try:
+        dpctl.lsplatform(3)
+    except Exception:
+        pytest.fail("Encountered an exception inside lsplatform().")
+
+
 def test_get_platforms():
     try:
         platforms = dpctl.get_platforms()


### PR DESCRIPTION
Closes #293 

Improvements to the `print_*_info()` functions in both C and Python APIs.

The `print_device_info()` function now prints the full filter string.

```python
In [2]: d = dpctl.select_gpu_device()

In [3]: d.print_device_info()
    Name            Intel(R) UHD Graphics 630 [0x3e98]
    Driver version  1.0.19438
    Vendor          Intel(R) Corporation
    Profile         FULL_PROFILE
    Filter string   level_zero:gpu:0

```
The `print_platform_info()` function now supports verbosity levels that can be `0, 1, 2`. The default verbosity level is set to 0.

```python
In [5]: p = dpctl.get_platforms()[0]

In [6]: p.print_platform_info(verbosity=0)
Intel(R) FPGA Emulation Platform for OpenCL(TM) OpenCL 1.2 Intel(R) FPGA SDK for OpenCL(TM), Version 20.3

In [7]: p.print_platform_info(verbosity=1)
    Name        Intel(R) FPGA Emulation Platform for OpenCL(TM)
    Version     OpenCL 1.2 Intel(R) FPGA SDK for OpenCL(TM), Version 20.3
    Vendor      Intel(R) Corporation
    Backend     opencl
    Num Devices 1

In [8]: p.print_platform_info(verbosity=2)
    Name        Intel(R) FPGA Emulation Platform for OpenCL(TM)
    Version     OpenCL 1.2 Intel(R) FPGA SDK for OpenCL(TM), Version 20.3
    Vendor      Intel(R) Corporation
    Backend     opencl
    Num Devices 1
      # 0
        Name                Intel(R) FPGA Emulation Device
        Version             2021.11.3.0.17_160000
        Filter string       opencl:accelerator:0

In [9]: p.print_platform_info()
Intel(R) FPGA Emulation Platform for OpenCL(TM) OpenCL 1.2 Intel(R) FPGA SDK for OpenCL(TM), Version 20.3
```
The behaviour of the `lsplatform` function is also modified. Verbosity levels are supported by this function as well and the default level is set to 0. The earlier level of detail is now only printed at verbosity level 2.

```python
In [10]: dpctl.lsplatform()
Intel(R) FPGA Emulation Platform for OpenCL(TM) OpenCL 1.2 Intel(R) FPGA SDK for OpenCL(TM), Version 20.3
Intel(R) OpenCL OpenCL 2.1 LINUX
Intel(R) OpenCL HD Graphics OpenCL 3.0 
Intel(R) OpenCL OpenCL 2.1 LINUX
Intel(R) Level-Zero 1.0
SYCL host platform 1.2

In [11]: dpctl.lsplatform(verbosity=0)
Intel(R) FPGA Emulation Platform for OpenCL(TM) OpenCL 1.2 Intel(R) FPGA SDK for OpenCL(TM), Version 20.3
Intel(R) OpenCL OpenCL 2.1 LINUX
Intel(R) OpenCL HD Graphics OpenCL 3.0 
Intel(R) OpenCL OpenCL 2.1 LINUX
Intel(R) Level-Zero 1.0
SYCL host platform 1.2

In [12]: dpctl.lsplatform(verbosity=1)
Platform  0 ::
    Name        Intel(R) FPGA Emulation Platform for OpenCL(TM)
    Version     OpenCL 1.2 Intel(R) FPGA SDK for OpenCL(TM), Version 20.3
    Vendor      Intel(R) Corporation
    Backend     opencl
    Num Devices 1
Platform  1 ::
    Name        Intel(R) OpenCL
    Version     OpenCL 2.1 LINUX
    Vendor      Intel(R) Corporation
    Backend     opencl
    Num Devices 1
Platform  2 ::
    Name        Intel(R) OpenCL HD Graphics
    Version     OpenCL 3.0 
    Vendor      Intel(R) Corporation
    Backend     opencl
    Num Devices 1
Platform  3 ::
    Name        Intel(R) OpenCL
    Version     OpenCL 2.1 LINUX
    Vendor      Intel(R) Corporation
    Backend     opencl
    Num Devices 1
Platform  4 ::
    Name        Intel(R) Level-Zero
    Version     1.0
    Vendor      Intel(R) Corporation
    Backend     level_zero
    Num Devices 1
Platform  5 ::
    Name        SYCL host platform
    Version     1.2
    Vendor      unknown
    Backend     unknown
    Num Devices 1

In [13]: dpctl.lsplatform(verbosity=2)
Platform  0 ::
    Name        Intel(R) FPGA Emulation Platform for OpenCL(TM)
    Version     OpenCL 1.2 Intel(R) FPGA SDK for OpenCL(TM), Version 20.3
    Vendor      Intel(R) Corporation
    Backend     opencl
    Num Devices 1
      # 0
        Name                Intel(R) FPGA Emulation Device
        Version             2021.11.3.0.17_160000
        Filter string       opencl:accelerator:0
Platform  1 ::
    Name        Intel(R) OpenCL
    Version     OpenCL 2.1 LINUX
    Vendor      Intel(R) Corporation
    Backend     opencl
    Num Devices 1
      # 0
        Name                Intel(R) Core(TM) i7-9700 CPU @ 3.00GHz
        Version             2021.11.3.0.17_160000
        Filter string       opencl:cpu:0
Platform  2 ::
    Name        Intel(R) OpenCL HD Graphics
    Version     OpenCL 3.0 
    Vendor      Intel(R) Corporation
    Backend     opencl
    Num Devices 1
      # 0
        Name                Intel(R) UHD Graphics 630 [0x3e98]
        Version             21.13.19438
        Filter string       opencl:gpu:0
Platform  3 ::
    Name        Intel(R) OpenCL
    Version     OpenCL 2.1 LINUX
    Vendor      Intel(R) Corporation
    Backend     opencl
    Num Devices 1
      # 0
        Name                Intel(R) Core(TM) i7-9700 CPU @ 3.00GHz
        Version             2021.11.3.0.17_160000
        Filter string       opencl:cpu:0
Platform  4 ::
    Name        Intel(R) Level-Zero
    Version     1.0
    Vendor      Intel(R) Corporation
    Backend     level_zero
    Num Devices 1
      # 0
        Name                Intel(R) UHD Graphics 630 [0x3e98]
        Version             1.0.19438
        Filter string       level_zero:gpu:0
Platform  5 ::
    Name        SYCL host platform
    Version     1.2
    Vendor      unknown
    Backend     unknown
    Num Devices 1
      # 0
        Name                SYCL host device
        Version             1.2
        Filter string       host:host:0
```
