### PR TITLE
Removing public keyword to get_current_queue Cython declaration.

### DIFF
--- a/dpctl/_sycl_queue_manager.pxd
+++ b/dpctl/_sycl_queue_manager.pxd
@@ -20,6 +20,6 @@
 from ._sycl_queue cimport SyclQueue
 
 
-cpdef public SyclQueue get_current_queue()
+cpdef SyclQueue get_current_queue()
 cpdef get_current_device_type ()
 cpdef get_current_backend()


### PR DESCRIPTION
Closes #436 

This addresses unused-variable compiler warning observed when compiling usm_array Cython file.