### PR TITLE
Extending `dpctl.device_context` with nested contexts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
 ## [0.11.2] - 11/xx/2021
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.11.2] - 11/xx/2021
 
+### Added
+- Extending `dpctl.device_context` with nested contexts (#678)
+
 ## Fixed
 - Fixed issue #649 about incorrect behavior of `.T` method on sliced arrays (#653)
 

--- a/dpctl/__init__.py
+++ b/dpctl/__init__.py
@@ -56,6 +56,7 @@ from dpctl._sycl_queue import (
 )
 from dpctl._sycl_queue_manager import (
     device_context,
+    nested_context_factories,
     get_current_backend,
     get_current_device_type,
     get_current_queue,

--- a/dpctl/__init__.py
+++ b/dpctl/__init__.py
@@ -56,12 +56,12 @@ from dpctl._sycl_queue import (
 )
 from dpctl._sycl_queue_manager import (
     device_context,
-    nested_context_factories,
     get_current_backend,
     get_current_device_type,
     get_current_queue,
     get_num_activated_queues,
     is_in_device_context,
+    nested_context_factories,
     set_global_queue,
 )
 

--- a/dpctl/__init__.py
+++ b/dpctl/__init__.py
@@ -112,6 +112,7 @@ __all__ += [
     "get_current_queue",
     "get_num_activated_queues",
     "is_in_device_context",
+    "nested_context_factories",
     "set_global_queue",
 ]
 __all__ += [

--- a/dpctl/_sycl_queue_manager.pyx
+++ b/dpctl/_sycl_queue_manager.pyx
@@ -19,7 +19,7 @@
 # cython: linetrace=True
 
 import logging
-from contextlib import contextmanager, ExitStack
+from contextlib import ExitStack, contextmanager
 
 from .enum_types import backend_type, device_type
 

--- a/dpctl/_sycl_queue_manager.pyx
+++ b/dpctl/_sycl_queue_manager.pyx
@@ -238,6 +238,9 @@ def device_context(arg):
     the context manager's scope. The yielded queue is removed as the currently
     usable queue on exiting the context manager.
 
+    You can register context factory in the list of factories.
+    This context manager uses context factories to create and activate nested contexts.
+
     Args:
 
         queue_str (str) : A string corresponding to the DPC++ filter selector.
@@ -258,6 +261,18 @@ def device_context(arg):
             import dpctl
             with dpctl.device_context("level0:gpu:0"):
                 pass
+
+        The following example registers nested context factory:
+
+        .. code-block:: python
+
+            import dctl
+
+            def factory(sycl_queue):
+                ...
+                return context
+
+            dpctl.nested_context_factories.append(factory)
 
     """
     ctxt = None

--- a/dpctl/_sycl_queue_manager.pyx
+++ b/dpctl/_sycl_queue_manager.pyx
@@ -19,7 +19,7 @@
 # cython: linetrace=True
 
 import logging
-from contextlib import contextmanager
+from contextlib import contextmanager, nullcontext
 
 from .enum_types import backend_type, device_type
 
@@ -210,6 +210,14 @@ cpdef get_current_backend():
     return _mgr.get_current_backend()
 
 
+def _get_registered_context_manager(sycl_queue):
+    try:
+        from numba_dppy import get_context_manager
+        return get_context_manager(sycl_queue)
+    except:
+        return nullcontext()
+
+
 @contextmanager
 def device_context(arg):
     """
@@ -247,7 +255,8 @@ def device_context(arg):
     ctxt = None
     try:
         ctxt = _mgr._set_as_current_queue(arg)
-        yield ctxt
+        with _get_registered_context_manager(ctxt):
+            yield ctxt
     finally:
         # Code to release resource
         if ctxt:

--- a/dpctl/_sycl_queue_manager.pyx
+++ b/dpctl/_sycl_queue_manager.pyx
@@ -214,7 +214,7 @@ def _get_registered_context_manager(sycl_queue):
     try:
         from numba_dppy import get_context_manager
         return get_context_manager(sycl_queue)
-    except:
+    except Exception:
         return nullcontext()
 
 

--- a/dpctl/tests/test_sycl_queue_manager.py
+++ b/dpctl/tests/test_sycl_queue_manager.py
@@ -185,7 +185,7 @@ def test_register_nested_context_factory_context():
     assert not dpctl.nested_context_factories
 
 
-@pytest.mark.skipif(not has_gpu(), reason="No OpenCL GPU queues available")
+@pytest.mark.skipif(not has_cpu(), reason="No OpenCL CPU queues available")
 def test_device_context_activates_nested_context():
     in_context = False
     factory_called = False
@@ -206,13 +206,14 @@ def test_device_context_activates_nested_context():
         assert not factory_called
         assert not in_context
 
-        with dpctl.device_context("opencl:gpu:0"):
+        with dpctl.device_context("opencl:cpu:0"):
             assert factory_called
             assert in_context
 
         assert not in_context
 
 
+@pytest.mark.skipif(not has_cpu(), reason="No OpenCL CPU queues available")
 @pytest.mark.parametrize(
     "factory, exception, match",
     [
@@ -225,5 +226,5 @@ def test_nested_context_factory_exception_if_wrong_factory(
 ):
     with pytest.raises(exception, match=match):
         with _register_nested_context_factory(factory):
-            with dpctl.device_context("opencl:gpu:0"):
+            with dpctl.device_context("opencl:cpu:0"):
                 pass


### PR DESCRIPTION
Relates to https://github.com/IntelPython/numba-dppy/pull/630.

- [x] Reverse dependencies
  - [x] numba-dppy registers context manager
  - [x] dpctl provides common functionality to register nested contexts
- [x] tests
- [x] docs
- [x] changelog
- [ ] dpctl does not know numba-dppy. Now dpctl helps numba-dppy to register by importing it. Use technique like numba plug-ins.
