### PR TITLE
Fix UnboundLocalError when default queue could not be created

### DIFF
--- a/dpctl/_sycl_queue.pyx
+++ b/dpctl/_sycl_queue.pyx
@@ -327,7 +327,11 @@ cdef class SyclQueue(_SyclQueue):
                     .format(arg)
                 )
             elif status == -2 or status == -8:
+                default_dev_error = (
+                    "Default SYCL Device could not be created."
+                )
                 raise SyclQueueCreationError(
+                    default_dev_error if (len_args == 0) else
                     "SYCL Device '{}' could not be created.".format(arg)
                 )
             elif status == -3 or status == -7:


### PR DESCRIPTION
This PR fixes `UnboundLocalError` exception raised during error handling of `dpctl.SyclQueue()` when do default device is available (SYCL should always provide a host device).

The exception was seen running Windows workflow in #534 