### PR TITLE
Used clang-format off, clang-format on to avoid include reordering

### DIFF
--- a/examples/pybind11/use_dpctl_syclqueue/example.py
+++ b/examples/pybind11/use_dpctl_syclqueue/example.py
@@ -25,9 +25,13 @@ q = dpctl.SyclQueue()
 
 # Pass dpctl.SyclQueue to Pybind11 extension
 eu_count = eg.get_max_compute_units(q)
+global_mem_size = eg.get_device_global_mem_size(q.sycl_device)
+local_mem_size = eg.get_device_local_mem_size(q.sycl_device)
 
 print(f"EU count returned by Pybind11 extension {eu_count}")
 print("EU count computed by dpctl {}".format(q.sycl_device.max_compute_units))
+print("Device's global memory size:  {} bytes".format(global_mem_size))
+print("Device's local memory size:  {} bytes".format(local_mem_size))
 
 print("")
 print("Computing modular reduction using SYCL on a NumPy array")

--- a/examples/pybind11/use_dpctl_syclqueue/pybind11_example.cpp
+++ b/examples/pybind11/use_dpctl_syclqueue/pybind11_example.cpp
@@ -3,9 +3,13 @@
 #include <pybind11/numpy.h>
 #include <pybind11/pybind11.h>
 
+// clang-format off
+#include "dpctl_sycl_types.h"
 #include "../_sycl_queue.h"
 #include "../_sycl_queue_api.h"
-#include "dpctl_sycl_types.h"
+#include "../_sycl_device.h"
+#include "../_sycl_device_api.h"
+// clang-format on
 
 namespace py = pybind11;
 
@@ -22,6 +26,34 @@ size_t get_max_compute_units(py::object queue)
     }
     else {
         throw std::runtime_error("expected dpctl.SyclQueue as argument");
+    }
+}
+
+uint64_t get_device_global_mem_size(py::object device)
+{
+    PyObject *device_pycapi = device.ptr();
+    if (PyObject_TypeCheck(device_pycapi, &PySyclDeviceType)) {
+        DPCTLSyclDeviceRef DRef = get_device_ref(
+            reinterpret_cast<PySyclDeviceObject *>(device_pycapi));
+        sycl::device *d_ptr = reinterpret_cast<sycl::device *>(DRef);
+        return d_ptr->get_info<sycl::info::device::global_mem_size>();
+    }
+    else {
+        throw std::runtime_error("expected dpctl.SyclDevice as argument");
+    }
+}
+
+uint64_t get_device_local_mem_size(py::object device)
+{
+    PyObject *device_pycapi = device.ptr();
+    if (PyObject_TypeCheck(device_pycapi, &PySyclDeviceType)) {
+        DPCTLSyclDeviceRef DRef = get_device_ref(
+            reinterpret_cast<PySyclDeviceObject *>(device_pycapi));
+        sycl::device *d_ptr = reinterpret_cast<sycl::device *>(DRef);
+        return d_ptr->get_info<sycl::info::device::local_mem_size>();
+    }
+    else {
+        throw std::runtime_error("expected dpctl.SyclDevice as argument");
     }
 }
 
@@ -82,11 +114,16 @@ offloaded_array_mod(py::object queue,
 
 PYBIND11_MODULE(pybind11_example, m)
 {
-    // Import the dpctl._sycl_queue extension
+    // Import the dpctl._sycl_queue, dpctl._sycl_device extensions
+    import_dpctl___sycl_device();
     import_dpctl___sycl_queue();
     m.def("get_max_compute_units", &get_max_compute_units,
           "Computes max_compute_units property of the device underlying given "
           "dpctl.SyclQueue");
+    m.def("get_device_global_mem_size", &get_device_global_mem_size,
+          "Computes amount of global memory of the given dpctl.SyclDevice");
+    m.def("get_device_local_mem_size", &get_device_local_mem_size,
+          "Computes amount of local memory of the given dpctl.SyclDevice");
     m.def("offloaded_array_mod", &offloaded_array_mod,
           "Compute offloaded modular reduction of integer-valued NumPy array");
 }


### PR DESCRIPTION
Fixed clang-format induced issue with ordering of includes in the pybind11 example. 

The "dpctl_sycl_types.h" must be included before dpctl's CPython API headers (e.g. `_sycl_queue_api.h`). Otherwise compilation errors with `DPCTLSyclQueueRef` is underfined.

Implemented two more functions, retrieving useful device properties, such as Global and local memory size in bytes. (see #587)