### PR TITLE
Static method SyclQueue._create_from_context_and_device change

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -24,6 +24,7 @@ per-file-ignores =
     dpctl/program/_program.pyx: E999, E225, E226, E227
     dpctl/tensor/_usmarray.pyx: E999, E225, E226, E227
     dpctl/tensor/numpy_usm_shared.py: F821
+    dpctl/tests/_cython_api.pyx: E999, E225, E227, E402
     examples/cython/sycl_buffer/_buffer_example.pyx: E999, E225, E402
     examples/cython/sycl_direct_linkage/_buffer_example.pyx: E999, E225, E402
     examples/cython/usm_memory/blackscholes.pyx: E999, E225, E226, E402

--- a/.github/workflows/generate-coverage.yaml
+++ b/.github/workflows/generate-coverage.yaml
@@ -87,7 +87,7 @@ jobs:
           source /opt/intel/oneapi/setvars.sh
           python setup.py develop --coverage=True
           python -c "import dpctl; print(dpctl.__version__); dpctl.lsplatform()"
-          pytest -q -ra --disable-warnings --cov dpctl --cov-report term-missing --pyargs dpctl -vv
+          pytest -q -ra --disable-warnings --cov-config pyproject.toml --cov dpctl --cov-report term-missing --pyargs dpctl -vv
 
       - name: Install coverall dependencies
         shell: bash -l {0}

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -14,3 +14,4 @@ include dpctl/memory/_memory_api.h
 include dpctl/tensor/_usmarray.h
 include dpctl/tensor/_usmarray_api.h
 include dpctl/tests/input_files/*
+include dpctl/tests/*.pyx

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -32,6 +32,7 @@ requirements:
 
 test:
     requires:
+        - cython
         - pytest
         - pytest-cov
 

--- a/dpctl/_sycl_queue.pxd
+++ b/dpctl/_sycl_queue.pxd
@@ -66,7 +66,7 @@ cdef public api class SyclQueue (_SyclQueue) [
     cdef  SyclQueue _create(DPCTLSyclQueueRef qref)
     @staticmethod
     cdef  SyclQueue _create_from_context_and_device(
-        SyclContext ctx, SyclDevice dev
+        SyclContext ctx, SyclDevice dev, int props=*
     )
     cdef cpp_bool equals(self, SyclQueue q)
     cpdef SyclContext get_sycl_context(self)

--- a/dpctl/_sycl_queue.pyx
+++ b/dpctl/_sycl_queue.pyx
@@ -537,13 +537,24 @@ cdef class SyclQueue(_SyclQueue):
 
     @staticmethod
     cdef SyclQueue _create_from_context_and_device(
-        SyclContext ctx, SyclDevice dev
+        SyclContext ctx, SyclDevice dev, int props=0
     ):
+        """
+        Static factory method to create :class:`dpctl.SyclQueue` instance
+        from given :class:`dpctl.SyclContext`, :class:`dpctl.SyclDevice`
+        and optional integer `props` encoding the queue properties.
+        """
         cdef _SyclQueue ret = _SyclQueue.__new__(_SyclQueue)
         cdef DPCTLSyclContextRef cref = ctx.get_context_ref()
         cdef DPCTLSyclDeviceRef dref = dev.get_device_ref()
-        cdef DPCTLSyclQueueRef qref = DPCTLQueue_Create(cref, dref, NULL, 0)
+        cdef DPCTLSyclQueueRef qref = NULL
 
+        qref = DPCTLQueue_Create(
+            cref,
+            dref,
+            <error_handler_callback *>&default_async_error_handler,
+            props
+        )
         if qref is NULL:
             raise SyclQueueCreationError("Queue creation failed.")
         ret._queue_ref = qref

--- a/dpctl/tests/_cython_api.pyx
+++ b/dpctl/tests/_cython_api.pyx
@@ -1,0 +1,18 @@
+# cython: language=c++
+# cython: language_level=3
+
+cimport dpctl as c_dpctl
+
+import dpctl
+
+
+def call_create_from_context_and_devices():
+    cdef c_dpctl.SyclQueue q
+    d = dpctl.SyclDevice()
+    ctx = dpctl.SyclContext(d)
+    # calling static method
+    q = c_dpctl.SyclQueue._create_from_context_and_device(
+        <c_dpctl.SyclContext> ctx,
+        <c_dpctl.SyclDevice> d
+    )
+    return q

--- a/dpctl/tests/setup_cython_api.py
+++ b/dpctl/tests/setup_cython_api.py
@@ -1,0 +1,12 @@
+import setuptools
+
+import dpctl
+
+ext = setuptools.Extension(
+    "_cython_api",
+    ["_cython_api.pyx"],
+    include_dirs=[dpctl.get_include()],
+    language="c++",
+)
+
+setuptools.setup(name="_cython_api", version="0.0.0", ext_modules=[ext])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,12 @@ omit = [
     "dpctl/_version.py",
 ]
 
+[tool.coverage.report]
+omit = [
+    "dpctl/tests/*",
+    "dpctl/_version.py",
+]
+
 [tool.pytest.ini.options]
 minversion = "6.0"
 norecursedirs= [


### PR DESCRIPTION
1. Added docstrings
2. Added optional keyword argument props, to allow queue creation
   with properties.
3. Modified pyproject.toml to not collect coverage of `dpctl/tests/*` and not to report it. Thus, this PR closes #374 
4. `test_sycl_queue` now adds a test that build a cython extension and calls Cython API functions, e.g. static methods of classes.