### PR TITLE
Correctly copy symlinks to the dpctl dir.

### DIFF
--- a/scripts/build_backend.py
+++ b/scripts/build_backend.py
@@ -143,7 +143,11 @@ def build_backend(
         for file in glob.glob(
             os.path.join(dpctl_dir, "install", "lib", "*.so*")
         ):
-            shutil.copy(file, os.path.join(dpctl_dir, "dpctl"))
+            shutil.copy(
+                src=file,
+                dst=os.path.join(dpctl_dir, "dpctl"),
+                follow_symlinks=False,
+            )
     elif IS_WIN:
         if os.path.exists(os.path.join(DPCPP_ROOT, "bin", "dpcpp.exe")):
             cmake_compiler_args = [

--- a/scripts/build_backend.py
+++ b/scripts/build_backend.py
@@ -143,11 +143,16 @@ def build_backend(
         for file in glob.glob(
             os.path.join(dpctl_dir, "install", "lib", "*.so*")
         ):
-            shutil.copy(
-                src=file,
-                dst=os.path.join(dpctl_dir, "dpctl"),
-                follow_symlinks=False,
-            )
+            # Check if the file already exists before copying. The check is
+            # needed when dealing with symlinks.
+            if not os.path.exists(
+                os.path.join(dpctl_dir, "dpctl", os.path.basename(file))
+            ):
+                shutil.copy(
+                    src=file,
+                    dst=os.path.join(dpctl_dir, "dpctl"),
+                    follow_symlinks=False,
+                )
     elif IS_WIN:
         if os.path.exists(os.path.join(DPCPP_ROOT, "bin", "dpcpp.exe")):
             cmake_compiler_args = [


### PR DESCRIPTION
After introducing so-versioning for `libDPCTLSyclInterface` the symlinks are not being correctly copied from the build directory (`build_cmake`) to the install directory (`dpctl`). The PR fixes this by using the `follow_symlinks` argument to `shutils.copy`.