### PR TITLE
Added two tests for filter_string property

### DIFF
--- a/dpctl-capi/helper/source/dpctl_utils_helper.cpp
+++ b/dpctl-capi/helper/source/dpctl_utils_helper.cpp
@@ -433,13 +433,15 @@ int64_t DPCTL_GetRelativeDeviceId(const device &Device)
 {
     auto relid = -1;
     auto p = Device.get_platform();
+    auto be = p.get_backend();
     auto dt = Device.get_info<sycl::info::device::device_type>();
-    auto dev_vec = p.get_devices(dt);
+    auto dev_vec = device::get_devices(dt);
     int64_t id = 0;
     for (const auto &d_i : dev_vec) {
         if (Device == d_i)
             relid = id;
-        ++id;
+        if (d_i.get_platform().get_backend() == be)
+            ++id;
     }
     return relid;
 }

--- a/dpctl/tests/test_sycl_device.py
+++ b/dpctl/tests/test_sycl_device.py
@@ -572,3 +572,32 @@ def test_invalid_filter_selectors(invalid_filter):
     """
     with pytest.raises(ValueError):
         dpctl.SyclDevice(invalid_filter)
+
+
+def test_filter_string(valid_filter):
+    """
+    Test that filter_string reconstructs the same device.
+    """
+    device = None
+    try:
+        device = dpctl.SyclDevice(valid_filter)
+    except ValueError:
+        pytest.skip("Failed to create device with supported filter")
+    dev_id = device.filter_string
+    assert (
+        dpctl.SyclDevice(dev_id) == device
+    ), "Reconstructed device is different, ({}, {})".format(
+        valid_filter, dev_id
+    )
+
+
+def test_filter_string2():
+    """
+    Test that filter_string reconstructs the same device.
+    """
+    devices = dpctl.get_devices()
+    for d in devices:
+        if d.default_selector_score > 0:
+            dev_id = d.filter_string
+            d_r = dpctl.SyclDevice(dev_id)
+            assert d == d_r


### PR DESCRIPTION
The property should be able to reconstruct the same parent device that produced it,
serving as a device identifier.

N.B.: in the setup we have currently, (additional driver in Python's `lib/`, we have two devices with the same filter selector string).