### PR TITLE
Silly typo behind slow copy

### DIFF
--- a/dpctl/tensor/_copy_utils.py
+++ b/dpctl/tensor/_copy_utils.py
@@ -181,6 +181,7 @@ def copy_same_dtype(dst, src):
 def copy_same_shape(dst, src):
     if src.dtype == dst.dtype:
         copy_same_dtype(dst, src)
+        return
 
     # check that memory regions do not overlap
     if has_memory_overlap(dst, src):


### PR DESCRIPTION
The following example used to be very slow

```python
import dpctl.tensor as dpt
X = dpt.usm_ndarray((1_000_000, 4), "d")
Z1 = dpt.usm_ndarray((1_000, 4), "d")
X[:1_000] = Z1
```

due to missing return after early optimization call.