### PR TITLE
Feature/submit barrier

### DIFF
--- a/dpctl-capi/include/dpctl_sycl_queue_interface.h
+++ b/dpctl-capi/include/dpctl_sycl_queue_interface.h
@@ -343,4 +343,32 @@ bool DPCTLQueue_IsInOrder(__dpctl_keep const DPCTLSyclQueueRef QRef);
 DPCTL_API
 size_t DPCTLQueue_Hash(__dpctl_keep const DPCTLSyclQueueRef QRef);
 
+/*!
+ * @brief C-API wraper for ``sycl::queue::submit_barrier()``.
+ *
+ * @param    QRef    An opaque pointer to the ``sycl::queue``.
+ * @return   An opaque pointer to the ``sycl::event`` returned by the
+ *           ``sycl::queue::submit_barrier()`` function.
+ */
+DPCTL_API
+DPCTLSyclEventRef
+DPCTLQueue_SubmitBarrier(__dpctl_keep const DPCTLSyclQueueRef QRef);
+
+/*!
+ * @brief C-API wraper for ``sycl::queue::submit_barrier(event_vector)``.
+ *
+ * @param    QRef    An opaque pointer to the ``sycl::queue``.
+ * @param    DepEvents     List of dependent DPCTLSyclEventRef objects (events)
+ *                         for the barrier. We call ``sycl::handler.depends_on``
+ *                         for each of the provided events.
+ * @param    NDepEvents    Size of the DepEvents list.
+ * @return   An opaque pointer to the ``sycl::event`` returned by the
+ *           ``sycl::queue::submit_barrier()`` function.
+ */
+DPCTL_API
+DPCTLSyclEventRef DPCTLQueue_SubmitBarrierForEvents(
+    __dpctl_keep const DPCTLSyclQueueRef QRef,
+    __dpctl_keep const DPCTLSyclEventRef *DepEvents,
+    size_t NDepEvents);
+
 DPCTL_C_EXTERN_C_END

--- a/dpctl-capi/tests/test_sycl_queue_submit.cpp
+++ b/dpctl-capi/tests/test_sycl_queue_submit.cpp
@@ -356,4 +356,56 @@ TEST_F(TestQueueSubmitNDRange, ChkSubmitNDRangeDouble)
     EXPECT_TRUE(worked);
 }
 
+struct TestQueueSubmitBarrier : public ::testing::Test
+{
+    DPCTLSyclQueueRef QRef = nullptr;
+
+    TestQueueSubmitBarrier()
+    {
+        DPCTLSyclDeviceSelectorRef DSRef = nullptr;
+        DPCTLSyclDeviceRef DRef = nullptr;
+
+        EXPECT_NO_FATAL_FAILURE(DSRef = DPCTLDefaultSelector_Create());
+        EXPECT_NO_FATAL_FAILURE(DRef = DPCTLDevice_CreateFromSelector(DSRef));
+        EXPECT_NO_FATAL_FAILURE(QRef = DPCTLQueue_CreateForDevice(
+                                    DRef, nullptr, DPCTL_DEFAULT_PROPERTY));
+        EXPECT_NO_FATAL_FAILURE(DPCTLDevice_Delete(DRef));
+        EXPECT_NO_FATAL_FAILURE(DPCTLDeviceSelector_Delete(DSRef));
+    }
+    ~TestQueueSubmitBarrier()
+    {
+        EXPECT_NO_FATAL_FAILURE(DPCTLQueue_Delete(QRef));
+    }
+};
+
+TEST_F(TestQueueSubmitBarrier, ChkSubmitBarrier)
+{
+    DPCTLSyclEventRef ERef = nullptr;
+
+    ASSERT_TRUE(QRef != nullptr);
+    EXPECT_NO_FATAL_FAILURE(ERef = DPCTLQueue_SubmitBarrier(QRef));
+    ASSERT_TRUE(ERef != nullptr);
+    EXPECT_NO_FATAL_FAILURE(DPCTLEvent_Wait(ERef));
+    EXPECT_NO_FATAL_FAILURE(DPCTLEvent_Delete(ERef));
+}
+
+TEST_F(TestQueueSubmitBarrier, ChkSubmitBarrierWithEvents)
+{
+    DPCTLSyclEventRef ERef = nullptr;
+    DPCTLSyclEventRef DepsERefs[2] = {nullptr, nullptr};
+
+    EXPECT_NO_FATAL_FAILURE(DepsERefs[0] = DPCTLEvent_Create());
+    EXPECT_NO_FATAL_FAILURE(DepsERefs[1] = DPCTLEvent_Create());
+
+    ASSERT_TRUE(QRef != nullptr);
+    EXPECT_NO_FATAL_FAILURE(
+        ERef = DPCTLQueue_SubmitBarrierForEvents(QRef, DepsERefs, 2));
+
+    ASSERT_TRUE(ERef != nullptr);
+    EXPECT_NO_FATAL_FAILURE(DPCTLEvent_Wait(ERef));
+    EXPECT_NO_FATAL_FAILURE(DPCTLEvent_Delete(ERef));
+    EXPECT_NO_FATAL_FAILURE(DPCTLEvent_Delete(DepsERefs[0]));
+    EXPECT_NO_FATAL_FAILURE(DPCTLEvent_Delete(DepsERefs[1]));
+}
+
 #endif

--- a/dpctl/_backend.pxd
+++ b/dpctl/_backend.pxd
@@ -347,6 +347,12 @@ cdef extern from "dpctl_sycl_queue_interface.h":
         size_t Count,
         int Advice)
     cdef bool DPCTLQueue_IsInOrder(const DPCTLSyclQueueRef QRef)
+    cdef DPCTLSyclEventRef DPCTLQueue_SubmitBarrier(
+        const DPCTLSyclQueueRef QRef)
+    cdef DPCTLSyclEventRef DPCTLQueue_SubmitBarrierForEvents(
+        const DPCTLSyclQueueRef QRef,
+        const DPCTLSyclEventRef *DepEvents,
+        size_t NDepEvents)
 
 
 cdef extern from "dpctl_sycl_queue_manager.h":

--- a/dpctl/_sycl_queue.pxd
+++ b/dpctl/_sycl_queue.pxd
@@ -81,3 +81,4 @@ cdef public class SyclQueue (_SyclQueue) [object PySyclQueueObject, type PySyclQ
     cpdef memcpy(self, dest, src, size_t count)
     cpdef prefetch(self, ptr, size_t count=*)
     cpdef mem_advise(self, ptr, size_t count, int mem)
+    cpdef SyclEvent submit_barrier(self, dependent_events=*)

--- a/dpctl/tests/test_sycl_queue.py
+++ b/dpctl/tests/test_sycl_queue.py
@@ -381,3 +381,16 @@ def test_hashing_of_queue():
     """
     queue_dict = {dpctl.SyclQueue(): "default_queue"}
     assert queue_dict
+
+
+def test_queue_submit_barrier(valid_filter):
+    try:
+        q = dpctl.SyclQueue(valid_filter)
+    except dpctl.SyclQueueCreationError:
+        pytest.skip("Failed to create device with supported filter")
+    ev1 = q.submit_barrier()
+    ev2 = q.submit_barrier()
+    ev3 = q.submit_barrier([ev1, ev2])
+    ev3.wait()
+    ev1.wait()
+    ev2.wait()


### PR DESCRIPTION
This PR adds 2 c-api functions:

```c
DPCTLSyclEventRef DPCTLQueue_SubmitBarrier(QRef)
DPCTLSyclEventRef DPCTLQueue_SubmitBarrierForEvents(QRef, DPCTLSyclEventRef * deps, size_t n_deps)
```

and corresponding Python API function `SyclQueue.submit_barrier(dependent_events=None)`.

Docs strings may still use some improvement.

Implements #503 