### PR TITLE
Fix sub devices

### DIFF
--- a/dpctl-capi/source/dpctl_sycl_device_interface.cpp
+++ b/dpctl-capi/source/dpctl_sycl_device_interface.cpp
@@ -578,7 +578,12 @@ DPCTLDevice_CreateSubDevicesEqually(__dpctl_keep const DPCTLSyclDeviceRef DRef,
                                     size_t count)
 {
     vector_class<DPCTLSyclDeviceRef> *Devices = nullptr;
-    if (DRef && count) {
+    if (DRef) {
+        if (count == 0) {
+            std::cerr << "Can not create sub-devices with zero compute units"
+                      << '\n';
+            return nullptr;
+        }
         auto D = unwrap(DRef);
         try {
             auto subDevices = D->create_sub_devices<
@@ -611,10 +616,15 @@ DPCTLDevice_CreateSubDevicesByCounts(__dpctl_keep const DPCTLSyclDeviceRef DRef,
                                      size_t ncounts)
 {
     vector_class<DPCTLSyclDeviceRef> *Devices = nullptr;
-    std::vector<size_t> vcounts;
+    std::vector<size_t> vcounts(ncounts);
     vcounts.assign(counts, counts + ncounts);
     size_t min_elem = *std::min_element(vcounts.begin(), vcounts.end());
-    if (DRef && min_elem) {
+    if (min_elem == 0) {
+        std::cerr << "Can not create sub-devices with zero compute units"
+                  << '\n';
+        return nullptr;
+    }
+    if (DRef) {
         auto D = unwrap(DRef);
         vector_class<std::remove_pointer<decltype(D)>::type> subDevices;
         try {

--- a/dpctl-capi/tests/test_sycl_device_subdevices.cpp
+++ b/dpctl-capi/tests/test_sycl_device_subdevices.cpp
@@ -92,6 +92,9 @@ TEST_P(TestDPCTLSyclDeviceInterface, ChkCreateSubDevicesEqually)
             EXPECT_NO_FATAL_FAILURE(DPCTLDevice_Delete(pDRef));
             EXPECT_NO_FATAL_FAILURE(DPCTLDeviceVector_Delete(DVRef));
         }
+        EXPECT_NO_FATAL_FAILURE(
+            DVRef = DPCTLDevice_CreateSubDevicesEqually(DRef, 0));
+        EXPECT_TRUE(DVRef == nullptr);
     }
 }
 
@@ -114,7 +117,12 @@ TEST_P(TestDPCTLSyclDeviceInterface, ChkCreateSubDevicesByCounts)
         if (DVRef) {
             EXPECT_TRUE(DPCTLDeviceVector_Size(DVRef) > 0);
             EXPECT_NO_FATAL_FAILURE(DPCTLDeviceVector_Delete(DVRef));
+            DVRef = nullptr;
         }
+        counts[n - 1] = 0;
+        EXPECT_NO_FATAL_FAILURE(
+            DVRef = DPCTLDevice_CreateSubDevicesByCounts(DRef, counts, n));
+        EXPECT_TRUE(DVRef == nullptr);
     }
 }
 

--- a/dpctl/tests/test_sycl_device.py
+++ b/dpctl/tests/test_sycl_device.py
@@ -360,6 +360,13 @@ def check_create_sub_devices_equally(device):
         pytest.fail("create_sub_devices failed")
 
 
+def check_create_sub_devices_equally_zeros(device):
+    try:
+        device.create_sub_devices(partition=0)
+    except TypeError:
+        pass
+
+
 def check_create_sub_devices_by_counts(device):
     try:
         n = device.max_compute_units / 2
@@ -370,6 +377,13 @@ def check_create_sub_devices_by_counts(device):
         )
     except Exception:
         pytest.fail("create_sub_devices failed")
+
+
+def check_create_sub_devices_by_counts_zeros(device):
+    try:
+        device.create_sub_devices(partition=(0, 1))
+    except TypeError:
+        pass
 
 
 def check_create_sub_devices_by_affinity_not_applicable(device):


### PR DESCRIPTION
Closes #475 

Issue alike crash of ``dpctl.SyclDevice("cpu").create_sub_devices(partition=0)`` should be fixed.