### PR TITLE
Pin coverage at 3.2.0 to work around TheKevJames/coveralls-python#333

### DIFF
--- a/.github/workflows/generate-coverage.yaml
+++ b/.github/workflows/generate-coverage.yaml
@@ -93,7 +93,7 @@ jobs:
         shell: bash -l {0}
         run: |
           sudo gem install coveralls-lcov
-          pip install coveralls
+          pip install coveralls==3.2.0
 
       - name: Upload coverage data to coveralls.io
         run: |


### PR DESCRIPTION
See 

https://github.com/TheKevJames/coveralls-python/issues/333

The known work-around is to pin coveralls to 3.2.0