### PR TITLE
Remove OpenCL from meta.yaml summary

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -40,7 +40,7 @@ about:
     home: https://github.com/IntelPython/dpctl.git
     license: Apache-2.0
     license_file: LICENSE
-    summary: 'A lightweight Python wrapper for a subset of OpenCL and SYCL API.'
+    summary: 'A lightweight Python wrapper for a subset of SYCL API.'
     description: |
         <strong>LEGAL NOTICE: Use of this software package is subject to the
         software license agreement (as set forth above, in the license section of


### PR DESCRIPTION
We no longer have OpenCL wrappers so remove the reference to OpenCL from the meta.yaml summary.