### PR TITLE
Add 3 new functions for sycl::event::get_profiling_info

### DIFF
--- a/dpctl-capi/include/dpctl_sycl_event_interface.h
+++ b/dpctl-capi/include/dpctl_sycl_event_interface.h
@@ -112,4 +112,42 @@ DPCTL_API
 DPCTLSyclEventStatusType
 DPCTLEvent_GetCommandExecutionStatus(__dpctl_keep DPCTLSyclEventRef ERef);
 
+/*!
+ * @brief Wrapper over
+ * ``event.get_profiling_info<info::event_profiling::command_submit>()``
+ *
+ * @param    ERef           Opaque pointer to a ``sycl::event``
+ * @return   Returns a value describing the time in nanoseconds
+ * when the associated command group was submitted to the queue.
+ * @ingroup EventInterface
+ */
+DPCTL_API
+uint64_t DPCTLEvent_GetProfilingInfoSubmit(__dpctl_keep DPCTLSyclEventRef ERef);
+
+/*!
+ * @brief Wrapper over
+ * ``event.get_profiling_info<info::event_profiling::command_start>()``
+ *
+ * @param    ERef           Opaque pointer to a ``sycl::event``
+ * @return   Returns a value describing the time in nanoseconds
+ * when the action associated with the command group (e.g. kernel invocation)
+ * started executing on the device.
+ * @ingroup EventInterface
+ */
+DPCTL_API
+uint64_t DPCTLEvent_GetProfilingInfoStart(__dpctl_keep DPCTLSyclEventRef ERef);
+
+/*!
+ * @brief Wrapper over
+ * ``event.get_profiling_info<info::event_profiling::command_end>()``
+ *
+ * @param    ERef           Opaque pointer to a ``sycl::event``
+ * @return   Returns a value describing the time in nanoseconds
+ * when the action associated with the command group (e.g. kernel invocation)
+ * finished executing on the device.
+ * @ingroup EventInterface
+ */
+DPCTL_API
+uint64_t DPCTLEvent_GetProfilingInfoEnd(__dpctl_keep DPCTLSyclEventRef ERef);
+
 DPCTL_C_EXTERN_C_END

--- a/dpctl-capi/source/dpctl_sycl_event_interface.cpp
+++ b/dpctl-capi/source/dpctl_sycl_event_interface.cpp
@@ -131,3 +131,54 @@ DPCTLEvent_GetCommandExecutionStatus(__dpctl_keep DPCTLSyclEventRef ERef)
     }
     return ESTy;
 }
+
+uint64_t DPCTLEvent_GetProfilingInfoSubmit(__dpctl_keep DPCTLSyclEventRef ERef)
+{
+    uint64_t profilingInfoSubmit = 0;
+    auto E = unwrap(ERef);
+    if (E) {
+        try {
+            E->wait();
+            profilingInfoSubmit = E->get_profiling_info<
+                sycl::info::event_profiling::command_submit>();
+        } catch (invalid_object_error &e) {
+            // \todo log error
+            std::cerr << e.what() << '\n';
+        }
+    }
+    return profilingInfoSubmit;
+}
+
+uint64_t DPCTLEvent_GetProfilingInfoStart(__dpctl_keep DPCTLSyclEventRef ERef)
+{
+    uint64_t profilingInfoStart = 0;
+    auto E = unwrap(ERef);
+    if (E) {
+        try {
+            E->wait();
+            profilingInfoStart = E->get_profiling_info<
+                sycl::info::event_profiling::command_start>();
+        } catch (invalid_object_error &e) {
+            // \todo log error
+            std::cerr << e.what() << '\n';
+        }
+    }
+    return profilingInfoStart;
+}
+
+uint64_t DPCTLEvent_GetProfilingInfoEnd(__dpctl_keep DPCTLSyclEventRef ERef)
+{
+    uint64_t profilingInfoEnd = 0;
+    auto E = unwrap(ERef);
+    if (E) {
+        try {
+            E->wait();
+            profilingInfoEnd = E->get_profiling_info<
+                sycl::info::event_profiling::command_end>();
+        } catch (invalid_object_error &e) {
+            // \todo log error
+            std::cerr << e.what() << '\n';
+        }
+    }
+    return profilingInfoEnd;
+}

--- a/dpctl-capi/tests/test_sycl_event_interface.cpp
+++ b/dpctl-capi/tests/test_sycl_event_interface.cpp
@@ -133,3 +133,33 @@ TEST_F(TestDPCTLSyclEventInterface, ChkGetCommandExecutionStatus)
     EXPECT_TRUE(ESTy != DPCTLSyclEventStatusType::DPCTL_UNKNOWN_STATUS);
     EXPECT_TRUE(ESTy == DPCTLSyclEventStatusType::DPCTL_COMPLETE);
 }
+
+#ifndef DPCTL_COVERAGE
+TEST_F(TestDPCTLSyclEventInterface, CheckGetProfiling)
+{
+    property_list propList{property::queue::enable_profiling()};
+    queue Q(cpu_selector(), propList);
+    auto eA = Q.submit(
+        [&](handler &h) { h.parallel_for(1000, [=](id<1>) { /*...*/ }); });
+    DPCTLSyclEventRef ERef = reinterpret_cast<DPCTLSyclEventRef>(&eA);
+
+    auto eStart = DPCTLEvent_GetProfilingInfoStart(ERef);
+    auto eEnd = DPCTLEvent_GetProfilingInfoEnd(ERef);
+    auto eSubmit = DPCTLEvent_GetProfilingInfoSubmit(ERef);
+
+    EXPECT_TRUE(eStart);
+    EXPECT_TRUE(eEnd);
+    EXPECT_TRUE(eSubmit);
+}
+#endif
+
+TEST_F(TestDPCTLSyclEventInterface, CheckGetProfiling_Invalid)
+{
+    auto eStart = DPCTLEvent_GetProfilingInfoStart(ERef);
+    auto eEnd = DPCTLEvent_GetProfilingInfoEnd(ERef);
+    auto eSubmit = DPCTLEvent_GetProfilingInfoSubmit(ERef);
+
+    EXPECT_FALSE(eStart);
+    EXPECT_FALSE(eEnd);
+    EXPECT_FALSE(eSubmit);
+}


### PR DESCRIPTION
This PR adds 3 wrapper functions ( `DPCTLEvent_GetProfilingInfoStart`, `DPCTLEvent_GetProfilingInfoEnd`, `DPCTLEvent_GetProfilingInfoSubmit`) for `sycl::event::get_profiling_info()`. 