### PR TITLE
Fixed __version__ test to allow for semantic versioning

### DIFF
--- a/dpctl/tests/test_service.py
+++ b/dpctl/tests/test_service.py
@@ -86,10 +86,11 @@ def test___version__():
     dpctl_ver = getattr(dpctl, "__version__", None)
     assert type(dpctl_ver) is str
     assert "unknown" not in dpctl_ver
-    # Reg expr from PEP-440
+    # Reg expr from PEP-440, relaxed to allow for semantic variant
+    # 0.9.0dev0 allowed, vs. PEP-440 compliant 0.9.0.dev0
     reg_expr = (
         r"^([1-9][0-9]*!)?(0|[1-9][0-9]*)(\.(0|[1-9][0-9]*))"
-        r"*((a|b|rc)(0|[1-9][0-9]*))?(\.post(0|[1-9][0-9]*))?(\.dev("
+        r"*((a|b|rc)(0|[1-9][0-9]*))?(\.?post(0|[1-9][0-9]*))?(\.?dev("
         r"0|[1-9][0-9]*))?(\+.*)?$"
     )
     assert re.match(reg_expr, dpctl_ver) is not None


### PR DESCRIPTION
`0.9.0dev0` is not strictly PEP-440 compliant. It follows semantic version convention. Reg-exp is relaxed to accommodate for that.