### PR TITLE
Add install requires

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,7 @@
+numpy
+cython
+setuptools
+sphinx
+sphinx_rtd_theme
+pydot
+graphviz

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+setuptools
+cython
+numpy
+wheel

--- a/setup.py
+++ b/setup.py
@@ -458,6 +458,7 @@ setup(
     ext_modules=extensions(),
     zip_safe=False,
     setup_requires=["Cython"],
+    install_requires=["numpy", "dpcpp_cpp_rt"],
     keywords="dpctl",
     classifiers=[
         "Development Status :: 3 - Alpha",


### PR DESCRIPTION
This PR adds `install_requires=["numpy", "dpcpp_cpp_rt"]` keyword argument to `setup` call. 

It also adds `requirements.txt` and `docs/requirements.txt` per #398 

Imposing minimal version requirement on `dpcpp_cpp_rt` does not appear possible in `setup.py` because `install_requires` must be provided before the `build_backend` script has a chance to run. 

We should add a Python visible function to get the output of `DPCTLService_GetDPCPPVersion()`.