### PR TITLE
Attempt to fix permission on push issue

### DIFF
--- a/.github/workflows/generate-docs.yml
+++ b/.github/workflows/generate-docs.yml
@@ -54,6 +54,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
+          persist-credentials: false
       - name: Build dpctl
         if: ${{ !github.event.pull_request || github.event.action != 'closed' }}
         shell: bash -l {0}


### PR DESCRIPTION
The hope is that using `persist-credential:false` would fix the following
failure to push

remote: Permission to IntelPython/dpctl.git denied to github-actions[bot].