### PR TITLE
Fix for slicing bugs

### DIFF
--- a/dpctl/tensor/_device.py
+++ b/dpctl/tensor/_device.py
@@ -65,7 +65,10 @@ class Device:
                     "targeting this device".format(dev)
                 )
         else:
-            obj.sycl_queue_ = dpctl.SyclQueue(dev)
+            if dev is None:
+                obj.sycl_queue_ = dpctl.SyclQueue()
+            else:
+                obj.sycl_queue_ = dpctl.SyclQueue(dev)
         return obj
 
     @property

--- a/dpctl/tensor/_types.pxi
+++ b/dpctl/tensor/_types.pxi
@@ -41,7 +41,7 @@ cdef str _make_typestr(int typenum):
     Make typestring from type number
     """
     cdef type_to_str = ['|b1', '|i1', '|u1', '|i2', '|u2',
-                        '|i4', '|u4', '', '', '|i8', '|u8',
+                        '|i4', '|u4', '|i4', '|u4', '|i8', '|u8',
                         '|f4', '|f8', '', '|c8', '|c16', '']
 
     if (typenum < 0):
@@ -63,8 +63,8 @@ cdef int type_bytesize(int typenum):
     NPY_USHORT=4       : 2
     NPY_INT=5          : 4
     NPY_UINT=6         : 4
-    NPY_LONG=7         :
-    NPY_ULONG=8        :
+    NPY_LONG=7         : 4
+    NPY_ULONG=8        : 4
     NPY_LONGLONG=9     : 8
     NPY_ULONGLONG=10   : 8
     NPY_FLOAT=11       : 4
@@ -76,7 +76,7 @@ cdef int type_bytesize(int typenum):
     NPY_HALF=23        : 2
     """
     cdef int *type_to_bytesize = [
-        1, 1, 1, 2, 2, 4, 4, 8, 8, 8, 8, 4, 8, -1, 8, 16, -1]
+        1, 1, 1, 2, 2, 4, 4, 4, 4, 8, 8, 4, 8, -1, 8, 16, -1]
 
     if typenum < 0:
         return -1

--- a/dpctl/tensor/_usmarray.pyx
+++ b/dpctl/tensor/_usmarray.pyx
@@ -475,7 +475,8 @@ cdef class usm_ndarray:
         cdef usm_ndarray res
 
         res = usm_ndarray.__new__(
-            usm_ndarray, _meta[0],
+            usm_ndarray,
+            _meta[0],
             dtype=_make_typestr(self.typenum_),
             strides=_meta[1],
             buffer=self.base_,


### PR DESCRIPTION
Fixed bugs in basic slicing and in constructors discovered by examples used during customer presentation. 

Specifically these had to deal with negative strides and sometimes non-unit strides.

For `Xusm  = dpt.usm_ndarray((12,), dtype='i4')`, and `Xusm[1::2]` had incorrect shape of `(5,)`, while the expected shape should be `(6,)`, consisting of elements of `{Xsum[1], Xusm[3], Xusm[5], Xusm[7], Xusm[9], Xusm[11]}`.

Expanded tests, and fixed memory leak in shape/strides parser on failures (C-array for shape was not being freed).