### PR TITLE
Change the way we load level zero DLL on windows.

### DIFF
--- a/dpctl-capi/helper/include/dpctl_dynamic_lib_helper.h
+++ b/dpctl-capi/helper/include/dpctl_dynamic_lib_helper.h
@@ -55,7 +55,8 @@ public:
 #ifdef __linux__
         _handle = dlopen(libName, flag);
 #elif defined(_WIN32) || defined(_WIN64)
-        _handle = LoadLibraryA(libName);
+        _handle =
+            LoadLibraryExA(libName, nullptr, LOAD_LIBRARY_SEARCH_SYSTEM32);
 #endif
     }
 


### PR DESCRIPTION
Use `LoadLibraryExA` instead of `LoadLibraryA` to mitigate a possible DLL injection issue when we load the Level zero DLL on windows.