### PR TITLE
Use pytest.warns in test_lsplatform3

### DIFF
--- a/dpctl/tests/test_sycl_platform.py
+++ b/dpctl/tests/test_sycl_platform.py
@@ -156,7 +156,8 @@ def test_lsplatform2():
 
 def test_lsplatform3():
     try:
-        dpctl.lsplatform(3)
+        with pytest.warns(UserWarning):
+            dpctl.lsplatform(3)
     except Exception:
         pytest.fail("Encountered an exception inside lsplatform().")
 


### PR DESCRIPTION
The test `test_lsplatform3` should be expecting the warning.

This way the test suite passes even with ``-W error::UserWarning``