### PR TITLE
Fixes #547

### DIFF
--- a/dpctl/tensor/_usmarray.pyx
+++ b/dpctl/tensor/_usmarray.pyx
@@ -118,7 +118,7 @@ cdef class usm_ndarray:
         buffer can be strings ('device'|'shared'|'host' to allocate new memory)
         or dpctl.memory.MemoryUSM* buffers, or usm_ndrray instances.
         """
-        cdef int nd = 9
+        cdef int nd = 0
         cdef int typenum = 0
         cdef int itemsize = 0
         cdef int err = 0
@@ -304,7 +304,7 @@ cdef class usm_ndarray:
         ary_ptr = <char *>(<size_t> self.data_)
         ro_flag = False if (self.flags_ & USM_ARRAY_WRITEABLE) else True
         ary_iface['data'] = (<size_t> ary_ptr, ro_flag)
-        ary_iface['shape'] = _make_int_tuple(self.nd_, self.shape_)
+        ary_iface['shape'] = self.shape
         if (self.strides_):
             ary_iface['strides'] = _make_int_tuple(self.nd_, self.strides_)
         else:

--- a/dpctl/tests/test_usm_ndarray_ctor.py
+++ b/dpctl/tests/test_usm_ndarray_ctor.py
@@ -55,6 +55,7 @@ def test_allocate_usm_ndarray(shape, usm_type):
     assert X.sycl_device == q.sycl_device
     assert X.size == Xnp.size
     assert X.shape == Xnp.shape
+    assert X.shape == X.__sycl_usm_array_interface__["shape"]
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Closes #547 

Property `__sycl_usm_array_interface__` is to use `self.shape` rather
than call _make_int_tuple directly.

```
In [4]: dpt.usm_ndarray(tuple(), dtype='d').__sycl_usm_array_interface__
Out[4]:
{'data': (94536841949184, True),
 'shape': (),
 'strides': None,
 'typestr': '|f8',
 'version': 1,
 'syclobj': <dpctl.SyclQueue at 0x7f5bbeb3f780>,
 'offset': 0}
```

@shssf @Alexander-Makaryev 