### PR TITLE
Added tests for constructors with invalid capsules

### DIFF
--- a/dpctl/_sycl_event.pyx
+++ b/dpctl/_sycl_event.pyx
@@ -88,8 +88,10 @@ cdef class _SyclEvent:
     """
 
     def __dealloc__(self):
-        DPCTLEvent_Wait(self._event_ref)
-        DPCTLEvent_Delete(self._event_ref)
+        if (self._event_ref):
+            DPCTLEvent_Wait(self._event_ref)
+            DPCTLEvent_Delete(self._event_ref)
+        self._event_ref = NULL
         self.args = None
 
 

--- a/dpctl/tests/_helper.py
+++ b/dpctl/tests/_helper.py
@@ -11,3 +11,15 @@ def has_cpu(backend="opencl"):
 
 def has_sycl_platforms():
     return bool(len(dpctl.get_platforms()))
+
+
+def create_invalid_capsule():
+    """Creates an invalid capsule for the purpose of testing dpctl
+    constructors that accept capsules.
+    """
+    import ctypes
+
+    ctor = ctypes.pythonapi.PyCapsule_New
+    ctor.restype = ctypes.py_object
+    ctor.argtypes = [ctypes.c_void_p, ctypes.c_char_p, ctypes.c_void_p]
+    return ctor(id(ctor), b"invalid", 0)

--- a/dpctl/tests/test_sycl_context.py
+++ b/dpctl/tests/test_sycl_context.py
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-""" Defines unit test cases for the SyclContxt class.
+""" Defines unit test cases for the :class:`dpctl.SyclContext` class.
 """
 
 import pytest
@@ -218,3 +218,10 @@ def test_invalid_capsule():
     cap = create_invalid_capsule()
     with pytest.raises(ValueError):
         dpctl.SyclContext(cap)
+
+
+def test_multi_device_different_platforms():
+    devs = dpctl.get_devices()  # all devices
+    if len(devs) > 1:
+        with pytest.raises(ValueError):
+            dpctl.SyclContext(devs)

--- a/dpctl/tests/test_sycl_context.py
+++ b/dpctl/tests/test_sycl_context.py
@@ -21,6 +21,8 @@ import pytest
 
 import dpctl
 
+from ._helper import create_invalid_capsule
+
 list_of_valid_filter_selectors = [
     "opencl",
     "opencl:gpu",
@@ -210,3 +212,9 @@ def test_cpython_api():
     r2 = ctx.addressof_ref()
     r1 = get_context_ref_fn(ctx)
     assert r1 == r2
+
+
+def test_invalid_capsule():
+    cap = create_invalid_capsule()
+    with pytest.raises(ValueError):
+        dpctl.SyclContext(cap)

--- a/dpctl/tests/test_sycl_event.py
+++ b/dpctl/tests/test_sycl_event.py
@@ -25,7 +25,7 @@ import dpctl.memory as dpctl_mem
 import dpctl.program as dpctl_prog
 from dpctl import event_status_type as esty
 
-from ._helper import has_cpu
+from ._helper import create_invalid_capsule, has_cpu
 
 
 def produce_event(profiling=False):
@@ -221,6 +221,12 @@ def test_event_capsule():
     del ev
     del cap1  # test deleter
     del cap2
+
+
+def test_event_invalid_capsule():
+    cap = create_invalid_capsule()
+    with pytest.raises(TypeError):
+        dpctl.SyclEvent(cap)
 
 
 def test_addressof_ref():


### PR DESCRIPTION
`SyclEvent` destructor now only calls wait and delete on non-null references.

Added tests to check that constructors handle invalid capsules. 

Added tests to very that queues from different platforms are unequal, added test for validation that creating `SyclQueue` from a context and a devices not from that context.

Added tests to check that creation of `SyclContext` from devices from different platforms fails.