### PR TITLE
DPCTLQueue_Memcpy, _Prefetch, _Memadvise become asynchronous

### DIFF
--- a/dpctl-capi/include/dpctl_sycl_queue_interface.h
+++ b/dpctl-capi/include/dpctl_sycl_queue_interface.h
@@ -266,7 +266,7 @@ DPCTLQueue_SubmitNDRange(__dpctl_keep const DPCTLSyclKernelRef KRef,
                          size_t NDepEvents);
 
 /*!
- * @brief Calls the ``sycl::queue.submit`` function to do a blocking wait on
+ * @brief Calls the ``sycl::queue::submit`` function to do a blocking wait on
  * all enqueued tasks in the queue.
  *
  * @param    QRef           Opaque pointer to a ``sycl::queue``.
@@ -276,38 +276,39 @@ DPCTL_API
 void DPCTLQueue_Wait(__dpctl_keep const DPCTLSyclQueueRef QRef);
 
 /*!
- * @brief C-API wrapper for ``sycl::queue::memcpy``, the function waits on an
- * event till the memcpy operation completes.
+ * @brief C-API wrapper for ``sycl::queue::memcpy``.
  *
  * @param    QRef           An opaque pointer to the ``sycl::queue``.
  * @param    Dest           An USM pointer to the destination memory.
  * @param    Src            An USM pointer to the source memory.
  * @param    Count          A number of bytes to copy.
+ * @return   An opaque pointer to the ``sycl::event`` returned by the
+ *           ``sycl::queue::memcpy`` function.
  * @ingroup QueueInterface
  */
 DPCTL_API
-void DPCTLQueue_Memcpy(__dpctl_keep const DPCTLSyclQueueRef QRef,
-                       void *Dest,
-                       const void *Src,
-                       size_t Count);
+DPCTLSyclEventRef DPCTLQueue_Memcpy(__dpctl_keep const DPCTLSyclQueueRef QRef,
+                                    void *Dest,
+                                    const void *Src,
+                                    size_t Count);
 
 /*!
- * @brief C-API wrapper for ``sycl::queue::prefetch``, the function waits on an
- * event till the prefetch operation completes.
+ * @brief C-API wrapper for ``sycl::queue::prefetch``.
  *
  * @param    QRef           An opaque pointer to the ``sycl::queue``.
  * @param    Ptr            An USM pointer to memory.
  * @param    Count          A number of bytes to prefetch.
+ * @return   An opaque pointer to the ``sycl::event`` returned by the
+ *           ``sycl::queue::prefetch`` function.
  * @ingroup QueueInterface
  */
 DPCTL_API
-void DPCTLQueue_Prefetch(__dpctl_keep DPCTLSyclQueueRef QRef,
-                         const void *Ptr,
-                         size_t Count);
+DPCTLSyclEventRef DPCTLQueue_Prefetch(__dpctl_keep DPCTLSyclQueueRef QRef,
+                                      const void *Ptr,
+                                      size_t Count);
 
 /*!
- * @brief C-API wrapper for sycl::queue::mem_advise, the function waits on an
- * event till the operation completes.
+ * @brief C-API wrapper for ``sycl::queue::mem_advise``.
  *
  * @param    QRef           An opaque pointer to the ``sycl::queue``.
  * @param    Ptr            An USM pointer to memory.
@@ -315,13 +316,15 @@ void DPCTLQueue_Prefetch(__dpctl_keep DPCTLSyclQueueRef QRef,
  * @param    Advice         Device-defined advice for the specified allocation.
  *                          A value of 0 reverts the advice for Ptr to the
  *                          default behavior.
+ * @return   An opaque pointer to the ``sycl::event`` returned by the
+ *           ``sycl::queue::mem_advise`` function.
  * @ingroup QueueInterface
  */
 DPCTL_API
-void DPCTLQueue_MemAdvise(__dpctl_keep DPCTLSyclQueueRef QRef,
-                          const void *Ptr,
-                          size_t Count,
-                          int Advice);
+DPCTLSyclEventRef DPCTLQueue_MemAdvise(__dpctl_keep DPCTLSyclQueueRef QRef,
+                                       const void *Ptr,
+                                       size_t Count,
+                                       int Advice);
 
 /*!
  * @brief C-API wrapper for sycl::queue::is_in_order that indicates whether

--- a/dpctl-capi/source/dpctl_sycl_queue_interface.cpp
+++ b/dpctl-capi/source/dpctl_sycl_queue_interface.cpp
@@ -484,39 +484,74 @@ void DPCTLQueue_Wait(__dpctl_keep DPCTLSyclQueueRef QRef)
     }
 }
 
-void DPCTLQueue_Memcpy(__dpctl_keep const DPCTLSyclQueueRef QRef,
-                       void *Dest,
-                       const void *Src,
-                       size_t Count)
+DPCTLSyclEventRef DPCTLQueue_Memcpy(__dpctl_keep const DPCTLSyclQueueRef QRef,
+                                    void *Dest,
+                                    const void *Src,
+                                    size_t Count)
 {
     auto Q = unwrap(QRef);
     if (Q) {
-        auto event = Q->memcpy(Dest, Src, Count);
-        event.wait();
+        sycl::event ev;
+        try {
+            ev = Q->memcpy(Dest, Src, Count);
+        } catch (const sycl::runtime_error &re) {
+            // todo: log error
+            std::cerr << re.what() << '\n';
+            return nullptr;
+        }
+        return wrap(new event(ev));
+    }
+    else {
+        // todo: log error
+        std::cerr << "QRef passed to memcpy was NULL" << '\n';
+        return nullptr;
     }
 }
 
-void DPCTLQueue_Prefetch(__dpctl_keep DPCTLSyclQueueRef QRef,
-                         const void *Ptr,
-                         size_t Count)
+DPCTLSyclEventRef DPCTLQueue_Prefetch(__dpctl_keep DPCTLSyclQueueRef QRef,
+                                      const void *Ptr,
+                                      size_t Count)
 {
     auto Q = unwrap(QRef);
     if (Q) {
-        auto event = Q->prefetch(Ptr, Count);
-        event.wait();
+        sycl::event ev;
+        try {
+            ev = Q->prefetch(Ptr, Count);
+        } catch (sycl::runtime_error &re) {
+            // todo: log error
+            std::cerr << re.what() << '\n';
+            return nullptr;
+        }
+        return wrap(new event(ev));
+    }
+    else {
+        // todo: log error
+        std::cerr << "QRef passed to prefetch was NULL" << '\n';
+        return nullptr;
     }
 }
 
-void DPCTLQueue_MemAdvise(__dpctl_keep DPCTLSyclQueueRef QRef,
-                          const void *Ptr,
-                          size_t Count,
-                          int Advice)
+DPCTLSyclEventRef DPCTLQueue_MemAdvise(__dpctl_keep DPCTLSyclQueueRef QRef,
+                                       const void *Ptr,
+                                       size_t Count,
+                                       int Advice)
 {
     auto Q = unwrap(QRef);
     if (Q) {
-        auto event =
-            Q->mem_advise(Ptr, Count, static_cast<pi_mem_advice>(Advice));
-        event.wait();
+        sycl::event ev;
+        try {
+            ev = Q->mem_advise(Ptr, Count, static_cast<pi_mem_advice>(Advice));
+        } catch (const sycl::runtime_error &re) {
+            // todo: log error
+            std::cerr << re.what() << '\n';
+            return nullptr;
+        }
+        return wrap(new event(ev));
+    }
+    else {
+        // todo: log error
+        std::cerr << "QRef passed to prefetch was NULL" << '\n';
+        return nullptr;
     }
 }
 

--- a/dpctl/_backend.pxd
+++ b/dpctl/_backend.pxd
@@ -355,16 +355,16 @@ cdef extern from "dpctl_sycl_queue_interface.h":
         const DPCTLSyclEventRef *DepEvents,
         size_t NDepEvents)
     cdef void DPCTLQueue_Wait(const DPCTLSyclQueueRef QRef)
-    cdef void DPCTLQueue_Memcpy(
+    cdef DPCTLSyclEventRef DPCTLQueue_Memcpy(
         const DPCTLSyclQueueRef Q,
         void *Dest,
         const void *Src,
         size_t Count)
-    cdef void DPCTLQueue_Prefetch(
+    cdef DPCTLSyclEventRef DPCTLQueue_Prefetch(
         const DPCTLSyclQueueRef Q,
         const void *Src,
         size_t Count)
-    cdef void DPCTLQueue_MemAdvise(
+    cdef DPCTLSyclEventRef DPCTLQueue_MemAdvise(
         const DPCTLSyclQueueRef Q,
         const void *Src,
         size_t Count,


### PR DESCRIPTION
The return value of these functions changed. Declaration, documentation,
tests and implementations updated in dpctl-capi/.

dpctl/_backend.pxd updated for changed return type. Usages updated
accordingly to get the event and wait on it to preserve the behavior
for now.