### PR TITLE
reinstate deprecated sycl::program and that was conditionally removed from open source DPC++ toolchain

### DIFF
--- a/dpctl-capi/source/dpctl_sycl_program_interface.cpp
+++ b/dpctl-capi/source/dpctl_sycl_program_interface.cpp
@@ -24,6 +24,11 @@
 ///
 //===----------------------------------------------------------------------===//
 
+#ifndef __SYCL_INTERNAL_API
+// make sure that sycl::program is defined and implemented
+#define __SYCL_INTERNAL_API
+#endif
+
 #include "dpctl_sycl_program_interface.h"
 #include "Config/dpctl_config.h"
 #include "Support/CBindingWrapping.h"


### PR DESCRIPTION
See intel/llvm#4461 for details.

`sycl::program` can be reinstated on if `__SYCL_INTERNAL_API` preprocessor variable is set before including `"CL/sycl.hpp"`.
