### PR TITLE
Add the SyclTimer class to the examples

### DIFF
--- a/examples/python/dppy_kernel.py
+++ b/examples/python/dppy_kernel.py
@@ -1,0 +1,53 @@
+#                      Data Parallel Control (dpctl)
+#
+# Copyright 2020-2021 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import numba_dppy as dppy
+import numpy as np
+from sycl_timer import SyclTimer
+
+import dpctl
+
+
+@dppy.kernel
+def dppy_gemm(a, b, c):
+    i = dppy.get_global_id(0)
+    j = dppy.get_global_id(1)
+    if i >= c.shape[0] or j >= c.shape[1]:
+        return
+    c[i, j] = 0
+    for k in range(c.shape[0]):
+        c[i, j] += a[i, k] * b[k, j]
+
+
+X = 1024
+Y = 16
+global_size = X, X
+
+griddim = X, X
+blockdim = Y, Y
+
+a = np.arange(X * X, dtype=np.float32).reshape(X, X)
+b = np.array(np.random.random(X * X), dtype=np.float32).reshape(X, X)
+c = np.ones_like(a).reshape(X, X)
+
+q = dpctl.SyclQueue("opencl:gpu", property="enable_profiling")
+with dpctl.device_context(q):
+    timers = SyclTimer(time_scale=1)
+    with timers(q):
+        dppy_gemm[griddim, blockdim](a, b, c)
+    host_time, device_time = timers.dt()
+    print("Wall time: ", host_time, "\n", "Device time: ", device_time)

--- a/examples/python/sycl_timer.py
+++ b/examples/python/sycl_timer.py
@@ -1,0 +1,62 @@
+#                      Data Parallel Control (dpctl)
+#
+# Copyright 2020-2021 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import timeit
+
+import dpctl
+
+
+class SyclTimer:
+    def __init__(self, host_time=timeit.default_timer, time_scale=1):
+        self.timer = host_time
+        self.time_scale = time_scale
+
+    def __call__(self, queue=None):
+        if isinstance(queue, dpctl.SyclQueue):
+            if queue.has_enable_profiling:
+                self.queue = queue
+            else:
+                raise ValueError(
+                    "The queue does not contain the enable_profiling property"
+                )
+        else:
+            raise ValueError(
+                "The passed queue must be <class 'dpctl._sycl_queue.SyclQueue'>"
+            )
+        return self.__enter__()
+
+    def __enter__(self):
+        self.event_start = dpctl.SyclEventRaw(self.queue.submit_barrier())
+        self.host_start = self.timer()
+        return self
+
+    def __exit__(self, *args):
+        self.event_finish = dpctl.SyclEventRaw(self.queue.submit_barrier())
+        self.host_finish = self.timer()
+
+    def dt(self):
+        self.event_start.wait()
+        self.event_finish.wait()
+        return (
+            (self.host_finish - self.host_start) * self.time_scale,
+            (
+                self.event_finish.profiling_info_start
+                - self.event_start.profiling_info_end
+            )
+            / 1e9
+            * self.time_scale,
+        )


### PR DESCRIPTION
This PR adds a python `sycl_timer file` containing the `SyclTimer` class and the `dppy-kernel file` as an example for working with this class