### PR TITLE
Consolidate configurations of tools that support PEP 518 into pyproject.toml

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,5 +1,0 @@
-[run]
-plugins = Cython.Coverage
-branch = True
-source = dpctl
-omit = dpctl/tests/*, dpctl/_version.py

--- a/.github/workflows/generate-coverage.yaml
+++ b/.github/workflows/generate-coverage.yaml
@@ -79,7 +79,7 @@ jobs:
       - name: Install dpctl dependencies
         shell: bash -l {0}
         run: |
-          pip install numpy cython setuptools pytest pytest-cov coverage
+          pip install numpy cython setuptools pytest pytest-cov coverage[toml]
 
       - name: Build dpctl with coverage
         shell: bash -l {0}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -154,6 +154,10 @@ these steps:
     To generate the coverage data for dpctl's Python sources, you only need to
     install `coverage`.
 
+    ```bash
+    python -m pip install coverage[toml]
+    ```
+
 3. Build dpctl with code coverage support.
 
     ```bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,3 +10,32 @@ use_parentheses = true
 ensure_newline_before_comments = true
 line_length = 80
 skip = ["versioneer.py", "dpctl/_version.py"]
+
+[tool.coverage.run]
+plugins = [
+    "Cython.Coverage"
+]
+branch = true
+source = [
+    "dpctl"
+]
+omit = [
+    "dpctl/tests/*",
+    "dpctl/_version.py",
+]
+
+[tool.pytest.ini.options]
+minversion = "6.0"
+norecursedirs= [
+    ".*", "*.egg*", "build", "dist", "conda.recipe",
+]
+addopts = [
+    "--junitxml=junit.xml",
+    "--ignore setup.py",
+    "--ignore run_test.py",
+    "--cov-report term-missing",
+    "--tb native",
+    "--strict",
+    "--durations=20",
+    "-q -ra",
+]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,18 +1,3 @@
-[tool:pytest]
-norecursedirs= .* *.egg* build dist conda.recipe
-addopts =
-    --junitxml=junit.xml
-    --ignore setup.py
-    --ignore run_test.py
-    --cov-report term-missing
-    --tb native
-    --strict
-    --durations=20
-env =
-    PYTHONHASHSEED=0
-markers =
-    serial: execute test serially (to avoid race conditions)
-
 [versioneer]
 VCS = git
 versionfile_source = dpctl/_version.py


### PR DESCRIPTION
`coverage` and `pytest` support PEP518 and `pyproject.toml`. The PR moves configurations for these tools into `pyproject.toml.`