### PR TITLE
Transition all Python API to use pytest over unittest, improved coverage in dpctl/memory 

### DIFF
--- a/dpctl/_sycl_queue_manager.pyx
+++ b/dpctl/_sycl_queue_manager.pyx
@@ -78,7 +78,7 @@ cdef class _SyclQueueManager:
         Returns:
             backend_type: The SYCL backend for the currently selected queue.
         """
-        return self.get_current_queue().get_sycl_backend()
+        return self.get_current_queue().backend
 
     cpdef get_current_device_type(self):
         """
@@ -88,7 +88,7 @@ cdef class _SyclQueueManager:
             device_type: The SYCL device type for the currently selected queue.
             Possible values can be gpu, cpu, accelerator, or host.
         """
-        return self.get_current_queue().get_sycl_device().device_type
+        return self.get_current_queue().sycl_device.device_type
 
     cpdef SyclQueue get_current_queue(self):
         """

--- a/dpctl/memory/_sycl_usm_array_interface_utils.pxi
+++ b/dpctl/memory/_sycl_usm_array_interface_utils.pxi
@@ -54,7 +54,7 @@ cdef DPCTLSyclQueueRef get_queue_ref_from_ptr_and_syclobj(
         if pycapsule.PyCapsule_IsValid(cap, "SyclQueueRef"):
             q = SyclQueue(cap)
             return _queue_ref_copy_from_SyclQueue(ptr, <SyclQueue> q)
-        elif pycapsule.PyCapsule_IsValid(cap, "SyclContexRef"):
+        elif pycapsule.PyCapsule_IsValid(cap, "SyclContextRef"):
             ctx = <SyclContext>SyclContext(cap)
             return _queue_ref_copy_from_USMRef_and_SyclContext(ptr, ctx)
         else:

--- a/dpctl/tests/test_dparray.py
+++ b/dpctl/tests/test_dparray.py
@@ -17,85 +17,104 @@
 """Unit test cases for dpctl.tensor.numpy_usm_shared.
 """
 
-import unittest
-
 import numpy
 
 from dpctl.tensor import numpy_usm_shared as dparray
 
 
-class Test_dparray(unittest.TestCase):
-    def setUp(self):
-        self.X = dparray.ndarray((256, 4), dtype="d")
-        self.X.fill(1.0)
-
-    def test_dparray_type(self):
-        self.assertIsInstance(self.X, dparray.ndarray)
-
-    def test_dparray_as_ndarray_self(self):
-        Y = self.X.as_ndarray()
-        self.assertEqual(type(Y), numpy.ndarray)
-
-    def test_dparray_as_ndarray(self):
-        Y = dparray.as_ndarray(self.X)
-        self.assertEqual(type(Y), numpy.ndarray)
-
-    def test_dparray_from_ndarray(self):
-        Y = dparray.as_ndarray(self.X)
-        dp1 = dparray.from_ndarray(Y)
-        self.assertIsInstance(dp1, dparray.ndarray)
-
-    def test_multiplication_dparray(self):
-        C = self.X * 5
-        self.assertIsInstance(C, dparray.ndarray)
-
-    def test_inplace_sub(self):
-        self.X -= 1
-
-    def test_dparray_through_python_func(self):
-        def func_operation_with_const(dpctl_array):
-            return dpctl_array * 2.0 + 13
-
-        C = self.X * 5
-        dp_func = func_operation_with_const(C)
-        self.assertIsInstance(dp_func, dparray.ndarray)
-
-    def test_dparray_mixing_dpctl_and_numpy(self):
-        dp_numpy = numpy.ones((256, 4), dtype="d")
-        res = dp_numpy * self.X
-        self.assertIsInstance(self.X, dparray.ndarray)
-        self.assertIsInstance(res, dparray.ndarray)
-
-    def test_dparray_shape(self):
-        res = self.X.shape
-        self.assertEqual(res, (256, 4))
-
-    def test_dparray_T(self):
-        res = self.X.T
-        self.assertEqual(res.shape, (4, 256))
-
-    def test_numpy_ravel_with_dparray(self):
-        res = numpy.ravel(self.X)
-        self.assertEqual(res.shape, (1024,))
-
-    def test_numpy_sum_with_dparray(self):
-        res = numpy.sum(self.X)
-        self.assertEqual(res, 1024.0)
-
-    def test_numpy_sum_with_dparray_out(self):
-        res = dparray.empty((self.X.shape[1],), dtype=self.X.dtype)
-        res2 = numpy.sum(self.X, axis=0, out=res)
-        self.assertTrue(res is res2)
-        self.assertIsInstance(res2, dparray.ndarray)
-
-    def test_frexp_with_out(self):
-        X = dparray.array([0.5, 4.7])
-        mant = dparray.empty((2,), dtype="d")
-        exp = dparray.empty((2,), dtype="i4")
-        res = numpy.frexp(X, out=(mant, exp))
-        self.assertTrue(res[0] is mant)
-        self.assertTrue(res[1] is exp)
+def get_arg():
+    X = dparray.ndarray((256, 4), dtype="d")
+    X.fill(1.0)
+    return X
 
 
-if __name__ == "__main__":
-    unittest.main()
+def test_dparray_type():
+    X = get_arg()
+    assert isinstance(X, dparray.ndarray)
+
+
+def test_dparray_as_ndarray_self():
+    X = get_arg()
+    Y = X.as_ndarray()
+    assert type(Y) == numpy.ndarray
+
+
+def test_dparray_as_ndarray():
+    X = get_arg()
+    Y = dparray.as_ndarray(X)
+    assert type(Y) == numpy.ndarray
+
+
+def test_dparray_from_ndarray():
+    X = get_arg()
+    Y = dparray.as_ndarray(X)
+    dp1 = dparray.from_ndarray(Y)
+    assert isinstance(dp1, dparray.ndarray)
+
+
+def test_multiplication_dparray():
+    C = get_arg() * 5
+    assert isinstance(C, dparray.ndarray)
+
+
+def test_inplace_sub():
+    X = get_arg()
+    X -= 1
+
+
+def test_dparray_through_python_func():
+    def func_operation_with_const(dpctl_array):
+        return dpctl_array * 2.0 + 13
+
+    C = get_arg() * 5
+    dp_func = func_operation_with_const(C)
+    assert isinstance(dp_func, dparray.ndarray)
+
+
+def test_dparray_mixing_dpctl_and_numpy():
+    dp_numpy = numpy.ones((256, 4), dtype="d")
+    X = get_arg()
+    res = dp_numpy * X
+    assert isinstance(X, dparray.ndarray)
+    assert isinstance(res, dparray.ndarray)
+
+
+def test_dparray_shape():
+    X = get_arg()
+    res = X.shape
+    assert res == (256, 4)
+
+
+def test_dparray_T():
+    X = get_arg()
+    res = X.T
+    assert res.shape == (4, 256)
+
+
+def test_numpy_ravel_with_dparray():
+    X = get_arg()
+    res = numpy.ravel(X)
+    assert res.shape == (1024,)
+
+
+def test_numpy_sum_with_dparray():
+    X = get_arg()
+    res = numpy.sum(X)
+    assert res == 1024.0
+
+
+def test_numpy_sum_with_dparray_out():
+    X = get_arg()
+    res = dparray.empty((X.shape[1],), dtype=X.dtype)
+    res2 = numpy.sum(X, axis=0, out=res)
+    assert res is res2
+    assert isinstance(res2, dparray.ndarray)
+
+
+def test_frexp_with_out():
+    X = dparray.array([0.5, 4.7])
+    mant = dparray.empty((2,), dtype="d")
+    exp = dparray.empty((2,), dtype="i4")
+    res = numpy.frexp(X, out=(mant, exp))
+    assert res[0] is mant
+    assert res[1] is exp

--- a/dpctl/tests/test_sycl_kernel_submit.py
+++ b/dpctl/tests/test_sycl_kernel_submit.py
@@ -18,60 +18,55 @@
 """
 
 import ctypes
-import unittest
 
 import numpy as np
+import pytest
 
 import dpctl
 import dpctl.memory as dpctl_mem
 import dpctl.program as dpctl_prog
 
-from ._helper import has_gpu
 
+def test_create_program_from_source():
+    try:
+        q = dpctl.SyclQueue("opencl", property="enable_profiling")
+    except dpctl.SyclQueueCreationError:
+        pytest.skip("OpenCL queue could not be created")
+    oclSrc = "                                                             \
+    kernel void axpy(global int* a, global int* b, global int* c, int d) { \
+        size_t index = get_global_id(0);                                   \
+        c[index] = d*a[index] + b[index];                                  \
+    }"
+    prog = dpctl_prog.create_program_from_source(q, oclSrc)
+    axpyKernel = prog.get_sycl_kernel("axpy")
 
-@unittest.skipUnless(has_gpu(), "No OpenCL GPU queues available")
-class Test1DKernelSubmit(unittest.TestCase):
-    def test_create_program_from_source(self):
-        oclSrc = "                                                             \
-        kernel void axpy(global int* a, global int* b, global int* c, int d) { \
-            size_t index = get_global_id(0);                                   \
-            c[index] = d*a[index] + b[index];                                  \
-        }"
-        q = dpctl.SyclQueue("opencl:gpu", property="enable_profiling")
-        prog = dpctl_prog.create_program_from_source(q, oclSrc)
-        axpyKernel = prog.get_sycl_kernel("axpy")
+    n_elems = 1024 * 512
+    bufBytes = n_elems * np.dtype("i").itemsize
+    abuf = dpctl_mem.MemoryUSMShared(bufBytes, queue=q)
+    bbuf = dpctl_mem.MemoryUSMShared(bufBytes, queue=q)
+    cbuf = dpctl_mem.MemoryUSMShared(bufBytes, queue=q)
+    a = np.ndarray((n_elems,), buffer=abuf, dtype="i")
+    b = np.ndarray((n_elems,), buffer=bbuf, dtype="i")
+    c = np.ndarray((n_elems,), buffer=cbuf, dtype="i")
+    a[:] = np.arange(n_elems)
+    b[:] = np.arange(n_elems, 0, -1)
+    c[:] = 0
+    d = 2
+    args = []
 
-        n_elems = 1024 * 512
-        bufBytes = n_elems * np.dtype("i").itemsize
-        abuf = dpctl_mem.MemoryUSMShared(bufBytes, queue=q)
-        bbuf = dpctl_mem.MemoryUSMShared(bufBytes, queue=q)
-        cbuf = dpctl_mem.MemoryUSMShared(bufBytes, queue=q)
-        a = np.ndarray((n_elems,), buffer=abuf, dtype="i")
-        b = np.ndarray((n_elems,), buffer=bbuf, dtype="i")
-        c = np.ndarray((n_elems,), buffer=cbuf, dtype="i")
-        a[:] = np.arange(n_elems)
-        b[:] = np.arange(n_elems, 0, -1)
-        c[:] = 0
-        d = 2
-        args = []
+    args.append(a.base)
+    args.append(b.base)
+    args.append(c.base)
+    args.append(ctypes.c_int(d))
 
-        args.append(a.base)
-        args.append(b.base)
-        args.append(c.base)
-        args.append(ctypes.c_int(d))
+    r = [
+        n_elems,
+    ]
 
-        r = [
-            n_elems,
-        ]
-
-        timer = dpctl.SyclTimer()
-        with timer(q):
-            q.submit(axpyKernel, args, r)
-            ref_c = a * d + b
-        host_dt, device_dt = timer.dt
-        self.assertTrue(host_dt > device_dt)
-        self.assertTrue(np.allclose(c, ref_c))
-
-
-if __name__ == "__main__":
-    unittest.main()
+    timer = dpctl.SyclTimer()
+    with timer(q):
+        q.submit(axpyKernel, args, r)
+        ref_c = a * d + b
+    host_dt, device_dt = timer.dt
+    assert host_dt > device_dt
+    assert np.allclose(c, ref_c)

--- a/dpctl/tests/test_sycl_program.py
+++ b/dpctl/tests/test_sycl_program.py
@@ -18,95 +18,96 @@
 """
 
 import os
-import unittest
+
+import pytest
 
 import dpctl
 import dpctl.program as dpctl_prog
 
-from ._helper import has_gpu
+
+def get_spirv_abspath(fn):
+    curr_dir = os.path.dirname(os.path.abspath(__file__))
+    spirv_file = os.path.join(curr_dir, "input_files", fn)
+    return spirv_file
 
 
-@unittest.skipUnless(has_gpu(), "No OpenCL GPU queues available")
-class TestProgramFromOCLSource(unittest.TestCase):
-    def test_create_program_from_source(self):
-        oclSrc = "                                                             \
-        kernel void add(global int* a, global int* b, global int* c) {         \
-            size_t index = get_global_id(0);                                   \
-            c[index] = a[index] + b[index];                                    \
-        }                                                                      \
-        kernel void axpy(global int* a, global int* b, global int* c, int d) { \
-            size_t index = get_global_id(0);                                   \
-            c[index] = a[index] + d*b[index];                                  \
-        }"
-        q = dpctl.SyclQueue("opencl:gpu")
-        prog = dpctl_prog.create_program_from_source(q, oclSrc)
-        self.assertIsNotNone(prog)
+def test_create_program_from_source_ocl():
+    oclSrc = "                                                             \
+    kernel void add(global int* a, global int* b, global int* c) {         \
+        size_t index = get_global_id(0);                                   \
+        c[index] = a[index] + b[index];                                    \
+    }                                                                      \
+    kernel void axpy(global int* a, global int* b, global int* c, int d) { \
+        size_t index = get_global_id(0);                                   \
+        c[index] = a[index] + d*b[index];                                  \
+    }"
+    try:
+        q = dpctl.SyclQueue("opencl")
+    except dpctl.SyclQueueCreationError:
+        pytest.skip("No OpenCL queue is available")
+    prog = dpctl_prog.create_program_from_source(q, oclSrc)
+    assert prog is not None
 
-        self.assertTrue(prog.has_sycl_kernel("add"))
-        self.assertTrue(prog.has_sycl_kernel("axpy"))
+    assert prog.has_sycl_kernel("add")
+    assert prog.has_sycl_kernel("axpy")
 
-        addKernel = prog.get_sycl_kernel("add")
-        axpyKernel = prog.get_sycl_kernel("axpy")
+    addKernel = prog.get_sycl_kernel("add")
+    axpyKernel = prog.get_sycl_kernel("axpy")
 
-        self.assertEqual(addKernel.get_function_name(), "add")
-        self.assertEqual(axpyKernel.get_function_name(), "axpy")
-        self.assertEqual(addKernel.get_num_args(), 3)
-        self.assertEqual(axpyKernel.get_num_args(), 4)
-
-
-@unittest.skipUnless(has_gpu(), "No OpenCL GPU queues available")
-class TestProgramFromSPRIV(unittest.TestCase):
-    def test_create_program_from_spirv(self):
-
-        CURR_DIR = os.path.dirname(os.path.abspath(__file__))
-        spirv_file = os.path.join(CURR_DIR, "input_files/multi_kernel.spv")
-        with open(spirv_file, "rb") as fin:
-            spirv = fin.read()
-            q = dpctl.SyclQueue("opencl:gpu")
-            prog = dpctl_prog.create_program_from_spirv(q, spirv)
-            self.assertIsNotNone(prog)
-            self.assertTrue(prog.has_sycl_kernel("add"))
-            self.assertTrue(prog.has_sycl_kernel("axpy"))
-
-            addKernel = prog.get_sycl_kernel("add")
-            axpyKernel = prog.get_sycl_kernel("axpy")
-
-            self.assertEqual(addKernel.get_function_name(), "add")
-            self.assertEqual(axpyKernel.get_function_name(), "axpy")
-            self.assertEqual(addKernel.get_num_args(), 3)
-            self.assertEqual(axpyKernel.get_num_args(), 4)
+    assert "add" == addKernel.get_function_name()
+    assert "axpy" == axpyKernel.get_function_name()
+    assert 3 == addKernel.get_num_args()
+    assert 4 == axpyKernel.get_num_args()
 
 
-@unittest.skipUnless(
-    has_gpu(backend=dpctl.backend_type.level_zero),
-    "No Level0 GPU queues available",
+def test_create_program_from_spirv_ocl():
+    try:
+        q = dpctl.SyclQueue("opencl")
+    except dpctl.SyclQueueCreationError:
+        pytest.skip("No OpenCL queue is available")
+    spirv_file = get_spirv_abspath("multi_kernel.spv")
+    with open(spirv_file, "rb") as fin:
+        spirv = fin.read()
+    prog = dpctl_prog.create_program_from_spirv(q, spirv)
+    assert prog is not None
+    assert prog.has_sycl_kernel("add")
+    assert prog.has_sycl_kernel("axpy")
+
+    addKernel = prog.get_sycl_kernel("add")
+    axpyKernel = prog.get_sycl_kernel("axpy")
+
+    assert "add" == addKernel.get_function_name()
+    assert "axpy" == axpyKernel.get_function_name()
+    assert 3 == addKernel.get_num_args()
+    assert 4 == axpyKernel.get_num_args()
+
+
+def test_create_program_from_spirv_l0():
+    try:
+        q = dpctl.SyclQueue("level_zero")
+    except dpctl.SyclQueueCreationError:
+        pytest.skip("No Level-zero queue is available")
+    spirv_file = get_spirv_abspath("multi_kernel.spv")
+    with open(spirv_file, "rb") as fin:
+        spirv = fin.read()
+    dpctl_prog.create_program_from_spirv(q, spirv)
+
+
+@pytest.mark.xfail(
+    reason="Level-zero backend does not support compilation from source"
 )
-class TestProgramForLevel0GPU(unittest.TestCase):
-
-    import sys
-
-    def test_create_program_from_spirv(self):
-        CURR_DIR = os.path.dirname(os.path.abspath(__file__))
-        spirv_file = os.path.join(CURR_DIR, "input_files/multi_kernel.spv")
-        with open(spirv_file, "rb") as fin:
-            spirv = fin.read()
-            q = dpctl.SyclQueue("level_zero:gpu")
-            dpctl_prog.create_program_from_spirv(q, spirv)
-
-    @unittest.expectedFailure
-    def test_create_program_from_source(self):
-        oclSrc = "                                                             \
-        kernel void add(global int* a, global int* b, global int* c) {         \
-            size_t index = get_global_id(0);                                   \
-            c[index] = a[index] + b[index];                                    \
-        }                                                                      \
-        kernel void axpy(global int* a, global int* b, global int* c, int d) { \
-            size_t index = get_global_id(0);                                   \
-            c[index] = a[index] + d*b[index];                                  \
-        }"
-        q = dpctl.SyclQueue("level_zero:gpu")
-        dpctl_prog.create_program_from_source(q, oclSrc)
-
-
-if __name__ == "__main__":
-    unittest.main()
+def test_create_program_from_source_l0():
+    try:
+        q = dpctl.SyclQueue("level_zero")
+    except dpctl.SyclQueueCreationError:
+        pytest.skip("No Level-zero queue is available")
+    oclSrc = "                                                             \
+    kernel void add(global int* a, global int* b, global int* c) {         \
+        size_t index = get_global_id(0);                                   \
+        c[index] = a[index] + b[index];                                    \
+    }                                                                      \
+    kernel void axpy(global int* a, global int* b, global int* c, int d) { \
+        size_t index = get_global_id(0);                                   \
+        c[index] = a[index] + d*b[index];                                  \
+    }"
+    dpctl_prog.create_program_from_source(q, oclSrc)

--- a/dpctl/tests/test_sycl_queue_manager.py
+++ b/dpctl/tests/test_sycl_queue_manager.py
@@ -17,100 +17,142 @@
 """Defines unit test cases for the SyclQueueManager class.
 """
 
-import unittest
+import pytest
 
 import dpctl
 
 from ._helper import has_cpu, has_gpu, has_sycl_platforms
 
 
-@unittest.skipIf(not has_sycl_platforms(), "No SYCL platforms available")
-class TestIsInDeviceContext(unittest.TestCase):
-    def test_is_in_device_context_outside_device_ctxt(self):
-        self.assertFalse(dpctl.is_in_device_context())
+@pytest.mark.skipif(
+    not has_sycl_platforms(), reason="No SYCL platforms available"
+)
+def test_is_in_device_context_outside_device_ctxt():
+    assert not dpctl.is_in_device_context()
 
-    @unittest.skipUnless(has_gpu(), "No OpenCL GPU queues available")
-    def test_is_in_device_context_inside_device_ctxt(self):
+
+@pytest.mark.skipif(not has_gpu(), reason="No OpenCL GPU queues available")
+def test_is_in_device_context_inside_device_ctxt_gpu():
+    with dpctl.device_context("opencl:gpu:0"):
+        assert dpctl.is_in_device_context()
+
+
+@pytest.mark.skipif(not has_cpu(), reason="No OpenCL CPU queues available")
+def test_is_in_device_context_inside_device_ctxt_cpu():
+    with dpctl.device_context("opencl:cpu:0"):
+        assert dpctl.is_in_device_context()
+
+
+@pytest.mark.skipif(not has_gpu(), reason="No OpenCL GPU queues available")
+@pytest.mark.skipif(not has_cpu(), reason="No OpenCL CPU queues available")
+def test_is_in_device_context_inside_nested_device_ctxt():
+    with dpctl.device_context("opencl:cpu:0"):
         with dpctl.device_context("opencl:gpu:0"):
-            self.assertTrue(dpctl.is_in_device_context())
-
-    @unittest.skipUnless(has_gpu(), "No OpenCL GPU queues available")
-    @unittest.skipUnless(has_cpu(), "No OpenCL CPU queues available")
-    def test_is_in_device_context_inside_nested_device_ctxt(self):
-        with dpctl.device_context("opencl:cpu:0"):
-            with dpctl.device_context("opencl:gpu:0"):
-                self.assertTrue(dpctl.is_in_device_context())
-            self.assertTrue(dpctl.is_in_device_context())
-        self.assertFalse(dpctl.is_in_device_context())
+            assert dpctl.is_in_device_context()
+        assert dpctl.is_in_device_context()
+    assert not dpctl.is_in_device_context()
 
 
-@unittest.skipIf(not has_sycl_platforms(), "No SYCL platforms available")
-@unittest.skipUnless(has_gpu(), "No OpenCL GPU queues available")
-class TestGetCurrentDevice(unittest.TestCase):
-    def test_get_current_device_type_outside_device_ctxt(self):
-        self.assertNotEqual(dpctl.get_current_device_type(), None)
+@pytest.mark.skipif(not has_cpu(), reason="No OpenCL CPU queues available")
+def test_is_in_device_context_inside_nested_device_ctxt_cpu():
+    cpu = dpctl.SyclDevice("cpu")
+    n = cpu.max_compute_units
+    n_half = n // 2
+    try:
+        d0, d1 = cpu.create_subdevices(partition=[n_half, n - n_half])
+    except Exception:
+        pytest.skip("Could not create subdevices")
+    assert 0 == dpctl.get_num_activated_queues()
+    with dpctl.device_context(d0):
+        assert 1 == dpctl.get_num_activated_queues()
+        with dpctl.device_context(d1):
+            assert 2 == dpctl.get_num_activated_queues()
+            assert dpctl.is_in_device_context()
+        assert dpctl.is_in_device_context()
+        assert 1 == dpctl.get_num_activated_queues()
+    assert not dpctl.is_in_device_context()
+    assert 0 == dpctl.get_num_activated_queues()
 
-    def test_get_current_device_type_inside_device_ctxt(self):
-        self.assertNotEqual(dpctl.get_current_device_type(), None)
+
+@pytest.mark.skipif(
+    not has_sycl_platforms(), reason="No SYCL platforms available"
+)
+def test_get_current_device_type_outside_device_ctxt():
+    assert dpctl.get_current_device_type() is not None
+
+
+@pytest.mark.skipif(
+    not has_sycl_platforms(), reason="No SYCL platforms available"
+)
+@pytest.mark.skipif(not has_gpu(), reason="No OpenCL GPU queues available")
+def test_get_current_device_type_inside_device_ctxt():
+    assert dpctl.get_current_device_type() is not None
+
+    with dpctl.device_context("opencl:gpu:0"):
+        assert dpctl.get_current_device_type() == dpctl.device_type.gpu
+
+    assert dpctl.get_current_device_type() is not None
+
+
+@pytest.mark.skipif(not has_cpu(), reason="No OpenCL CPU queues available")
+@pytest.mark.skipif(not has_gpu(), reason="No OpenCL GPU queues available")
+def test_get_current_device_type_inside_nested_device_ctxt():
+    assert dpctl.get_current_device_type() is not None
+
+    with dpctl.device_context("opencl:cpu:0"):
+        assert dpctl.get_current_device_type() == dpctl.device_type.cpu
 
         with dpctl.device_context("opencl:gpu:0"):
-            self.assertEqual(
-                dpctl.get_current_device_type(), dpctl.device_type.gpu
-            )
+            assert dpctl.get_current_device_type() == dpctl.device_type.gpu
+        assert dpctl.get_current_device_type() == dpctl.device_type.cpu
 
-        self.assertNotEqual(dpctl.get_current_device_type(), None)
-
-    @unittest.skipUnless(has_cpu(), "No OpenCL CPU queues available")
-    def test_get_current_device_type_inside_nested_device_ctxt(self):
-        self.assertNotEqual(dpctl.get_current_device_type(), None)
-
-        with dpctl.device_context("opencl:cpu:0"):
-            self.assertEqual(
-                dpctl.get_current_device_type(), dpctl.device_type.cpu
-            )
-
-            with dpctl.device_context("opencl:gpu:0"):
-                self.assertEqual(
-                    dpctl.get_current_device_type(), dpctl.device_type.gpu
-                )
-            self.assertEqual(
-                dpctl.get_current_device_type(), dpctl.device_type.cpu
-            )
-
-        self.assertNotEqual(dpctl.get_current_device_type(), None)
+    assert dpctl.get_current_device_type() is not None
 
 
-@unittest.skipIf(not has_sycl_platforms(), "No SYCL platforms available")
-class TestGetCurrentQueueInMultipleThreads(unittest.TestCase):
-    def test_num_current_queues_outside_with_clause(self):
-        self.assertEqual(dpctl.get_num_activated_queues(), 0)
-
-    @unittest.skipUnless(has_gpu(), "No OpenCL GPU queues available")
-    @unittest.skipUnless(has_cpu(), "No OpenCL CPU queues available")
-    def test_num_current_queues_inside_with_clause(self):
-        with dpctl.device_context("opencl:cpu:0"):
-            self.assertEqual(dpctl.get_num_activated_queues(), 1)
-            with dpctl.device_context("opencl:gpu:0"):
-                self.assertEqual(dpctl.get_num_activated_queues(), 2)
-        self.assertEqual(dpctl.get_num_activated_queues(), 0)
-
-    @unittest.skipUnless(has_gpu(), "No OpenCL GPU queues available")
-    @unittest.skipUnless(has_cpu(), "No OpenCL CPU queues available")
-    def test_num_current_queues_inside_threads(self):
-        from threading import Thread
-
-        def SessionThread(self):
-            self.assertEqual(dpctl.get_num_activated_queues(), 0)
-            with dpctl.device_context("opencl:gpu:0"):
-                self.assertEqual(dpctl.get_num_activated_queues(), 1)
-
-        Session1 = Thread(target=SessionThread(self))
-        Session2 = Thread(target=SessionThread(self))
-        with dpctl.device_context("opencl:cpu:0"):
-            self.assertEqual(dpctl.get_num_activated_queues(), 1)
-            Session1.start()
-            Session2.start()
+@pytest.mark.skipif(
+    not has_sycl_platforms(), reason="No SYCL platforms available"
+)
+def test_num_current_queues_outside_with_clause():
+    assert 0 == dpctl.get_num_activated_queues()
 
 
-if __name__ == "__main__":
-    unittest.main()
+@pytest.mark.skipif(not has_gpu(), reason="No OpenCL GPU queues available")
+@pytest.mark.skipif(not has_cpu(), reason="No OpenCL CPU queues available")
+def test_num_current_queues_inside_with_clause():
+    with dpctl.device_context("opencl:cpu:0"):
+        assert 1 == dpctl.get_num_activated_queues()
+        with dpctl.device_context("opencl:gpu:0"):
+            assert 2 == dpctl.get_num_activated_queues()
+    assert 0 == dpctl.get_num_activated_queues()
+
+
+@pytest.mark.skipif(not has_gpu(), reason="No OpenCL GPU queues available")
+@pytest.mark.skipif(not has_cpu(), reason="No OpenCL CPU queues available")
+def test_num_current_queues_inside_threads():
+    from threading import Thread
+
+    def SessionThread():
+        assert dpctl.get_num_activated_queues() == 0
+        with dpctl.device_context("opencl:gpu:0"):
+            assert dpctl.get_num_activated_queues() == 1
+
+    Session1 = Thread(target=SessionThread())
+    Session2 = Thread(target=SessionThread())
+    with dpctl.device_context("opencl:cpu:0"):
+        assert dpctl.get_num_activated_queues() == 1
+        Session1.start()
+        Session2.start()
+
+
+@pytest.mark.skipif(
+    not has_sycl_platforms(), reason="No SYCL platforms available"
+)
+def test_get_current_backend():
+    dpctl.get_current_backend()
+    dpctl.get_current_device_type()
+    q = dpctl.SyclQueue()
+    dpctl.set_global_queue(q)
+    if has_gpu():
+        dpctl.set_global_queue("gpu")
+    elif has_cpu():
+        dpctl.set_global_queue("cpu")

--- a/dpctl/tests/test_sycl_usm.py
+++ b/dpctl/tests/test_sycl_usm.py
@@ -17,9 +17,8 @@
 """Defines unit test cases for the Memory classes in _memory.pyx.
 """
 
-import unittest
-
 import numpy as np
+import pytest
 
 import dpctl
 from dpctl.memory import (
@@ -45,212 +44,215 @@ class Dummy(MemoryUSMShared):
         return iface
 
 
-class TestMemory(unittest.TestCase):
-    @unittest.skipUnless(
-        has_sycl_platforms(), "No SYCL devices except the default host device."
-    )
-    def test_memory_create(self):
-        nbytes = 1024
-        queue = dpctl.get_current_queue()
-        mobj = MemoryUSMShared(nbytes, alignment=64, queue=queue)
-        self.assertEqual(mobj.nbytes, nbytes)
-        self.assertTrue(hasattr(mobj, "__sycl_usm_array_interface__"))
-
-    @unittest.skipUnless(
-        has_sycl_platforms(), "No SYCL devices except the default host device."
-    )
-    def test_memory_create_with_np(self):
-        nbytes = 16384
-        mobj = dpctl.memory.MemoryUSMShared(np.int64(nbytes))
-        self.assertEqual(mobj.nbytes, nbytes)
-        self.assertTrue(hasattr(mobj, "__sycl_usm_array_interface__"))
-
-    def _create_memory(self):
-        nbytes = 1024
-        queue = dpctl.get_current_queue()
-        mobj = MemoryUSMShared(nbytes, alignment=64, queue=queue)
-        return mobj
-
-    def _create_host_buf(self, nbytes):
-        ba = bytearray(nbytes)
-        for i in range(nbytes):
-            ba[i] = (i % 32) + ord("a")
-        return ba
-
-    @unittest.skipUnless(
-        has_sycl_platforms(), "No SYCL devices except the default host device."
-    )
-    def test_memory_without_context(self):
-        mobj = self._create_memory()
-
-        # Without context
-        self.assertEqual(mobj.get_usm_type(), "shared")
-
-    @unittest.skipUnless(has_cpu(), "No OpenCL CPU queues available")
-    def test_memory_cpu_context(self):
-        mobj = self._create_memory()
-
-        # CPU context
-        with dpctl.device_context("opencl:cpu:0"):
-            # type respective to the context in which
-            # memory was created
-            usm_type = mobj.get_usm_type()
-            self.assertEqual(usm_type, "shared")
-
-            current_queue = dpctl.get_current_queue()
-            # type as view from current queue
-            usm_type = mobj.get_usm_type(current_queue)
-            # type can be unknown if current queue is
-            # not in the same SYCL context
-            self.assertTrue(usm_type in ["unknown", "shared"])
-
-    @unittest.skipUnless(has_gpu(), "No OpenCL GPU queues available")
-    def test_memory_gpu_context(self):
-        mobj = self._create_memory()
-
-        # GPU context
-        with dpctl.device_context("opencl:gpu:0"):
-            usm_type = mobj.get_usm_type()
-            self.assertEqual(usm_type, "shared")
-            current_queue = dpctl.get_current_queue()
-            usm_type = mobj.get_usm_type(current_queue)
-            self.assertTrue(usm_type in ["unknown", "shared"])
-
-    @unittest.skipUnless(
-        has_sycl_platforms(), "No SYCL devices except the default host device."
-    )
-    def test_buffer_protocol(self):
-        mobj = self._create_memory()
-        mv1 = memoryview(mobj)
-        mv2 = memoryview(mobj)
-        self.assertEqual(mv1, mv2)
-
-    @unittest.skipUnless(
-        has_sycl_platforms(), "No SYCL devices except the default host device."
-    )
-    def test_copy_host_roundtrip(self):
-        mobj = self._create_memory()
-        host_src_obj = self._create_host_buf(mobj.nbytes)
-        mobj.copy_from_host(host_src_obj)
-        host_dest_obj = mobj.copy_to_host()
-        del mobj
-        self.assertEqual(host_src_obj, host_dest_obj)
-
-    @unittest.skipUnless(
-        has_sycl_platforms(), "No SYCL devices except the default host device."
-    )
-    def test_zero_copy(self):
-        mobj = self._create_memory()
-        mobj2 = type(mobj)(mobj)
-
-        self.assertTrue(mobj2.reference_obj is mobj)
-        mobj_data = mobj.__sycl_usm_array_interface__["data"]
-        mobj2_data = mobj2.__sycl_usm_array_interface__["data"]
-        self.assertEqual(mobj_data, mobj2_data)
-
-    @unittest.skipUnless(
-        has_sycl_platforms(), "No SYCL devices except the default host device."
-    )
-    def test_pickling(self):
-        import pickle
-
-        mobj = self._create_memory()
-        host_src_obj = self._create_host_buf(mobj.nbytes)
-        mobj.copy_from_host(host_src_obj)
-
-        mobj_reconstructed = pickle.loads(pickle.dumps(mobj))
-        self.assertEqual(
-            type(mobj),
-            type(mobj_reconstructed),
-            "Pickling should preserve type",
-        )
-        self.assertEqual(
-            mobj.tobytes(),
-            mobj_reconstructed.tobytes(),
-            "Pickling should preserve buffer content",
-        )
-        self.assertNotEqual(
-            mobj._pointer,
-            mobj_reconstructed._pointer,
-            "Pickling/unpickling changes pointer",
-        )
+@pytest.mark.skipif(
+    not has_sycl_platforms(),
+    reason="No SYCL devices except the default host device.",
+)
+def test_memory_create():
+    nbytes = 1024
+    queue = dpctl.get_current_queue()
+    mobj = MemoryUSMShared(nbytes, alignment=64, queue=queue)
+    assert mobj.nbytes == nbytes
+    assert hasattr(mobj, "__sycl_usm_array_interface__")
 
 
-class _TestMemoryUSMBase:
-    """Base tests for MemoryUSM*"""
-
-    def setUp(self):
-        pass
-
-    @unittest.skipUnless(
-        has_sycl_platforms(), "No SYCL devices except the default host device."
-    )
-    def test_create_with_size_and_alignment_and_queue(self):
-        q = dpctl.get_current_queue()
-        m = self.MemoryUSMClass(1024, alignment=64, queue=q)
-        self.assertEqual(m.nbytes, 1024)
-        self.assertEqual(m.get_usm_type(), self.usm_type)
-
-    @unittest.skipUnless(
-        has_sycl_platforms(), "No SYCL devices except the default host device."
-    )
-    def test_create_with_size_and_queue(self):
-        q = dpctl.get_current_queue()
-        m = self.MemoryUSMClass(1024, queue=q)
-        self.assertEqual(m.nbytes, 1024)
-        self.assertEqual(m.get_usm_type(), self.usm_type)
-
-    @unittest.skipUnless(
-        has_sycl_platforms(), "No SYCL devices except the default host device."
-    )
-    def test_create_with_size_and_alignment(self):
-        m = self.MemoryUSMClass(1024, alignment=64)
-        self.assertEqual(m.nbytes, 1024)
-        self.assertEqual(m.get_usm_type(), self.usm_type)
-
-    @unittest.skipUnless(
-        has_sycl_platforms(), "No SYCL devices except the default host device."
-    )
-    def test_create_with_only_size(self):
-        m = self.MemoryUSMClass(1024)
-        self.assertEqual(m.nbytes, 1024)
-        self.assertEqual(m.get_usm_type(), self.usm_type)
-
-    @unittest.skipUnless(
-        has_sycl_platforms(), "No SYCL Devices except the default host device."
-    )
-    def test_sycl_usm_array_interface(self):
-        m = self.MemoryUSMClass(256)
-        m2 = Dummy(m.nbytes)
-        hb = np.random.randint(0, 256, size=256, dtype="|u1")
-        m2.copy_from_host(hb)
-        # test that USM array interface works with SyclContext as 'syclobj'
-        m.copy_from_device(m2)
-        self.assertTrue(np.array_equal(m.copy_to_host(), hb))
+@pytest.mark.skipif(
+    not has_sycl_platforms(),
+    reason="No SYCL devices except the default host device.",
+)
+def test_memory_create_with_np():
+    nbytes = 16384
+    mobj = dpctl.memory.MemoryUSMShared(np.int64(nbytes))
+    assert mobj.nbytes == nbytes
+    assert hasattr(mobj, "__sycl_usm_array_interface__")
 
 
-class TestMemoryUSMShared(_TestMemoryUSMBase, unittest.TestCase):
-    """Tests for MemoryUSMShared"""
-
-    def setUp(self):
-        self.MemoryUSMClass = MemoryUSMShared
-        self.usm_type = "shared"
-
-
-class TestMemoryUSMHost(_TestMemoryUSMBase, unittest.TestCase):
-    """Tests for MemoryUSMHost"""
-
-    def setUp(self):
-        self.MemoryUSMClass = MemoryUSMHost
-        self.usm_type = "host"
+def _create_memory():
+    nbytes = 1024
+    queue = dpctl.get_current_queue()
+    mobj = MemoryUSMShared(nbytes, alignment=64, queue=queue)
+    return mobj
 
 
-class TestMemoryUSMDevice(_TestMemoryUSMBase, unittest.TestCase):
-    """Tests for MemoryUSMDevice"""
+def _create_host_buf(nbytes):
+    ba = bytearray(nbytes)
+    for i in range(nbytes):
+        ba[i] = (i % 32) + ord("a")
+    return ba
 
-    def setUp(self):
-        self.MemoryUSMClass = MemoryUSMDevice
-        self.usm_type = "device"
+
+@pytest.mark.skipif(
+    not has_sycl_platforms(),
+    reason="No SYCL devices except the default host device.",
+)
+def test_memory_without_context():
+    mobj = _create_memory()
+
+    # Without context
+    assert mobj.get_usm_type() == "shared"
+
+
+@pytest.mark.skipif(not has_cpu(), reason="No SYCL CPU device available.")
+def test_memory_cpu_context():
+    mobj = _create_memory()
+
+    # CPU context
+    with dpctl.device_context("opencl:cpu:0"):
+        # type respective to the context in which
+        # memory was created
+        usm_type = mobj.get_usm_type()
+        assert usm_type == "shared"
+
+        current_queue = dpctl.get_current_queue()
+        # type as view from current queue
+        usm_type = mobj.get_usm_type(current_queue)
+        # type can be unknown if current queue is
+        # not in the same SYCL context
+        assert usm_type in ["unknown", "shared"]
+
+
+@pytest.mark.skipif(not has_gpu(), reason="No OpenCL GPU queues available")
+def test_memory_gpu_context():
+    mobj = _create_memory()
+
+    # GPU context
+    with dpctl.device_context("opencl:gpu:0"):
+        usm_type = mobj.get_usm_type()
+        assert usm_type == "shared"
+        current_queue = dpctl.get_current_queue()
+        usm_type = mobj.get_usm_type(current_queue)
+        assert usm_type in ["unknown", "shared"]
+
+
+@pytest.mark.skipif(
+    not has_sycl_platforms(),
+    reason="No SYCL devices except the default host device.",
+)
+def test_buffer_protocol():
+    mobj = _create_memory()
+    mv1 = memoryview(mobj)
+    mv2 = memoryview(mobj)
+    assert mv1 == mv2
+
+
+@pytest.mark.skipif(
+    not has_sycl_platforms(),
+    reason="No SYCL devices except the default host device.",
+)
+def test_copy_host_roundtrip():
+    mobj = _create_memory()
+    host_src_obj = _create_host_buf(mobj.nbytes)
+    mobj.copy_from_host(host_src_obj)
+    host_dest_obj = mobj.copy_to_host()
+    del mobj
+    assert host_src_obj == host_dest_obj
+
+
+@pytest.mark.skipif(
+    not has_sycl_platforms(),
+    reason="No SYCL devices except the default host device.",
+)
+def test_zero_copy():
+    mobj = _create_memory()
+    mobj2 = type(mobj)(mobj)
+
+    assert mobj2.reference_obj is mobj
+    mobj_data = mobj.__sycl_usm_array_interface__["data"]
+    mobj2_data = mobj2.__sycl_usm_array_interface__["data"]
+    assert mobj_data == mobj2_data
+
+
+@pytest.mark.skipif(
+    not has_sycl_platforms(),
+    reason="No SYCL devices except the default host device.",
+)
+def test_pickling():
+    import pickle
+
+    mobj = _create_memory()
+    host_src_obj = _create_host_buf(mobj.nbytes)
+    mobj.copy_from_host(host_src_obj)
+
+    mobj_reconstructed = pickle.loads(pickle.dumps(mobj))
+    assert type(mobj) == type(
+        mobj_reconstructed
+    ), "Pickling should preserve type"
+    assert (
+        mobj.tobytes() == mobj_reconstructed.tobytes()
+    ), "Pickling should preserve buffer content"
+    assert (
+        mobj._pointer != mobj_reconstructed._pointer
+    ), "Pickling/unpickling should be changing pointer"
+
+
+@pytest.fixture(params=[MemoryUSMShared, MemoryUSMDevice, MemoryUSMHost])
+def memory_ctor(request):
+    return request.param
+
+
+def expected_usm_type(ctor):
+    mapping = {
+        MemoryUSMShared: "shared",
+        MemoryUSMDevice: "device",
+        MemoryUSMHost: "host",
+    }
+    return mapping.get(ctor, "unknown")
+
+
+@pytest.mark.skipif(
+    not has_sycl_platforms(),
+    reason="No SYCL devices except the default host device.",
+)
+def test_create_with_size_and_alignment_and_queue(memory_ctor):
+    q = dpctl.SyclQueue()
+    m = memory_ctor(1024, alignment=64, queue=q)
+    assert m.nbytes == 1024
+    assert m.get_usm_type() == expected_usm_type(memory_ctor)
+
+
+@pytest.mark.skipif(
+    not has_sycl_platforms(),
+    reason="No SYCL devices except the default host device.",
+)
+def test_create_with_size_and_queue(memory_ctor):
+    q = dpctl.SyclQueue()
+    m = memory_ctor(1024, queue=q)
+    assert m.nbytes == 1024
+    assert m.get_usm_type() == expected_usm_type(memory_ctor)
+
+
+@pytest.mark.skipif(
+    not has_sycl_platforms(),
+    reason="No SYCL devices except the default host device.",
+)
+def test_create_with_size_and_alignment(memory_ctor):
+    m = memory_ctor(1024, alignment=64)
+    assert m.nbytes == 1024
+    assert m.get_usm_type() == expected_usm_type(memory_ctor)
+
+
+@pytest.mark.skipif(
+    not has_sycl_platforms(),
+    reason="No SYCL devices except the default host device.",
+)
+def test_create_with_only_size(memory_ctor):
+    m = memory_ctor(1024)
+    assert m.nbytes == 1024
+    assert m.get_usm_type() == expected_usm_type(memory_ctor)
+
+
+@pytest.mark.skipif(
+    not has_sycl_platforms(),
+    reason="No SYCL devices except the default host device.",
+)
+def test_sycl_usm_array_interface(memory_ctor):
+    m = memory_ctor(256)
+    m2 = Dummy(m.nbytes)
+    hb = np.random.randint(0, 256, size=256, dtype="|u1")
+    m2.copy_from_host(hb)
+    # test that USM array interface works with SyclContext as 'syclobj'
+    m.copy_from_device(m2)
+    assert np.array_equal(m.copy_to_host(), hb)
 
 
 class View:
@@ -272,140 +274,118 @@ class View:
         return sua_iface
 
 
-class TestMemoryWithView(unittest.TestCase):
-    def test_suai_non_contig_1D(self):
-        """
-        Test of zero-copy using sycl_usm_array_interface with non-contiguous
-        data.
-        """
+def test_suai_non_contig_1D(memory_ctor):
+    """
+    Test of zero-copy using sycl_usm_array_interface with non-contiguous
+    data.
+    """
 
-        MemoryUSMClass = MemoryUSMShared
-        try:
-            buf = MemoryUSMClass(32)
-        except Exception:
-            self.skipTest("MemoryUSMShared could not be allocated")
-        host_canary = np.full((buf.nbytes,), 77, dtype="|u1")
-        buf.copy_from_host(host_canary)
-        n1d = 10
-        step_1d = 2
-        offset = 8
-        v = View(buf, shape=(n1d,), strides=(step_1d,), offset=offset)
-        buf2 = MemoryUSMClass(v)
-        expected_nbytes = (
-            np.flip(
-                host_canary[offset : offset + n1d * step_1d : step_1d]
-            ).ctypes.data
-            + 1
-            - host_canary[offset:].ctypes.data
-        )
-        self.assertEqual(buf2.nbytes, expected_nbytes)
-        inset_canary = np.arange(0, buf2.nbytes, dtype="|u1")
-        buf2.copy_from_host(inset_canary)
-        res = buf.copy_to_host()
-        del buf
-        del buf2
-        expected_res = host_canary.copy()
-        expected_res[offset : offset + (n1d - 1) * step_1d + 1] = inset_canary
-        self.assertTrue(np.array_equal(res, expected_res))
-
-    def test_suai_non_contig_2D(self):
-        MemoryUSMClass = MemoryUSMDevice
-        try:
-            buf = MemoryUSMClass(20)
-        except Exception:
-            self.skipTest("MemoryUSMShared could not be allocated")
-        host_canary = np.arange(20, dtype="|u1")
-        buf.copy_from_host(host_canary)
-        shape_2d = (2, 2)
-        strides_2d = (10, -2)
-        offset = 9
-        idx = []
-        for i0 in range(shape_2d[0]):
-            for i1 in range(shape_2d[1]):
-                idx.append(offset + i0 * strides_2d[0] + i1 * strides_2d[1])
-        idx.sort()
-        v = View(buf, shape=shape_2d, strides=strides_2d, offset=offset)
-        buf2 = MemoryUSMClass(v)
-        expected_nbytes = idx[-1] - idx[0] + 1
-        self.assertEqual(buf2.nbytes, expected_nbytes)
-        inset_canary = np.full((buf2.nbytes), 255, dtype="|u1")
-        buf2.copy_from_host(inset_canary)
-        res = buf.copy_to_host()
-        del buf
-        del buf2
-        expected_res = host_canary.copy()
-        expected_res[idx[0] : idx[-1] + 1] = inset_canary
-        self.assertTrue(np.array_equal(res, expected_res))
+    try:
+        buf = memory_ctor(32)
+    except Exception:
+        pytest.skip("{} could not be allocated".format(memory_ctor.__name__))
+    host_canary = np.full((buf.nbytes,), 77, dtype="|u1")
+    buf.copy_from_host(host_canary)
+    n1d = 10
+    step_1d = 2
+    offset = 8
+    v = View(buf, shape=(n1d,), strides=(step_1d,), offset=offset)
+    buf2 = memory_ctor(v)
+    expected_nbytes = (
+        np.flip(
+            host_canary[offset : offset + n1d * step_1d : step_1d]
+        ).ctypes.data
+        + 1
+        - host_canary[offset:].ctypes.data
+    )
+    assert buf2.nbytes == expected_nbytes
+    inset_canary = np.arange(0, buf2.nbytes, dtype="|u1")
+    buf2.copy_from_host(inset_canary)
+    res = buf.copy_to_host()
+    del buf
+    del buf2
+    expected_res = host_canary.copy()
+    expected_res[offset : offset + (n1d - 1) * step_1d + 1] = inset_canary
+    assert np.array_equal(res, expected_res)
 
 
-class TestAsUSMMemory(unittest.TestCase):
-    def _with_constructor(self, buffer_cls):
-        try:
-            buf = buffer_cls(64)
-        except Exception:
-            self.SkipTest(
-                "{} could not be allocated".format(buffer_cls.__name__)
-            )
-        # reuse queue from buffer's SUAI
-        v = View(buf, shape=(64,), strides=(1,), offset=0)
-        m = as_usm_memory(v)
-        self.assertTrue(m.get_usm_type() == buf.get_usm_type())
-        self.assertTrue(m._pointer == buf._pointer)
-        self.assertTrue(m.sycl_device == buf.sycl_device)
-        # Use SyclContext
-        v = View(
-            buf, shape=(64,), strides=(1,), offset=0, syclobj=buf.sycl_context
-        )
-        m = as_usm_memory(v)
-        self.assertTrue(m.get_usm_type() == buf.get_usm_type())
-        self.assertTrue(m._pointer == buf._pointer)
-        self.assertTrue(m.sycl_device == buf.sycl_device)
-        # Use queue capsule
-        v = View(
-            buf,
-            shape=(64,),
-            strides=(1,),
-            offset=0,
-            syclobj=buf._queue._get_capsule(),
-        )
-        m = as_usm_memory(v)
-        self.assertTrue(m.get_usm_type() == buf.get_usm_type())
-        self.assertTrue(m._pointer == buf._pointer)
-        self.assertTrue(m.sycl_device == buf.sycl_device)
-        # Use context capsule
-        v = View(
-            buf,
-            shape=(64,),
-            strides=(1,),
-            offset=0,
-            syclobj=buf.sycl_context._get_capsule(),
-        )
-        m = as_usm_memory(v)
-        self.assertTrue(m.get_usm_type() == buf.get_usm_type())
-        self.assertTrue(m._pointer == buf._pointer)
-        self.assertTrue(m.sycl_device == buf.sycl_device)
-        # Use filter string
-        v = View(
-            buf,
-            shape=(64,),
-            strides=(1,),
-            offset=0,
-            syclobj=buf.sycl_device.filter_string,
-        )
-        m = as_usm_memory(v)
-        self.assertTrue(m.get_usm_type() == buf.get_usm_type())
-        self.assertTrue(m._pointer == buf._pointer)
-        self.assertTrue(m.sycl_device == buf.sycl_device)
-
-    def test_from_device(self):
-        self._with_constructor(MemoryUSMDevice)
-
-    def test_from_shared(self):
-        self._with_constructor(MemoryUSMShared)
-
-    def test_from_host(self):
-        self._with_constructor(MemoryUSMHost)
+def test_suai_non_contig_2D(memory_ctor):
+    try:
+        buf = memory_ctor(20)
+    except Exception:
+        pytest.skip("{} could not be allocated".format(memory_ctor.__name__))
+    host_canary = np.arange(20, dtype="|u1")
+    buf.copy_from_host(host_canary)
+    shape_2d = (2, 2)
+    strides_2d = (10, -2)
+    offset = 9
+    idx = []
+    for i0 in range(shape_2d[0]):
+        for i1 in range(shape_2d[1]):
+            idx.append(offset + i0 * strides_2d[0] + i1 * strides_2d[1])
+    idx.sort()
+    v = View(buf, shape=shape_2d, strides=strides_2d, offset=offset)
+    buf2 = memory_ctor(v)
+    expected_nbytes = idx[-1] - idx[0] + 1
+    assert buf2.nbytes == expected_nbytes
+    inset_canary = np.full((buf2.nbytes), 255, dtype="|u1")
+    buf2.copy_from_host(inset_canary)
+    res = buf.copy_to_host()
+    del buf
+    del buf2
+    expected_res = host_canary.copy()
+    expected_res[idx[0] : idx[-1] + 1] = inset_canary
+    assert np.array_equal(res, expected_res)
 
 
-if __name__ == "__main__":
-    unittest.main()
+def check_view(v):
+    """
+    Memory object created from duck __sycl_usm_array_interface__ argument
+    should be consistent with the buffer from which the argument was constructed
+    """
+    assert type(v) is View
+    buf = v.buffer_
+    m = as_usm_memory(v)
+    assert m.get_usm_type() == buf.get_usm_type()
+    assert m._pointer == buf._pointer
+    assert m.sycl_device == buf.sycl_device
+
+
+def test_with_constructor(memory_ctor):
+    try:
+        buf = memory_ctor(64)
+    except Exception:
+        pytest.skip("{} could not be allocated".format(memory_ctor.__name__))
+    # reuse queue from buffer's SUAI
+    v = View(buf, shape=(64,), strides=(1,), offset=0)
+    check_view(v)
+    # Use SyclContext
+    v = View(buf, shape=(64,), strides=(1,), offset=0, syclobj=buf.sycl_context)
+    check_view(v)
+    # Use queue capsule
+    v = View(
+        buf,
+        shape=(64,),
+        strides=(1,),
+        offset=0,
+        syclobj=buf._queue._get_capsule(),
+    )
+    check_view(v)
+    # Use context capsule
+    v = View(
+        buf,
+        shape=(64,),
+        strides=(1,),
+        offset=0,
+        syclobj=buf.sycl_context._get_capsule(),
+    )
+    check_view(v)
+    # Use filter string
+    v = View(
+        buf,
+        shape=(64,),
+        strides=(1,),
+        offset=0,
+        syclobj=buf.sycl_device.filter_string,
+    )
+    check_view(v)


### PR DESCRIPTION
Changed all test files that used `unittest` to use `pytest` instead.

Expanded tests to improve coverage. 

Fixed several unreferenced bugs/crashes uncovered by expanded test suite.

