### PR TITLE
Remove `_init_helper` from the SyclEventRaw class

### DIFF
--- a/dpctl/_sycl_event.pxd
+++ b/dpctl/_sycl_event.pxd
@@ -42,8 +42,6 @@ cdef class _SyclEventRaw:
 cdef public class SyclEventRaw(_SyclEventRaw) [object PySyclEventRawObject, type PySyclEventRawType]:
     @staticmethod
     cdef SyclEventRaw _create (DPCTLSyclEventRef event)
-    @staticmethod
-    cdef void _init_helper(_SyclEventRaw event, DPCTLSyclEventRef ERef)
     cdef int _init_event_default(self)
     cdef int _init_event_from__SyclEventRaw(self, _SyclEventRaw other)
     cdef int _init_event_from_SyclEvent(self, SyclEvent event)

--- a/dpctl/_sycl_event.pyx
+++ b/dpctl/_sycl_event.pyx
@@ -93,6 +93,8 @@ cdef void _event_capsule_deleter(object o):
         )
         DPCTLEvent_Delete(ERef)
 
+cdef void _init_helper(_SyclEventRaw event, DPCTLSyclEventRef ERef):
+    event._event_ref = ERef
 
 cdef class _SyclEventRaw:
     """ Python wrapper class for a ``cl::sycl::event``.
@@ -107,13 +109,9 @@ cdef class SyclEventRaw(_SyclEventRaw):
     """
 
     @staticmethod
-    cdef void _init_helper(_SyclEventRaw event, DPCTLSyclEventRef ERef):
-        event._event_ref = ERef
-
-    @staticmethod
     cdef SyclEventRaw _create(DPCTLSyclEventRef eref):
         cdef _SyclEventRaw ret = _SyclEventRaw.__new__(_SyclEventRaw)
-        SyclEventRaw._init_helper(ret, eref)
+        _init_helper(ret, eref)
         return SyclEventRaw(ret)
 
     cdef int _init_event_default(self):


### PR DESCRIPTION
This PR removes method the static method `_init_helper` from the SyclEventRaw class.