### PR TITLE
set the last byte in allocated char array to zero.

### DIFF
--- a/dpctl-capi/helper/include/dpctl_string_utils.hpp
+++ b/dpctl-capi/helper/include/dpctl_string_utils.hpp
@@ -50,6 +50,11 @@ cstring_from_string(const std::string &str)
 #else
         std::strncpy(cstr, str.c_str(), cstr_len);
 #endif
+        // Added to resolve CheckMarx's false positive.
+        // NB: This is redundant because str.c_str() is guaranteed
+        // to be null-terminated and the copy function is asked to
+        // copy enough characters to include that null-character.
+        cstr[cstr_len - 1] = '\0';
     } catch (std::bad_alloc const &ba) {
         // \todo log error
         std::cerr << ba.what() << '\n';


### PR DESCRIPTION
Set the last byte of new array of chars to 0 to explicitly ensure null-termination.

Noting that the source of the copy, `str.c_str()` is always null-terminated  (see [c++-reference](https://www.cplusplus.com/reference/string/string/c_str/)), the terminating character of the destination depends on how many bytes the `strncpy_s` actually copies.

Feel free to dismiss.