### PR TITLE
Fixes the addressof_ref function of SyclContext and improves unit tests.

### DIFF
--- a/dpctl/_sycl_context.pyx
+++ b/dpctl/_sycl_context.pyx
@@ -350,7 +350,7 @@ cdef class SyclContext(_SyclContext):
             used to create this :class:`dpctl.SyclContext` cast to a
             ``size_t``.
         """
-        return int(<size_t>self._ctx_ref)
+        return int(<size_t>self._ctxt_ref)
 
     def get_devices(self):
         """

--- a/dpctl/_sycl_context.pyx
+++ b/dpctl/_sycl_context.pyx
@@ -350,7 +350,7 @@ cdef class SyclContext(_SyclContext):
             used to create this :class:`dpctl.SyclContext` cast to a
             ``size_t``.
         """
-        return int(<size_t>self._ctxt_ref)
+        return <size_t>self._ctxt_ref
 
     def get_devices(self):
         """

--- a/dpctl/tests/test_sycl_context.py
+++ b/dpctl/tests/test_sycl_context.py
@@ -21,14 +21,6 @@ import pytest
 
 import dpctl
 
-list_of_standard_selectors = [
-    dpctl.select_accelerator_device,
-    dpctl.select_cpu_device,
-    dpctl.select_default_device,
-    dpctl.select_gpu_device,
-    dpctl.select_host_device,
-]
-
 list_of_valid_filter_selectors = [
     "opencl",
     "opencl:gpu",
@@ -45,308 +37,36 @@ list_of_valid_filter_selectors = [
     "1",
 ]
 
-list_of_invalid_filter_selectors = [
-    "-1",
-    "opencl:gpu:-1",
-    "level_zero:cpu:0",
-    "abc",
-]
-
-
-# Unit test cases that will be run for every device
-def check_get_max_compute_units(device):
-    max_compute_units = device.max_compute_units
-    assert max_compute_units > 0
-
-
-def check_get_max_work_item_dims(device):
-    max_work_item_dims = device.max_work_item_dims
-    assert max_work_item_dims > 0
-
-
-def check_get_max_work_item_sizes(device):
-    max_work_item_sizes = device.max_work_item_sizes
-    for size in max_work_item_sizes:
-        assert size is not None
-
-
-def check_get_max_work_group_size(device):
-    max_work_group_size = device.max_work_group_size
-    # Special case for FPGA simulator
-    if device.is_accelerator:
-        assert max_work_group_size >= 0
-    else:
-        assert max_work_group_size > 0
-
-
-def check_get_max_num_sub_groups(device):
-    max_num_sub_groups = device.max_num_sub_groups
-    # Special case for FPGA simulator
-    if device.is_accelerator or device.is_host:
-        assert max_num_sub_groups >= 0
-    else:
-        assert max_num_sub_groups > 0
-
-
-def check_has_aspect_host(device):
-    try:
-        device.has_aspect_host
-    except Exception:
-        pytest.fail("has_aspect_host call failed")
-
-
-def check_has_aspect_cpu(device):
-    try:
-        device.has_aspect_cpu
-    except Exception:
-        pytest.fail("has_aspect_cpu call failed")
-
-
-def check_has_aspect_gpu(device):
-    try:
-        device.has_aspect_gpu
-    except Exception:
-        pytest.fail("has_aspect_gpu call failed")
-
-
-def check_has_aspect_accelerator(device):
-    try:
-        device.has_aspect_accelerator
-    except Exception:
-        pytest.fail("has_aspect_accelerator call failed")
-
-
-def check_has_aspect_custom(device):
-    try:
-        device.has_aspect_custom
-    except Exception:
-        pytest.fail("has_aspect_custom call failed")
-
-
-def check_has_aspect_fp16(device):
-    try:
-        device.has_aspect_fp16
-    except Exception:
-        pytest.fail("has_aspect_fp16 call failed")
-
-
-def check_has_aspect_fp64(device):
-    try:
-        device.has_aspect_fp64
-    except Exception:
-        pytest.fail("has_aspect_fp64 call failed")
-
-
-def check_has_aspect_int64_base_atomics(device):
-    try:
-        device.has_aspect_int64_base_atomics
-    except Exception:
-        pytest.fail("has_aspect_int64_base_atomics call failed")
-
-
-def check_has_aspect_int64_extended_atomics(device):
-    try:
-        device.has_aspect_int64_extended_atomics
-    except Exception:
-        pytest.fail("has_aspect_int64_extended_atomics call failed")
-
-
-def check_has_aspect_image(device):
-    try:
-        device.has_aspect_image
-    except Exception:
-        pytest.fail("has_aspect_image call failed")
-
-
-def check_has_aspect_online_compiler(device):
-    try:
-        device.has_aspect_online_compiler
-    except Exception:
-        pytest.fail("has_aspect_online_compiler call failed")
-
-
-def check_has_aspect_online_linker(device):
-    try:
-        device.has_aspect_online_linker
-    except Exception:
-        pytest.fail("has_aspect_online_linker call failed")
-
-
-def check_has_aspect_queue_profiling(device):
-    try:
-        device.has_aspect_queue_profiling
-    except Exception:
-        pytest.fail("has_aspect_queue_profiling call failed")
-
-
-def check_has_aspect_usm_device_allocations(device):
-    try:
-        device.has_aspect_usm_device_allocations
-    except Exception:
-        pytest.fail("has_aspect_usm_device_allocations call failed")
-
-
-def check_has_aspect_usm_host_allocations(device):
-    try:
-        device.has_aspect_usm_host_allocations
-    except Exception:
-        pytest.fail("has_aspect_usm_host_allocations call failed")
-
-
-def check_has_aspect_usm_shared_allocations(device):
-    try:
-        device.has_aspect_usm_shared_allocations
-    except Exception:
-        pytest.fail("has_aspect_usm_shared_allocations call failed")
-
-
-def check_has_aspect_usm_restricted_shared_allocations(device):
-    try:
-        device.has_aspect_usm_restricted_shared_allocations
-    except Exception:
-        pytest.fail("has_aspect_usm_restricted_shared_allocations call failed")
-
-
-def check_has_aspect_usm_system_allocator(device):
-    try:
-        device.has_aspect_usm_system_allocator
-    except Exception:
-        pytest.fail("has_aspect_usm_system_allocator call failed")
-
-
-def check_is_accelerator(device):
-    try:
-        device.is_accelerator
-    except Exception:
-        pytest.fail("is_accelerator call failed")
-
-
-def check_is_cpu(device):
-    try:
-        device.is_cpu
-    except Exception:
-        pytest.fail("is_cpu call failed")
-
-
-def check_is_gpu(device):
-    try:
-        device.is_gpu
-    except Exception:
-        pytest.fail("is_gpu call failed")
-
-
-def check_is_host(device):
-    try:
-        device.is_host
-    except Exception:
-        pytest.fail("is_hostcall failed")
-
-
-list_of_checks = [
-    check_get_max_compute_units,
-    check_get_max_work_item_dims,
-    check_get_max_work_item_sizes,
-    check_get_max_work_group_size,
-    check_get_max_num_sub_groups,
-    check_is_accelerator,
-    check_is_cpu,
-    check_is_gpu,
-    check_is_host,
-    check_has_aspect_host,
-    check_has_aspect_cpu,
-    check_has_aspect_gpu,
-    check_has_aspect_accelerator,
-    check_has_aspect_custom,
-    check_has_aspect_fp16,
-    check_has_aspect_fp64,
-    check_has_aspect_int64_base_atomics,
-    check_has_aspect_int64_extended_atomics,
-    check_has_aspect_image,
-    check_has_aspect_online_compiler,
-    check_has_aspect_online_linker,
-    check_has_aspect_queue_profiling,
-    check_has_aspect_usm_device_allocations,
-    check_has_aspect_usm_host_allocations,
-    check_has_aspect_usm_shared_allocations,
-    check_has_aspect_usm_restricted_shared_allocations,
-    check_has_aspect_usm_system_allocator,
-]
-
 
 @pytest.fixture(params=list_of_valid_filter_selectors)
 def valid_filter(request):
     return request.param
 
 
-@pytest.fixture(params=list_of_invalid_filter_selectors)
-def invalid_filter(request):
-    return request.param
-
-
-@pytest.fixture(params=list_of_standard_selectors)
-def device_selector(request):
-    return request.param
-
-
-@pytest.fixture(params=list_of_checks)
-def check(request):
-    return request.param
-
-
-def test_standard_selectors(device_selector, check):
+def test_ctxt_creation_from_filter(valid_filter):
     """
-    Tests if the standard SYCL device_selectors are able to select a device.
+    Test SyclContext creation using a filter selector string.
     """
     try:
-        device = device_selector()
-        if device.default_selector_score < 0:
-            pytest.skip()
-        ctx = dpctl.SyclContext(device)
-        devs = ctx.get_devices()
-        assert len(devs) == 1
-        check(devs[0])
-    except ValueError:
-        pytest.skip()
-
-
-def test_current_device(check):
-    """
-    Test is the device for the current queue is valid.
-    """
-    try:
-        q = dpctl.get_current_queue()
-    except Exception:
-        pytest.fail("Encountered an exception inside get_current_queue().")
-    ctx = q.get_sycl_context()
-    devs = ctx.get_devices()
-    # add check that device is among devs
-    check(devs[0])
-
-
-def test_valid_filter_selectors(valid_filter, check):
-    """
-    Tests if we can create a SyclDevice using a supported filter selector
-    string.
-    """
-    device = None
-    try:
-        ctx = dpctl.SyclContext(valid_filter)
-        device = ctx.get_devices()
+        dpctl.SyclContext(valid_filter)
     except ValueError:
         pytest.skip("Failed to create context with supported filter")
-    check(device[0])
 
 
-def test_invalid_filter_selectors(invalid_filter):
+def test_address_of():
     """
-    An invalid filter string should always be caught and a
-    SyclQueueCreationError raised.
+    Test if the address_of method returns an int value.
     """
-    with pytest.raises(ValueError):
-        dpctl.SyclContext(invalid_filter)
+    ctx = dpctl.SyclContext()
+    assert ctx.addressof_ref() is not None
+    assert isinstance(ctx.addressof_ref(), int)
 
 
 def test_context_not_equals():
+    """
+    Test if context equality fails when devices in different contexts are
+    compared.
+    """
     try:
         ctx_gpu = dpctl.SyclContext("gpu")
     except ValueError:
@@ -358,6 +78,15 @@ def test_context_not_equals():
     assert ctx_cpu != ctx_gpu
 
 
+def test_context_not_equals2():
+    """
+    Test if comparing a SyclContext object to some random Python object is
+    correctly handled and returns False.
+    """
+    ctx = dpctl.SyclContext()
+    assert ctx != "some context"
+
+
 def test_context_equals():
     try:
         ctx1 = dpctl.SyclContext("gpu")
@@ -365,6 +94,22 @@ def test_context_equals():
     except ValueError:
         pytest.skip()
     assert ctx0 == ctx1
+
+
+def test_name():
+    """
+    Test if a __name__ method is defined for SyclContext.
+    """
+    ctx = dpctl.SyclContext()
+    assert ctx.__name__ == "SyclContext"
+
+
+def test_repr():
+    """
+    Test if a __repr__ method is defined for SyclContext.
+    """
+    ctx = dpctl.SyclContext()
+    assert ctx.__repr__ is not None
 
 
 def test_context_can_be_used_in_queue(valid_filter):


### PR DESCRIPTION
Closes #484 

- Fixes a typo in the `addressof_ref` function of `SyclContext` that was causing an `AttributeError` and added a unit test for the member.
- Also, added missing unit tests for `SyclContext` and removed the duplicate tests that were copied over from `SyclDevice`.