### PR TITLE
Add 3 methods of the SyclEventRaw class for profiling

### DIFF
--- a/dpctl/_backend.pxd
+++ b/dpctl/_backend.pxd
@@ -21,7 +21,7 @@
 types defined by dpctl's C API.
 """
 
-from libc.stdint cimport int64_t, uint32_t
+from libc.stdint cimport int64_t, uint32_t, uint64_t
 from libcpp cimport bool
 
 
@@ -238,6 +238,9 @@ cdef extern from "dpctl_sycl_event_interface.h":
         size_t index)
     cdef DPCTLEventVectorRef DPCTLEvent_GetWaitList(
         DPCTLSyclEventRef ERef)
+    cdef uint64_t DPCTLEvent_GetProfilingInfoSubmit(DPCTLSyclEventRef ERef)
+    cdef uint64_t DPCTLEvent_GetProfilingInfoStart(DPCTLSyclEventRef ERef)
+    cdef uint64_t DPCTLEvent_GetProfilingInfoEnd(DPCTLSyclEventRef ERef)
 
 
 cdef extern from "dpctl_sycl_kernel_interface.h":

--- a/dpctl/_sycl_event.pyx
+++ b/dpctl/_sycl_event.pyx
@@ -24,6 +24,7 @@
 import logging
 
 from cpython cimport pycapsule
+from libc.stdint cimport uint64_t
 
 from ._backend cimport (  # noqa: E211
     DPCTLEvent_Copy,
@@ -31,6 +32,9 @@ from ._backend cimport (  # noqa: E211
     DPCTLEvent_Delete,
     DPCTLEvent_GetBackend,
     DPCTLEvent_GetCommandExecutionStatus,
+    DPCTLEvent_GetProfilingInfoEnd,
+    DPCTLEvent_GetProfilingInfoStart,
+    DPCTLEvent_GetProfilingInfoSubmit,
     DPCTLEvent_GetWaitList,
     DPCTLEvent_Wait,
     DPCTLEventVector_Delete,
@@ -260,3 +264,22 @@ cdef class SyclEventRaw(_SyclEventRaw):
             events.append(SyclEventRaw._create(ERef))
         DPCTLEventVector_Delete(EVRef)
         return events
+
+    def profiling_info_submit(self):
+        cdef uint64_t profiling_info_submit = 0
+        profiling_info_submit = DPCTLEvent_GetProfilingInfoSubmit(
+                                self._event_ref
+        )
+        return profiling_info_submit
+
+    @property
+    def profiling_info_start(self):
+        cdef uint64_t profiling_info_start = 0
+        profiling_info_start = DPCTLEvent_GetProfilingInfoStart(self._event_ref)
+        return profiling_info_start
+
+    @property
+    def profiling_info_end(self):
+        cdef uint64_t profiling_info_end = 0
+        profiling_info_end = DPCTLEvent_GetProfilingInfoEnd(self._event_ref)
+        return profiling_info_end


### PR DESCRIPTION
This PR adds 3 methods (`profiling_info_submit`. `profiling_info_start`. `profiling_info_end`) for the `SyclEventRaw` class that return a value describing the time in nanoseconds.