### PR TITLE
Defines __hash__ for all classes that define __eq__ method.

### DIFF
--- a/dpctl/_sycl_context.pyx
+++ b/dpctl/_sycl_context.pyx
@@ -337,6 +337,14 @@ cdef class SyclContext(_SyclContext):
         else:
             return False
 
+    def __hash__(self):
+        """
+        Return a Py_ssize_t hash value by using the address of the
+        ``DPCTLSyclContextRef`` pointer stored in ``self._ctxt_ref``.
+
+        """
+        return hash(self.addressof_ref())
+
     cdef DPCTLSyclContextRef get_context_ref(self):
         return self._ctxt_ref
 

--- a/dpctl/_sycl_device.pyx
+++ b/dpctl/_sycl_device.pyx
@@ -709,6 +709,14 @@ cdef class SyclDevice(_SyclDevice):
             + "] at {}>".format(hex(id(self)))
         )
 
+    def __hash__(self):
+        """
+        Return a Py_ssize_t hash value by using the address of the
+        ``DPCTLSyclDeviceRef`` pointer stored in ``self._device_ref``.
+
+        """
+        return hash(self.addressof_ref())
+
     cdef list create_sub_devices_equally(self, size_t count):
         """ Returns a list of sub-devices partitioned from this SYCL device
             based on the ``count`` parameter.

--- a/dpctl/_sycl_queue.pyx
+++ b/dpctl/_sycl_queue.pyx
@@ -865,6 +865,14 @@ cdef class SyclQueue(_SyclQueue):
         else:
             return "<dpctl." + self.__name__ + " at {}>".format(hex(id(self)))
 
+    def __hash__(self):
+        """
+        Return a Py_ssize_t hash value by using the address of the
+        ``DPCTLSyclQueueRef`` pointer stored in ``self._queue_ref``.
+
+        """
+        return hash(self.addressof_ref())
+
     def _get_capsule(self):
         cdef DPCTLSyclQueueRef QRef = NULL
         QRef = DPCTLQueue_Copy(self._queue_ref)

--- a/dpctl/tests/test_sycl_context.py
+++ b/dpctl/tests/test_sycl_context.py
@@ -412,3 +412,12 @@ def test_context_multi_device():
     shmem_1 = dpmem.MemoryUSMShared(256, queue=q1)
     shmem_2 = dpmem.MemoryUSMDevice(256, queue=q2)
     shmem_2.copy_from_device(shmem_1)
+
+
+def test_hashing_of_context():
+    """
+    Test that a SyclContext object can be used as a dictionary key.
+
+    """
+    ctx_dict = {dpctl.SyclContext(): "default_context"}
+    assert ctx_dict

--- a/dpctl/tests/test_sycl_device.py
+++ b/dpctl/tests/test_sycl_device.py
@@ -631,3 +631,12 @@ def test_filter_string_method():
                     )
                     d_r = dpctl.SyclDevice(dev_id)
                     assert d == d_r, "Failed "
+
+
+def test_hashing_of_device():
+    """
+    Test that a SyclDevice object can be used as a dictionary key.
+
+    """
+    device_dict = {dpctl.SyclDevice(): "default_device"}
+    assert device_dict

--- a/dpctl/tests/test_sycl_queue.py
+++ b/dpctl/tests/test_sycl_queue.py
@@ -369,3 +369,12 @@ def test_context_equals():
     ctx0 = gpuQ0.get_sycl_context()
     ctx1 = gpuQ1.get_sycl_context()
     assert ctx0 == ctx1
+
+
+def test_hashing_of_queue():
+    """
+    Test that a SyclQueue object can be used as a dictionary key.
+
+    """
+    queue_dict = {dpctl.SyclQueue(): "default_queue"}
+    assert queue_dict


### PR DESCRIPTION
  - SyclContext, SyclDevice, SyclQueue classes previously where
    not hashable. The PR defines __hash__ function based on the
    C API native pointer value stored in the classes.

Closes #483 