### PR TITLE
Static method of _Memory to create from external allocation

### DIFF
--- a/dpctl-capi/source/dpctl_sycl_usm_interface.cpp
+++ b/dpctl-capi/source/dpctl_sycl_usm_interface.cpp
@@ -44,9 +44,18 @@ DEFINE_SIMPLE_CONVERSION_FUNCTIONS(void, DPCTLSyclUSMRef)
 __dpctl_give DPCTLSyclUSMRef
 DPCTLmalloc_shared(size_t size, __dpctl_keep const DPCTLSyclQueueRef QRef)
 {
-    auto Q = unwrap(QRef);
-    auto Ptr = malloc_shared(size, *Q);
-    return wrap(Ptr);
+    if (!QRef) {
+        std::cerr << "Input QRef is nullptr\n";
+        return nullptr;
+    }
+    try {
+        auto Q = unwrap(QRef);
+        auto Ptr = malloc_shared(size, *Q);
+        return wrap(Ptr);
+    } catch (feature_not_supported const &fns) {
+        std::cerr << fns.what() << '\n';
+        return nullptr;
+    }
 }
 
 __dpctl_give DPCTLSyclUSMRef
@@ -54,14 +63,29 @@ DPCTLaligned_alloc_shared(size_t alignment,
                           size_t size,
                           __dpctl_keep const DPCTLSyclQueueRef QRef)
 {
-    auto Q = unwrap(QRef);
-    auto Ptr = aligned_alloc_shared(alignment, size, *Q);
-    return wrap(Ptr);
+    if (!QRef) {
+        std::cerr << "Input QRef is nullptr\n";
+        return nullptr;
+    }
+    try {
+        auto Q = unwrap(QRef);
+        auto Ptr = aligned_alloc_shared(alignment, size, *Q);
+        return wrap(Ptr);
+    } catch (feature_not_supported const &fns) {
+        std::cerr << fns.what() << '\n';
+        return nullptr;
+    }
 }
 
 __dpctl_give DPCTLSyclUSMRef
 DPCTLmalloc_host(size_t size, __dpctl_keep const DPCTLSyclQueueRef QRef)
 {
+    if (!QRef) {
+        std::cerr << "Input QRef is nullptr\n";
+        return nullptr;
+    }
+    // SYCL 2020 spec: for devices without aspect::usm_host_allocations:
+    // undefined behavior
     auto Q = unwrap(QRef);
     auto Ptr = malloc_host(size, *Q);
     return wrap(Ptr);
@@ -72,6 +96,12 @@ DPCTLaligned_alloc_host(size_t alignment,
                         size_t size,
                         __dpctl_keep const DPCTLSyclQueueRef QRef)
 {
+    if (!QRef) {
+        std::cerr << "Input QRef is nullptr\n";
+        return nullptr;
+    }
+    // SYCL 2020 spec: for devices without aspect::usm_host_allocations:
+    // undefined behavior
     auto Q = unwrap(QRef);
     auto Ptr = aligned_alloc_host(alignment, size, *Q);
     return wrap(Ptr);
@@ -80,9 +110,18 @@ DPCTLaligned_alloc_host(size_t alignment,
 __dpctl_give DPCTLSyclUSMRef
 DPCTLmalloc_device(size_t size, __dpctl_keep const DPCTLSyclQueueRef QRef)
 {
-    auto Q = unwrap(QRef);
-    auto Ptr = malloc_device(size, *Q);
-    return wrap(Ptr);
+    if (!QRef) {
+        std::cerr << "Input QRef is nullptr\n";
+        return nullptr;
+    }
+    try {
+        auto Q = unwrap(QRef);
+        auto Ptr = malloc_device(size, *Q);
+        return wrap(Ptr);
+    } catch (feature_not_supported const &fns) {
+        std::cerr << fns.what() << '\n';
+        return nullptr;
+    }
 }
 
 __dpctl_give DPCTLSyclUSMRef
@@ -90,14 +129,31 @@ DPCTLaligned_alloc_device(size_t alignment,
                           size_t size,
                           __dpctl_keep const DPCTLSyclQueueRef QRef)
 {
-    auto Q = unwrap(QRef);
-    auto Ptr = aligned_alloc_device(alignment, size, *Q);
-    return wrap(Ptr);
+    if (!QRef) {
+        std::cerr << "Input QRef is nullptr\n";
+        return nullptr;
+    }
+    try {
+        auto Q = unwrap(QRef);
+        auto Ptr = aligned_alloc_device(alignment, size, *Q);
+        return wrap(Ptr);
+    } catch (feature_not_supported const &fns) {
+        std::cerr << fns.what() << '\n';
+        return nullptr;
+    }
 }
 
 void DPCTLfree_with_queue(__dpctl_take DPCTLSyclUSMRef MRef,
                           __dpctl_keep const DPCTLSyclQueueRef QRef)
 {
+    if (!QRef) {
+        std::cerr << "Input QRef is nullptr\n";
+        return;
+    }
+    if (!MRef) {
+        std::cerr << "Input MRef is nullptr, nothing to free\n";
+        return;
+    }
     auto Ptr = unwrap(MRef);
     auto Q = unwrap(QRef);
     free(Ptr, *Q);
@@ -106,6 +162,14 @@ void DPCTLfree_with_queue(__dpctl_take DPCTLSyclUSMRef MRef,
 void DPCTLfree_with_context(__dpctl_take DPCTLSyclUSMRef MRef,
                             __dpctl_keep const DPCTLSyclContextRef CRef)
 {
+    if (!CRef) {
+        std::cerr << "Input CRef is nullptr\n";
+        return;
+    }
+    if (!MRef) {
+        std::cerr << "Input MRef is nullptr, nothing to free\n";
+        return;
+    }
     auto Ptr = unwrap(MRef);
     auto C = unwrap(CRef);
     free(Ptr, *C);
@@ -114,6 +178,14 @@ void DPCTLfree_with_context(__dpctl_take DPCTLSyclUSMRef MRef,
 const char *DPCTLUSM_GetPointerType(__dpctl_keep const DPCTLSyclUSMRef MRef,
                                     __dpctl_keep const DPCTLSyclContextRef CRef)
 {
+    if (!CRef) {
+        std::cerr << "Input CRef is nullptr\n";
+        return "unknown";
+    }
+    if (!MRef) {
+        std::cerr << "Input MRef is nullptr\n";
+        return "unknown";
+    }
     auto Ptr = unwrap(MRef);
     auto C = unwrap(CRef);
 
@@ -134,6 +206,15 @@ DPCTLSyclDeviceRef
 DPCTLUSM_GetPointerDevice(__dpctl_keep const DPCTLSyclUSMRef MRef,
                           __dpctl_keep const DPCTLSyclContextRef CRef)
 {
+    if (!CRef) {
+        std::cerr << "Input CRef is nullptr\n";
+        return nullptr;
+    }
+    if (!MRef) {
+        std::cerr << "Input MRef is nullptr\n";
+        return nullptr;
+    }
+
     auto Ptr = unwrap(MRef);
     auto C = unwrap(CRef);
 

--- a/dpctl/memory/_memory.pxd
+++ b/dpctl/memory/_memory.pxd
@@ -55,6 +55,13 @@ cdef public class _Memory [object Py_MemoryObject, type Py_MemoryType]:
         DPCTLSyclUSMRef p, SyclContext ctx)
     @staticmethod
     cdef public bytes get_pointer_type(DPCTLSyclUSMRef p, SyclContext ctx)
+    @staticmethod
+    cdef public object create_from_usm_pointer_size_qref(
+        DPCTLSyclUSMRef USMRef,
+        Py_ssize_t nbytes,
+        DPCTLSyclQueueRef QRef,
+        object memory_owner=*
+    )
 
 
 cdef public class MemoryUSMShared(_Memory) [object PyMemoryUSMSharedObject,


### PR DESCRIPTION
Method takes USMRef, number of bytes and queue reference.

If USMRef is bound to context in the queue and USM type comes
back not 'unknown', appropriate MemoryUSM* object is created
which assumes ownership of this memory.

Optional `memory_owner` keyword argument may be specified to set
the recorded reference object to something other than None (signaling
that _Memory is responsible for memory deallocation).

This can be used to create MemoryUSM* Python object from natively
allocated memory, populate it, but leave deallocation to the caller.
It could also be set to a PyCapsule object that carries a custom deleter.