### PR TITLE
Use dpcpp compiler package for Linux

### DIFF
--- a/conda-recipe/build.sh
+++ b/conda-recipe/build.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 ${PYTHON} setup.py clean --all
-${PYTHON} setup.py install
+${PYTHON} setup.py install --sycl-compiler-prefix=$CONDA_PREFIX
 
 # Build wheel package
 if [ "$CONDA_PY" == "36" ]; then

--- a/conda-recipe/build.sh
+++ b/conda-recipe/build.sh
@@ -10,6 +10,14 @@ else
     WHEELS_BUILD_ARGS="-p manylinux2014_x86_64"
 fi
 if [ -n "${WHEELS_OUTPUT_FOLDER}" ]; then
+    # We need dpcpp to compile dpctl_sycl_interface
+    if [ ! -z "${ONEAPI_ROOT}" ]; then
+        # Suppress error b/c it could fail on Ubuntu 18.04
+        source ${ONEAPI_ROOT}/compiler/latest/env/vars.sh || true
+    else
+        echo "DPCPP is needed to build DPCTL. Abort!"
+        exit 1
+    fi
     $PYTHON setup.py bdist_wheel ${WHEELS_BUILD_ARGS}
     cp dist/dpctl*.whl ${WHEELS_OUTPUT_FOLDER}
 fi

--- a/conda-recipe/build.sh
+++ b/conda-recipe/build.sh
@@ -1,14 +1,5 @@
 #!/bin/bash
 
-# We need dpcpp to compile dpctl_sycl_interface
-if [ ! -z "${ONEAPI_ROOT}" ]; then
-    # Suppress error b/c it could fail on Ubuntu 18.04
-    source ${ONEAPI_ROOT}/compiler/latest/env/vars.sh || true
-else
-    echo "DPCPP is needed to build DPCTL. Abort!"
-    exit 1
-fi
-
 ${PYTHON} setup.py clean --all
 ${PYTHON} setup.py install
 

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -28,7 +28,7 @@ requirements:
     run:
         - python
         - numpy >=1.17
-        - dpcpp_cpp_rt >=2021.2  # [not linux]
+        - dpcpp_cpp_rt >=2021.2
 
 test:
     requires:

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -8,7 +8,7 @@ source:
 build:
     number: {{ GIT_DESCRIBE_NUMBER }}
     script_env:
-        - ONEAPI_ROOT  # [not linux]
+        - ONEAPI_ROOT  # for wheel on Linux
         - WHEELS_OUTPUT_FOLDER
 
 requirements:

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -1,7 +1,5 @@
-{% set name = "dpctl" %}
-
 package:
-    name: {{ name|lower }}
+    name: dpctl
     version: {{ GIT_DESCRIBE_TAG }}
 
 source:
@@ -10,12 +8,13 @@ source:
 build:
     number: {{ GIT_DESCRIBE_NUMBER }}
     script_env:
-        - ONEAPI_ROOT
+        - ONEAPI_ROOT  # [not linux]
         - WHEELS_OUTPUT_FOLDER
 
 requirements:
     build:
         - {{ compiler('cxx') }}
+        - {{ compiler('dpcpp') }}  # [linux]
     host:
         - setuptools
         - cython
@@ -29,7 +28,7 @@ requirements:
     run:
         - python
         - numpy >=1.17
-        - dpcpp_cpp_rt >=2021.2
+        - dpcpp_cpp_rt >=2021.2  # [not linux]
 
 test:
     requires:


### PR DESCRIPTION
Now dpcpp_linux-64 compiler is available on `-c intel`. It is not necessary to install oneAPI.
This PR uses dpcpp compiler package instead of using oneAPI.
Only for Linux.