### PR TITLE
dtype keyword of usm_ndarray now supports np.double and other types

### DIFF
--- a/dpctl/tests/test_usm_ndarray_ctor.py
+++ b/dpctl/tests/test_usm_ndarray_ctor.py
@@ -74,6 +74,7 @@ def test_allocate_usm_ndarray(shape, usm_type):
         "c8",
         "c16",
         np.dtype("d"),
+        np.half,
     ],
 )
 def test_dtypes(dtype):


### PR DESCRIPTION
A test added to check for this.