### PR TITLE
Moved repeated status message outside of if/else statement

### DIFF
--- a/dpctl-capi/CMakeLists.txt
+++ b/dpctl-capi/CMakeLists.txt
@@ -207,11 +207,10 @@ if(DPCTL_GENERATE_COVERAGE)
     set(DPCTL_BUILD_CAPI_TESTS "ON")
     if(DPCTL_COVERAGE_REPORT_OUTPUT_DIR)
         set(COVERAGE_OUTPUT_DIR ${DPCTL_COVERAGE_REPORT_OUTPUT_DIR})
-        message(STATUS "Coverage reports to be saved at ${COVERAGE_OUTPUT_DIR}")
     else()
         set(COVERAGE_OUTPUT_DIR ${CMAKE_CURRENT_BINARY_DIR})
-        message(STATUS "Coverage reports to be saved at ${COVERAGE_OUTPUT_DIR}")
     endif()
+    message(STATUS "Coverage reports to be saved at ${COVERAGE_OUTPUT_DIR}")
 endif()
 
 # Add sub-directory to build the dpctl C API test cases


### PR DESCRIPTION
No meaningful functional change, just moved status message, identical in both branches of the if/else statement to after the conditional.