### PR TITLE
Implemented support for non-standard installation of oneAPI compiler by dpctl

### DIFF
--- a/dpctl-capi/CMakeLists.txt
+++ b/dpctl-capi/CMakeLists.txt
@@ -9,9 +9,13 @@ project(
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/modules/")
 find_package(Git REQUIRED)
 
-option(DPCTL_CUSTOM_DPCPP_INSTALL_DIR
-    "Use a custom version of DPCPP installed at the provided location."
+option(DPCTL_DPCPP_HOME_DIR
+    "The installation home for the DPC++ toolchain compiler."
     OFF
+)
+option(DPCTL_DPCPP_FROM_ONEAPI
+    "Indicates whether DPCTL_DPCPP_HOME_DIR points to a oneAPI installation."
+    ON
 )
 # Option to turn on support for creating Level Zero interoperability programs
 # from a SPIR-V binary file.
@@ -36,10 +40,10 @@ option(DPCTL_BUILD_CAPI_TESTS
 )
 
 # Minimum version requirement only when oneAPI dpcpp is used.
-if(DPCTL_CUSTOM_DPCPP_INSTALL_DIR)
-    find_package(IntelSycl REQUIRED)
-else()
+if(DPCTL_DPCPP_FROM_ONEAPI)
     find_package(IntelSycl 2021.2.0 REQUIRED)
+else()
+    find_package(IntelSycl REQUIRED)
 endif()
 
 if(DPCTL_ENABLE_LO_PROGRAM_CREATION)

--- a/dpctl-capi/cmake/modules/FindIntelSycl.cmake
+++ b/dpctl-capi/cmake/modules/FindIntelSycl.cmake
@@ -36,10 +36,9 @@ include(FindPackageHandleStandardArgs)
 
 # Check if a specific DPC++ installation directory was provided then set
 # IntelSycl_ROOT to that path.
-if(DPCTL_CUSTOM_DPCPP_INSTALL_DIR)
-    set(IntelSycl_ROOT ${DPCTL_CUSTOM_DPCPP_INSTALL_DIR})
-    set(USING_ONEAPI_DPCPP False)
-    message(STATUS "Not using oneAPI, but IntelSycl at " ${IntelSycl_ROOT})
+if(DPCTL_DPCPP_HOME_DIR)
+    set(IntelSycl_ROOT ${DPCTL_DPCPP_HOME_DIR})
+    message(STATUS "Not using standard oneAPI installation, but IntelSycl at " ${IntelSycl_ROOT})
 # If DPC++ installation was not specified, check for ONEAPI_ROOT
 elseif(DEFINED ENV{ONEAPI_ROOT})
     if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
@@ -49,38 +48,31 @@ elseif(DEFINED ENV{ONEAPI_ROOT})
     else()
         message(FATAL_ERROR "Unsupported system.")
     endif()
-    set(USING_ONEAPI_DPCPP True)
 else()
     message(FATAL_ERROR,
         "Could not locate a DPC++ installation. Either pass the path to a "
-        "custom location using CUSTOM_IntelSycl_INSTALL_DIR or set the "
+        "custom location using DPCTL_DPCPP_HOME_DIR or set the "
         " ONEAPI_ROOT environment variable."
     )
     return()
 endif()
 
 # We will extract the version information from the compiler
-if(USING_ONEAPI_DPCPP)
-    set(dpcpp_cmd "${IntelSycl_ROOT}/bin/dpcpp")
-    set(dpcpp_arg "--version")
-else()
-    set(dpcpp_cmd "${IntelSycl_ROOT}/bin/clang++")
-    set(dpcpp_arg "--version")
-endif()
+set(clangxx_cmd "${IntelSycl_ROOT}/bin/clang++")
+set(clangxx_arg "--version")
 
 # Check if dpcpp is available
 execute_process(
-    COMMAND ${dpcpp_cmd} ${dpcpp_arg}
+    COMMAND ${clangxx_cmd} ${clangxx_arg}
     WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
-    RESULT_VARIABLE dpcpp_result
-    OUTPUT_VARIABLE dpcpp_ver
+    RESULT_VARIABLE clangxx_result
+    OUTPUT_VARIABLE clangxx_ver
 )
 
 # If dpcpp is found then set the package variables
-if(${dpcpp_result} MATCHES "0")
-    string(REPLACE "\n" ";" IntelSycl_VERSION_LIST "${dpcpp_ver}")
+if(${clangxx_result} MATCHES "0")
+    string(REPLACE "\n" ";" IntelSycl_VERSION_LIST "${clangxx_ver}")
     set(IDX 0)
-    list(GET IntelSycl_VERSION_LIST 0 dpcpp_ver_line)
     foreach(X ${IntelSycl_VERSION_LIST})
         message(STATUS "dpcpp ver[${IDX}]: ${X}")
         MATH(EXPR IDX "${IDX}+1")

--- a/scripts/build_backend.py
+++ b/scripts/build_backend.py
@@ -81,6 +81,8 @@ def build_backend(
     if IS_LIN:
         if os.path.exists(os.path.join(DPCPP_ROOT, "bin", "dpcpp")):
             cmake_compiler_args = [
+                "-DDPCTL_DPCPP_HOME_DIR=" + DPCPP_ROOT,
+                "-DDPCTL_DPCPP_FROM_ONEAPI=ON",
                 "-DCMAKE_C_COMPILER:PATH="
                 + os.path.join(DPCPP_ROOT, "bin", "clang"),
                 "-DCMAKE_CXX_COMPILER:PATH="
@@ -88,7 +90,8 @@ def build_backend(
             ]
         else:
             cmake_compiler_args = [
-                "-DDPCTL_CUSTOM_DPCPP_INSTALL_DIR=" + DPCPP_ROOT,
+                "-DDPCTL_DPCPP_HOME_DIR=" + DPCPP_ROOT,
+                "-DDPCTL_DPCPP_FROM_ONEAPI=OFF",
                 "-DCMAKE_C_COMPILER:PATH="
                 + os.path.join(DPCPP_ROOT, "bin", "clang"),
                 "-DCMAKE_CXX_COMPILER:PATH="


### PR DESCRIPTION
Closes #480 

@AndresGuzman-Ballen Please check to see if this changes unblocks the use of DPC++ installation in Python environment.