### PR TITLE
Feature/get devices ordering

### DIFF
--- a/dpctl-capi/include/dpctl_sycl_enum_types.h
+++ b/dpctl-capi/include/dpctl_sycl_enum_types.h
@@ -38,12 +38,12 @@ DPCTL_C_EXTERN_C_BEGIN
 enum DPCTLSyclBackendType
 {
     // clang-format off
-    DPCTL_CUDA            = 1 << 13,
-    DPCTL_HOST            = 1 << 14,
-    DPCTL_LEVEL_ZERO      = 1 << 15,
-    DPCTL_OPENCL          = 1 << 16,
+    DPCTL_CUDA            = 1 << 16,
+    DPCTL_HOST            = 1 << 17,
+    DPCTL_LEVEL_ZERO      = 1 << 18,
+    DPCTL_OPENCL          = 1 << 19,
     DPCTL_UNKNOWN_BACKEND = 0,
-    DPCTL_ALL_BACKENDS    = ((1<<10)-1) << 7
+    DPCTL_ALL_BACKENDS    = ((1<<5)-1) << 16
     // clang-format on
 };
 
@@ -57,13 +57,13 @@ enum DPCTLSyclDeviceType
     // The values should not overlap.
 
     // clang-format off
-    DPCTL_ACCELERATOR    = 1 << 1,
-    DPCTL_AUTOMATIC      = 1 << 2,
-    DPCTL_CPU            = 1 << 3,
-    DPCTL_CUSTOM         = 1 << 4,
-    DPCTL_GPU            = 1 << 5,
-    DPCTL_HOST_DEVICE    = 1 << 6,
-    DPCTL_ALL            = (1 << 7) -1 ,
+    DPCTL_ACCELERATOR    = 1 << 0,
+    DPCTL_AUTOMATIC      = 1 << 1,
+    DPCTL_CPU            = 1 << 2,
+    DPCTL_CUSTOM         = 1 << 3,
+    DPCTL_GPU            = 1 << 4,
+    DPCTL_HOST_DEVICE    = 1 << 5,
+    DPCTL_ALL            = (1 << 6) - 1,
     DPCTL_UNKNOWN_DEVICE = 0
     // clang-format on
 };

--- a/dpctl/tests/test_sycl_device_factory.py
+++ b/dpctl/tests/test_sycl_device_factory.py
@@ -177,10 +177,17 @@ def test_get_devices_with_device_type_enum(device_type):
 
 
 def test_get_devices_with_device_type_str(device_type_str):
-    devices = dpctl.get_devices(device_type=device_type_str)
-    if len(devices):
-        d = string_to_device_type(device_type_str)
-        check_if_device_type_matches(devices, d)
+    num_devices = dpctl.get_num_devices(device_type=device_type_str)
+    if num_devices > 0:
+        devices = dpctl.get_devices(device_type=device_type_str)
+        assert len(devices) == num_devices
+        dty = string_to_device_type(device_type_str)
+        check_if_device_type_matches(devices, dty)
         check_if_device_type_is_valid(devices)
+        # check for consistency of ordering between filter selector
+        # where backend is omitted, but device type and id is specified
+        for i in range(num_devices):
+            dev = dpctl.SyclDevice(":".join((device_type_str, str(i))))
+            assert dev == devices[i]
     else:
         pytest.skip()


### PR DESCRIPTION
Closes #447 

The root cause for 447 was that `devices.get_devices` relied on cached unordered map, which does not guarantee the ordering.

The fix was to change implementation of `DPCLDeviceMgr_GetDevices` to iterate over `device::get_devices` (which is also internally cached by SYCL runtime) which would guarantee the same ordering as used by filter selector.

Python tests were added.

```python
In [1]: import dpctl

In [2]: d0 = dpctl.SyclDevice("gpu:0")

In [3]: d0.filter_string
Out[3]: 'opencl:gpu:0'

In [4]: [i for i, di in enumerate(dpctl.get_devices(dpctl.backend_type.all, dpctl.device_type.gpu)) if di == d0]
Out[4]: [0]

In [5]: d0 == dpctl.SyclDevice(d0.filter_string)
Out[5]: True

In [6]: d1 = dpctl.SyclDevice("gpu:1")

In [7]: d1.filter_string
Out[7]: 'level_zero:gpu:0'

In [8]: [i for i, di in enumerate(dpctl.get_devices(dpctl.backend_type.all, dpctl.device_type.gpu)) if di == d1]
Out[8]: [1]

In [9]: d1 == dpctl.SyclDevice(d1.filter_string)
Out[9]: True
```