### PR TITLE
Try using <img> tag with alignment attribute set

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,12 @@
 
 What?
 ====
-A lightweight Python package exposing a subset of SYCL functionalities, part of [![](https://spec.oneapi.io/oneapi-logo-white-scaled.jpg)](https://oneapi.io).
+<img align="left" src="https://spec.oneapi.io/oneapi-logo-white-scaled.jpg" alt="oneAPI logo" />
+
+A lightweight Python package exposing a subset of SYCL functionalities, part of Intel(R) [oneAPI](https://oneapi.io) [Base ToolKit](https://software.intel.com/content/www/us/en/develop/tools/oneapi/base-toolkit.html).
+
+`dpctl` [provides](https://intelpython.github.io/dpctl) for discovery and selection of SYCL devices, construction of SYCL queues, as well as working with USM allocations.
+<br /><br />
 
 Requirements
 ============


### PR DESCRIPTION
This PR modifies README.md to format better. Only the "What" section was modified. 

Use this [link](https://github.com/IntelPython/dpctl/tree/tweak-oneAPI-logo-placement) to view the rendered README.md page.

![image](https://user-images.githubusercontent.com/21087696/131695217-1c5c6bd5-279a-4b6d-aea7-7b06912899ff.png)
