### PR TITLE
Changed repr for Memory objects

### DIFF
--- a/dpctl/memory/_memory.pyx
+++ b/dpctl/memory/_memory.pyx
@@ -232,33 +232,62 @@ cdef class _Memory:
         buffer.suboffsets = NULL                # for pointer arrays only
 
     property nbytes:
+        """ Extent of this USM buffer in bytes. """
         def __get__(self):
             return self.nbytes
 
     property size:
+        """ Extent of this USM buffer in bytes. """
         def __get__(self):
             return self.nbytes
 
     property _pointer:
+        """
+        USM pointer at the start of this buffer
+        represented in Python integer.
+        """
         def __get__(self):
             return <size_t>(self.memory_ptr)
 
     property _context:
+        """ :class:`dpctl.SyclContext` the USM pointer is bound to. """
         def __get__(self):
             return self.queue.get_sycl_context()
 
     property _queue:
+        """
+        :class:`dpctl.SyclQueue` with :class:`dpctl.SyclContext` the
+        USM pointer is bound to and :class:`dpctl.SyclDevice` it was
+        allocated on.
+        """
         def __get__(self):
             return self.queue
 
     property reference_obj:
+        """
+        Reference to the Python object owning this USM buffer.
+        """
         def __get__(self):
             return self.refobj
 
+    property sycl_context:
+        """ :class:`dpctl.SyclContext` the USM pointer is bound to. """
+        def __get__(self):
+            return self.queue.get_sycl_context()
+
+    property sycl_device:
+        """ :class:`dpctl.SyclDevice` the USM pointer is bound to. """
+        def __get__(self):
+            return self.queue.get_sycl_device()
+
     def __repr__(self):
         return (
-            "<Intel(R) USM allocated memory block of {} bytes at {}>"
-            .format(self.nbytes, hex(<object>(<size_t>self.memory_ptr)))
+            "<SYCL(TM) USM-{} allocated memory block of {} bytes at {}>"
+            .format(
+                self.get_usm_type(),
+                self.nbytes,
+                hex(<object>(<size_t>self.memory_ptr))
+            )
         )
 
     def __len__(self):


### PR DESCRIPTION
Added docstrings

Added public properties:
    sycl_context
    sycl_device

```
In [4]: dpm.MemoryUSMShared(1024, queue=dpctl.SyclQueue("cpu"))
Out[4]: <SYCL(TM) USM-shared allocated memory block of 1024 bytes at 0x55656e945780>

In [5]: Out[4].sycl_device
Out[5]: <dpctl.SyclDevice [backend_type.opencl, device_type.cpu,  Intel(R) Core(TM) i7-10710U CPU @ 1.10GHz] at 0x7fdeaf804c70>

In [6]: Out[4].sycl_context
Out[6]: <dpctl.SyclContext at 0x7fded1413c50>

In [7]: Out[4].get_usm_type(syclobj=Out[6])
Out[7]: 'shared'
```