### PR TITLE
remove dpcpp_cpp_rt as run-time dependency as it is not a Python pack…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,7 +66,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Static methods `_init_helper` made into functions and removed from PXD files (#532)
 - Fixed typo in pip installation instruction (#536)
 - Fixed dpctl_config.h, added dpctl_service.h, .cpp (#539)
-- Fixed `__sycl_usm_array_interface__` output for 0d arrays (#547) 
+- Fixed `__sycl_usm_array_interface__` output for 0d arrays (#547)
 
 ## [0.8.0] - 05/26/2021
 

--- a/setup.py
+++ b/setup.py
@@ -458,7 +458,9 @@ setup(
     ext_modules=extensions(),
     zip_safe=False,
     setup_requires=["Cython"],
-    install_requires=["numpy", "dpcpp_cpp_rt"],
+    install_requires=[
+        "numpy",
+    ],
     keywords="dpctl",
     classifiers=[
         "Development Status :: 3 - Alpha",


### PR DESCRIPTION
…age, from pip's vantage point