### PR TITLE
Use default device for slicing test case instead of gpu device.

### DIFF
--- a/dpctl/tensor/_device.py
+++ b/dpctl/tensor/_device.py
@@ -40,9 +40,9 @@ class Device:
         Creates instance of Device from argument.
 
         Args:
-            device: None, :class:`.Device`, :class:`dpctl.SyclQueue`, or
-                    a :class:`dpctl.SyclDevice` corresponding to a root
-                    SYCL device.
+            dev: None, :class:`.Device`, :class:`dpctl.SyclQueue`, or
+                 a :class:`dpctl.SyclDevice` corresponding to a root SYCL
+                 device.
         Raises:
             ValueError: if an instance of :class:`dpctl.SycDevice` corresponding
                         to a sub-device was specified as the argument

--- a/dpctl/tests/test_usm_ndarray_ctor.py
+++ b/dpctl/tests/test_usm_ndarray_ctor.py
@@ -175,7 +175,8 @@ def _to_numpy(usm_ary):
 
 def test_slice_constructor_1d():
     Xh = np.arange(37, dtype="i4")
-    Xusm = _from_numpy(Xh, device="gpu", usm_type="device")
+    default_device = dpctl.select_default_device()
+    Xusm = _from_numpy(Xh, device=default_device, usm_type="device")
     for ind in [
         slice(1, None, 2),
         slice(0, None, 3),
@@ -193,7 +194,8 @@ def test_slice_constructor_1d():
 
 def test_slice_constructor_3d():
     Xh = np.empty((37, 24, 35), dtype="i4")
-    Xusm = _from_numpy(Xh, device="gpu", usm_type="device")
+    default_device = dpctl.select_default_device()
+    Xusm = _from_numpy(Xh, device=default_device, usm_type="device")
     for ind in [
         slice(1, None, 2),
         slice(0, None, 3),


### PR DESCRIPTION
Convert couple of Python test cases to use default device instead of the "gpu" device. The change ensures these tests do not fail when a GPU is not available on the build system.