### PR TITLE
Revert "Use linker scripts instead of symlink."

### DIFF
--- a/dpctl-capi/CMakeLists.txt
+++ b/dpctl-capi/CMakeLists.txt
@@ -147,35 +147,23 @@ target_link_libraries(DPCTLSyclInterface
     PRIVATE ${IntelSycl_OPENCL_LIBRARY}
 )
 
-include(GetProjectVersion)
-# the get_version function is defined in the GetProjectVersion module and
-# defines: VERSION, SEMVER, MAJOR, MINOR, PATCH. These variables are populated
-# by parsing the output of git describe.
-get_version()
-set_target_properties(DPCTLSyclInterface
-    PROPERTIES
-        VERSION ${VERSION_MAJOR}.${VERSION_MINOR}
-        SOVERSION ${VERSION_MAJOR}.${VERSION_MINOR}
-)
-
-if(UNIX)
-    set(linker_script1
-        "INPUT(libDPCTLSyclInterface.so.${VERSION_MAJOR}.${VERSION_MINOR})"
-    )
-    add_custom_command(TARGET DPCTLSyclInterface POST_BUILD
-        COMMAND "${CMAKE_COMMAND}" -E remove "libDPCTLSyclInterface.so"
-        COMMAND "${CMAKE_COMMAND}"
-            -E echo "${linker_script1}" > "libDPCTLSyclInterface.so"
-        VERBATIM
-    )
-endif()
-
 if(DPCTL_ENABLE_LO_PROGRAM_CREATION)
     target_include_directories(DPCTLSyclInterface
         PRIVATE
         ${LEVEL_ZERO_INCLUDE_DIR}
     )
 endif()
+
+# FIXME: Turning off for release until conda build can be packaging symbolic links
+# NOTE: Till we hit 1.0.0 we will keep using the MINOR version to set the API
+# version of the library.
+# include(GetProjectVersion)
+# the get_version function is defined in the GetProjectVersion module and
+# defines: VERSION, SEMVER, MAJOR, MINOR, PATCH. These variables are populated
+# by parsing the output of git describe.
+# get_version()
+# set_target_properties(DPCTLSyclInterface PROPERTIES VERSION ${VERSION_MINOR})
+# set_target_properties(DPCTLSyclInterface PROPERTIES SOVERSION 1)
 
 install(TARGETS
     DPCTLSyclInterface


### PR DESCRIPTION
Reverts IntelPython/dpctl#472

The linker scripts are intended for `ld`, not for `dlopen`. So using linker_scripts to support so-versioning in Python is not going to work. To support so-version we need to figure out how not to turn symbolic links cmake is generating into hard links by conda building.