### PR TITLE
Fix a typo in the pytest configuration.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ omit = [
 [tool.pytest.ini.options]
 minversion = "6.0"
 norecursedirs= [
-    ".*", "*.egg*", "build", "dist", "conda.recipe",
+    ".*", "*.egg*", "build", "dist", "conda-recipe",
 ]
 addopts = [
     "--junitxml=junit.xml",


### PR DESCRIPTION
Pytest directory exclusion misnamed "conda-recipe" as "conda.recipe" in the pytproject.toml config. The PR fixes the typo.