### PR TITLE
Undid restrictions for on: push triggers

### DIFF
--- a/.github/workflows/conda-package.yml
+++ b/.github/workflows/conda-package.yml
@@ -1,9 +1,6 @@
 name: Conda package
 
-on:
-  push:
-    branches:
-    tags:
+on: push
 
 env:
   PACKAGE_NAME: dpctl


### PR DESCRIPTION
This undoes questionable change from #634, specifically this one:

```diff
index 4e70c39c..6b99baf3 100644
--- a/.github/workflows/conda-package.yml
+++ b/.github/workflows/conda-package.yml
@@ -1,6 +1,9 @@
 name: Conda package
 
-on: push
+on:
+  push:
+    branches:
+    tags:
 
 env:
   PACKAGE_NAME: dpctl
```

The net effect of this change was that workflow was disabled, since `branches` and `tags` requirements were never met.