### PR TITLE
Fixed dpctl_config, added dpctl_service.h, .cpp

### DIFF
--- a/dpctl-capi/include/dpctl_service.h
+++ b/dpctl-capi/include/dpctl_service.h
@@ -1,4 +1,4 @@
-//===--------- dpctl_config.h - Configured options for dpctl C API         ===//
+//===- dpctl_service.h - C API for service functions   -*-C++-*- ===//
 //
 //                      Data Parallel Control (dpctl)
 //
@@ -19,14 +19,28 @@
 //===----------------------------------------------------------------------===//
 ///
 /// \file
-/// This file exports a set of dpctl C API configurations.
+/// This header defines dpctl service functions.
 ///
 //===----------------------------------------------------------------------===//
 
 #pragma once
 
-/* Defined when dpctl was built with level zero program creation enabled. */
-#cmakedefine DPCTL_ENABLE_LO_PROGRAM_CREATION @DPCTL_ENABLE_LO_PROGRAM_CREATION@
+#include "Support/DllExport.h"
+#include "Support/ExternC.h"
+#include "Support/MemOwnershipAttrs.h"
 
-/* The DPCPP version used to build dpctl */
-#define DPCTL_DPCPP_VERSION "@IntelSycl_VERSION@"
+DPCTL_C_EXTERN_C_BEGIN
+/**
+ * @defgroup Service Service functions
+ */
+
+/*!
+ * @brief Get version of DPC++ toolchain the library was compiled with.
+ *
+ * @return A C string containing the version of DPC++ toolchain.
+ * @ingroup Service
+ */
+DPCTL_API
+__dpctl_give const char *DPCTLService_GetDPCPPVersion(void);
+
+DPCTL_C_EXTERN_C_END

--- a/dpctl-capi/source/dpctl_service.cpp
+++ b/dpctl-capi/source/dpctl_service.cpp
@@ -1,4 +1,4 @@
-//===--------- dpctl_config.h - Configured options for dpctl C API         ===//
+//===- dpctl_service.cpp - C API for service functions   -*-C++-*- ===//
 //
 //                      Data Parallel Control (dpctl)
 //
@@ -19,14 +19,32 @@
 //===----------------------------------------------------------------------===//
 ///
 /// \file
-/// This file exports a set of dpctl C API configurations.
+/// This header defines dpctl service functions.
 ///
 //===----------------------------------------------------------------------===//
 
-#pragma once
+#include "dpctl_service.h"
+#include "Config/dpctl_config.h"
 
-/* Defined when dpctl was built with level zero program creation enabled. */
-#cmakedefine DPCTL_ENABLE_LO_PROGRAM_CREATION @DPCTL_ENABLE_LO_PROGRAM_CREATION@
+#include <algorithm>
+#include <cstring>
+#include <iostream>
 
-/* The DPCPP version used to build dpctl */
-#define DPCTL_DPCPP_VERSION "@IntelSycl_VERSION@"
+__dpctl_give const char *DPCTLService_GetDPCPPVersion(void)
+{
+    std::string version = DPCTL_DPCPP_VERSION;
+    char *version_cstr = nullptr;
+    try {
+        auto cstr_len = version.length() + 1;
+        version_cstr = new char[cstr_len];
+#ifdef _WIN32
+        strncpy_s(version_cstr, cstr_len, version.c_str(), cstr_len);
+#else
+        std::strncpy(version_cstr, version.c_str(), cstr_len);
+#endif
+    } catch (std::bad_alloc const &ba) {
+        // \todo log error
+        std::cerr << ba.what() << '\n';
+    }
+    return version_cstr;
+}

--- a/dpctl-capi/tests/test_service.cpp
+++ b/dpctl-capi/tests/test_service.cpp
@@ -1,4 +1,4 @@
-//===--------- dpctl_config.h - Configured options for dpctl C API         ===//
+//===--- test_service.cpp - Test cases for sevice functions  ===//
 //
 //                      Data Parallel Control (dpctl)
 //
@@ -19,14 +19,30 @@
 //===----------------------------------------------------------------------===//
 ///
 /// \file
-/// This file exports a set of dpctl C API configurations.
+/// This file has unit test cases for functions defined in
+/// dpctl_service.h.
 ///
 //===----------------------------------------------------------------------===//
 
-#pragma once
+#include "Config/dpctl_config.h"
+#include "dpctl_service.h"
+#include <gtest/gtest.h>
+#include <string>
 
-/* Defined when dpctl was built with level zero program creation enabled. */
-#cmakedefine DPCTL_ENABLE_LO_PROGRAM_CREATION @DPCTL_ENABLE_LO_PROGRAM_CREATION@
+#define ASSTR(a) TOSTR(a)
+#define TOSTR(a) #a
 
-/* The DPCPP version used to build dpctl */
-#define DPCTL_DPCPP_VERSION "@IntelSycl_VERSION@"
+TEST(TestServicesFns, ChkDPCPPVersion)
+{
+    auto c_ver = DPCTLService_GetDPCPPVersion();
+    std::string ver = std::string(c_ver);
+    ASSERT_TRUE(ver.length() > 0);
+
+    std::string ver_from_cmplr(ASSTR(__VERSION__));
+    std::size_t found = ver_from_cmplr.find(ver);
+
+    // version returned by DPCTLService_GetDPCPPVersion
+    // should occur as a substring in the version obtained
+    // from compiler
+    ASSERT_TRUE(found != std::string::npos);
+}


### PR DESCRIPTION
Fixed Config/dpctl_config.h.in so that `DPCTL_DPCPP_VERSION` preprocessor
variable is now non-empty.

Created `const char * DPCTLService_GetDPCPPVersion(void)` service function
to get the version stored in that preprocessor variable.

This would allow Python to record minimum version requirement for the
DPC++ toolchain runtime.

```
Python 3.7.10 (default, Jun  4 2021, 06:52:02)
Type 'copyright', 'credits' or 'license' for more information
IPython 7.25.0 -- An enhanced Interactive Python. Type '?' for help.

In [1]: import dpctl, ctypes

In [2]: lib = ctypes.cdll.LoadLibrary('dpctl/libDPCTLSyclInterface.so')

In [3]: fn = lib.DPCTLService_GetDPCPPVersion

In [4]: fn.argtypes=[]

In [5]: fn.restype = ctypes.c_char_p

In [6]: fn()
Out[6]: b'2021.3.0'
```