### PR TITLE
test_get_dpcppversion relaxed

### DIFF
--- a/dpctl/tests/test_service.py
+++ b/dpctl/tests/test_service.py
@@ -79,7 +79,8 @@ def test_get_dpcppversion():
     assert len(dpcpp_ver) > 0
     dpcpp_ver = dpcpp_ver.decode("utf-8")
     mkl_ver = _get_mkl_version_if_present()
-    assert mkl_ver is None or mkl_ver == dpcpp_ver
+    if mkl_ver is not None:
+        assert mkl_ver >= dpcpp_ver
 
 
 def test___version__():


### PR DESCRIPTION
allowing mkl_version (proxy for the version of the DPC++ runtime) to be bigger than the version of the DPC++ toolchain the package was built with

