### PR TITLE
Simplified arg parsing in SyclDevice constructor

### DIFF
--- a/dpctl/_sycl_device.pyx
+++ b/dpctl/_sycl_device.pyx
@@ -253,17 +253,8 @@ cdef class SyclDevice(_SyclDevice):
         cdef const char *filter_c_str = NULL
         cdef int ret = 0
 
-        if type(arg) is unicode:
-            string = bytes(<unicode>arg, "utf-8")
-            filter_c_str = string
-            DSRef = DPCTLFilterSelector_Create(filter_c_str)
-            ret = self._init_from_selector(DSRef)
-            if ret == -1:
-                raise ValueError(
-                    "Could not create a SyclDevice with the selector string"
-                )
-        elif isinstance(arg, unicode):
-            string = bytes(<unicode>unicode(arg), "utf-8")
+        if type(arg) is str:
+            string = bytes(<str>arg, "utf-8")
             filter_c_str = string
             DSRef = DPCTLFilterSelector_Create(filter_c_str)
             ret = self._init_from_selector(DSRef)

--- a/dpctl/tests/test_sycl_device.py
+++ b/dpctl/tests/test_sycl_device.py
@@ -51,6 +51,7 @@ list_of_invalid_filter_selectors = [
     "opencl:gpu:-1",
     "cuda:cpu:0",
     "abc",
+    1,
 ]
 
 
@@ -470,6 +471,10 @@ def check_print_device_info(device):
         pytest.fail("Encountered an exception inside print_device_info().")
 
 
+def check_repr(device):
+    assert type(repr(device)) is str
+
+
 list_of_checks = [
     check_get_max_compute_units,
     check_get_max_work_item_dims,
@@ -523,6 +528,7 @@ list_of_checks = [
     check_create_sub_devices_by_affinity_L1_cache,
     check_create_sub_devices_by_affinity_next_partitionable,
     check_print_device_info,
+    check_repr,
 ]
 
 


### PR DESCRIPTION
Since Cython is compiled with language_level=3 working with unicode type
is obsolete (we should work with str type instead).

Removed the dead branch of code.

Added test to exercise repr method