### PR TITLE
Added Device class representing Data-API notion of device

### DIFF
--- a/dpctl/tensor/_device.py
+++ b/dpctl/tensor/_device.py
@@ -18,15 +18,15 @@ import dpctl
 
 class Device:
     """
-    Class representing Data-API concept of Device
+    Class representing Data-API concept of device.
 
-    This is a wrapper around `dpctl.SyclQueue` with custom
+    This is a wrapper around :class:`dpctl.SyclQueue` with custom
     formatting. The class does not have public constructor,
     but a class method to construct it from device= keyword
     in Array-API functions.
 
-    Instance can be queries for `sycl_queue`, `sycl_context`,
-    or `sycl_device`
+    Instance can be queried for ``sycl_queue``, ``sycl_context``,
+    or ``sycl_device``.
     """
 
     def __new__(cls, *args, **kwargs):
@@ -34,6 +34,21 @@ class Device:
 
     @classmethod
     def create_device(cls, dev):
+        """
+        Device.create_device(device)
+
+        Creates instance of Device from argument.
+
+        Args:
+            device: None, :class:`.Device`, :class:`dpctl.SyclQueue`, or
+                    a :class:`dpctl.SyclDevice` corresponding to a root
+                    SYCL device.
+        Raises:
+            ValueError: if an instance of :class:`dpctl.SycDevice` corresponding
+                        to a sub-device was specified as the argument
+            SyclQueueCreationError: if :class:`dpctl.SyclQueue` could not be
+                                    created from the argument
+        """
         obj = super().__new__(cls)
         if isinstance(dev, Device):
             obj.sycl_queue_ = dev.sycl_queue
@@ -55,14 +70,23 @@ class Device:
 
     @property
     def sycl_queue(self):
+        """
+        :class:`dpctl.SyclQueue` used to offload to this :class:`.Device`.
+        """
         return self.sycl_queue_
 
     @property
     def sycl_context(self):
+        """
+        :class:`dpctl.SyclContext` associated with this :class:`.Device`.
+        """
         return self.sycl_queue_.sycl_context
 
     @property
     def sycl_device(self):
+        """
+        :class:`dpctl.SyclDevice` targed by this :class:`.Device`.
+        """
         return self.sycl_queue_.sycl_device
 
     def __repr__(self):

--- a/dpctl/tensor/_device.py
+++ b/dpctl/tensor/_device.py
@@ -1,0 +1,80 @@
+#                       Data Parallel Control (dpctl)
+#
+#  Copyright 2020-2021 Intel Corporation
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+import dpctl
+
+
+class Device:
+    """
+    Class representing Data-API concept of Device
+
+    This is a wrapper around `dpctl.SyclQueue` with custom
+    formatting. The class does not have public constructor,
+    but a class method to construct it from device= keyword
+    in Array-API functions.
+
+    Instance can be queries for `sycl_queue`, `sycl_context`,
+    or `sycl_device`
+    """
+
+    def __new__(cls, *args, **kwargs):
+        raise TypeError("No public constructor")
+
+    @classmethod
+    def create_device(cls, dev):
+        obj = super().__new__(cls)
+        if isinstance(dev, Device):
+            obj.sycl_queue_ = dev.sycl_queue
+        elif isinstance(dev, dpctl.SyclQueue):
+            obj.sycl_queue_ = dev
+        elif isinstance(dev, dpctl.SyclDevice):
+            par = dev.parent_device
+            if par is None:
+                obj.sycl_queue_ = dpctl.SyclQueue(dev)
+            else:
+                raise ValueError(
+                    "Using non-root device {} to specify offloading "
+                    "target is ambiguous. Please use dpctl.SyclQueue "
+                    "targeting this device".format(dev)
+                )
+        else:
+            obj.sycl_queue_ = dpctl.SyclQueue(dev)
+        return obj
+
+    @property
+    def sycl_queue(self):
+        return self.sycl_queue_
+
+    @property
+    def sycl_context(self):
+        return self.sycl_queue_.sycl_context
+
+    @property
+    def sycl_device(self):
+        return self.sycl_queue_.sycl_device
+
+    def __repr__(self):
+        try:
+            sd = self.sycl_device
+        except AttributeError:
+            raise ValueError(
+                "Instance of {} is not initialized".format(self.__class__)
+            )
+        try:
+            fs = sd.filter_string
+            return "Device({})".format(fs)
+        except TypeError:
+            # This is a sub-device
+            return repr(self.sycl_queue)


### PR DESCRIPTION
Data-API notion of device is higher level abstraction. The class
does allow for public constructor, has class method to create
instance instead.

It typesets as Device(filter_string) for parent devices and
Device(queue) for sub-devices. It can constructed from

   - filter selector string
   - SyclDevice corresponding to a root device
     (attempt at passing sub-device raises and error)
   - SyclQueue
   - Another instance of Device class

It implements sycl_queue, sycl_device, sycl_context attributes.

usm_ndarray adds .device property, and .to_device(device) method.

```
In [5]: X = dpt.usm_ndarray((4, 5), dtype='d')

In [6]: X.device
Out[6]: Device(level_zero:gpu:0)

In [7]: Y = X.to_device('cpu')

In [8]: Y.device
Out[8]: Device(opencl:cpu:0)
```