### PR TITLE
Improve test coverage for dpctl_sycl_queue_interface

### DIFF
--- a/dpctl-capi/source/dpctl_sycl_program_interface.cpp
+++ b/dpctl-capi/source/dpctl_sycl_program_interface.cpp
@@ -164,13 +164,16 @@ createLevelZeroInterOpProgram(const context &SyclCtx,
 
     auto stZeModuleCreateF = getZeModuleCreateFn();
 
-    if (!stZeModuleCreateF)
+    if (!stZeModuleCreateF) {
+        std::cerr << "ZeModuleCreateFn is invalid.\n";
         return nullptr;
+    }
 
     auto ret =
         stZeModuleCreateF(ZeCtx, ZeDevice, &ZeModuleDesc, &ZeModule, nullptr);
     if (ret != ZE_RESULT_SUCCESS) {
         // TODO: handle error
+        std::cerr << "ZeModule creation failed.\n";
         return nullptr;
     }
 
@@ -199,6 +202,8 @@ DPCTLProgram_CreateFromSpirv(__dpctl_keep const DPCTLSyclContextRef CtxRef,
     context *SyclCtx = nullptr;
     if (!CtxRef) {
         // \todo handle error
+        std::cerr << "Cannot create program from SPIR-V as the supplied SYCL "
+                     "context is NULL.\n";
         return Pref;
     }
     SyclCtx = unwrap(CtxRef);

--- a/dpctl-capi/source/dpctl_sycl_queue_interface.cpp
+++ b/dpctl-capi/source/dpctl_sycl_queue_interface.cpp
@@ -294,14 +294,18 @@ bool DPCTLQueue_AreEq(__dpctl_keep const DPCTLSyclQueueRef QRef1,
 DPCTLSyclBackendType DPCTLQueue_GetBackend(__dpctl_keep DPCTLSyclQueueRef QRef)
 {
     auto Q = unwrap(QRef);
-    try {
-        auto C = Q->get_context();
-        return DPCTLContext_GetBackend(wrap(&C));
-    } catch (runtime_error &re) {
-        std::cerr << re.what() << '\n';
-        // store error message
-        return DPCTL_UNKNOWN_BACKEND;
+    if (Q) {
+        try {
+            auto C = Q->get_context();
+            return DPCTLContext_GetBackend(wrap(&C));
+        } catch (runtime_error &re) {
+            std::cerr << re.what() << '\n';
+            // store error message
+            return DPCTL_UNKNOWN_BACKEND;
+        }
     }
+    else
+        return DPCTL_UNKNOWN_BACKEND;
 }
 
 __dpctl_give DPCTLSyclDeviceRef
@@ -327,8 +331,13 @@ __dpctl_give DPCTLSyclContextRef
 DPCTLQueue_GetContext(__dpctl_keep const DPCTLSyclQueueRef QRef)
 {
     auto Q = unwrap(QRef);
-    auto Context = new context(Q->get_context());
-    return wrap(Context);
+    DPCTLSyclContextRef CRef = nullptr;
+    if (Q)
+        CRef = wrap(new context(Q->get_context()));
+    else {
+        std::cerr << "Could not get the context for this queue.\n";
+    }
+    return CRef;
 }
 
 __dpctl_give DPCTLSyclEventRef

--- a/dpctl-capi/tests/test_sycl_queue_submit.cpp
+++ b/dpctl-capi/tests/test_sycl_queue_submit.cpp
@@ -1,0 +1,125 @@
+//===-- test_sycl_queue_submit.cpp - Test cases for kernel submission fns. ===//
+//
+//                      Data Parallel Control (dpctl)
+//
+// Copyright 2020-2021 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// This file has unit test cases for the various submit functions defined
+/// inside dpctl_sycl_queue_interface.cpp.
+//===----------------------------------------------------------------------===//
+
+#include "Support/CBindingWrapping.h"
+#include "dpctl_sycl_context_interface.h"
+#include "dpctl_sycl_device_interface.h"
+#include "dpctl_sycl_device_selector_interface.h"
+#include "dpctl_sycl_event_interface.h"
+#include "dpctl_sycl_kernel_interface.h"
+#include "dpctl_sycl_program_interface.h"
+#include "dpctl_sycl_queue_interface.h"
+#include "dpctl_sycl_usm_interface.h"
+#include <CL/sycl.hpp>
+#include <filesystem>
+#include <fstream>
+#include <gtest/gtest.h>
+
+namespace
+{
+constexpr size_t SIZE = 1024;
+DEFINE_SIMPLE_CONVERSION_FUNCTIONS(void, DPCTLSyclUSMRef);
+} /* end of anonymous namespace */
+
+struct TestQueueSubmit : public ::testing::Test
+{
+    std::ifstream spirvFile;
+    size_t spirvFileSize;
+    std::vector<char> spirvBuffer;
+
+    TestQueueSubmit()
+    {
+        spirvFile.open("./multi_kernel.spv", std::ios::binary | std::ios::ate);
+        spirvFileSize = std::filesystem::file_size("./multi_kernel.spv");
+        spirvBuffer.reserve(spirvFileSize);
+        spirvFile.seekg(0, std::ios::beg);
+        spirvFile.read(spirvBuffer.data(), spirvFileSize);
+    }
+
+    ~TestQueueSubmit()
+    {
+        spirvFile.close();
+    }
+};
+
+TEST_F(TestQueueSubmit, CheckSubmitRange_saxpy)
+{
+    DPCTLSyclDeviceSelectorRef DSRef = nullptr;
+    DPCTLSyclDeviceRef DRef = nullptr;
+
+    EXPECT_NO_FATAL_FAILURE(DSRef = DPCTLDefaultSelector_Create());
+    EXPECT_NO_FATAL_FAILURE(DRef = DPCTLDevice_CreateFromSelector(DSRef));
+    DPCTLDeviceMgr_PrintDeviceInfo(DRef);
+    ASSERT_TRUE(DRef);
+    auto QRef =
+        DPCTLQueue_CreateForDevice(DRef, nullptr, DPCTL_DEFAULT_PROPERTY);
+    ASSERT_TRUE(QRef);
+    auto CRef = DPCTLQueue_GetContext(QRef);
+    ASSERT_TRUE(CRef);
+    auto PRef = DPCTLProgram_CreateFromSpirv(CRef, spirvBuffer.data(),
+                                             spirvFileSize, nullptr);
+    ASSERT_TRUE(PRef != nullptr);
+    ASSERT_TRUE(DPCTLProgram_HasKernel(PRef, "axpy"));
+    auto AxpyKernel = DPCTLProgram_GetKernel(PRef, "axpy");
+
+    // Create the input args
+    auto a = DPCTLmalloc_shared(SIZE * sizeof(float), QRef);
+    ASSERT_TRUE(a != nullptr);
+    auto b = DPCTLmalloc_shared(SIZE * sizeof(float), QRef);
+    ASSERT_TRUE(b != nullptr);
+    auto c = DPCTLmalloc_shared(SIZE * sizeof(float), QRef);
+    ASSERT_TRUE(c != nullptr);
+
+    auto a_ptr = reinterpret_cast<float *>(unwrap(a));
+    auto b_ptr = reinterpret_cast<float *>(unwrap(b));
+    // Initialize a,b
+    for (auto i = 0ul; i < SIZE; ++i) {
+        a_ptr[i] = i + 1.0;
+        b_ptr[i] = i + 2.0;
+    }
+
+    // Create kernel args for axpy
+    float d = 10.0;
+    size_t Range[] = {SIZE};
+    void *args2[4] = {unwrap(a), unwrap(b), unwrap(c), (void *)&d};
+    DPCTLKernelArgType addKernelArgTypes[] = {DPCTL_VOID_PTR, DPCTL_VOID_PTR,
+                                              DPCTL_VOID_PTR, DPCTL_FLOAT};
+    auto ERef = DPCTLQueue_SubmitRange(
+        AxpyKernel, QRef, args2, addKernelArgTypes, 4, Range, 1, nullptr, 0);
+    ASSERT_TRUE(ERef != nullptr);
+    DPCTLQueue_Wait(QRef);
+
+    // clean ups
+    DPCTLEvent_Delete(ERef);
+    DPCTLKernel_Delete(AxpyKernel);
+    DPCTLfree_with_queue((DPCTLSyclUSMRef)a, QRef);
+    DPCTLfree_with_queue((DPCTLSyclUSMRef)b, QRef);
+    DPCTLfree_with_queue((DPCTLSyclUSMRef)c, QRef);
+    DPCTLQueue_Delete(QRef);
+    DPCTLContext_Delete(CRef);
+    DPCTLProgram_Delete(PRef);
+    DPCTLDevice_Delete(DRef);
+    DPCTLDeviceSelector_Delete(DSRef);
+}


### PR DESCRIPTION
Improvements to dpctl_c_api

- Add missing checks to `dpctl_sycl_queue_interface.cpp`
- Add error messages to `dpctl_sycl_program_interface.cpp` inside the level-zero module creation function.
- Refactor the unit tests for `dpctl_sycl_queue_interface.cpp` introducing negative test cases.
- Moved the queue submit test cases into a separate source file.

Note - Unit tests for `DPCTLQueue_Memcpy` and family are not added here. I will be adding them in a separate PR.