### PR TITLE
Data members renamed, accessors added

### DIFF
--- a/dpctl/tensor/_slicing.pxi
+++ b/dpctl/tensor/_slicing.pxi
@@ -20,7 +20,12 @@ import numbers
 cdef object _basic_slice_meta(object ind, tuple shape,
                               tuple strides, Py_ssize_t offset):
     """
+    Give basic slicing index `ind` and array layout information produce
+    a tuple (resulting_shape, resulting_strides, resultin_offset)
+    used to contruct a view into underlying array.
 
+    Raises IndexError for invalid index `ind`, and NotImplementedError
+    if `ind` is an array.
     """
     if ind is Ellipsis:
         return (shape, strides, offset)

--- a/dpctl/tensor/_usmarray.pxd
+++ b/dpctl/tensor/_usmarray.pxd
@@ -1,23 +1,40 @@
 # distutils: language = c++
 # cython: language_level=3
 
+cimport dpctl
+
+
 cdef public int USM_ARRAY_C_CONTIGUOUS
 cdef public int USM_ARRAY_F_CONTIGUOUS
 cdef public int USM_ARRAY_WRITEABLE
 
 
 cdef public class usm_ndarray [object PyUSMArrayObject, type PyUSMArrayType]:
-    cdef char* data
-    cdef int nd
-    cdef Py_ssize_t *shape
-    cdef Py_ssize_t *strides
-    cdef int typenum
-    cdef int flags
-    cdef object base
+    # data fields
+    cdef char* data_
+    cdef readonly int nd_
+    cdef Py_ssize_t *shape_
+    cdef Py_ssize_t *strides_
+    cdef readonly int typenum_
+    cdef readonly int flags_
+    cdef readonly object base_
+    # make usm_ndarray weak-referenceable
+    cdef object __weakref__
 
     cdef void _reset(usm_ndarray self)
     cdef void _cleanup(usm_ndarray self)
     cdef usm_ndarray _clone(usm_ndarray self)
     cdef Py_ssize_t get_offset(usm_ndarray self) except *
+
+    cdef char* get_data(self)
+    cdef int get_ndim(self)
+    cdef Py_ssize_t * get_shape(self)
+    cdef Py_ssize_t * get_strides(self)
+    cdef int get_typenum(self)
+    cdef int get_itemsize(self)
+    cdef int get_flags(self)
+    cdef object get_base(self)
+    cdef dpctl.DPCTLSyclQueueRef get_queue_ref(self) except *
+    cdef dpctl.SyclQueue get_sycl_queue(self)
 
     cdef __cythonbufferdefaults__ = {"mode": "strided"}


### PR DESCRIPTION
Data members are renamed to reflect their internal status, since some
of them are read-accessible from Python.

Cython visible field accessors added to retrieve their value.

Made `dpctl.tensor.usm_ndarray` weak-referenceable
https://cython.readthedocs.io/en/latest/src/userguide/extension_types.html#making-extension-types-weak-referenceable