### PR TITLE
Add a new DPCTLEvent_WaitAndThrow function 

### DIFF
--- a/dpctl-capi/include/dpctl_sycl_event_interface.h
+++ b/dpctl-capi/include/dpctl_sycl_event_interface.h
@@ -58,6 +58,15 @@ DPCTL_API
 void DPCTLEvent_Wait(__dpctl_keep DPCTLSyclEventRef ERef);
 
 /*!
+ * @brief C-API wrapper for 'sycl::event.wait_and_throw'.
+ *
+ * @param    ERef           Opaque pointer to a ``sycl::event``
+ * @ingroup EventInterface
+ */
+DPCTL_API
+void DPCTLEvent_WaitAndThrow(__dpctl_keep DPCTLSyclEventRef ERef);
+
+/*!
  * @brief Deletes the DPCTLSyclEventRef after casting it to a ``sycl::event``.
  *
  * @param    ERef           An opaque DPCTLSyclEventRef pointer that would be

--- a/dpctl-capi/source/dpctl_sycl_event_interface.cpp
+++ b/dpctl-capi/source/dpctl_sycl_event_interface.cpp
@@ -63,6 +63,20 @@ void DPCTLEvent_Wait(__dpctl_keep DPCTLSyclEventRef ERef)
     }
 }
 
+void DPCTLEvent_WaitAndThrow(__dpctl_keep DPCTLSyclEventRef ERef)
+{
+    if (ERef) {
+        auto SyclEvent = unwrap(ERef);
+        if (SyclEvent)
+            SyclEvent->wait_and_throw();
+    }
+    else {
+        std::cerr << "Cannot wait_and_throw for the event. DPCTLSyclEventRef "
+                     "as input is "
+                     "a nullptr\n";
+    }
+}
+
 void DPCTLEvent_Delete(__dpctl_take DPCTLSyclEventRef ERef)
 {
     delete unwrap(ERef);

--- a/dpctl-capi/tests/test_sycl_event_interface.cpp
+++ b/dpctl-capi/tests/test_sycl_event_interface.cpp
@@ -68,6 +68,18 @@ TEST_F(TestDPCTLSyclEventInterface, CheckWait_Invalid)
     EXPECT_NO_FATAL_FAILURE(DPCTLEvent_Delete(E));
 }
 
+TEST_F(TestDPCTLSyclEventInterface, CheckEvent_WaitAndThrow)
+{
+    EXPECT_NO_FATAL_FAILURE(DPCTLEvent_WaitAndThrow(ERef));
+}
+
+TEST_F(TestDPCTLSyclEventInterface, CheckWaitAndThrow_Invalid)
+{
+    DPCTLSyclEventRef E = nullptr;
+    EXPECT_NO_FATAL_FAILURE(DPCTLEvent_WaitAndThrow(E));
+    EXPECT_NO_FATAL_FAILURE(DPCTLEvent_Delete(E));
+}
+
 TEST_F(TestDPCTLSyclEventInterface, CheckEvent_Copy)
 {
     DPCTLSyclEventRef Copied_ERef = nullptr;


### PR DESCRIPTION
This PR adds a function `DPCTLEvent_GetWaitList` which waits for the event to complete and calls the asynchronous error handler