### PR TITLE
Feature/producing filter selector

### DIFF
--- a/dpctl-capi/include/dpctl_sycl_device_manager.h
+++ b/dpctl-capi/include/dpctl_sycl_device_manager.h
@@ -77,6 +77,26 @@ __dpctl_give DPCTLDeviceVectorRef
 DPCTLDeviceMgr_GetDevices(int device_identifier);
 
 /*!
+ * @brief Returns an index on the given device in the vector returned by
+ * #DPCTLDeviceMgr_GetDevices if found, -1 otherwise.
+ *
+ * The device_identifier can be a combination of #DPCTLSyclBackendType and
+ * #DPCTLSyclDeviceType bit flags. The function returns all devices that
+ * match the specified bit flags.
+ *
+ * @param    DRef              A #DPCTLSyclDeviceRef opaque pointer.
+ * @param    device_identifier A bitflag that can be any combination of
+ *                             #DPCTLSyclBackendType and #DPCTLSyclDeviceType
+ *                             enum values.
+ * @return   If found, returns the position of the given device in the
+ * vector that would be returned by #DPCTLDeviceMgr_GetDevices if called
+ * with the same device_identifier argument.
+ */
+DPCTL_API
+int DPCTLDeviceMgr_GetPositionInDevices(__dpctl_keep DPCTLSyclDeviceRef DRef,
+                                        int device_identifier);
+
+/*!
  * @brief If the DPCTLSyclDeviceRef argument is a root device, then this
  * function returns a cached default SYCL context for that device.
  *

--- a/dpctl-capi/tests/test_sycl_device_manager.cpp
+++ b/dpctl-capi/tests/test_sycl_device_manager.cpp
@@ -146,12 +146,12 @@ struct TestDPCTLGetDevicesOrdering : public ::testing::TestWithParam<int>
 {
     DPCTLDeviceVectorRef DV = nullptr;
     size_t nDevices = 0;
+    int device_type_mask;
 
     TestDPCTLGetDevicesOrdering()
     {
-        const int device_type_mask =
-            (GetParam() & DPCTLSyclDeviceType::DPCTL_ALL) |
-            DPCTLSyclBackendType::DPCTL_ALL_BACKENDS;
+        device_type_mask = (GetParam() & DPCTLSyclDeviceType::DPCTL_ALL) |
+                           DPCTLSyclBackendType::DPCTL_ALL_BACKENDS;
         EXPECT_NO_FATAL_FAILURE(
             DV = DPCTLDeviceMgr_GetDevices(device_type_mask));
         EXPECT_TRUE(DV != nullptr);
@@ -179,6 +179,7 @@ TEST_P(TestDPCTLGetDevicesOrdering, ChkConsistencyWithFilterSelector)
         std::string fs_device_type, fs;
         DPCTLSyclDeviceRef DRef = nullptr, D0Ref = nullptr;
         DPCTLSyclDeviceSelectorRef DSRef = nullptr;
+        int j = -1;
         EXPECT_NO_FATAL_FAILURE(DRef = DPCTLDeviceVector_GetAt(DV, i));
         EXPECT_NO_FATAL_FAILURE(Dty = DPCTLDevice_GetDeviceType(DRef));
         EXPECT_NO_FATAL_FAILURE(
@@ -189,6 +190,10 @@ TEST_P(TestDPCTLGetDevicesOrdering, ChkConsistencyWithFilterSelector)
         EXPECT_NO_FATAL_FAILURE(D0Ref = DPCTLDevice_CreateFromSelector(DSRef));
         EXPECT_NO_FATAL_FAILURE(DPCTLDeviceSelector_Delete(DSRef));
         EXPECT_TRUE(DPCTLDevice_AreEq(DRef, D0Ref));
+        EXPECT_NO_FATAL_FAILURE(
+            j = DPCTLDeviceMgr_GetPositionInDevices(DRef, device_type_mask));
+        EXPECT_TRUE(j >= 0);
+        EXPECT_TRUE(i == static_cast<decltype(i)>(j));
         EXPECT_NO_FATAL_FAILURE(DPCTLDevice_Delete(D0Ref));
         EXPECT_NO_FATAL_FAILURE(DPCTLDevice_Delete(DRef));
     }

--- a/dpctl/_backend.pxd
+++ b/dpctl/_backend.pxd
@@ -208,6 +208,9 @@ cdef extern from "dpctl_sycl_device_manager.h":
         DPCTLDeviceVectorRef DVRef,
         size_t index)
     cdef DPCTLDeviceVectorRef DPCTLDeviceMgr_GetDevices(int device_identifier)
+    cdef int DPCTLDeviceMgr_GetPositionInDevices(
+        const DPCTLSyclDeviceRef DRef,
+        int device_identifier)
     cdef size_t DPCTLDeviceMgr_GetNumDevices(int device_identifier)
     cdef void DPCTLDeviceMgr_PrintDeviceInfo(const DPCTLSyclDeviceRef DRef)
     cdef DPCTLSyclContextRef DPCTLDeviceMgr_GetCachedContext(

--- a/dpctl/_sycl_device.pxd
+++ b/dpctl/_sycl_device.pxd
@@ -51,3 +51,7 @@ cdef public class SyclDevice(_SyclDevice) [object PySyclDeviceObject, type PySyc
     cdef list create_sub_devices_by_counts(self, object counts)
     cdef list create_sub_devices_by_affinity(self, _partition_affinity_domain_type domain)
     cdef cpp_bool equals(self, SyclDevice q)
+    cdef int get_device_type_ordinal(self)
+    cdef int get_overall_ordinal(self)
+    cdef int get_backend_ordinal(self)
+    cdef int get_backend_and_device_type_ordinal(self)

--- a/dpctl/tests/test_sycl_device.py
+++ b/dpctl/tests/test_sycl_device.py
@@ -591,13 +591,29 @@ def test_filter_string(valid_filter):
     )
 
 
-def test_filter_string2():
+def test_filter_string_property():
     """
     Test that filter_string reconstructs the same device.
     """
     devices = dpctl.get_devices()
     for d in devices:
-        if d.default_selector_score > 0:
+        if d.default_selector_score >= 0:
             dev_id = d.filter_string
             d_r = dpctl.SyclDevice(dev_id)
             assert d == d_r
+
+
+def test_filter_string_method():
+    """
+    Test that filter_string reconstructs the same device.
+    """
+    devices = dpctl.get_devices()
+    for d in devices:
+        for be in [True, False]:
+            for dt in [True, False]:
+                if d.default_selector_score >= 0:
+                    dev_id = d.get_filter_string(
+                        include_backend=be, include_device_type=dt
+                    )
+                    d_r = dpctl.SyclDevice(dev_id)
+                    assert d == d_r, "Failed "


### PR DESCRIPTION
dpctl-capi/:
   * Added `DPCTLDeviceMgr_GetPositionInDevices(DRef, device_mask)` that returns ordinal of the given DRef in the filtered vector returned by ``sycl::device::get_devices()``, or -1 if not found (e.g. `DRef` points to a sub-device).
   * Added tests, and docstring

dpctl/:
   * Added `DPCTLDeviceMgr_GetPositionInDevices` to `_backend.pxd`
   * Implemented 4 cdef methods of `dpctl.SyclDevice`:
        * `get_overall_ordinal(self)` - index in unfiltered vector returned by ``get_devices()``.
        * `get_backend_ordinal(self)` - index in vector filtered to only contain devices with the backend of this device
        * `get_device_type_ordinal(self)` - index in vector filtered to only contain devices with device_type as in this device
        * `get_backend_and_device_type_ordinal(self)` - indexed in vector filtered to only contain devices with device_type and backend of this device
    * Added Python visible method `get_filter_string(self, include_backend=True, include_device_type=True)` which producer filter selector string selecting this device that would include or omit backend/device_type as requested.
    * Test added

Example:

```python
In [1]: import dpctl

In [2]: default_dev = dpctl.SyclDevice()

In [3]: default_dev.get_filter_string() # same as default_dev.filter_string
Out[3]: 'level_zero:gpu:0'

In [4]: default_dev.get_filter_string(include_backend=False)
Out[4]: 'gpu:1'

In [5]: default_dev == dpctl.SyclDevice(_)
Out[5]: True

In [6]: default_dev.get_filter_string(include_device_type=False)
Out[6]: 'level_zero:0'

In [7]: default_dev == dpctl.SyclDevice(_)
Out[7]: True

In [8]: default_dev.get_filter_string(include_device_type=False, include_backend=False)
Out[8]: '4'

In [9]: default_dev == dpctl.SyclDevice(_)
Out[9]: True
```