### PR TITLE
Added free Python function as_usm_memory(obj)

### DIFF
--- a/dpctl/memory/__init__.py
+++ b/dpctl/memory/__init__.py
@@ -34,12 +34,12 @@ from ._memory import (
     MemoryUSMDevice,
     MemoryUSMHost,
     MemoryUSMShared,
-    create_MemoryUSM,
+    as_usm_memory,
 )
 
 __all__ = [
     "MemoryUSMDevice",
     "MemoryUSMHost",
     "MemoryUSMShared",
-    "create_MemoryUSM",
+    "as_usm_memory",
 ]

--- a/dpctl/memory/__init__.py
+++ b/dpctl/memory/__init__.py
@@ -30,6 +30,16 @@
     `memoryview`, or `array.array` classes.
 
 """
-from ._memory import MemoryUSMDevice, MemoryUSMHost, MemoryUSMShared
+from ._memory import (
+    MemoryUSMDevice,
+    MemoryUSMHost,
+    MemoryUSMShared,
+    create_MemoryUSM,
+)
 
-__all__ = ["MemoryUSMDevice", "MemoryUSMHost", "MemoryUSMShared"]
+__all__ = [
+    "MemoryUSMDevice",
+    "MemoryUSMHost",
+    "MemoryUSMShared",
+    "create_MemoryUSM",
+]

--- a/dpctl/memory/_memory.pyx
+++ b/dpctl/memory/_memory.pyx
@@ -712,9 +712,9 @@ cdef class MemoryUSMDevice(_Memory):
                     )
 
 
-def create_MemoryUSM(obj):
+def as_usm_memory(obj):
     """
-    create_MemoryUSM(obj)
+    as_usm_memory(obj)
 
     Converts Python object with `__sycl_usm_array_interface__` property
     to one of :class:`.MemoryUSMShared`, :class:`.MemoryUSMDevice`, or

--- a/dpctl/memory/_memory.pyx
+++ b/dpctl/memory/_memory.pyx
@@ -325,7 +325,7 @@ cdef class _Memory:
 
     def __repr__(self):
         return (
-            "<SYCL(TM) USM-{} allocated memory block of {} bytes at {}>"
+            "<SYCL(TM) USM-{} allocation of {} bytes at {}>"
             .format(
                 self.get_usm_type(),
                 self.nbytes,

--- a/dpctl/memory/_sycl_usm_array_interface_utils.pxi
+++ b/dpctl/memory/_sycl_usm_array_interface_utils.pxi
@@ -89,6 +89,8 @@ cdef object _pointers_from_shape_and_stride(
             for i in range(nd):
                 str_i = int(ary_strides[i])
                 sh_i = int(ary_shape[i])
+                if (sh_i <= 0):
+                    raise ValueError("Array shape elements need to be positive")
                 if (str_i > 0):
                     max_disp += str_i * (sh_i - 1)
                 else:


### PR DESCRIPTION
Used the Cython static method from _Memmory.get_pointer_type in the added function,
as well as in the method `get_usm_type`.

Added docstrings.

```python
In [1]: import dpctl, dpctl.memory as dpm, dpctl.memory._memory as dpm_m

In [2]: import dpctl.tensor as dpt

In [3]: X = dpt.usm_ndarray((4, 5))

In [4]: dpm_m.as_usm_memory(X)
Out[4]: <SYCL(TM) USM-device allocation of 160 bytes at 0xffffd556aa5f0000>

In [5]: X.usm_data
Out[5]: <SYCL(TM) USM-device allocation of 160 bytes at 0xffffd556aa5f0000>

In [6]: class Duck_USMAllocation:
   ...:     def __init__(self, buf, syclobj):
   ...:         self.buf_ = buf
   ...:         self.syclobj_ = syclobj
   ...:

In [7]: class Duck_USMAllocation:
   ...:     def __init__(self, buf, syclobj):
   ...:         self.buf_ = buf
   ...:         self.syclobj_ = syclobj
   ...:     @Property
   ...:     def __sycl_usm_array_interface__(self):
   ...:         iface = self.buf_.__sycl_usm_array_interface__
   ...:         iface['syclobj'] = self.syclobj_
   ...:         return iface
   ...:

In [8]: d = Duck_USMAllocation(X, X.sycl_device.filter_string)

In [9]: dpm_m.as_usm_memory(d)
Out[9]: <SYCL(TM) USM-device allocation of 160 bytes at 0xffffd556aa5f0000>

In [10]: Out[9].get_usm_type()
Out[10]: 'device'
```