### PR TITLE
Use readelf on pi_level_zero library to find exact name of ze_loader

### DIFF
--- a/dpctl-capi/CMakeLists.txt
+++ b/dpctl-capi/CMakeLists.txt
@@ -50,6 +50,22 @@ if(DPCTL_ENABLE_LO_PROGRAM_CREATION)
     set(DPCTL_ENABLE_LO_PROGRAM_CREATION 1)
     include(GetLevelZeroHeaders)
     get_level_zero_headers()
+    if (UNIX)
+        find_library(PI_LEVEL_ZERO_LIB
+            NAMES pi_level_zero
+            HINTS ${IntelSycl_LIBRARY_DIR}
+        )
+        find_program(READELF_PROG readelf)
+        find_program(GREP_PROG grep)
+        execute_process(
+            COMMAND ${READELF_PROG} -d ${PI_LEVEL_ZERO_LIB}
+            COMMAND ${GREP_PROG} libze_loader
+            COMMAND ${GREP_PROG} -Po "libze_loader[^\]]*"
+            OUTPUT_VARIABLE LIBZE_LOADER_FILENAME
+            OUTPUT_STRIP_TRAILING_WHITESPACE
+            ERROR_STRIP_TRAILING_WHITESPACE
+            )
+    endif()
 endif()
 
 configure_file(

--- a/dpctl-capi/include/Config/dpctl_config.h.in
+++ b/dpctl-capi/include/Config/dpctl_config.h.in
@@ -30,3 +30,5 @@
 
 /* The DPCPP version used to build dpctl */
 #define DPCTL_DPCPP_VERSION "@IntelSycl_VERSION@"
+
+#define DPCTL_LIBZE_LOADER_FILENAME "@LIBZE_LOADER_FILENAME@"

--- a/dpctl-capi/source/dpctl_sycl_program_interface.cpp
+++ b/dpctl-capi/source/dpctl_sycl_program_interface.cpp
@@ -45,7 +45,7 @@ namespace
 #ifdef DPCTL_ENABLE_LO_PROGRAM_CREATION
 
 #ifdef __linux__
-static const char *zeLoaderName = "libze_loader.so";
+static const char *zeLoaderName = DPCTL_LIBZE_LOADER_FILENAME;
 static const int libLoadFlags = RTLD_NOLOAD | RTLD_NOW | RTLD_LOCAL;
 #elif defined(_WIN64)
 static const char *zeLoaderName = "ze_loader.dll";


### PR DESCRIPTION
Store that in include/Config/dpctl_config.h and use the define in
dpctl_sycl_program_interface.cpp

CMake is running the equivalent of the following

```
readelf -d $DPCPP_ROOT/lib/libpi_level_zero.so | grep libze_loader | grep -Po "libze_loader[^\]]*"
libze_loader.so.1
```

This change, together with #603 and #616 make project buildable with OS compiler.