### PR TITLE
Set stype fields in ZeModuleDesc struct

### DIFF
--- a/libsyclinterface/source/dpctl_sycl_program_interface.cpp
+++ b/libsyclinterface/source/dpctl_sycl_program_interface.cpp
@@ -159,6 +159,7 @@ createLevelZeroInterOpProgram(const context &SyclCtx,
 
     // Populate the Level Zero module descriptions
     ze_module_desc_t ZeModuleDesc = {};
+    ZeModuleDesc.stype = ZE_STRUCTURE_TYPE_MODULE_DESC;
     ZeModuleDesc.format = ZE_MODULE_FORMAT_IL_SPIRV;
     ZeModuleDesc.inputSize = length;
     ZeModuleDesc.pInputModule = (uint8_t *)IL;


### PR DESCRIPTION
Minor change to set the structure type of the descriptor struct.

Set structure type to ZE_STRUCTURE_TYPE_MODULE_DESC

See https://spec.oneapi.io/level-zero/latest/core/api.html#_CPPv416ze_module_desc_t

