### PR TITLE
isort GH action changed and no longer accepts `args` input

### DIFF
--- a/.github/workflows/python_style_checks.yml
+++ b/.github/workflows/python_style_checks.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/setup-python@v2
       - uses: jamescurtin/isort-action@master
         with:
-          args: ". --check-only"
+          configuration: "--check-only"
 
   black:
     # The type of runner that the job will run on


### PR DESCRIPTION
Changed to use configuration input to specify CLI arguments.

Prompted by warning in https://github.com/IntelPython/dpctl/actions/runs/1249104763

![image](https://user-images.githubusercontent.com/21087696/134258933-1943c014-d472-4bee-a501-6e538af0163c.png)
