### PR TITLE
Use public for data owning class definitions

### DIFF
--- a/dpctl/_sycl_context.pxd
+++ b/dpctl/_sycl_context.pxd
@@ -26,13 +26,19 @@ from ._backend cimport DPCTLSyclContextRef
 from ._sycl_device cimport SyclDevice
 
 
-cdef class _SyclContext:
+cdef public class _SyclContext [
+    object Py_SyclContextObject,
+    type Py_SyclContextType
+]:
     """ Data owner for SyclContext
     """
     cdef DPCTLSyclContextRef _ctxt_ref
 
 
-cdef public class SyclContext(_SyclContext) [object PySyclContextObject, type PySyclContextType]:
+cdef public class SyclContext(_SyclContext) [
+    object PySyclContextObject,
+    type PySyclContextType
+]:
     ''' Wrapper class for a Sycl Context
     '''
 

--- a/dpctl/_sycl_context.pyx
+++ b/dpctl/_sycl_context.pyx
@@ -473,3 +473,10 @@ cdef class SyclContext(_SyclContext):
             "SyclContextRef",
             &_context_capsule_deleter
         )
+
+cdef public DPCTLSyclContextRef get_context_ref(SyclContext ctx):
+    """
+    C-API function to get opaque context reference from
+    :class:`dpctl.SyclContext` instance.
+    """
+    return ctx.get_context_ref()

--- a/dpctl/_sycl_device.pxd
+++ b/dpctl/_sycl_device.pxd
@@ -29,7 +29,10 @@ from ._backend cimport (
 )
 
 
-cdef class _SyclDevice:
+cdef public class _SyclDevice [
+    object Py_SyclDeviceObject,
+    type Py_SyclDeviceType
+]:
     """ A helper data-owner class to abstract a `cl::sycl::device` instance.
     """
     cdef DPCTLSyclDeviceRef _device_ref
@@ -39,7 +42,10 @@ cdef class _SyclDevice:
     cdef size_t *_max_work_item_sizes
 
 
-cdef public class SyclDevice(_SyclDevice) [object PySyclDeviceObject, type PySyclDeviceType]:
+cdef public class SyclDevice(_SyclDevice) [
+    object PySyclDeviceObject,
+    type PySyclDeviceType
+]:
     @staticmethod
     cdef SyclDevice _create(DPCTLSyclDeviceRef dref)
     @staticmethod

--- a/dpctl/_sycl_device.pyx
+++ b/dpctl/_sycl_device.pyx
@@ -1117,3 +1117,10 @@ cdef class SyclDevice(_SyclDevice):
                     return ":".join((dt_str, str(relId)))
                 else:
                     return str(relId)
+
+cdef public DPCTLSyclDeviceRef get_device_ref(SyclDevice dev):
+    """
+    C-API function to get opaque device reference from
+    :class:`dpctl.SyclDevice` instance.
+    """
+    return dev.get_device_ref()

--- a/dpctl/_sycl_queue.pxd
+++ b/dpctl/_sycl_queue.pxd
@@ -31,15 +31,19 @@ from .program._program cimport SyclKernel
 
 cdef void default_async_error_handler(int) nogil except *
 
-cdef class _SyclQueue:
-    """ Python wrapper class for a sycl::queue.
+cdef public class _SyclQueue [
+    object Py_SyclQueueObject, type Py_SyclQueueType
+]:
+    """ Python data owner class for a sycl::queue.
     """
     cdef DPCTLSyclQueueRef _queue_ref
     cdef SyclContext _context
     cdef SyclDevice _device
 
 
-cdef public class SyclQueue (_SyclQueue) [object PySyclQueueObject, type PySyclQueueType]:
+cdef public class SyclQueue (_SyclQueue) [
+    object PySyclQueueObject, type PySyclQueueType
+]:
     """ Python wrapper class for a sycl::queue.
     """
     cdef int _init_queue_default(self, int)

--- a/dpctl/_sycl_queue.pyx
+++ b/dpctl/_sycl_queue.pyx
@@ -918,3 +918,10 @@ cdef class SyclQueue(_SyclQueue):
             )
 
         return SyclEvent._create(ERef, [])
+
+cdef public DPCTLSyclQueueRef get_queue_ref(SyclQueue q):
+    """
+    C-API function to get opaque queue reference from
+    :class:`dpctl.SyclQueue` instance.
+    """
+    return q.get_queue_ref()


### PR DESCRIPTION
Also introduce C-API functions to retrieve opaque DPCTL references
from Python objects.

This is useful in using `dpctl` entities as arguments in pybind11
applications