### PR TITLE
Add a `get_backend` method for the SyclEventRaw class

### DIFF
--- a/dpctl/_backend.pxd
+++ b/dpctl/_backend.pxd
@@ -228,6 +228,7 @@ cdef extern from "dpctl_sycl_event_interface.h":
     cdef void DPCTLEvent_Wait(DPCTLSyclEventRef ERef)
     cdef void DPCTLEvent_Delete(DPCTLSyclEventRef ERef)
     cdef _event_status_type DPCTLEvent_GetCommandExecutionStatus(DPCTLSyclEventRef ERef)
+    cdef _backend_type DPCTLEvent_GetBackend(DPCTLSyclEventRef ERef)
 
 
 cdef extern from "dpctl_sycl_kernel_interface.h":

--- a/dpctl/_sycl_event.pyx
+++ b/dpctl/_sycl_event.pyx
@@ -29,9 +29,11 @@ from ._backend cimport (  # noqa: E211
     DPCTLEvent_Copy,
     DPCTLEvent_Create,
     DPCTLEvent_Delete,
+    DPCTLEvent_GetBackend,
     DPCTLEvent_GetCommandExecutionStatus,
     DPCTLEvent_Wait,
     DPCTLSyclEventRef,
+    _backend_type,
     _event_status_type,
 )
 
@@ -222,3 +224,19 @@ cdef class SyclEventRaw(_SyclEventRaw):
             return event_status_type.complete
         else:
             raise ValueError("Unknown event status.")
+
+    @property
+    def backend(self):
+        """ Returns the Sycl backend associated with the event.
+        """
+        cdef _backend_type BE = DPCTLEvent_GetBackend(self._event_ref)
+        if BE == _backend_type._OPENCL:
+            return backend_type.opencl
+        elif BE == _backend_type._LEVEL_ZERO:
+            return backend_type.level_zero
+        elif BE == _backend_type._HOST:
+            return backend_type.host
+        elif BE == _backend_type._CUDA:
+            return backend_type.cuda
+        else:
+            raise ValueError("Unknown backend type.")

--- a/dpctl/tests/test_sycl_event.py
+++ b/dpctl/tests/test_sycl_event.py
@@ -80,3 +80,10 @@ def test_execution_status():
     except ValueError:
         pytest.fail("Failed to get an event status")
     assert event_status == esty.complete
+
+
+def test_backend():
+    try:
+        dpctl.SyclEventRaw().backend
+    except ValueError:
+        pytest.fail("Failed to get backend from event")


### PR DESCRIPTION
This PR will add a `get_backend` method for the `SyclEventRaw` class which returns the backend enum.