### PR TITLE
Improved verbiage in "What?" section

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,20 +5,20 @@
 What?
 ====
 
-`dpctl` (data parallel control) is a lightweight Python package [exposing](https://intelpython.github.io/dpctl)
-subset of the Intel(R) oneAPI DPC++ [runtime entities](https://www.khronos.org/registry/SYCL/specs/sycl-2020/html/sycl-2020.html#_sycl_runtime_classes)
-aiming to aid Python users in
-discovering and representing SYCL devices, constructing SYCL queues, representing USM
-allocations as well as ndarrays built on top of these.
+`dpctl` (data parallel control) is a lightweight [Python package](https://intelpython.github.io/dpctl) exposing a
+subset of the Intel(R) oneAPI DPC++ [runtime classes](https://www.khronos.org/registry/SYCL/specs/sycl-2020/html/sycl-2020.html#_sycl_runtime_classes).
+`dpctl` aids Python users in discovering and representing SYCL devices, constructing SYCL queues, and queuerying SYCL platforms.
+
+`dpctl` features classes representing [SYCL unified shared memory](https://www.khronos.org/registry/SYCL/specs/sycl-2020/html/sycl-2020.html#sec:usm)
+allocations as well as higher-level objects such as [`dpctl.tensor.usm_ndarray`](https://intelpython.github.io/dpctl/latest/docfiles/dpctl.tensor_api.html#module-dpctl.tensor) on top of these.
 
 <img align="right" src="https://spec.oneapi.io/oneapi-logo-white-scaled.jpg" alt="oneAPI logo" />
 
-`dpctl` is a part of DPPY (data parallel Python) stack powered by oneAPI. It is included
-in Intel(R) [oneAPI](https://oneapi.io) [Base ToolKit](https://software.intel.com/content/www/us/en/develop/tools/oneapi/base-toolkit.html).
+`dpctl` is a part of [Intel(R) Distribution for Python*](https://software.intel.com/content/www/us/en/develop/tools/oneapi/components/distribution-for-python.html) and
+is included in Intel(R) [oneAPI](https://oneapi.io) [Base ToolKit](https://software.intel.com/content/www/us/en/develop/tools/oneapi/base-toolkit.html).
 
-`dpctl` consists of sycl-interface C library and Python bindings. The C library
-depends on DPC++ runtime only, while Python package additionally requires
-`numpy` to be installed.
+`dpctl` also provides C library for SYCL interfaces which depends on DPC++ runtime
+only, while the Python package additionally requires `numpy` to be installed.
 
 `dpctl` strives to assist authors of Python native extensions written in C,
 Cython, or pybind11 to use its `dpctl.SyclQueue` object to indicate the offload

--- a/README.md
+++ b/README.md
@@ -6,10 +6,27 @@ What?
 ====
 <img align="left" src="https://spec.oneapi.io/oneapi-logo-white-scaled.jpg" alt="oneAPI logo" />
 
-A lightweight Python package exposing a subset of DPC++ functionality, part of Intel(R) [oneAPI](https://oneapi.io) [Base ToolKit](https://software.intel.com/content/www/us/en/develop/tools/oneapi/base-toolkit.html).
+`dpctl` (data parallel control) is a lightweight Python package [exposing](https://intelpython.github.io/dpctl)
+subset of the Intel(R) oneAPI DPC++ runtime entities aiming to aid Python users in
+discovering and representing SYCL devices, constructing SYCL queues, representing USM
+allocations as well as ndarrays built on top of these.
 
-`dpctl` [provides](https://intelpython.github.io/dpctl) for discovery and selection of SYCL devices, construction of SYCL queues, as well as working with SYCL USM allocations. `dpctl.tensor` contains growing implementation of n-dimensional array conforming to [array-API specification](https://data-apis.org/array-api) backed by a USM-allocation and powered by SYCL kernels.
-<br />
+`dpctl` is a part of DPPY (data parallel Python) stack powered by oneAPI. It is included
+in Intel(R) [oneAPI](https://oneapi.io) [Base ToolKit](https://software.intel.com/content/www/us/en/develop/tools/oneapi/base-toolkit.html).
+
+`dpctl` consists of sycl-interface C library and Python bindings. The C library
+depends on DPC++ runtime only, while Python package additionally requires
+`numpy` to be installed.
+
+`dpctl` strives to assist authors of Python native extensions written in C,
+Cython, or pybind11 to use its `dpctl.SyclQueue` object to indicate the offload
+target as well as objects in `dpctl.memory` and `dpctl.tensor` submodules to
+represent USM allocations that are accessible from within SYCL kernels executed
+on the target queue.
+
+`dpctl.tensor` submodule provides an array container representing an array in a
+strided layout on top of a USM allocation. The submodule provides an array-API
+conforming oneAPI DPC++ powered library to manipulate the array container.
 
 Requirements
 ============

--- a/README.md
+++ b/README.md
@@ -4,13 +4,14 @@
 
 What?
 ====
-<img align="left" src="https://spec.oneapi.io/oneapi-logo-white-scaled.jpg" alt="oneAPI logo" />
 
 `dpctl` (data parallel control) is a lightweight Python package [exposing](https://intelpython.github.io/dpctl)
 subset of the Intel(R) oneAPI DPC++ [runtime entities](https://www.khronos.org/registry/SYCL/specs/sycl-2020/html/sycl-2020.html#_sycl_runtime_classes)
 aiming to aid Python users in
 discovering and representing SYCL devices, constructing SYCL queues, representing USM
 allocations as well as ndarrays built on top of these.
+
+<img align="right" src="https://spec.oneapi.io/oneapi-logo-white-scaled.jpg" alt="oneAPI logo" />
 
 `dpctl` is a part of DPPY (data parallel Python) stack powered by oneAPI. It is included
 in Intel(R) [oneAPI](https://oneapi.io) [Base ToolKit](https://software.intel.com/content/www/us/en/develop/tools/oneapi/base-toolkit.html).

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ What?
 ====
 <img align="left" src="https://spec.oneapi.io/oneapi-logo-white-scaled.jpg" alt="oneAPI logo" />
 
-A lightweight Python package exposing a subset of SYCL functionalities, part of Intel(R) [oneAPI](https://oneapi.io) [Base ToolKit](https://software.intel.com/content/www/us/en/develop/tools/oneapi/base-toolkit.html).
+A lightweight Python package exposing a subset of DPC++ functionality, part of Intel(R) [oneAPI](https://oneapi.io) [Base ToolKit](https://software.intel.com/content/www/us/en/develop/tools/oneapi/base-toolkit.html).
 
 `dpctl` [provides](https://intelpython.github.io/dpctl) for discovery and selection of SYCL devices, construction of SYCL queues, as well as working with USM allocations.
 <br /><br />

--- a/README.md
+++ b/README.md
@@ -7,7 +7,8 @@ What?
 <img align="left" src="https://spec.oneapi.io/oneapi-logo-white-scaled.jpg" alt="oneAPI logo" />
 
 `dpctl` (data parallel control) is a lightweight Python package [exposing](https://intelpython.github.io/dpctl)
-subset of the Intel(R) oneAPI DPC++ runtime entities aiming to aid Python users in
+subset of the Intel(R) oneAPI DPC++ [runtime entities](https://www.khronos.org/registry/SYCL/specs/sycl-2020/html/sycl-2020.html#_sycl_runtime_classes)
+aiming to aid Python users in
 discovering and representing SYCL devices, constructing SYCL queues, representing USM
 allocations as well as ndarrays built on top of these.
 

--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ What?
 
 A lightweight Python package exposing a subset of DPC++ functionality, part of Intel(R) [oneAPI](https://oneapi.io) [Base ToolKit](https://software.intel.com/content/www/us/en/develop/tools/oneapi/base-toolkit.html).
 
-`dpctl` [provides](https://intelpython.github.io/dpctl) for discovery and selection of SYCL devices, construction of SYCL queues, as well as working with USM allocations.
-<br /><br />
+`dpctl` [provides](https://intelpython.github.io/dpctl) for discovery and selection of SYCL devices, construction of SYCL queues, as well as working with SYCL USM allocations. `dpctl.tensor` contains growing implementation of n-dimensional array conforming to [array-API specification](https://data-apis.org/array-api) backed by a USM-allocation and powered by SYCL kernels.
+<br />
 
 Requirements
 ============

--- a/README.md
+++ b/README.md
@@ -2,12 +2,13 @@
 [![Imports: isort](https://img.shields.io/badge/%20imports-isort-%231674b1?style=flat&labelColor=ef8336)](https://pycqa.github.io/isort/)
 [![Coverage Status](https://coveralls.io/repos/github/IntelPython/dpctl/badge.svg?branch=master)](https://coveralls.io/github/IntelPython/dpctl?branch=master)
 
-What?
-====
+About dpctl
+===========
 
 `dpctl` (data parallel control) is a lightweight [Python package](https://intelpython.github.io/dpctl) exposing a
 subset of the Intel(R) oneAPI DPC++ [runtime classes](https://www.khronos.org/registry/SYCL/specs/sycl-2020/html/sycl-2020.html#_sycl_runtime_classes).
-`dpctl` aids Python users in discovering and representing SYCL devices, constructing SYCL queues, and queuerying SYCL platforms.
+`dpctl` aids Python users in queuerying SYCL platforms, discovering and representing SYCL devices, and constructing SYCL queues. `dpctl` facilitates
+use of constructed SYCL queues to target execution of SYCL kernels on [Intel(R) XPUs](https://www.intel.com/content/www/us/en/newsroom/news/xpu-vision-oneapi-server-gpu.html).
 
 `dpctl` features classes representing [SYCL unified shared memory](https://www.khronos.org/registry/SYCL/specs/sycl-2020/html/sycl-2020.html#sec:usm)
 allocations as well as higher-level objects such as [`dpctl.tensor.usm_ndarray`](https://intelpython.github.io/dpctl/latest/docfiles/dpctl.tensor_api.html#module-dpctl.tensor) on top of these.

--- a/README.md
+++ b/README.md
@@ -5,26 +5,21 @@
 About dpctl
 ===========
 
+<img align="left" src="https://spec.oneapi.io/oneapi-logo-white-scaled.jpg" alt="oneAPI logo" />
+
 `dpctl` (data parallel control) is a lightweight [Python package](https://intelpython.github.io/dpctl) exposing a
-subset of the Intel(R) oneAPI DPC++ [runtime classes](https://www.khronos.org/registry/SYCL/specs/sycl-2020/html/sycl-2020.html#_sycl_runtime_classes).
-`dpctl` aids Python users in queuerying SYCL platforms, discovering and representing SYCL devices, and constructing SYCL queues. `dpctl` facilitates
-use of constructed SYCL queues to target execution of SYCL kernels on [Intel(R) XPUs](https://www.intel.com/content/www/us/en/newsroom/news/xpu-vision-oneapi-server-gpu.html).
+subset of the Intel(R) oneAPI DPC++ [runtime classes](https://www.khronos.org/registry/SYCL/specs/sycl-2020/html/sycl-2020.html#_sycl_runtime_classes)
+that is distributed as part of [Intel(R) Distribution for Python*](https://software.intel.com/content/www/us/en/develop/tools/oneapi/components/distribution-for-python.html) and
+is included in Intel(R) [oneAPI](https://oneapi.io) [Base ToolKit](https://software.intel.com/content/www/us/en/develop/tools/oneapi/base-toolkit.html).
+`dpctl` lets Python users query SYCL platforms, discover and represent SYCL devices, and construct SYCL queues to control data-parallel code execution on [Intel(R) XPUs](https://www.intel.com/content/www/us/en/newsroom/news/xpu-vision-oneapi-server-gpu.html) from Python.
 
 `dpctl` features classes representing [SYCL unified shared memory](https://www.khronos.org/registry/SYCL/specs/sycl-2020/html/sycl-2020.html#sec:usm)
-allocations as well as higher-level objects such as [`dpctl.tensor.usm_ndarray`](https://intelpython.github.io/dpctl/latest/docfiles/dpctl.tensor_api.html#module-dpctl.tensor) on top of these.
+allocations as well as higher-level objects such as [`dpctl.tensor.usm_ndarray`](https://intelpython.github.io/dpctl/latest/docfiles/dpctl.tensor_api.html#module-dpctl.tensor) on top of USM allocations.
 
-<img align="right" src="https://spec.oneapi.io/oneapi-logo-white-scaled.jpg" alt="oneAPI logo" />
-
-`dpctl` is a part of [Intel(R) Distribution for Python*](https://software.intel.com/content/www/us/en/develop/tools/oneapi/components/distribution-for-python.html) and
-is included in Intel(R) [oneAPI](https://oneapi.io) [Base ToolKit](https://software.intel.com/content/www/us/en/develop/tools/oneapi/base-toolkit.html).
-
-`dpctl` also provides C library for SYCL interfaces which depends on DPC++ runtime
-only, while the Python package additionally requires `numpy` to be installed.
-
-`dpctl` strives to assist authors of Python native extensions written in C,
+`dpctl` assists authors of Python native extensions written in C,
 Cython, or pybind11 to use its `dpctl.SyclQueue` object to indicate the offload
 target as well as objects in `dpctl.memory` and `dpctl.tensor` submodules to
-represent USM allocations that are accessible from within SYCL kernels executed
+represent USM allocations that are accessible from within data-parallel code executed
 on the target queue.
 
 `dpctl.tensor` submodule provides an array container representing an array in a


### PR DESCRIPTION
Python API of `dpctl` is tied up to DPC++, depending on some of its SYCL extensions, such as [`filter_selector`](https://github.com/intel/llvm/tree/sycl/sycl/doc/extensions/FilterSelector), [default platform context](https://github.com/intel/llvm/tree/sycl/sycl/doc/extensions/PlatformContext), [queue barrier](https://github.com/intel/llvm/tree/sycl/sycl/doc/extensions/EnqueueBarrier), etc. 

It is best thus to say that `dpctl` exposes to Python a subset of DPC++ functionality, rather than a subset of SYCL functionality.