### PR TITLE
Ensure that package version reflects dirtiness

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -400,7 +400,7 @@ def _get_cmdclass():
 
 setup(
     name="dpctl",
-    version=versioneer.get_version().split("+")[0],
+    version=versioneer.get_version(),
     cmdclass=_get_cmdclass(),
     description="A lightweight Python wrapper for a subset of OpenCL and SYCL.",
     long_description=long_description,


### PR DESCRIPTION
Use full versioneer-inferred name to define package version.

This is uber useful for development.