### PR TITLE
Update opencl interoprability code to fix build with open source llvm/sycl bundle

### DIFF
--- a/dpctl-capi/source/dpctl_sycl_program_interface.cpp
+++ b/dpctl-capi/source/dpctl_sycl_program_interface.cpp
@@ -29,6 +29,7 @@
 #include "Support/CBindingWrapping.h"
 #include <CL/cl.h>     /* OpenCL headers     */
 #include <CL/sycl.hpp> /* Sycl headers       */
+#include <CL/sycl/backend/opencl.hpp>
 
 #ifdef DPCTL_ENABLE_LO_PROGRAM_CREATION
 #include "../helper/include/dpctl_dynamic_lib_helper.h"
@@ -75,7 +76,7 @@ createOpenCLInterOpProgram(const context &SyclCtx,
                            const char *CompileOpts)
 {
     cl_int err;
-    auto CLCtx = SyclCtx.get();
+    auto CLCtx = get_native<backend::opencl>(SyclCtx);
     auto CLProgram = clCreateProgramWithIL(CLCtx, IL, length, &err);
     if (err) {
         // \todo: record the error string and any other information.
@@ -89,7 +90,7 @@ createOpenCLInterOpProgram(const context &SyclCtx,
     // Get a list of CL Devices from the Sycl devices
     auto CLDevices = new cl_device_id[SyclDevices.size()];
     for (auto i = 0ul; i < SyclDevices.size(); ++i)
-        CLDevices[i] = SyclDevices[i].get();
+        CLDevices[i] = get_native<backend::opencl>(SyclDevices[i]);
 
     // Build the OpenCL interoperability program
     err = clBuildProgram(CLProgram, (cl_uint)(SyclDevices.size()), CLDevices,
@@ -138,7 +139,7 @@ createLevelZeroInterOpProgram(const context &SyclCtx,
                               size_t length,
                               const char *CompileOpts)
 {
-    auto ZeCtx = SyclCtx.get_native<backend::level_zero>();
+    auto ZeCtx = get_native<backend::level_zero>(SyclCtx);
     auto SyclDevices = SyclCtx.get_devices();
     if (SyclDevices.size() > 1) {
         std::cerr << "Level zero program can be created for only one device.\n";
@@ -159,7 +160,7 @@ createLevelZeroInterOpProgram(const context &SyclCtx,
     ZeModuleDesc.pBuildFlags = CompileOpts;
     ZeModuleDesc.pConstants = &ZeSpecConstants;
 
-    auto ZeDevice = SyclDevices[0].get_native<backend::level_zero>();
+    auto ZeDevice = get_native<backend::level_zero>(SyclDevices[0]);
     ze_module_handle_t ZeModule;
 
     auto stZeModuleCreateF = getZeModuleCreateFn();


### PR DESCRIPTION
Closes #624 

Replaced ``sycl::context::get()`` with
``sycl::context::get_native<sycl::backend::opencl>()``.