### PR TITLE
Use renamed DPC++ runtime package `dpcpp-cpp-rt`

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -28,7 +28,7 @@ requirements:
     run:
         - python
         - numpy >=1.17
-        - dpcpp_cpp_rt >=2021.2
+        - dpcpp-cpp-rt >=2021.2
 
 test:
     requires:


### PR DESCRIPTION
From @tomashek (SAT-4412):
> dpcpp_cpp_rt was renamed to dpcpp-cpp-rt. We need to make sure we are using the new ones. The old are still around for backward compatibility.