### PR TITLE
dpctl.device_type.host_device -> dpctl.device_type.host

### DIFF
--- a/dpctl/tests/test_sycl_device_factory.py
+++ b/dpctl/tests/test_sycl_device_factory.py
@@ -56,7 +56,7 @@ def string_to_device_type(dty_str):
     elif dty_str == "cpu":
         return dty.cpu
     elif dty_str == "host":
-        return dty.host_device
+        return dty.host
     elif dty_str == "gpu":
         return dty.gpu
 


### PR DESCRIPTION
one stray unrefactored use corrected. 

Fixes these two test failures:

```
FAILED dpctl/tests/test_sycl_device_factory.py::test_get_devices_with_string_args[str_args0] - AttributeError: host_device
FAILED dpctl/tests/test_sycl_device_factory.py::test_get_devices_with_device_type_str[host] - AttributeError: host_device
```