### PR TITLE
Remove imports from __future__. The future is here now.

### DIFF
--- a/dpctl/_sycl_context.pyx
+++ b/dpctl/_sycl_context.pyx
@@ -21,8 +21,6 @@
 """ Implements SyclContext Cython extension type.
 """
 
-from __future__ import print_function
-
 import logging
 
 from cpython cimport pycapsule

--- a/dpctl/_sycl_event.pyx
+++ b/dpctl/_sycl_event.pyx
@@ -21,8 +21,6 @@
 """ Implements SyclEvent Cython extension type.
 """
 
-from __future__ import print_function
-
 import logging
 
 from ._backend cimport DPCTLEvent_Delete, DPCTLEvent_Wait, DPCTLSyclEventRef

--- a/dpctl/_sycl_platform.pyx
+++ b/dpctl/_sycl_platform.pyx
@@ -21,8 +21,6 @@
 """ Implements SyclPlatform Cython extension type.
 """
 
-from __future__ import print_function
-
 from ._backend cimport (  # noqa: E211
     DPCTLCString_Delete,
     DPCTLDeviceSelector_Delete,

--- a/dpctl/_sycl_queue.pyx
+++ b/dpctl/_sycl_queue.pyx
@@ -21,8 +21,6 @@
 """ Implements SyclQueue Cython extension type.
 """
 
-from __future__ import print_function
-
 from ._backend cimport (  # noqa: E211
     DPCTLContext_Create,
     DPCTLContext_Delete,

--- a/dpctl/_sycl_queue_manager.pyx
+++ b/dpctl/_sycl_queue_manager.pyx
@@ -18,8 +18,6 @@
 # cython: language_level=3
 # cython: linetrace=True
 
-from __future__ import print_function
-
 import logging
 from contextlib import contextmanager
 


### PR DESCRIPTION
dpctl supports only Python 3, we do not need to import from `__future__`.