### PR TITLE
Ignore all Cython generated headers.

### DIFF
--- a/dpctl/.gitignore
+++ b/dpctl/.gitignore
@@ -1,4 +1,6 @@
 *.so
 *.cpp
 *.c
+*.h
+memory/*.h
 include/*


### PR DESCRIPTION
The cython generated header files are added to .gitignore.