### PR TITLE
Fixed typo in pip installation instruction. Fixes #525

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Install Wheel Package from Pypi
 ==================================
 1. Install dpctl
 ```cmd
-python -m pip install --index-url https://pypi.anaconda.org/intel/simple -extra-index-url https://pypi.org/simple dpctl
+python -m pip install --index-url https://pypi.anaconda.org/intel/simple --extra-index-url https://pypi.org/simple dpctl
 ```
 Note: dpctl wheel package is placed on Pypi, but some of its dependencies (like Intel numpy) are in Anaconda Cloud.
 That is why install command requires additional intel Pypi channel from Anaconda Cloud.


### PR DESCRIPTION
Double dash was needed instead of single dash in front of
extra-index-url option.

Fixes #525 