### PR TITLE
Avoid passing nullptr to sycl::queue::prefetch to avoid buggy hang

### DIFF
--- a/dpctl-capi/source/dpctl_sycl_queue_interface.cpp
+++ b/dpctl-capi/source/dpctl_sycl_queue_interface.cpp
@@ -514,15 +514,23 @@ DPCTLSyclEventRef DPCTLQueue_Prefetch(__dpctl_keep DPCTLSyclQueueRef QRef,
 {
     auto Q = unwrap(QRef);
     if (Q) {
-        sycl::event ev;
-        try {
-            ev = Q->prefetch(Ptr, Count);
-        } catch (sycl::runtime_error &re) {
+        if (Ptr) {
+            sycl::event ev;
+            try {
+                ev = Q->prefetch(Ptr, Count);
+            } catch (sycl::runtime_error &re) {
+                // todo: log error
+                std::cerr << re.what() << '\n';
+                return nullptr;
+            }
+            return wrap(new event(ev));
+        }
+        else {
             // todo: log error
-            std::cerr << re.what() << '\n';
+            std::cerr << "Attempt to prefetch USM-allocation at nullptr"
+                      << '\n';
             return nullptr;
         }
-        return wrap(new event(ev));
     }
     else {
         // todo: log error


### PR DESCRIPTION
For bookkeeping filed an issue behind the hang as XDEPS-2765. 

Fix for the hang is to avoid passing nullptr argument to ``sycl::queue::prefetch``.