### PR TITLE
Remove use of DPC++ features deprecated in 2021.4 and open source intel/llvm compiler

### DIFF
--- a/dpctl-capi/CMakeLists.txt
+++ b/dpctl-capi/CMakeLists.txt
@@ -41,7 +41,7 @@ option(DPCTL_BUILD_CAPI_TESTS
 
 # Minimum version requirement only when oneAPI dpcpp is used.
 if(DPCTL_DPCPP_FROM_ONEAPI)
-    find_package(IntelSycl 2021.2.0 REQUIRED)
+    find_package(IntelSycl 2021.3.0 REQUIRED)
 else()
     find_package(IntelSycl REQUIRED)
 endif()

--- a/dpctl-capi/source/dpctl_sycl_context_interface.cpp
+++ b/dpctl-capi/source/dpctl_sycl_context_interface.cpp
@@ -28,6 +28,7 @@
 #include "../helper/include/dpctl_async_error_handler.h"
 #include "Support/CBindingWrapping.h"
 #include <CL/sycl.hpp>
+#include <vector>
 
 using namespace cl::sycl;
 
@@ -36,7 +37,7 @@ namespace
 // Create wrappers for C Binding types (see CBindingWrapping.h).
 DEFINE_SIMPLE_CONVERSION_FUNCTIONS(context, DPCTLSyclContextRef)
 DEFINE_SIMPLE_CONVERSION_FUNCTIONS(device, DPCTLSyclDeviceRef)
-DEFINE_SIMPLE_CONVERSION_FUNCTIONS(vector_class<DPCTLSyclDeviceRef>,
+DEFINE_SIMPLE_CONVERSION_FUNCTIONS(std::vector<DPCTLSyclDeviceRef>,
                                    DPCTLDeviceVectorRef)
 } /* end of anonymous namespace */
 
@@ -67,7 +68,7 @@ DPCTLContext_CreateFromDevices(__dpctl_keep const DPCTLDeviceVectorRef DVRef,
                                int /**/)
 {
     DPCTLSyclContextRef CRef = nullptr;
-    vector_class<device> Devices;
+    std::vector<device> Devices;
     auto DeviceRefs = unwrap(DVRef);
     if (!DeviceRefs)
         return CRef;
@@ -125,9 +126,9 @@ DPCTLContext_GetDevices(__dpctl_keep const DPCTLSyclContextRef CRef)
                      "input is a nullptr\n";
         return nullptr;
     }
-    vector_class<DPCTLSyclDeviceRef> *DevicesVectorPtr = nullptr;
+    std::vector<DPCTLSyclDeviceRef> *DevicesVectorPtr = nullptr;
     try {
-        DevicesVectorPtr = new vector_class<DPCTLSyclDeviceRef>();
+        DevicesVectorPtr = new std::vector<DPCTLSyclDeviceRef>();
     } catch (std::bad_alloc const &ba) {
         // \todo log error
         std::cerr << ba.what() << '\n';

--- a/dpctl-capi/source/dpctl_sycl_device_interface.cpp
+++ b/dpctl-capi/source/dpctl_sycl_device_interface.cpp
@@ -31,6 +31,7 @@
 #include <CL/sycl.hpp> /* SYCL headers   */
 #include <algorithm>
 #include <cstring>
+#include <vector>
 
 using namespace cl::sycl;
 
@@ -40,7 +41,7 @@ namespace
 DEFINE_SIMPLE_CONVERSION_FUNCTIONS(device, DPCTLSyclDeviceRef)
 DEFINE_SIMPLE_CONVERSION_FUNCTIONS(device_selector, DPCTLSyclDeviceSelectorRef)
 DEFINE_SIMPLE_CONVERSION_FUNCTIONS(platform, DPCTLSyclPlatformRef)
-DEFINE_SIMPLE_CONVERSION_FUNCTIONS(vector_class<DPCTLSyclDeviceRef>,
+DEFINE_SIMPLE_CONVERSION_FUNCTIONS(std::vector<DPCTLSyclDeviceRef>,
                                    DPCTLDeviceVectorRef)
 
 } /* end of anonymous namespace */
@@ -608,7 +609,7 @@ __dpctl_give DPCTLDeviceVectorRef
 DPCTLDevice_CreateSubDevicesEqually(__dpctl_keep const DPCTLSyclDeviceRef DRef,
                                     size_t count)
 {
-    vector_class<DPCTLSyclDeviceRef> *Devices = nullptr;
+    std::vector<DPCTLSyclDeviceRef> *Devices = nullptr;
     if (DRef) {
         if (count == 0) {
             std::cerr << "Can not create sub-devices with zero compute units"
@@ -619,7 +620,7 @@ DPCTLDevice_CreateSubDevicesEqually(__dpctl_keep const DPCTLSyclDeviceRef DRef,
         try {
             auto subDevices = D->create_sub_devices<
                 info::partition_property::partition_equally>(count);
-            Devices = new vector_class<DPCTLSyclDeviceRef>();
+            Devices = new std::vector<DPCTLSyclDeviceRef>();
             for (const auto &sd : subDevices) {
                 Devices->emplace_back(wrap(new device(sd)));
             }
@@ -646,7 +647,7 @@ DPCTLDevice_CreateSubDevicesByCounts(__dpctl_keep const DPCTLSyclDeviceRef DRef,
                                      __dpctl_keep size_t *counts,
                                      size_t ncounts)
 {
-    vector_class<DPCTLSyclDeviceRef> *Devices = nullptr;
+    std::vector<DPCTLSyclDeviceRef> *Devices = nullptr;
     std::vector<size_t> vcounts(ncounts);
     vcounts.assign(counts, counts + ncounts);
     size_t min_elem = *std::min_element(vcounts.begin(), vcounts.end());
@@ -657,7 +658,7 @@ DPCTLDevice_CreateSubDevicesByCounts(__dpctl_keep const DPCTLSyclDeviceRef DRef,
     }
     if (DRef) {
         auto D = unwrap(DRef);
-        vector_class<std::remove_pointer<decltype(D)>::type> subDevices;
+        std::vector<std::remove_pointer<decltype(D)>::type> subDevices;
         try {
             subDevices = D->create_sub_devices<
                 info::partition_property::partition_by_counts>(vcounts);
@@ -670,7 +671,7 @@ DPCTLDevice_CreateSubDevicesByCounts(__dpctl_keep const DPCTLSyclDeviceRef DRef,
             return nullptr;
         }
         try {
-            Devices = new vector_class<DPCTLSyclDeviceRef>();
+            Devices = new std::vector<DPCTLSyclDeviceRef>();
             for (const auto &sd : subDevices) {
                 Devices->emplace_back(wrap(new device(sd)));
             }
@@ -692,7 +693,7 @@ __dpctl_give DPCTLDeviceVectorRef DPCTLDevice_CreateSubDevicesByAffinity(
     __dpctl_keep const DPCTLSyclDeviceRef DRef,
     DPCTLPartitionAffinityDomainType PartitionAffinityDomainTy)
 {
-    vector_class<DPCTLSyclDeviceRef> *Devices = nullptr;
+    std::vector<DPCTLSyclDeviceRef> *Devices = nullptr;
     auto D = unwrap(DRef);
     if (D) {
         try {
@@ -700,7 +701,7 @@ __dpctl_give DPCTLDeviceVectorRef DPCTLDevice_CreateSubDevicesByAffinity(
                 PartitionAffinityDomainTy);
             auto subDevices = D->create_sub_devices<
                 info::partition_property::partition_by_affinity_domain>(domain);
-            Devices = new vector_class<DPCTLSyclDeviceRef>();
+            Devices = new std::vector<DPCTLSyclDeviceRef>();
             for (const auto &sd : subDevices) {
                 Devices->emplace_back(wrap(new device(sd)));
             }

--- a/dpctl-capi/source/dpctl_sycl_device_manager.cpp
+++ b/dpctl-capi/source/dpctl_sycl_device_manager.cpp
@@ -31,6 +31,7 @@
 #include <iomanip>
 #include <iostream>
 #include <unordered_map>
+#include <vector>
 
 using namespace cl::sycl;
 
@@ -142,10 +143,10 @@ DPCTLDeviceMgr_GetCachedContext(__dpctl_keep const DPCTLSyclDeviceRef DRef)
 __dpctl_give DPCTLDeviceVectorRef
 DPCTLDeviceMgr_GetDevices(int device_identifier)
 {
-    vector_class<DPCTLSyclDeviceRef> *Devices = nullptr;
+    std::vector<DPCTLSyclDeviceRef> *Devices = nullptr;
 
     try {
-        Devices = new vector_class<DPCTLSyclDeviceRef>();
+        Devices = new std::vector<DPCTLSyclDeviceRef>();
     } catch (std::bad_alloc const &ba) {
         delete Devices;
         return nullptr;

--- a/dpctl-capi/source/dpctl_sycl_device_selector_interface.cpp
+++ b/dpctl-capi/source/dpctl_sycl_device_selector_interface.cpp
@@ -83,7 +83,7 @@ __dpctl_give DPCTLSyclDeviceSelectorRef
 DPCTLFilterSelector_Create(__dpctl_keep const char *filter_str)
 {
     try {
-        auto Selector = new ONEAPI::filter_selector(filter_str);
+        auto Selector = new ext::oneapi::filter_selector(filter_str);
         return wrap(Selector);
     } catch (std::bad_alloc &ba) {
         std::cerr << ba.what() << '\n';

--- a/dpctl-capi/source/dpctl_sycl_device_selector_interface.cpp
+++ b/dpctl-capi/source/dpctl_sycl_device_selector_interface.cpp
@@ -82,8 +82,13 @@ __dpctl_give DPCTLSyclDeviceSelectorRef DPCTLCPUSelector_Create()
 __dpctl_give DPCTLSyclDeviceSelectorRef
 DPCTLFilterSelector_Create(__dpctl_keep const char *filter_str)
 {
+#if __SYCL_COMPILER_VERSION < 20210925
+    using filter_selector_t = sycl::ONEAPI::filter_selector;
+#else
+    using filter_selector_t = sycl::ext::oneapi::filter_selector;
+#endif
     try {
-        auto Selector = new ext::oneapi::filter_selector(filter_str);
+        auto Selector = new filter_selector_t(filter_str);
         return wrap(Selector);
     } catch (std::bad_alloc &ba) {
         std::cerr << ba.what() << '\n';

--- a/dpctl-capi/source/dpctl_sycl_event_interface.cpp
+++ b/dpctl-capi/source/dpctl_sycl_event_interface.cpp
@@ -28,6 +28,7 @@
 #include "../helper/include/dpctl_utils_helper.h"
 #include "Support/CBindingWrapping.h"
 #include <CL/sycl.hpp> /* SYCL headers   */
+#include <vector>
 
 using namespace cl::sycl;
 
@@ -196,9 +197,9 @@ DPCTLEvent_GetWaitList(__dpctl_keep DPCTLSyclEventRef ERef)
         std::cerr << "Cannot get wait list as input is a nullptr\n";
         return nullptr;
     }
-    vector_class<DPCTLSyclEventRef> *EventsVectorPtr = nullptr;
+    std::vector<DPCTLSyclEventRef> *EventsVectorPtr = nullptr;
     try {
-        EventsVectorPtr = new vector_class<DPCTLSyclEventRef>();
+        EventsVectorPtr = new std::vector<DPCTLSyclEventRef>();
     } catch (std::bad_alloc const &ba) {
         // \todo log error
         std::cerr << ba.what() << '\n';

--- a/dpctl-capi/source/dpctl_sycl_platform_interface.cpp
+++ b/dpctl-capi/source/dpctl_sycl_platform_interface.cpp
@@ -32,6 +32,7 @@
 #include <iostream>
 #include <set>
 #include <sstream>
+#include <vector>
 
 using namespace cl::sycl;
 
@@ -39,7 +40,7 @@ namespace
 {
 DEFINE_SIMPLE_CONVERSION_FUNCTIONS(platform, DPCTLSyclPlatformRef);
 DEFINE_SIMPLE_CONVERSION_FUNCTIONS(device_selector, DPCTLSyclDeviceSelectorRef);
-DEFINE_SIMPLE_CONVERSION_FUNCTIONS(vector_class<DPCTLSyclPlatformRef>,
+DEFINE_SIMPLE_CONVERSION_FUNCTIONS(std::vector<DPCTLSyclPlatformRef>,
                                    DPCTLPlatformVectorRef);
 } // namespace
 
@@ -207,12 +208,12 @@ DPCTLPlatform_GetVersion(__dpctl_keep const DPCTLSyclPlatformRef PRef)
 
 __dpctl_give DPCTLPlatformVectorRef DPCTLPlatform_GetPlatforms()
 {
-    vector_class<DPCTLSyclPlatformRef> *Platforms = nullptr;
+    std::vector<DPCTLSyclPlatformRef> *Platforms = nullptr;
 
     auto platforms = platform::get_platforms();
 
     try {
-        Platforms = new vector_class<DPCTLSyclPlatformRef>();
+        Platforms = new std::vector<DPCTLSyclPlatformRef>();
         Platforms->reserve(platforms.size());
     } catch (std::bad_alloc const &ba) {
         return nullptr;

--- a/dpctl-capi/source/dpctl_sycl_queue_manager.cpp
+++ b/dpctl-capi/source/dpctl_sycl_queue_manager.cpp
@@ -43,7 +43,7 @@ DEFINE_SIMPLE_CONVERSION_FUNCTIONS(context, DPCTLSyclContextRef)
 
 struct QueueManager
 {
-    using QueueStack = vector_class<queue>;
+    using QueueStack = std::vector<queue>;
     static QueueStack &getQueueStack()
     {
         thread_local static QueueStack *activeQueues = new QueueStack([] {

--- a/dpctl-capi/source/dpctl_vector_templ.cpp
+++ b/dpctl-capi/source/dpctl_vector_templ.cpp
@@ -26,10 +26,11 @@
 #include "../helper/include/dpctl_vector_macros.h"
 #include "Support/MemOwnershipAttrs.h"
 #include <type_traits>
+#include <vector>
 
 namespace
 {
-DEFINE_SIMPLE_CONVERSION_FUNCTIONS(vector_class<SYCLREF(EL)>, VECTOR(EL))
+DEFINE_SIMPLE_CONVERSION_FUNCTIONS(std::vector<SYCLREF(EL)>, VECTOR(EL))
 }
 
 /*!
@@ -39,9 +40,9 @@ DEFINE_SIMPLE_CONVERSION_FUNCTIONS(vector_class<SYCLREF(EL)>, VECTOR(EL))
  */
 __dpctl_give VECTOR(EL) FN(EL, Create)()
 {
-    vector_class<SYCLREF(EL)> *Vec = nullptr;
+    std::vector<SYCLREF(EL)> *Vec = nullptr;
     try {
-        Vec = new vector_class<SYCLREF(EL)>();
+        Vec = new std::vector<SYCLREF(EL)>();
         return wrap(Vec);
     } catch (std::bad_alloc const &ba) {
         delete Vec;
@@ -58,9 +59,9 @@ __dpctl_give VECTOR(EL) FN(EL, Create)()
 __dpctl_give VECTOR(EL)
     FN(EL, CreateFromArray)(size_t n, __dpctl_keep SYCLREF(EL) * elems)
 {
-    vector_class<SYCLREF(EL)> *Vec = nullptr;
+    std::vector<SYCLREF(EL)> *Vec = nullptr;
     try {
-        Vec = new vector_class<SYCLREF(EL)>();
+        Vec = new std::vector<SYCLREF(EL)>();
         for (size_t i = 0; i < n; ++i) {
             auto Ref = unwrap(elems[i]);
             Vec->emplace_back(

--- a/dpctl-capi/tests/test_sycl_context_interface.cpp
+++ b/dpctl-capi/tests/test_sycl_context_interface.cpp
@@ -31,13 +31,14 @@
 #include "dpctl_sycl_types.h"
 #include <CL/sycl.hpp>
 #include <gtest/gtest.h>
+#include <vector>
 
 using namespace cl::sycl;
 
 namespace
 {
 DEFINE_SIMPLE_CONVERSION_FUNCTIONS(sycl::device, DPCTLSyclDeviceRef);
-DEFINE_SIMPLE_CONVERSION_FUNCTIONS(vector_class<DPCTLSyclDeviceRef>,
+DEFINE_SIMPLE_CONVERSION_FUNCTIONS(std::vector<DPCTLSyclDeviceRef>,
                                    DPCTLDeviceVectorRef)
 } // namespace
 

--- a/dpctl-capi/tests/test_sycl_context_interface.cpp
+++ b/dpctl-capi/tests/test_sycl_context_interface.cpp
@@ -37,9 +37,6 @@ using namespace cl::sycl;
 
 namespace
 {
-DEFINE_SIMPLE_CONVERSION_FUNCTIONS(sycl::device, DPCTLSyclDeviceRef);
-DEFINE_SIMPLE_CONVERSION_FUNCTIONS(std::vector<DPCTLSyclDeviceRef>,
-                                   DPCTLDeviceVectorRef)
 } // namespace
 
 struct TestDPCTLContextInterface : public ::testing::TestWithParam<const char *>
@@ -84,25 +81,16 @@ TEST_P(TestDPCTLContextInterface, ChkCreateWithDevices)
     DPCTLSyclContextRef CRef = nullptr;
     DPCTLDeviceVectorRef DVRef = nullptr;
 
-    /* TODO: Once we have wrappers for sub-device creation let us use those
-     * functions.
-     */
     EXPECT_NO_FATAL_FAILURE(nCUs = DPCTLDevice_GetMaxComputeUnits(DRef));
-    if (nCUs) {
-        auto D = unwrap(DRef);
-        try {
-            auto subDevices = D->create_sub_devices<
-                info::partition_property::partition_equally>(nCUs / 2);
-            EXPECT_NO_FATAL_FAILURE(DVRef = DPCTLDeviceVector_Create());
-            for (auto &sd : subDevices) {
-                unwrap(DVRef)->emplace_back(wrap(new device(sd)));
-            }
-            EXPECT_NO_FATAL_FAILURE(
-                CRef = DPCTLContext_CreateFromDevices(DVRef, nullptr, 0));
-            ASSERT_TRUE(CRef);
-        } catch (feature_not_supported const &fnse) {
+    if (nCUs > 1) {
+        EXPECT_NO_FATAL_FAILURE(
+            DVRef = DPCTLDevice_CreateSubDevicesEqually(DRef, nCUs / 2));
+        if (!DVRef) {
             GTEST_SKIP_("Skipping creating context for sub-devices");
         }
+        EXPECT_NO_FATAL_FAILURE(
+            CRef = DPCTLContext_CreateFromDevices(DVRef, nullptr, 0));
+        ASSERT_TRUE(CRef);
     }
     EXPECT_NO_FATAL_FAILURE(DPCTLDeviceVector_Delete(DVRef));
     EXPECT_NO_FATAL_FAILURE(DPCTLContext_Delete(CRef));
@@ -119,28 +107,19 @@ TEST_P(TestDPCTLContextInterface, ChkCreateWithDevicesGetDevices)
      * functions.
      */
     EXPECT_NO_FATAL_FAILURE(nCUs = DPCTLDevice_GetMaxComputeUnits(DRef));
-    if (nCUs) {
-        auto D = unwrap(DRef);
-        try {
-            auto subDevices = D->create_sub_devices<
-                info::partition_property::partition_equally>(nCUs / 2);
-            const size_t len = subDevices.size();
-            auto ar = new DPCTLSyclDeviceRef[len];
-            for (size_t i = 0; i < len; ++i) {
-                ar[i] = wrap(&subDevices.at(i));
-            }
-            EXPECT_NO_FATAL_FAILURE(
-                DVRef = DPCTLDeviceVector_CreateFromArray(len, ar));
-            EXPECT_NO_FATAL_FAILURE(
-                CRef = DPCTLContext_CreateFromDevices(DVRef, nullptr, 0));
-            ASSERT_TRUE(CRef);
-            ASSERT_TRUE(DPCTLContext_DeviceCount(CRef) == len);
-            EXPECT_NO_FATAL_FAILURE(Res_DVRef = DPCTLContext_GetDevices(CRef));
-            ASSERT_TRUE(DPCTLDeviceVector_Size(Res_DVRef) == len);
-            delete[] ar;
-        } catch (feature_not_supported const &fnse) {
+    if (nCUs > 1) {
+        EXPECT_NO_FATAL_FAILURE(
+            DVRef = DPCTLDevice_CreateSubDevicesEqually(DRef, nCUs / 2));
+        if (!DVRef) {
             GTEST_SKIP_("Skipping creating context for sub-devices");
         }
+        EXPECT_NO_FATAL_FAILURE(
+            CRef = DPCTLContext_CreateFromDevices(DVRef, nullptr, 0));
+        ASSERT_TRUE(CRef);
+        const size_t len = DPCTLDeviceVector_Size(DVRef);
+        ASSERT_TRUE(DPCTLContext_DeviceCount(CRef) == len);
+        EXPECT_NO_FATAL_FAILURE(Res_DVRef = DPCTLContext_GetDevices(CRef));
+        ASSERT_TRUE(DPCTLDeviceVector_Size(Res_DVRef) == len);
     }
     EXPECT_NO_FATAL_FAILURE(DPCTLDeviceVector_Delete(DVRef));
     EXPECT_NO_FATAL_FAILURE(DPCTLContext_Delete(CRef));

--- a/dpctl-capi/tests/test_sycl_event_interface.cpp
+++ b/dpctl-capi/tests/test_sycl_event_interface.cpp
@@ -29,13 +29,14 @@
 #include "dpctl_sycl_types.h"
 #include <CL/sycl.hpp>
 #include <gtest/gtest.h>
+#include <vector>
 
 using namespace cl::sycl;
 
 namespace
 {
 DEFINE_SIMPLE_CONVERSION_FUNCTIONS(event, DPCTLSyclEventRef);
-DEFINE_SIMPLE_CONVERSION_FUNCTIONS(vector_class<DPCTLSyclEventRef>,
+DEFINE_SIMPLE_CONVERSION_FUNCTIONS(std::vector<DPCTLSyclEventRef>,
                                    DPCTLEventVectorRef);
 
 #ifndef DPCTL_COVERAGE

--- a/dpctl-capi/tests/test_sycl_event_interface.cpp
+++ b/dpctl-capi/tests/test_sycl_event_interface.cpp
@@ -35,10 +35,6 @@ using namespace cl::sycl;
 
 namespace
 {
-DEFINE_SIMPLE_CONVERSION_FUNCTIONS(event, DPCTLSyclEventRef);
-DEFINE_SIMPLE_CONVERSION_FUNCTIONS(std::vector<DPCTLSyclEventRef>,
-                                   DPCTLEventVectorRef);
-
 #ifndef DPCTL_COVERAGE
 sycl::event produce_event(sycl::queue &Q, sycl::buffer<int> &data)
 {

--- a/dpctl-capi/tests/test_sycl_platform_interface.cpp
+++ b/dpctl-capi/tests/test_sycl_platform_interface.cpp
@@ -37,8 +37,6 @@ using namespace cl::sycl;
 
 namespace
 {
-DEFINE_SIMPLE_CONVERSION_FUNCTIONS(std::vector<DPCTLSyclPlatformRef>,
-                                   DPCTLPlatformVectorRef);
 
 void check_platform_name(__dpctl_keep const DPCTLSyclPlatformRef PRef)
 {

--- a/dpctl-capi/tests/test_sycl_platform_interface.cpp
+++ b/dpctl-capi/tests/test_sycl_platform_interface.cpp
@@ -31,12 +31,13 @@
 #include "dpctl_utils.h"
 #include <CL/sycl.hpp>
 #include <gtest/gtest.h>
+#include <vector>
 
 using namespace cl::sycl;
 
 namespace
 {
-DEFINE_SIMPLE_CONVERSION_FUNCTIONS(vector_class<DPCTLSyclPlatformRef>,
+DEFINE_SIMPLE_CONVERSION_FUNCTIONS(std::vector<DPCTLSyclPlatformRef>,
                                    DPCTLPlatformVectorRef);
 
 void check_platform_name(__dpctl_keep const DPCTLSyclPlatformRef PRef)


### PR DESCRIPTION
Also replaced ``sycl::ONEAPI::filter_selector`` with ``sycl::ext::oneapi::filter_selector``

The packages compiles using open source SYCL compiler after these changes, specifically I used

```
(py39) [13:20:15 ansatnuc04 dpctl]$ clang++ --version
clang version 14.0.0 (https://github.com/intel/llvm 7c17ad9a2bfbf6ff2757f8c7fbd2939841f35fa5)
Target: x86_64-unknown-linux-gnu
Thread model: posix
InstalledDir: /localdisk/work/opavlyk/sycl_workspace/llvm/build/bin
```

Only one meaningful failure in the so compiled package:

```
>       dpctl_prog.create_program_from_spirv(q, spirv)

dpctl/tests/test_sycl_program.py:93:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
dpctl/program/_program.pyx:178: in dpctl.program._program.create_program_from_spirv
    cpdef create_program_from_spirv(SyclQueue q, const unsigned char[:] IL,
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

>   raise SyclProgramCompilationError()
E   dpctl.program._program.SyclProgramCompilationError

dpctl/program/_program.pyx:209: SyclProgramCompilationError
--------------------------------------------------------------------------- Captured stderr call ----------------------------------------------------------------------------
The level zero loader dynamic library could not be opened.
ZeModuleCreateFn is invalid.
========================================================================== short test summary info ==========================================================================
FAILED dpctl/tests/test_sycl_program.py::test_create_program_from_spirv_l0 - dpctl.program._program.SyclProgramCompilationError
```

but not sure of the cause. 

This change closes #602, although I think changes here will need adjustments to ensure the package can be built by using both newer and older compiler versions. 