### PR TITLE
Add a `execution_status` method for the SyclEventRaw class

### DIFF
--- a/dpctl/__init__.py
+++ b/dpctl/__init__.py
@@ -65,7 +65,7 @@ from dpctl._sycl_queue_manager import (
 )
 
 from ._version import get_versions
-from .enum_types import backend_type, device_type
+from .enum_types import backend_type, device_type, event_status_type
 
 __all__ = [
     "SyclContext",
@@ -113,6 +113,7 @@ __all__ += [
 __all__ += [
     "device_type",
     "backend_type",
+    "event_status_type",
 ]
 __all__ += [
     "get_include",

--- a/dpctl/_backend.pxd
+++ b/dpctl/_backend.pxd
@@ -104,6 +104,12 @@ cdef extern from "dpctl_sycl_enum_types.h":
         _L1_cache                           'L1_cache',
         _next_partitionable                 'next_partitionable',
 
+    ctypedef enum _event_status_type 'DPCTLSyclEventStatusType':
+        _UNKNOWN_STATUS     'DPCTL_UNKNOWN_STATUS'
+        _SUBMITTED          'DPCTL_SUBMITTED'
+        _RUNNING            'DPCTL_RUNNING'
+        _COMPLETE           'DPCTL_COMPLETE'
+
 
 cdef extern from "dpctl_sycl_types.h":
     cdef struct DPCTLOpaqueSyclContext
@@ -221,6 +227,7 @@ cdef extern from "dpctl_sycl_event_interface.h":
     cdef DPCTLSyclEventRef DPCTLEvent_Copy(const DPCTLSyclEventRef ERef)
     cdef void DPCTLEvent_Wait(DPCTLSyclEventRef ERef)
     cdef void DPCTLEvent_Delete(DPCTLSyclEventRef ERef)
+    cdef _event_status_type DPCTLEvent_GetCommandExecutionStatus(DPCTLSyclEventRef ERef)
 
 
 cdef extern from "dpctl_sycl_kernel_interface.h":

--- a/dpctl/_sycl_event.pyx
+++ b/dpctl/_sycl_event.pyx
@@ -29,9 +29,13 @@ from ._backend cimport (  # noqa: E211
     DPCTLEvent_Copy,
     DPCTLEvent_Create,
     DPCTLEvent_Delete,
+    DPCTLEvent_GetCommandExecutionStatus,
     DPCTLEvent_Wait,
     DPCTLSyclEventRef,
+    _event_status_type,
 )
+
+from .enum_types import backend_type, event_status_type
 
 __all__ = [
     "SyclEvent",
@@ -202,3 +206,19 @@ cdef class SyclEventRaw(_SyclEventRaw):
             "SyclEventRef",
             &_event_capsule_deleter
         )
+
+    @property
+    def execution_status(self):
+        """ Returns the event status.
+        """
+        cdef _event_status_type ESTy = DPCTLEvent_GetCommandExecutionStatus(
+                                        self._event_ref
+        )
+        if ESTy == _event_status_type._SUBMITTED:
+            return event_status_type.submitted
+        elif ESTy == _event_status_type._RUNNING:
+            return event_status_type.running
+        elif ESTy == _event_status_type._COMPLETE:
+            return event_status_type.complete
+        else:
+            raise ValueError("Unknown event status.")

--- a/dpctl/enum_types.py
+++ b/dpctl/enum_types.py
@@ -25,6 +25,7 @@ from enum import Enum, auto
 __all__ = [
     "device_type",
     "backend_type",
+    "event_status_type",
 ]
 
 
@@ -71,3 +72,11 @@ class backend_type(Enum):
     host = auto()
     level_zero = auto()
     opencl = auto()
+
+
+class event_status_type(Enum):
+
+    unknown_status = auto()
+    submitted = auto()
+    running = auto()
+    complete = auto()

--- a/dpctl/tests/test_sycl_event.py
+++ b/dpctl/tests/test_sycl_event.py
@@ -23,6 +23,7 @@ import pytest
 import dpctl
 import dpctl.memory as dpctl_mem
 import dpctl.program as dpctl_prog
+from dpctl import event_status_type as esty
 
 from ._helper import has_cpu
 
@@ -70,3 +71,12 @@ def test_create_event_raw_from_capsule():
         dpctl.SyclEventRaw(event_capsule)
     except ValueError:
         pytest.fail("Failed to create an event from capsule")
+
+
+def test_execution_status():
+    event = dpctl.SyclEventRaw()
+    try:
+        event_status = event.execution_status
+    except ValueError:
+        pytest.fail("Failed to get an event status")
+    assert event_status == esty.complete


### PR DESCRIPTION
This PR adds the  `execution_status`  method which returns the value of the 'event_status_type' enumeration.