### PR TITLE
Add a new DPCTLEvent_GetCommandExecutionStatus function

### DIFF
--- a/dpctl-capi/helper/include/dpctl_utils_helper.h
+++ b/dpctl-capi/helper/include/dpctl_utils_helper.h
@@ -196,3 +196,16 @@ DPCTLPartitionAffinityDomainType DPCTL_SyclPartitionAffinityDomainToDPCTLType(
  */
 DPCTL_API
 int64_t DPCTL_GetRelativeDeviceId(const sycl::device &Device);
+
+/*!
+ * @brief Converts a ``sycl::info::event_command_status`` enum value to
+ * corresponding DPCTLSyclEventStatusType enum value.
+ *
+ * @param    SyclESTy           ``sycl::info::event_command_status`` to be
+ * converted to DPCTLSyclEventStatusType enum.
+ * @return   A DPCTLSyclEventStatusType enum value for the input
+ * ``sycl::info::event_command_status`` enum value.
+ */
+DPCTL_API
+DPCTLSyclEventStatusType DPCTL_SyclEventStatusToDPCTLEventStatusType(
+    sycl::info::event_command_status SyclESTy);

--- a/dpctl-capi/helper/source/dpctl_utils_helper.cpp
+++ b/dpctl-capi/helper/source/dpctl_utils_helper.cpp
@@ -447,3 +447,18 @@ int64_t DPCTL_GetRelativeDeviceId(const device &Device)
     }
     return relid;
 }
+
+DPCTLSyclEventStatusType
+DPCTL_SyclEventStatusToDPCTLEventStatusType(info::event_command_status E)
+{
+    switch (E) {
+    case info::event_command_status::submitted:
+        return DPCTLSyclEventStatusType::DPCTL_SUBMITTED;
+    case info::event_command_status::running:
+        return DPCTLSyclEventStatusType::DPCTL_RUNNING;
+    case info::event_command_status::complete:
+        return DPCTLSyclEventStatusType::DPCTL_COMPLETE;
+    default:
+        return DPCTLSyclEventStatusType::DPCTL_UNKNOWN_STATUS;
+    }
+}

--- a/dpctl-capi/include/dpctl_sycl_enum_types.h
+++ b/dpctl-capi/include/dpctl_sycl_enum_types.h
@@ -151,4 +151,12 @@ typedef enum
     // clang-format on
 } DPCTLQueuePropertyType;
 
+typedef enum
+{
+    DPCTL_UNKNOWN_STATUS,
+    DPCTL_SUBMITTED,
+    DPCTL_RUNNING,
+    DPCTL_COMPLETE
+} DPCTLSyclEventStatusType;
+
 DPCTL_C_EXTERN_C_END

--- a/dpctl-capi/include/dpctl_sycl_event_interface.h
+++ b/dpctl-capi/include/dpctl_sycl_event_interface.h
@@ -91,4 +91,16 @@ DPCTLEvent_Copy(__dpctl_keep const DPCTLSyclEventRef ERef);
 DPCTL_API
 DPCTLSyclBackendType DPCTLEvent_GetBackend(__dpctl_keep DPCTLSyclEventRef ERef);
 
+/*!
+ * @brief Returns the DPCTLSyclEventStatusType enum value for the
+ * DPCTLSyclEventRef argument.
+ *
+ * @param    ERef           Opaque pointer to a ``sycl::event``
+ * @return   The DPCTLSyclDEventStatusType value corresponding to the event.
+ * @ingroup EventInterface
+ */
+DPCTL_API
+DPCTLSyclEventStatusType
+DPCTLEvent_GetCommandExecutionStatus(__dpctl_keep DPCTLSyclEventRef ERef);
+
 DPCTL_C_EXTERN_C_END

--- a/dpctl-capi/source/dpctl_sycl_event_interface.cpp
+++ b/dpctl-capi/source/dpctl_sycl_event_interface.cpp
@@ -98,3 +98,22 @@ DPCTLSyclBackendType DPCTLEvent_GetBackend(__dpctl_keep DPCTLSyclEventRef ERef)
     }
     return BTy;
 }
+
+DPCTLSyclEventStatusType
+DPCTLEvent_GetCommandExecutionStatus(__dpctl_keep DPCTLSyclEventRef ERef)
+{
+    DPCTLSyclEventStatusType ESTy =
+        DPCTLSyclEventStatusType::DPCTL_UNKNOWN_STATUS;
+    auto E = unwrap(ERef);
+    if (E) {
+        try {
+            auto SyclESTy =
+                E->get_info<sycl::info::event::command_execution_status>();
+            ESTy = DPCTL_SyclEventStatusToDPCTLEventStatusType(SyclESTy);
+        } catch (runtime_error const &re) {
+            // \todo log error
+            std::cerr << re.what() << '\n';
+        }
+    }
+    return ESTy;
+}

--- a/dpctl-capi/tests/test_sycl_event_interface.cpp
+++ b/dpctl-capi/tests/test_sycl_event_interface.cpp
@@ -112,3 +112,12 @@ TEST_F(TestDPCTLSyclEventInterface, CheckGetBackend_Invalid)
     EXPECT_NO_FATAL_FAILURE(Bty = DPCTLEvent_GetBackend(E));
     EXPECT_TRUE(Bty == DPCTL_UNKNOWN_BACKEND);
 }
+
+TEST_F(TestDPCTLSyclEventInterface, ChkGetCommandExecutionStatus)
+{
+    DPCTLSyclEventStatusType ESTy =
+        DPCTLSyclEventStatusType::DPCTL_UNKNOWN_STATUS;
+    EXPECT_NO_FATAL_FAILURE(ESTy = DPCTLEvent_GetCommandExecutionStatus(ERef));
+    EXPECT_TRUE(ESTy != DPCTLSyclEventStatusType::DPCTL_UNKNOWN_STATUS);
+    EXPECT_TRUE(ESTy == DPCTLSyclEventStatusType::DPCTL_COMPLETE);
+}


### PR DESCRIPTION
This PR 
- adds the `DPCTLEvent_GetCommandExecutionStatus` function, which returns the value of the `DPCTLSyclEventStatusType` enumeration for the DPCTLSyclEventRef argument.
 - adds a new `DPCTLSyclEventStatusType` enumeration for all types from the [SYCL specification](https://www.khronos.org/registry/SYCL/specs/sycl-2020/html/sycl-2020.html#appendix.event.descriptors)
- adds `DPCTL_SyclEventStatusToDPCTLEventStatusType` converter function from `sycl:: info` to `DPCTLSyclEventStatusType` enumeration types

