### PR TITLE
Ignore all changes done in #422 from git-blame.

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -8,3 +8,6 @@
 
 # Reformat backend.pxd file
 40bf59a56bedd2814ba22dd51298b0b5fdad0cb3
+
+# Linter changes
+084ba59ce87efb55e09fff6ae33665d0f14f22b5


### PR DESCRIPTION
Added the git commit that fixed linting issues to the git-blame-ignore-revs.