### PR TITLE
Add a new DPCTLEvent_GetBackend function

### DIFF
--- a/dpctl-capi/include/dpctl_sycl_event_interface.h
+++ b/dpctl-capi/include/dpctl_sycl_event_interface.h
@@ -29,6 +29,7 @@
 #include "Support/ExternC.h"
 #include "Support/MemOwnershipAttrs.h"
 #include "dpctl_data_types.h"
+#include "dpctl_sycl_enum_types.h"
 #include "dpctl_sycl_types.h"
 
 DPCTL_C_EXTERN_C_BEGIN
@@ -77,5 +78,17 @@ void DPCTLEvent_Delete(__dpctl_take DPCTLSyclEventRef ERef);
 DPCTL_API
 __dpctl_give DPCTLSyclEventRef
 DPCTLEvent_Copy(__dpctl_keep const DPCTLSyclEventRef ERef);
+
+/*!
+ * @brief  Returns a DPCTLSyclBackendType enum value identifying the SYCL
+ * backend associated with the event.
+ *
+ * @param    ERef           Opaque pointer to a ``sycl::event``
+ * @return   A DPCTLSyclBackendType enum value identifying the SYCL backend
+ * associated with the event.
+ * @ingroup EventInterface
+ */
+DPCTL_API
+DPCTLSyclBackendType DPCTLEvent_GetBackend(__dpctl_keep DPCTLSyclEventRef ERef);
 
 DPCTL_C_EXTERN_C_END

--- a/dpctl-capi/source/dpctl_sycl_event_interface.cpp
+++ b/dpctl-capi/source/dpctl_sycl_event_interface.cpp
@@ -25,6 +25,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "dpctl_sycl_event_interface.h"
+#include "../helper/include/dpctl_utils_helper.h"
 #include "Support/CBindingWrapping.h"
 #include <CL/sycl.hpp> /* SYCL headers   */
 
@@ -76,4 +77,17 @@ DPCTLEvent_Copy(__dpctl_keep DPCTLSyclEventRef ERef)
         std::cerr << ba.what() << '\n';
         return nullptr;
     }
+}
+
+DPCTLSyclBackendType DPCTLEvent_GetBackend(__dpctl_keep DPCTLSyclEventRef ERef)
+{
+    DPCTLSyclBackendType BTy = DPCTLSyclBackendType::DPCTL_UNKNOWN_BACKEND;
+    auto E = unwrap(ERef);
+    if (E) {
+        BTy = DPCTL_SyclBackendToDPCTLBackendType(E->get_backend());
+    }
+    else {
+        std::cerr << "Backend cannot be looked up for a NULL event\n";
+    }
+    return BTy;
 }

--- a/dpctl-capi/tests/test_sycl_event_interface.cpp
+++ b/dpctl-capi/tests/test_sycl_event_interface.cpp
@@ -72,3 +72,31 @@ TEST_F(TestDPCTLSyclEventInterface, CheckCopy_Invalid)
     EXPECT_NO_FATAL_FAILURE(DPCTLEvent_Delete(E1));
     EXPECT_NO_FATAL_FAILURE(DPCTLEvent_Delete(E2));
 }
+
+TEST_F(TestDPCTLSyclEventInterface, CheckEvent_GetBackend)
+{
+    DPCTLSyclBackendType BTy = DPCTLSyclBackendType::DPCTL_UNKNOWN_BACKEND;
+    EXPECT_NO_FATAL_FAILURE(BTy = DPCTLEvent_GetBackend(ERef));
+    EXPECT_TRUE([BTy] {
+        switch (BTy) {
+        case DPCTLSyclBackendType::DPCTL_CUDA:
+            return true;
+        case DPCTLSyclBackendType::DPCTL_HOST:
+            return true;
+        case DPCTLSyclBackendType::DPCTL_LEVEL_ZERO:
+            return true;
+        case DPCTLSyclBackendType::DPCTL_OPENCL:
+            return true;
+        default:
+            return false;
+        }
+    }());
+}
+
+TEST_F(TestDPCTLSyclEventInterface, CheckGetBackend_Invalid)
+{
+    DPCTLSyclEventRef E = nullptr;
+    DPCTLSyclBackendType Bty = DPCTL_UNKNOWN_BACKEND;
+    EXPECT_NO_FATAL_FAILURE(Bty = DPCTLEvent_GetBackend(E));
+    EXPECT_TRUE(Bty == DPCTL_UNKNOWN_BACKEND);
+}


### PR DESCRIPTION
This PR adds the DPCTLEvent_GetBackend function which returns the DPCTLSyclBackendType enum value identifying the SYCL backend associated with the event.