### PR TITLE
DPCTL C API headers are not always truly C complaint (e.g. -Wstrict-prototype)

### DIFF
--- a/dpctl-capi/include/dpctl_sycl_device_interface.h
+++ b/dpctl-capi/include/dpctl_sycl_device_interface.h
@@ -62,7 +62,7 @@ DPCTLDevice_Copy(__dpctl_keep const DPCTLSyclDeviceRef DRef);
  * @ingroup DeviceInterface
  */
 DPCTL_API
-__dpctl_give DPCTLSyclDeviceRef DPCTLDevice_Create();
+__dpctl_give DPCTLSyclDeviceRef DPCTLDevice_Create(void);
 
 /*!
  * @brief Returns a new DPCTLSyclDeviceRef opaque object created using the

--- a/dpctl-capi/include/dpctl_sycl_device_selector_interface.h
+++ b/dpctl-capi/include/dpctl_sycl_device_selector_interface.h
@@ -44,7 +44,7 @@ DPCTL_C_EXTERN_C_BEGIN
  * @ingroup DeviceSelectors
  */
 DPCTL_API
-__dpctl_give DPCTLSyclDeviceSelectorRef DPCTLAcceleratorSelector_Create();
+__dpctl_give DPCTLSyclDeviceSelectorRef DPCTLAcceleratorSelector_Create(void);
 
 /*!
  * @brief Returns an opaque wrapper for sycl::default_selector object.
@@ -53,7 +53,7 @@ __dpctl_give DPCTLSyclDeviceSelectorRef DPCTLAcceleratorSelector_Create();
  * @ingroup DeviceSelectors
  */
 DPCTL_API
-__dpctl_give DPCTLSyclDeviceSelectorRef DPCTLDefaultSelector_Create();
+__dpctl_give DPCTLSyclDeviceSelectorRef DPCTLDefaultSelector_Create(void);
 
 /*!
  * @brief Returns an opaque wrapper for sycl::cpu_selector object.
@@ -62,7 +62,7 @@ __dpctl_give DPCTLSyclDeviceSelectorRef DPCTLDefaultSelector_Create();
  * @ingroup DeviceSelectors
  */
 DPCTL_API
-__dpctl_give DPCTLSyclDeviceSelectorRef DPCTLCPUSelector_Create();
+__dpctl_give DPCTLSyclDeviceSelectorRef DPCTLCPUSelector_Create(void);
 
 /*!
  * @brief Returns an opaque wrapper for sycl::ONEAPI::filter_selector object
@@ -84,7 +84,7 @@ DPCTLFilterSelector_Create(__dpctl_keep const char *filter_str);
  * @ingroup DeviceSelectors
  */
 DPCTL_API
-__dpctl_give DPCTLSyclDeviceSelectorRef DPCTLGPUSelector_Create();
+__dpctl_give DPCTLSyclDeviceSelectorRef DPCTLGPUSelector_Create(void);
 
 /*!
  * @brief Returns an opaque wrapper for sycl::host_selector object.
@@ -93,7 +93,7 @@ __dpctl_give DPCTLSyclDeviceSelectorRef DPCTLGPUSelector_Create();
  * @ingroup DeviceSelectors
  */
 DPCTL_API
-__dpctl_give DPCTLSyclDeviceSelectorRef DPCTLHostSelector_Create();
+__dpctl_give DPCTLSyclDeviceSelectorRef DPCTLHostSelector_Create(void);
 
 /*!
  * @brief Deletes the DPCTLSyclDeviceSelectorRef after casting it to a

--- a/dpctl-capi/include/dpctl_sycl_enum_types.h
+++ b/dpctl-capi/include/dpctl_sycl_enum_types.h
@@ -35,7 +35,7 @@ DPCTL_C_EXTERN_C_BEGIN
  * @brief Redefinition of DPC++-specific Sycl backend types.
  *
  */
-enum DPCTLSyclBackendType
+typedef enum
 {
     // clang-format off
     DPCTL_CUDA            = 1 << 16,
@@ -45,13 +45,13 @@ enum DPCTLSyclBackendType
     DPCTL_UNKNOWN_BACKEND = 0,
     DPCTL_ALL_BACKENDS    = ((1<<5)-1) << 16
     // clang-format on
-};
+} DPCTLSyclBackendType;
 
 /*!
  * @brief DPCTL device types that are equivalent to Sycl's device_type.
  *
  */
-enum DPCTLSyclDeviceType
+typedef enum
 {
     // Note: before adding new values here look at DPCTLSyclBackendType enum.
     // The values should not overlap.
@@ -66,7 +66,7 @@ enum DPCTLSyclDeviceType
     DPCTL_ALL            = (1 << 6) - 1,
     DPCTL_UNKNOWN_DEVICE = 0
     // clang-format on
-};
+} DPCTLSyclDeviceType;
 
 /*!
  * @brief Supported types for kernel arguments to be passed to a Sycl kernel
@@ -100,7 +100,7 @@ typedef enum
  * characteristics of the device.
  *
  */
-enum DPCTLSyclAspectType
+typedef enum
 {
     host,
     cpu,
@@ -120,13 +120,13 @@ enum DPCTLSyclAspectType
     usm_shared_allocations,
     usm_restricted_shared_allocations,
     usm_system_allocator
-};
+} DPCTLSyclAspectType;
 
 /*!
  * @brief DPCTL analogue of ``sycl::info::partition_affinity_domain`` enum.
  *
  */
-enum DPCTLPartitionAffinityDomainType
+typedef enum
 {
     not_applicable,
     numa,
@@ -135,7 +135,7 @@ enum DPCTLPartitionAffinityDomainType
     L2_cache,
     L1_cache,
     next_partitionable
-};
+} DPCTLPartitionAffinityDomainType;
 
 /*!
  * @brief Enums to depict the properties that can be passed to a sycl::queue

--- a/dpctl-capi/include/dpctl_sycl_platform_interface.h
+++ b/dpctl-capi/include/dpctl_sycl_platform_interface.h
@@ -59,7 +59,7 @@ DPCTLPlatform_Copy(__dpctl_keep const DPCTLSyclPlatformRef PRef);
  * @ingroup PlatformInterface
  */
 DPCTL_API
-__dpctl_give DPCTLSyclPlatformRef DPCTLPlatform_Create();
+__dpctl_give DPCTLSyclPlatformRef DPCTLPlatform_Create(void);
 
 /*!
  * @brief Creates a new DPCTLSyclPlatformRef for a SYCL platform constructed
@@ -140,6 +140,6 @@ DPCTLPlatform_GetVersion(__dpctl_keep const DPCTLSyclPlatformRef PRef);
  * @ingroup PlatformInterface
  */
 DPCTL_API
-__dpctl_give DPCTLPlatformVectorRef DPCTLPlatform_GetPlatforms();
+__dpctl_give DPCTLPlatformVectorRef DPCTLPlatform_GetPlatforms(void);
 
 DPCTL_C_EXTERN_C_END

--- a/dpctl-capi/include/dpctl_sycl_queue_manager.h
+++ b/dpctl-capi/include/dpctl_sycl_queue_manager.h
@@ -55,7 +55,7 @@ DPCTL_C_EXTERN_C_BEGIN
  * @ingroup QueueManager
  */
 DPCTL_API
-__dpctl_give DPCTLSyclQueueRef DPCTLQueueMgr_GetCurrentQueue();
+__dpctl_give DPCTLSyclQueueRef DPCTLQueueMgr_GetCurrentQueue(void);
 
 /*!
  * @brief Returns true if the global queue set for the queue manager is also the
@@ -72,7 +72,7 @@ __dpctl_give DPCTLSyclQueueRef DPCTLQueueMgr_GetCurrentQueue();
  * @ingroup QueueManager
  */
 DPCTL_API
-bool DPCTLQueueMgr_GlobalQueueIsCurrent();
+bool DPCTLQueueMgr_GlobalQueueIsCurrent(void);
 
 /*!
  * @brief Check if the queue argument is also the current queue.
@@ -121,7 +121,7 @@ void DPCTLQueueMgr_PushQueue(__dpctl_keep const DPCTLSyclQueueRef QRef);
  * @ingroup QueueManager
  */
 DPCTL_API
-void DPCTLQueueMgr_PopQueue();
+void DPCTLQueueMgr_PopQueue(void);
 
 /*!
  * @brief A helper function meant for unit testing. Returns the current number
@@ -132,6 +132,6 @@ void DPCTLQueueMgr_PopQueue();
  * @ingroup QueueManager
  */
 DPCTL_API
-size_t DPCTLQueueMgr_GetQueueStackSize();
+size_t DPCTLQueueMgr_GetQueueStackSize(void);
 
 DPCTL_C_EXTERN_C_END

--- a/dpctl-capi/include/dpctl_vector.h
+++ b/dpctl-capi/include/dpctl_vector.h
@@ -47,7 +47,7 @@ DPCTL_C_EXTERN_C_BEGIN
        @return Returns a new opaque pointer to a vector.                       \
      */                                                                        \
     DPCTL_API                                                                  \
-    __dpctl_give DPCTL##EL##VectorRef DPCTL##EL##Vector_Create();              \
+    __dpctl_give DPCTL##EL##VectorRef DPCTL##EL##Vector_Create(void);          \
     /*!                                                                        \
        @brief Create an opaque pointer to a std::vector created from the       \
        input raw array. The elements of the input array are deep copied before \

--- a/dpctl/_backend.pxd
+++ b/dpctl/_backend.pxd
@@ -34,7 +34,7 @@ cdef extern from "dpctl_utils.h":
 
 
 cdef extern from "dpctl_sycl_enum_types.h":
-    cdef enum _backend_type 'DPCTLSyclBackendType':
+    ctypedef enum _backend_type 'DPCTLSyclBackendType':
         _ALL_BACKENDS    'DPCTL_ALL_BACKENDS'
         _CUDA            'DPCTL_CUDA'
         _HOST            'DPCTL_HOST'
@@ -42,9 +42,7 @@ cdef extern from "dpctl_sycl_enum_types.h":
         _OPENCL          'DPCTL_OPENCL'
         _UNKNOWN_BACKEND 'DPCTL_UNKNOWN_BACKEND'
 
-    ctypedef _backend_type DPCTLSyclBackendType
-
-    cdef enum _device_type 'DPCTLSyclDeviceType':
+    ctypedef enum _device_type 'DPCTLSyclDeviceType':
         _ACCELERATOR    'DPCTL_ACCELERATOR'
         _ALL_DEVICES    'DPCTL_ALL'
         _AUTOMATIC      'DPCTL_AUTOMATIC'
@@ -54,9 +52,7 @@ cdef extern from "dpctl_sycl_enum_types.h":
         _HOST_DEVICE    'DPCTL_HOST_DEVICE'
         _UNKNOWN_DEVICE 'DPCTL_UNKNOWN_DEVICE'
 
-    ctypedef _device_type DPCTLSyclDeviceType
-
-    cdef enum _arg_data_type 'DPCTLKernelArgType':
+    ctypedef enum _arg_data_type 'DPCTLKernelArgType':
         _CHAR               'DPCTL_CHAR',
         _SIGNED_CHAR        'DPCTL_SIGNED_CHAR',
         _UNSIGNED_CHAR      'DPCTL_UNSIGNED_CHAR',
@@ -74,14 +70,12 @@ cdef extern from "dpctl_sycl_enum_types.h":
         _LONG_DOUBLE        'DPCTL_DOUBLE',
         _VOID_PTR           'DPCTL_VOID_PTR'
 
-    ctypedef _arg_data_type DPCTLKernelArgType
-
     ctypedef enum _queue_property_type 'DPCTLQueuePropertyType':
         _DEFAULT_PROPERTY   'DPCTL_DEFAULT_PROPERTY'
         _ENABLE_PROFILING   'DPCTL_ENABLE_PROFILING'
         _IN_ORDER           'DPCTL_IN_ORDER'
 
-    cdef enum _aspect_type 'DPCTLSyclAspectType':
+    ctypedef enum _aspect_type 'DPCTLSyclAspectType':
         _host                               'host',
         _cpu                                'cpu',
         _gpu                                'gpu',
@@ -101,10 +95,7 @@ cdef extern from "dpctl_sycl_enum_types.h":
         _usm_restricted_shared_allocations  'usm_restricted_shared_allocations',
         _usm_system_allocator               'usm_system_allocator'
 
-    ctypedef _aspect_type DPCTLSyclAspectType
-
-
-    cdef enum _partition_affinity_domain_type 'DPCTLPartitionAffinityDomainType':
+    ctypedef enum _partition_affinity_domain_type 'DPCTLPartitionAffinityDomainType':
         _not_applicable                     'not_applicable',
         _numa                               'numa',
         _L4_cache                           'L4_cache',
@@ -112,8 +103,6 @@ cdef extern from "dpctl_sycl_enum_types.h":
         _L2_cache                           'L2_cache',
         _L1_cache                           'L1_cache',
         _next_partitionable                 'next_partitionable',
-
-    ctypedef _partition_affinity_domain_type DPCTLPartitionAffinityDomainType
 
 
 cdef extern from "dpctl_sycl_types.h":
@@ -151,10 +140,8 @@ cdef extern from "dpctl_sycl_device_interface.h":
     cdef DPCTLSyclDeviceRef DPCTLDevice_CreateFromSelector(
         const DPCTLSyclDeviceSelectorRef DSRef)
     cdef void DPCTLDevice_Delete(DPCTLSyclDeviceRef DRef)
-    cdef DPCTLSyclBackendType DPCTLDevice_GetBackend(
-        const DPCTLSyclDeviceRef DRef)
-    cdef DPCTLSyclDeviceType DPCTLDevice_GetDeviceType(
-        const DPCTLSyclDeviceRef DRef)
+    cdef _backend_type DPCTLDevice_GetBackend(const DPCTLSyclDeviceRef)
+    cdef _device_type DPCTLDevice_GetDeviceType(const DPCTLSyclDeviceRef)
     cdef const char *DPCTLDevice_GetDriverVersion(const DPCTLSyclDeviceRef DRef)
     cdef uint32_t DPCTLDevice_GetMaxComputeUnits(const DPCTLSyclDeviceRef DRef)
     cdef uint32_t DPCTLDevice_GetMaxNumSubGroups(const DPCTLSyclDeviceRef DRef)
@@ -178,8 +165,7 @@ cdef extern from "dpctl_sycl_device_interface.h":
     cdef uint32_t DPCTLDevice_GetPreferredVectorWidthFloat(const DPCTLSyclDeviceRef DRef)
     cdef uint32_t DPCTLDevice_GetPreferredVectorWidthDouble(const DPCTLSyclDeviceRef DRef)
     cdef uint32_t DPCTLDevice_GetPreferredVectorWidthHalf(const DPCTLSyclDeviceRef DRef)
-    cpdef bool DPCTLDevice_HasAspect(
-        const DPCTLSyclDeviceRef DRef, DPCTLSyclAspectType AT)
+    cpdef bool DPCTLDevice_HasAspect(const DPCTLSyclDeviceRef, _aspect_type)
     cdef uint32_t DPCTLDevice_GetMaxReadImageArgs(const DPCTLSyclDeviceRef DRef)
     cdef uint32_t DPCTLDevice_GetMaxWriteImageArgs(const DPCTLSyclDeviceRef DRef)
     cdef size_t DPCTLDevice_GetImage2dMaxWidth(const DPCTLSyclDeviceRef DRef)
@@ -193,7 +179,7 @@ cdef extern from "dpctl_sycl_device_interface.h":
         const DPCTLSyclDeviceRef DRef, size_t *counts, size_t ncounts)
     cdef DPCTLDeviceVectorRef DPCTLDevice_CreateSubDevicesByAffinity(
         const DPCTLSyclDeviceRef DRef,
-        DPCTLPartitionAffinityDomainType PartitionAffinityDomainTy)
+        _partition_affinity_domain_type PartitionAffinityDomainTy)
     cdef DPCTLSyclDeviceRef DPCTLDevice_GetParentDevice(const DPCTLSyclDeviceRef DRef)
 
 
@@ -259,8 +245,7 @@ cdef extern from "dpctl_sycl_platform_interface.h":
     cdef DPCTLSyclPlatformRef DPCTLPlatform_CreateFromSelector(
         const DPCTLSyclDeviceSelectorRef)
     cdef void DPCTLPlatform_Delete(DPCTLSyclPlatformRef)
-    cdef DPCTLSyclBackendType DPCTLPlatform_GetBackend(
-        const DPCTLSyclPlatformRef)
+    cdef _backend_type DPCTLPlatform_GetBackend(const DPCTLSyclPlatformRef)
     cdef const char *DPCTLPlatform_GetName(const DPCTLSyclPlatformRef)
     cdef const char *DPCTLPlatform_GetVendor(const DPCTLSyclPlatformRef)
     cdef const char *DPCTLPlatform_GetVersion(const DPCTLSyclPlatformRef)
@@ -283,8 +268,7 @@ cdef extern from "dpctl_sycl_context_interface.h":
     cdef size_t DPCTLContext_DeviceCount(const DPCTLSyclContextRef CRef)
     cdef bool DPCTLContext_AreEq(const DPCTLSyclContextRef CtxRef1,
                                  const DPCTLSyclContextRef CtxRef2)
-    cdef DPCTLSyclBackendType DPCTLContext_GetBackend(
-        const DPCTLSyclContextRef CtxRef)
+    cdef _backend_type DPCTLContext_GetBackend(const DPCTLSyclContextRef)
     cdef void DPCTLContext_Delete(DPCTLSyclContextRef CtxRef)
 
 
@@ -320,14 +304,14 @@ cdef extern from "dpctl_sycl_queue_interface.h":
         int properties)
     cdef void DPCTLQueue_Delete(DPCTLSyclQueueRef QRef)
     cdef DPCTLSyclQueueRef DPCTLQueue_Copy(DPCTLSyclQueueRef QRef)
-    cdef DPCTLSyclBackendType DPCTLQueue_GetBackend(const DPCTLSyclQueueRef Q)
+    cdef _backend_type DPCTLQueue_GetBackend(const DPCTLSyclQueueRef Q)
     cdef DPCTLSyclContextRef DPCTLQueue_GetContext(const DPCTLSyclQueueRef Q)
     cdef DPCTLSyclDeviceRef DPCTLQueue_GetDevice(const DPCTLSyclQueueRef Q)
     cdef DPCTLSyclEventRef  DPCTLQueue_SubmitRange(
         const DPCTLSyclKernelRef Ref,
         const DPCTLSyclQueueRef QRef,
         void **Args,
-        const DPCTLKernelArgType *ArgTypes,
+        const _arg_data_type *ArgTypes,
         size_t NArgs,
         const size_t Range[3],
         size_t NDims,
@@ -337,7 +321,7 @@ cdef extern from "dpctl_sycl_queue_interface.h":
         const DPCTLSyclKernelRef Ref,
         const DPCTLSyclQueueRef QRef,
         void **Args,
-        const DPCTLKernelArgType *ArgTypes,
+        const _arg_data_type *ArgTypes,
         size_t NArgs,
         const size_t gRange[3],
         const size_t lRange[3],

--- a/dpctl/_sycl_device.pyx
+++ b/dpctl/_sycl_device.pyx
@@ -74,10 +74,8 @@ from ._backend cimport (  # noqa: E211
     DPCTLDeviceVectorRef,
     DPCTLFilterSelector_Create,
     DPCTLSize_t_Array_Delete,
-    DPCTLSyclBackendType,
     DPCTLSyclDeviceRef,
     DPCTLSyclDeviceSelectorRef,
-    DPCTLSyclDeviceType,
     _aspect_type,
     _backend_type,
     _device_type,
@@ -136,7 +134,7 @@ cdef list _get_devices(DPCTLDeviceVectorRef DVRef):
     return devices
 
 
-cdef str _backend_type_to_filter_string_part(DPCTLSyclBackendType BTy):
+cdef str _backend_type_to_filter_string_part(_backend_type BTy):
     if BTy == _backend_type._CUDA:
         return "cuda"
     elif BTy == _backend_type._HOST:
@@ -149,7 +147,7 @@ cdef str _backend_type_to_filter_string_part(DPCTLSyclBackendType BTy):
         return "unknown"
 
 
-cdef str _device_type_to_filter_string_part(DPCTLSyclDeviceType DTy):
+cdef str _device_type_to_filter_string_part(_device_type DTy):
     if DTy == _device_type._ACCELERATOR:
         return "accelerator"
     elif DTy == _device_type._AUTOMATIC:
@@ -317,7 +315,7 @@ cdef class SyclDevice(_SyclDevice):
         Returns:
             backend_type: The backend for the device.
         """
-        cdef DPCTLSyclBackendType BTy = (
+        cdef _backend_type BTy = (
             DPCTLDevice_GetBackend(self._device_ref)
         )
         if BTy == _backend_type._CUDA:
@@ -340,7 +338,7 @@ cdef class SyclDevice(_SyclDevice):
         Raises:
             A ValueError is raised if the device type is not recognized.
         """
-        cdef DPCTLSyclDeviceType DTy = (
+        cdef _device_type DTy = (
             DPCTLDevice_GetDeviceType(self._device_ref)
         )
         if DTy == _device_type._ACCELERATOR:
@@ -847,8 +845,8 @@ cdef class SyclDevice(_SyclDevice):
                 assert level_zero_gpu == dev
         """
         cdef DPCTLSyclDeviceRef pDRef = NULL
-        cdef DPCTLSyclBackendType BTy
-        cdef DPCTLSyclDeviceType DTy
+        cdef _backend_type BTy
+        cdef _device_type DTy
         cdef int64_t relId = -1
         pDRef = DPCTLDevice_GetParentDevice(self._device_ref)
         if (pDRef is NULL):
@@ -888,7 +886,7 @@ cdef class SyclDevice(_SyclDevice):
         Returns -1 if the device is a sub-device, or the device could not
         be found in the vector.
         """
-        cdef DPCTLSyclDeviceType DTy
+        cdef _device_type DTy
         cdef int64_t relId = -1
 
         DTy = DPCTLDevice_GetDeviceType(self._device_ref)
@@ -906,7 +904,7 @@ cdef class SyclDevice(_SyclDevice):
         Returns -1 if the device is a sub-device, or the device could not
         be found in the vector.
         """
-        cdef DPCTLSyclBackendType BTy
+        cdef _backend_type BTy
         cdef int64_t relId = -1
 
         BTy = DPCTLDevice_GetBackend(self._device_ref)
@@ -956,8 +954,8 @@ cdef class SyclDevice(_SyclDevice):
         """
         cdef int relId = -1
         cdef DPCTLSyclDeviceRef pDRef = NULL
-        cdef DPCTLSyclDeviceType DTy
-        cdef DPCTLSyclBackendType BTy
+        cdef _device_type DTy
+        cdef _backend_type BTy
 
         if include_backend:
             if include_device_type:

--- a/dpctl/_sycl_device_factory.pyx
+++ b/dpctl/_sycl_device_factory.pyx
@@ -40,10 +40,8 @@ from ._backend cimport (  # noqa: E211
     DPCTLDeviceVectorRef,
     DPCTLGPUSelector_Create,
     DPCTLHostSelector_Create,
-    DPCTLSyclBackendType,
     DPCTLSyclDeviceRef,
     DPCTLSyclDeviceSelectorRef,
-    DPCTLSyclDeviceType,
     _backend_type,
     _device_type,
 )
@@ -171,8 +169,8 @@ cpdef list get_devices(backend=backend_type.all, device_type=device_type_t.all):
         satisfy the provided :class:`dpctl.backend_type` and
         :class:`dpctl.device_type` values.
     """
-    cdef DPCTLSyclBackendType BTy = _backend_type._ALL_BACKENDS
-    cdef DPCTLSyclDeviceType DTy = _device_type._ALL_DEVICES
+    cdef _backend_type BTy = _backend_type._ALL_BACKENDS
+    cdef _device_type DTy = _device_type._ALL_DEVICES
     cdef DPCTLDeviceVectorRef DVRef = NULL
     cdef list devices
 
@@ -222,8 +220,8 @@ cpdef int get_num_devices(
         int: The number of available SYCL devices that satisfy the provided
         :class:`dpctl.backend_type` and :class:`dpctl.device_type` values.
     """
-    cdef DPCTLSyclBackendType BTy = _backend_type._ALL_BACKENDS
-    cdef DPCTLSyclDeviceType DTy = _device_type._ALL_DEVICES
+    cdef _backend_type BTy = _backend_type._ALL_BACKENDS
+    cdef _device_type DTy = _device_type._ALL_DEVICES
     cdef int num_devices = 0
 
     if isinstance(backend, str):

--- a/dpctl/_sycl_platform.pyx
+++ b/dpctl/_sycl_platform.pyx
@@ -41,7 +41,6 @@ from ._backend cimport (  # noqa: E211
     DPCTLPlatformVector_GetAt,
     DPCTLPlatformVector_Size,
     DPCTLPlatformVectorRef,
-    DPCTLSyclBackendType,
     DPCTLSyclDeviceSelectorRef,
     DPCTLSyclPlatformRef,
     _backend_type,
@@ -241,7 +240,7 @@ cdef class SyclPlatform(_SyclPlatform):
         Returns:
             backend_type: The backend for the device.
         """
-        cdef DPCTLSyclBackendType BTy = (
+        cdef _backend_type BTy = (
             DPCTLPlatform_GetBackend(self._platform_ref)
         )
         if BTy == _backend_type._CUDA:

--- a/dpctl/_sycl_queue.pxd
+++ b/dpctl/_sycl_queue.pxd
@@ -22,7 +22,7 @@
 
 from libcpp cimport bool as cpp_bool
 
-from ._backend cimport DPCTLKernelArgType, DPCTLSyclDeviceRef, DPCTLSyclQueueRef
+from ._backend cimport DPCTLSyclDeviceRef, DPCTLSyclQueueRef, _arg_data_type
 from ._sycl_context cimport SyclContext
 from ._sycl_device cimport SyclDevice
 from ._sycl_event cimport SyclEvent
@@ -55,7 +55,7 @@ cdef public class SyclQueue (_SyclQueue) [object PySyclQueueObject, type PySyclQ
         self,
         list args,
         void **kargs,
-        DPCTLKernelArgType *kargty
+        _arg_data_type *kargty
     )
     cdef int _populate_range(self, size_t Range[3], list gS, size_t nGS)
     @staticmethod

--- a/dpctl/_sycl_queue.pyx
+++ b/dpctl/_sycl_queue.pyx
@@ -47,7 +47,6 @@ from ._backend cimport (  # noqa: E211
     DPCTLQueue_SubmitNDRange,
     DPCTLQueue_SubmitRange,
     DPCTLQueue_Wait,
-    DPCTLSyclBackendType,
     DPCTLSyclContextRef,
     DPCTLSyclDeviceSelectorRef,
     DPCTLSyclEventRef,
@@ -639,7 +638,7 @@ cdef class SyclQueue(_SyclQueue):
     def get_sycl_backend(self):
         """ Returns the Sycl backend associated with the queue.
         """
-        cdef DPCTLSyclBackendType BE = DPCTLQueue_GetBackend(self._queue_ref)
+        cdef _backend_type BE = DPCTLQueue_GetBackend(self._queue_ref)
         if BE == _backend_type._OPENCL:
             return backend_type.opencl
         elif BE == _backend_type._LEVEL_ZERO:

--- a/dpctl/_sycl_queue.pyx
+++ b/dpctl/_sycl_queue.pyx
@@ -546,7 +546,7 @@ cdef class SyclQueue(_SyclQueue):
         self,
         list args,
         void **kargs,
-        DPCTLKernelArgType *kargty
+        _arg_data_type *kargty
     ):
         cdef int ret = 0
         for idx, arg in enumerate(args):
@@ -687,7 +687,7 @@ cdef class SyclQueue(_SyclQueue):
         list dEvents=None
     ):
         cdef void **kargs = NULL
-        cdef DPCTLKernelArgType *kargty = NULL
+        cdef _arg_data_type *kargty = NULL
         cdef DPCTLSyclEventRef *depEvents = NULL
         cdef DPCTLSyclEventRef Eref = NULL
         cdef int ret
@@ -702,7 +702,7 @@ cdef class SyclQueue(_SyclQueue):
         if not kargs:
             raise MemoryError()
         kargty = (
-            <DPCTLKernelArgType*>malloc(len(args)*sizeof(DPCTLKernelArgType))
+            <_arg_data_type*>malloc(len(args)*sizeof(_arg_data_type))
         )
         if not kargty:
             free(kargs)


### PR DESCRIPTION
Change function prototypes to suppress compiler warnings and errors when dpctl C API headers are included in an actual C file.

- All function signatures now satisfy ` -Wstrict-prototype` (e.g. `DPCTLQueueMgr_GetCurrentQueue()` to `DPCTLQueueMgr_GetCurrentQueue(void)`
- Make all enums definitions to use a `typedef` so that the `enum` keyword is not needed explicitly.
- Commensurate changes to Cython files.