### PR TITLE
Fix an issue identified by klockwork.

### DIFF
--- a/dpctl-capi/source/dpctl_sycl_platform_interface.cpp
+++ b/dpctl-capi/source/dpctl_sycl_platform_interface.cpp
@@ -84,11 +84,12 @@ __dpctl_give DPCTLSyclPlatformRef DPCTLPlatform_CreateFromSelector(
             P = new platform(*DS);
             PRef = wrap(P);
         } catch (std::bad_alloc const &ba) {
-            delete P;
             std::cerr << ba.what() << '\n';
+            return nullptr;
         } catch (runtime_error const &re) {
             delete P;
             std::cerr << re.what() << '\n';
+            return nullptr;
         }
     }
     else {


### PR DESCRIPTION
Object 'PRef' was returned at line 98 after being freed by calling 'delete' at line 90. The issue was unlikely to happen as it was done after catching a bad_alloc. The issue was identified by Klockwork static code analysis.