### PR TITLE
Cleanup/find intel sycl

### DIFF
--- a/conda-recipe/bld.bat
+++ b/conda-recipe/bld.bat
@@ -1,11 +1,9 @@
-call "%ONEAPI_ROOT%\compiler\latest\env\vars.bat"
-if errorlevel 1 (
-    echo "oneAPI compiler activation failed"
-    exit /b 1
-)
+
+REM A workaround for activate-dpcpp.bat issue to be addressed in 2021.4
+set "LIB=%CONDA_PREFIX%\Library\lib;%CONDA_PREFIX%\compiler\lib;%LIB%"
 
 "%PYTHON%" setup.py clean --all
-"%PYTHON%" setup.py install
+"%PYTHON%" setup.py install --sycl-compiler-prefix=%CONDA_PREFIX%\Library
 if errorlevel 1 exit 1
 
 rem Build wheel package

--- a/conda-recipe/bld.bat
+++ b/conda-recipe/bld.bat
@@ -3,7 +3,7 @@ REM A workaround for activate-dpcpp.bat issue to be addressed in 2021.4
 set "LIB=%CONDA_PREFIX%\Library\lib;%CONDA_PREFIX%\compiler\lib;%LIB%"
 
 "%PYTHON%" setup.py clean --all
-"%PYTHON%" setup.py install --sycl-compiler-prefix=%CONDA_PREFIX%\Library
+"%PYTHON%" setup.py install --sycl-compiler-prefix=%BUILD_PREFIX%\Library
 if errorlevel 1 exit 1
 
 rem Build wheel package

--- a/conda-recipe/bld.bat
+++ b/conda-recipe/bld.bat
@@ -1,6 +1,7 @@
 
 REM A workaround for activate-dpcpp.bat issue to be addressed in 2021.4
-set "LIB=%CONDA_PREFIX%\Library\lib;%CONDA_PREFIX%\compiler\lib;%LIB%"
+set "LIB=%BUILD_PREFIX%\Library\lib;%BUILD_PREFIX%\compiler\lib;%LIB%"
+set "INCLUDE=%BUILD_PREFIX%\include;%INCLUDE%"
 
 "%PYTHON%" setup.py clean --all
 "%PYTHON%" setup.py install --sycl-compiler-prefix=%BUILD_PREFIX%\Library

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -14,7 +14,7 @@ build:
 requirements:
     build:
         - {{ compiler('cxx') }}
-        - {{ compiler('dpcpp') }}  # [linux]
+        - {{ compiler('dpcpp') }}  # [not osx]
     host:
         - setuptools
         - cython

--- a/dpctl-capi/cmake/modules/FindIntelSycl.cmake
+++ b/dpctl-capi/cmake/modules/FindIntelSycl.cmake
@@ -49,7 +49,7 @@ elseif(DEFINED ENV{ONEAPI_ROOT})
         message(FATAL_ERROR "Unsupported system.")
     endif()
 else()
-    message(FATAL_ERROR,
+    message(FATAL_ERROR
         "Could not locate a DPC++ installation. Either pass the path to a "
         "custom location using DPCTL_DPCPP_HOME_DIR or set the "
         " ONEAPI_ROOT environment variable."
@@ -95,11 +95,11 @@ if(${clangxx_result} MATCHES "0")
     set(IntelSycl_SYCL_INCLUDE_DIR ${IntelSycl_ROOT}/include/sycl)
     set(IntelSycl_LIBRARY_DIR ${IntelSycl_ROOT}/lib)
     if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
-        set(IntelSycl_SYCL_LIBRARY ${IntelSycl_ROOT}/lib/sycl.lib)
-        set(IntelSycl_OPENCL_LIBRARY ${IntelSycl_ROOT}/lib/OpenCL.lib)
+        set(IntelSycl_SYCL_LIBRARY ${IntelSycl_LIBRARY_DIR}/sycl.lib)
+        set(IntelSycl_OPENCL_LIBRARY ${IntelSycl_LIBRARY_DIR}/OpenCL.lib)
     elseif(CMAKE_SYSTEM_NAME STREQUAL "Linux")
-        set(IntelSycl_SYCL_LIBRARY ${IntelSycl_ROOT}/lib/libsycl.so)
-        set(IntelSycl_OPENCL_LIBRARY ${IntelSycl_ROOT}/lib/libOpenCL.so)
+        set(IntelSycl_SYCL_LIBRARY ${IntelSycl_LIBRARY_DIR}/libsycl.so)
+        set(IntelSycl_OPENCL_LIBRARY ${IntelSycl_LIBRARY_DIR}/libOpenCL.so)
     endif()
 
 endif()

--- a/scripts/build_backend.py
+++ b/scripts/build_backend.py
@@ -39,6 +39,8 @@ def build_backend(
 
     if sycl_compiler_prefix is None:
         oneapi_root = os.getenv("ONEAPI_ROOT")
+        if oneapi_root is None:
+            raise ValueError("Environment variable ONEAPI_ROOT is not set")
         if IS_LIN:
             DPCPP_ROOT = os.path.join(oneapi_root, r"compiler/latest/linux")
         elif IS_WIN:
@@ -159,6 +161,8 @@ def build_backend(
     elif IS_WIN:
         if os.path.exists(os.path.join(DPCPP_ROOT, "bin", "dpcpp.exe")):
             cmake_compiler_args = [
+                "-DDPCTL_DPCPP_HOME_DIR=" + DPCPP_ROOT,
+                "-DDPCTL_DPCPP_FROM_ONEAPI=ON",
                 "-DCMAKE_C_COMPILER:PATH="
                 + os.path.join(DPCPP_ROOT, "bin", "clang-cl.exe"),
                 "-DCMAKE_CXX_COMPILER:PATH="
@@ -166,7 +170,8 @@ def build_backend(
             ]
         else:
             cmake_compiler_args = [
-                "-DDPCTL_CUSTOM_DPCPP_INSTALL_DIR=" + DPCPP_ROOT,
+                "-DDPCTL_DPCPP_HOME_DIR=" + DPCPP_ROOT,
+                "-DDPCTL_DPCPP_FROM_ONEAPI=OFF",
                 "-DCMAKE_C_COMPILER:PATH="
                 + os.path.join(DPCPP_ROOT, "bin", "clang-cl.exe"),
                 "-DCMAKE_CXX_COMPILER:PATH="


### PR DESCRIPTION
These are the changes needed to make support for `--sycl-compiler-prefix` on Windows. 

Conda recipe is modified to use that. Local build was successful.