### PR TITLE
Add a flag to make doxygen HTML generation optional.

### DIFF
--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -14,11 +14,21 @@ option(DPCTL_USE_MULTIVERSION_TEMPLATE
     OFF
 )
 
+# Option to generate HTML from dpxygen
+option(DPCTL_ENABLE_DOXYGEN_HTML
+    "Enable generation of html files for C API using Doxygen"
+    OFF
+)
+
 # This function defines everything needed to generate Doxygen docs
 function(_setup_doxygen)
     # We generate doxygen only for the public headers to keep the Doxyrest
     # generated rst files clean.
     # FIXME: make it possible to generate doxygen for all files.
+    set(GENERATE_HTML "NO")
+    if(DPCTL_ENABLE_DOXYGEN_HTML)
+        set(GENERATE_HTML "YES")
+    endif()
     set(DOXYGEN_INPUT_DIR ../dpctl-capi/include)
     set(DOXYGEN_OUTPUT_DIR ${DOC_OUTPUT_DIR}/doxygen)
     set(DOXYGEN_INDEX_FILE ${DOXYGEN_OUTPUT_DIR}/xml/index.xml)

--- a/docs/Doxyfile.in
+++ b/docs/Doxyfile.in
@@ -1180,7 +1180,7 @@ IGNORE_PREFIX          =
 # If the GENERATE_HTML tag is set to YES, doxygen will generate HTML output
 # The default value is: YES.
 
-GENERATE_HTML          = YES
+GENERATE_HTML          = @GENERATE_HTML@
 
 # The HTML_OUTPUT tag is used to specify where the HTML docs will be put. If a
 # relative path is entered the value of OUTPUT_DIRECTORY will be put in front of


### PR DESCRIPTION
We use Doxyrest to generate the API docs for the dpctl C API sources. The changes in the PR make it possible to turn off Doxygen HTML generation, and by default the HTML generation is turned off.