### PR TITLE
DPCTLSyclInterface should avoid functions that print to std::cout

### DIFF
--- a/dpctl/_backend.pxd
+++ b/dpctl/_backend.pxd
@@ -207,7 +207,7 @@ cdef extern from "dpctl_sycl_device_manager.h":
         const DPCTLSyclDeviceRef DRef,
         int device_identifier)
     cdef size_t DPCTLDeviceMgr_GetNumDevices(int device_identifier)
-    cdef void DPCTLDeviceMgr_PrintDeviceInfo(const DPCTLSyclDeviceRef DRef)
+    cdef const char * DPCTLDeviceMgr_GetDeviceInfoStr(const DPCTLSyclDeviceRef DRef)
     cdef DPCTLSyclContextRef DPCTLDeviceMgr_GetCachedContext(
         const DPCTLSyclDeviceRef DRef)
     cdef int64_t DPCTLDeviceMgr_GetRelativeId(const DPCTLSyclDeviceRef DRef)

--- a/dpctl/_sycl_device.pyx
+++ b/dpctl/_sycl_device.pyx
@@ -65,10 +65,10 @@ from ._backend cimport (  # noqa: E211
     DPCTLDevice_IsCPU,
     DPCTLDevice_IsGPU,
     DPCTLDevice_IsHost,
+    DPCTLDeviceMgr_GetDeviceInfoStr,
     DPCTLDeviceMgr_GetDevices,
     DPCTLDeviceMgr_GetPositionInDevices,
     DPCTLDeviceMgr_GetRelativeId,
-    DPCTLDeviceMgr_PrintDeviceInfo,
     DPCTLDeviceSelector_Delete,
     DPCTLDeviceSelector_Score,
     DPCTLDeviceVector_Delete,
@@ -286,7 +286,12 @@ cdef class SyclDevice(_SyclDevice):
     def print_device_info(self):
         """ Print information about the SYCL device.
         """
-        DPCTLDeviceMgr_PrintDeviceInfo(self._device_ref)
+        cdef const char * info_str = DPCTLDeviceMgr_GetDeviceInfoStr(
+            self._device_ref
+        )
+        py_info = <bytes> info_str
+        DPCTLCString_Delete(info_str)
+        print(py_info.decode("utf-8"))
 
     cdef DPCTLSyclDeviceRef get_device_ref(self):
         """ Returns the DPCTLSyclDeviceRef pointer for this class.


### PR DESCRIPTION
The stream `std::cout` that the library writes to in a function like
`DPCTLDeviceMgr_PrintDeviceInfo` is not the same as Python's `sys.stdout`.

It makes it difficult to verify that printed output is what should be
expected.

Used `OutputGrabber` class to try to capture `std::cout` outputs of `DPCTLSyclInterface`.
The class is implemented in new `test/_redirector.py` file.

The changes in this commit allow the test to pass, while ensuring
that the captured output is non-empty, but pytest must be envoked with
`--capture=no` option.

It works as follows:

```
(idp) [14:36:03 ansatnuc04 dpctl]$ ipython
Python 3.7.10 (default, Jun  4 2021, 06:52:02)
Type 'copyright', 'credits' or 'license' for more information
IPython 7.25.0 -- An enhanced Interactive Python. Type '?' for help.

In [1]: import dpctl

In [2]: q = dpctl.SyclQueue()

In [3]: q.print_device_info()
    Name            Intel(R) UHD Graphics [0x9bca]
    Driver version  1.1.20389
    Vendor          Intel(R) Corporation
    Profile         FULL_PROFILE
    Filter string   level_zero:gpu:0

In [4]: import tests._redirector

In [5]: out = tests._redirector.OutputGrabber()

In [6]: with out: q.print_device_info()

In [7]: out.capturedtext
Out[7]: '    Name            Intel(R) UHD Graphics [0x9bca]\n    Driver version  1.1.20389\n    Vendor          Intel(R) Corporation\n    Profile         FULL_PROFILE\n    Filter string   level_zero:gpu:0\n'
```

It is all good, but `In[3]` for needed for `Out[7]` to be non-empty.

```
(idp) [14:38:36 ansatnuc04 dpctl]$ ipython
Python 3.7.10 (default, Jun  4 2021, 06:52:02)
Type 'copyright', 'credits' or 'license' for more information
IPython 7.25.0 -- An enhanced Interactive Python. Type '?' for help.

In [1]: import dpctl

In [2]: q = dpctl.SyclQueue()

In [3]: import tests._redirector

In [4]: out = tests._redirector.OutputGrabber()

In [5]: with out: q.print_device_info()

In [6]: out.capturedtext
Out[6]: ''
```

This is because `libDPCTLSyclInterface` does not initialize `std::cout`, and In[5] writes into a different `std::cout` that output grabber captured. 