### PR TITLE
Improvements to setup.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,14 @@ For development:
 python setup.py develop
 ```
 
+It is also possible to build dpctl using [DPC++ toolchain](https://github.com/intel/llvm/blob/sycl/sycl/doc/GetStartedGuide.md) instead of oneAPI DPC++. Instead of activating the oneAPI environment, indicate the toolchain installation prefix with `--sycl-compiler-prefix` option, e.g.
+
+```cmd
+python setup.py develop --sycl-compiler-prefix=${DPCPP_ROOT}/llvm/build
+```
+
+Please use `python setup.py develop --help` for more details.
+
 Install Wheel Package from Pypi
 ==================================
 1. Install dpctl

--- a/docs/docfiles/user_guides/QuickStart.rst
+++ b/docs/docfiles/user_guides/QuickStart.rst
@@ -165,9 +165,19 @@ to build and install
 Building using custom dpcpp
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. todo::
+It is possible to build dpctl from source using .. _DPC++ toolchain: https://github.com/intel/llvm/blob/sycl/sycl/doc/GetStartedGuide.md
+instead of the DPC++ compiler that comes with oneAPI. One reason for doing this
+may be to enable support for CUDA devices.
 
-    Instructions coming soon.
+Following steps in :ref:`Build and Install with setuptools` use command line
+option :code:`--sycl-compiler-prefix`, for example:
+
+.. code-block:: bash
+
+    python setup.py develop --sycl-compiler-prefix=${DPCPP_ROOT}/llvm/build
+
+Available options and their descriptions can be retrieved using option
+:code:`--help`.
 
 Using dpctl
 -----------

--- a/dpctl/_sycl_context.pyx
+++ b/dpctl/_sycl_context.pyx
@@ -16,6 +16,7 @@
 
 # distutils: language = c++
 # cython: language_level=3
+# cython: linetrace=True
 
 """ Implements SyclContext Cython extension type.
 """

--- a/dpctl/_sycl_device.pyx
+++ b/dpctl/_sycl_device.pyx
@@ -16,6 +16,7 @@
 
 # distutils: language = c++
 # cython: language_level=3
+# cython: linetrace=True
 
 """ Implements SyclDevice Cython extension type.
 """

--- a/dpctl/_sycl_device_factory.pyx
+++ b/dpctl/_sycl_device_factory.pyx
@@ -16,6 +16,7 @@
 
 # distutils: language = c++
 # cython: language_level=3
+# cython: linetrace=True
 
 """ This module implements several device creation helper functions:
 

--- a/dpctl/_sycl_event.pyx
+++ b/dpctl/_sycl_event.pyx
@@ -16,6 +16,7 @@
 
 # distutils: language = c++
 # cython: language_level=3
+# cython: linetrace=True
 
 """ Implements SyclEvent Cython extension type.
 """

--- a/dpctl/_sycl_platform.pyx
+++ b/dpctl/_sycl_platform.pyx
@@ -16,6 +16,7 @@
 #
 # distutils: language = c++
 # cython: language_level=3
+# cython: linetrace=True
 
 """ Implements SyclPlatform Cython extension type.
 """

--- a/dpctl/_sycl_queue.pyx
+++ b/dpctl/_sycl_queue.pyx
@@ -16,6 +16,7 @@
 
 # distutils: language = c++
 # cython: language_level=3
+# cython: linetrace=True
 
 """ Implements SyclQueue Cython extension type.
 """

--- a/dpctl/_sycl_queue_manager.pyx
+++ b/dpctl/_sycl_queue_manager.pyx
@@ -16,6 +16,7 @@
 #
 # distutils: language = c++
 # cython: language_level=3
+# cython: linetrace=True
 
 from __future__ import print_function
 

--- a/dpctl/memory/_memory.pyx
+++ b/dpctl/memory/_memory.pyx
@@ -16,6 +16,7 @@
 
 # distutils: language = c++
 # cython: language_level=3
+# cython: linetrace=True
 
 """This file implements Python buffer protocol using Sycl USM shared and host
 allocators. The USM device allocator is also exposed through this module for

--- a/dpctl/program/_program.pyx
+++ b/dpctl/program/_program.pyx
@@ -16,6 +16,7 @@
 
 # distutils: language = c++
 # cython: language_level=3
+# cython: linetrace=True
 
 """Implements a Python interface for SYCL's program and kernel runtime classes.
 

--- a/dpctl/tensor/_usmarray.pyx
+++ b/dpctl/tensor/_usmarray.pyx
@@ -16,6 +16,7 @@
 
 # distutils: language = c++
 # cython: language_level=3
+# cython: linetrace=True
 
 import numpy as np
 

--- a/scripts/build_backend.py
+++ b/scripts/build_backend.py
@@ -18,129 +18,148 @@
 """
 
 
-import glob
-import os
-import shutil
-import subprocess
-import sys
+def build_backend(l0_support=False):
+    import glob
+    import os
+    import shutil
+    import subprocess
+    import sys
 
-IS_WIN = False
-IS_LIN = False
+    IS_WIN = False
+    IS_LIN = False
 
-if "linux" in sys.platform:
-    IS_LIN = True
-elif sys.platform in ["win32", "cygwin"]:
-    IS_WIN = True
-else:
-    assert False, sys.platform + " not supported"
-
-ONEAPI_ROOT = os.environ.get("ONEAPI_ROOT")
-CODE_COVERAGE = os.environ.get("CODE_COVERAGE")
-
-if IS_LIN:
-    DPCPP_ROOT = os.path.join(ONEAPI_ROOT, r"compiler/latest/linux")
-if IS_WIN:
-    DPCPP_ROOT = os.path.join(ONEAPI_ROOT, r"compiler\latest\windows")
-
-dpctl_dir = os.getcwd()
-build_cmake_dir = os.path.join(dpctl_dir, "build_cmake")
-if os.path.exists(build_cmake_dir):
-    for f in os.listdir(build_cmake_dir):
-        f_path = os.path.join(build_cmake_dir, f)
-        if os.path.isdir(f_path):
-            if (f == "level-zero") and os.path.isdir(
-                os.path.join(f_path, ".git")
-            ):
-                # do not delete Git checkout of level zero headers
-                pass
-            else:
-                shutil.rmtree(f_path)
-        else:
-            os.remove(f_path)
-else:
-    os.mkdir(build_cmake_dir)
-os.chdir(build_cmake_dir)
-
-INSTALL_PREFIX = os.path.join(dpctl_dir, "install")
-if os.path.exists(INSTALL_PREFIX):
-    shutil.rmtree(INSTALL_PREFIX)
-
-backends = os.path.join(dpctl_dir, "dpctl-capi")
-
-if IS_LIN:
-    if CODE_COVERAGE:
-        cmake_args = [
-            "cmake",
-            "-DCMAKE_BUILD_TYPE=Debug",
-            "-DCMAKE_INSTALL_PREFIX=" + INSTALL_PREFIX,
-            "-DCMAKE_PREFIX_PATH=" + INSTALL_PREFIX,
-            "-DDPCPP_INSTALL_DIR=" + DPCPP_ROOT,
-            "-DCMAKE_C_COMPILER:PATH="
-            + os.path.join(DPCPP_ROOT, "bin", "clang"),
-            "-DCMAKE_CXX_COMPILER:PATH="
-            + os.path.join(DPCPP_ROOT, "bin", "dpcpp"),
-            "-DDPCTL_ENABLE_LO_PROGRAM_CREATION=ON",
-            "-DDPCTL_BUILD_CAPI_TESTS=ON",
-            "-DDPCTL_GENERATE_COVERAGE=ON",
-            "-DDPCTL_COVERAGE_REPORT_OUTPUT_DIR=" + dpctl_dir,
-            backends,
-        ]
-        subprocess.check_call(cmake_args, stderr=subprocess.STDOUT, shell=False)
-        subprocess.check_call(["make", "V=1", "-j", "4"])
-        subprocess.check_call(["make", "install"])
-        subprocess.check_call(["make", "lcov-genhtml"])
-
+    if "linux" in sys.platform:
+        IS_LIN = True
+    elif sys.platform in ["win32", "cygwin"]:
+        IS_WIN = True
     else:
+        assert False, sys.platform + " not supported"
+
+    CODE_COVERAGE = os.environ.get("CODE_COVERAGE")
+    ONEAPI_ROOT = os.environ.get("ONEAPI_ROOT")
+
+    if IS_LIN:
+        DPCPP_ROOT = os.path.join(ONEAPI_ROOT, r"compiler/latest/linux")
+    elif IS_WIN:
+        DPCPP_ROOT = os.path.join(ONEAPI_ROOT, r"compiler\latest\windows")
+
+    dpctl_dir = os.getcwd()
+    build_cmake_dir = os.path.join(dpctl_dir, "build_cmake")
+    if os.path.exists(build_cmake_dir):
+        for f in os.listdir(build_cmake_dir):
+            f_path = os.path.join(build_cmake_dir, f)
+            if os.path.isdir(f_path):
+                if (f == "level-zero") and os.path.isdir(
+                    os.path.join(f_path, ".git")
+                ):
+                    # do not delete Git checkout of level zero headers
+                    pass
+                else:
+                    shutil.rmtree(f_path)
+            else:
+                os.remove(f_path)
+    else:
+        os.mkdir(build_cmake_dir)
+    os.chdir(build_cmake_dir)
+
+    INSTALL_PREFIX = os.path.join(dpctl_dir, "install")
+    if os.path.exists(INSTALL_PREFIX):
+        shutil.rmtree(INSTALL_PREFIX)
+
+    backends = os.path.join(dpctl_dir, "dpctl-capi")
+
+    ENABLE_LO_PROGRAM_CREATION = "ON" if l0_support else "OFF"
+
+    if IS_LIN:
+        if CODE_COVERAGE:
+            cmake_args = [
+                "cmake",
+                "-DCMAKE_BUILD_TYPE=Debug",
+                "-DCMAKE_INSTALL_PREFIX=" + INSTALL_PREFIX,
+                "-DCMAKE_PREFIX_PATH=" + INSTALL_PREFIX,
+                "-DDPCPP_INSTALL_DIR=" + DPCPP_ROOT,
+                "-DCMAKE_C_COMPILER:PATH="
+                + os.path.join(DPCPP_ROOT, "bin", "clang"),
+                "-DCMAKE_CXX_COMPILER:PATH="
+                + os.path.join(DPCPP_ROOT, "bin", "dpcpp"),
+                "-DDPCTL_ENABLE_LO_PROGRAM_CREATION="
+                + ENABLE_LO_PROGRAM_CREATION,
+                "-DDPCTL_BUILD_CAPI_TESTS=ON",
+                "-DDPCTL_GENERATE_COVERAGE=ON",
+                "-DDPCTL_COVERAGE_REPORT_OUTPUT_DIR=" + dpctl_dir,
+                backends,
+            ]
+            subprocess.check_call(
+                cmake_args, stderr=subprocess.STDOUT, shell=False
+            )
+            subprocess.check_call(["make", "V=1", "-j", "4"])
+            subprocess.check_call(["make", "install"])
+            subprocess.check_call(["make", "lcov-genhtml"])
+        else:
+            cmake_args = [
+                "cmake",
+                "-DCMAKE_BUILD_TYPE=Release",
+                "-DCMAKE_INSTALL_PREFIX=" + INSTALL_PREFIX,
+                "-DCMAKE_PREFIX_PATH=" + INSTALL_PREFIX,
+                "-DDPCPP_INSTALL_DIR=" + DPCPP_ROOT,
+                "-DCMAKE_C_COMPILER:PATH="
+                + os.path.join(DPCPP_ROOT, "bin", "clang"),
+                "-DCMAKE_CXX_COMPILER:PATH="
+                + os.path.join(DPCPP_ROOT, "bin", "dpcpp"),
+                "-DDPCTL_ENABLE_LO_PROGRAM_CREATION="
+                + ENABLE_LO_PROGRAM_CREATION,
+                backends,
+            ]
+            subprocess.check_call(
+                cmake_args, stderr=subprocess.STDOUT, shell=False
+            )
+            subprocess.check_call(["make", "V=1", "-j", "4"])
+            subprocess.check_call(["make", "install"])
+
+        os.chdir(dpctl_dir)
+        for file in glob.glob(
+            os.path.join(dpctl_dir, "install", "lib", "*.so*")
+        ):
+            shutil.copy(file, os.path.join(dpctl_dir, "dpctl"))
+    elif IS_WIN:
         cmake_args = [
             "cmake",
+            "-G",
+            "Ninja",
             "-DCMAKE_BUILD_TYPE=Release",
             "-DCMAKE_INSTALL_PREFIX=" + INSTALL_PREFIX,
             "-DCMAKE_PREFIX_PATH=" + INSTALL_PREFIX,
             "-DDPCPP_INSTALL_DIR=" + DPCPP_ROOT,
             "-DCMAKE_C_COMPILER:PATH="
-            + os.path.join(DPCPP_ROOT, "bin", "clang"),
+            + os.path.join(DPCPP_ROOT, "bin", "clang-cl.exe"),
             "-DCMAKE_CXX_COMPILER:PATH="
-            + os.path.join(DPCPP_ROOT, "bin", "dpcpp"),
-            "-DDPCTL_ENABLE_LO_PROGRAM_CREATION=ON",
+            + os.path.join(DPCPP_ROOT, "bin", "dpcpp.exe"),
+            "-DDPCTL_ENABLE_LO_PROGRAM_CREATION=" + ENABLE_LO_PROGRAM_CREATION,
             backends,
         ]
         subprocess.check_call(cmake_args, stderr=subprocess.STDOUT, shell=False)
-        subprocess.check_call(["make", "V=1", "-j", "4"])
-        subprocess.check_call(["make", "install"])
+        subprocess.check_call(["ninja", "-n"])
+        subprocess.check_call(["ninja", "install"])
 
-    os.chdir(dpctl_dir)
-    for file in glob.glob(os.path.join(dpctl_dir, "install", "lib", "*.so*")):
-        shutil.copy(file, os.path.join(dpctl_dir, "dpctl"))
+        os.chdir(dpctl_dir)
+        for file in glob.glob(
+            os.path.join(dpctl_dir, "install", "lib", "*.lib")
+        ):
+            shutil.copy(file, os.path.join(dpctl_dir, "dpctl"))
 
-if IS_WIN:
-    cmake_args = [
-        "cmake",
-        "-G",
-        "Ninja",
-        "-DCMAKE_BUILD_TYPE=Release",
-        "-DCMAKE_INSTALL_PREFIX=" + INSTALL_PREFIX,
-        "-DCMAKE_PREFIX_PATH=" + INSTALL_PREFIX,
-        "-DDPCPP_INSTALL_DIR=" + DPCPP_ROOT,
-        "-DCMAKE_C_COMPILER:PATH="
-        + os.path.join(DPCPP_ROOT, "bin", "clang-cl.exe"),
-        "-DCMAKE_CXX_COMPILER:PATH="
-        + os.path.join(DPCPP_ROOT, "bin", "dpcpp.exe"),
-        "-DDPCTL_ENABLE_LO_PROGRAM_CREATION=ON",
-        backends,
-    ]
-    subprocess.check_call(cmake_args, stderr=subprocess.STDOUT, shell=False)
-    subprocess.check_call(["ninja", "-n"])
-    subprocess.check_call(["ninja", "install"])
+        for file in glob.glob(
+            os.path.join(dpctl_dir, "install", "bin", "*.dll")
+        ):
+            shutil.copy(file, os.path.join(dpctl_dir, "dpctl"))
 
-    os.chdir(dpctl_dir)
-    for file in glob.glob(os.path.join(dpctl_dir, "install", "lib", "*.lib")):
-        shutil.copy(file, os.path.join(dpctl_dir, "dpctl"))
+    include_dir = os.path.join(dpctl_dir, "dpctl", "include")
+    if os.path.exists(include_dir):
+        shutil.rmtree(include_dir)
 
-    for file in glob.glob(os.path.join(dpctl_dir, "install", "bin", "*.dll")):
-        shutil.copy(file, os.path.join(dpctl_dir, "dpctl"))
+    shutil.copytree(
+        os.path.join(dpctl_dir, "dpctl-capi", "include"), include_dir
+    )
 
-include_dir = os.path.join(dpctl_dir, "dpctl", "include")
-if os.path.exists(include_dir):
-    shutil.rmtree(include_dir)
 
-shutil.copytree(os.path.join(dpctl_dir, "dpctl-capi", "include"), include_dir)
+if __name__ == "__main__":
+    build_backend()

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,6 @@
 
 import os
 import os.path
-import subprocess
 import sys
 
 import numpy as np
@@ -103,8 +102,15 @@ def get_suppressed_warning_flags():
 
 
 def build_backend():
-    build_script = os.path.join(os.getcwd(), "scripts", "build_backend.py")
-    subprocess.check_call([sys.executable, build_script])
+    import os.path
+    from importlib.util import module_from_spec, spec_from_file_location
+
+    spec = spec_from_file_location(
+        "build_backend", os.path.join("scripts", "build_backend.py")
+    )
+    builder_module = module_from_spec(spec)
+    spec.loader.exec_module(builder_module)
+    builder_module.build_backend(l0_support=True)
 
 
 def extensions():

--- a/setup.py
+++ b/setup.py
@@ -38,21 +38,10 @@ elif sys.platform == "darwin":
 elif sys.platform in ["win32", "cygwin"]:
     IS_WIN = True
 else:
-    assert False, sys.platform + " not supported"
+    assert False, "We currently do not build for " + sys.platform
 
-if IS_LIN:
-    DPCPP_ROOT = os.environ["ONEAPI_ROOT"] + r"/compiler/latest/linux"
-    os.environ["DPCTL_SYCL_INTERFACE_LIBDIR"] = "dpctl"
-    os.environ["DPCTL_SYCL_INTERFACE_INCLDIR"] = r"dpctl/include"
-    os.environ["CFLAGS"] = "-fPIC"
-
-elif IS_WIN:
-    os.environ["DPCTL_SYCL_INTERFACE_LIBDIR"] = "dpctl"
-    os.environ["DPCTL_SYCL_INTERFACE_INCLDIR"] = r"dpctl\include"
-
-dpctl_sycl_interface_lib = os.environ["DPCTL_SYCL_INTERFACE_LIBDIR"]
-dpctl_sycl_interface_include = os.environ["DPCTL_SYCL_INTERFACE_INCLDIR"]
-sycl_lib = os.environ["ONEAPI_ROOT"] + r"\compiler\latest\windows\lib"
+dpctl_sycl_interface_lib = "dpctl"
+dpctl_sycl_interface_include = r"dpctl/include"
 
 # Get long description
 with open("README.md", "r", encoding="utf-8") as file:
@@ -131,12 +120,12 @@ def extensions():
     elif IS_MAC:
         pass
     elif IS_WIN:
-        libs += ["DPCTLSyclInterface", "sycl"]
+        libs += ["DPCTLSyclInterface"]
 
     if IS_LIN:
         librarys = [dpctl_sycl_interface_lib]
     elif IS_WIN:
-        librarys = [dpctl_sycl_interface_lib, sycl_lib]
+        librarys = [dpctl_sycl_interface_lib]
     elif IS_MAC:
         librarys = [dpctl_sycl_interface_lib]
 


### PR DESCRIPTION
Closes #361 

- The `build_backend.py` is not invoked using a sub-process. We now use `importlib` to properly import the file as a module.
- `build_backend.py` now provides a function to run the build steps to compile `DPCTLSyclInteface`.
- Initial changes to `build_backend.py` to make it possible to pass in different build options. Presently, the only new option that was added is `l0_support`.
- Minor clean ups and fixes to `setup.py`.