### PR TITLE
Cleanup/examples

### DIFF
--- a/examples/cython/sycl_buffer/.gitignore
+++ b/examples/cython/sycl_buffer/.gitignore
@@ -1,0 +1,3 @@
+_buffer_example.cpp
+*.cpython*.so
+*~

--- a/examples/cython/sycl_buffer/use_sycl_buffer.cpp
+++ b/examples/cython/sycl_buffer/use_sycl_buffer.cpp
@@ -123,13 +123,13 @@ int c_columnwise_total_no_mkl(DPCTLSyclQueueRef q_ref,
             sycl::nd_range<2>(global, local), [=](sycl::nd_item<2> it) {
                 size_t i = it.get_global_id(0);
                 size_t j = it.get_global_id(1);
-                double group_sum = sycl::ONEAPI::reduce(
+                double group_sum = sycl::reduce_over_group(
                     it.get_group(), (i < n) ? mat_acc[it.get_global_id()] : 0.0,
                     std::plus<double>());
                 if (it.get_local_id(0) == 0) {
-                    sycl::ONEAPI::atomic_ref<
-                        double, sycl::ONEAPI::memory_order::relaxed,
-                        sycl::ONEAPI::memory_scope::system,
+                    sycl::ext::oneapi::atomic_ref<
+                        double, sycl::ext::oneapi::memory_order::relaxed,
+                        sycl::ext::oneapi::memory_scope::system,
                         sycl::access::address_space::global_space>(ct_acc[j]) +=
                         group_sum;
                 }

--- a/examples/cython/sycl_direct_linkage/.gitignore
+++ b/examples/cython/sycl_direct_linkage/.gitignore
@@ -1,0 +1,3 @@
+_buffer_example.cpp
+*.cpython*.so
+*~

--- a/examples/cython/sycl_direct_linkage/setup.py
+++ b/examples/cython/sycl_direct_linkage/setup.py
@@ -14,74 +14,54 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from os import environ
-from os.path import dirname, join
+import numpy as np
+from setuptools import Extension, setup
 
-from Cython.Build import cythonize
+import dpctl
 
+setup(
+    name="syclbuffer",
+    version="0.0.0",
+    description="An example of Cython extension calling SYCL routines",
+    long_description="""
+    Example of using SYCL to work on host allocated NumPy array using
+    SYCL buffers by calling oneMKL functions.
 
-def configuration(parent_package="", top_path=None):
-    import numpy as np
-    from numpy.distutils.misc_util import Configuration
+    This extension create SYCL queue in the scope of the function call
+    incurring large performance overhead. See `sycl_buffer/` example,
+    where user-constructed `dpctl.SyclQueue` can be given by the user.
 
-    import dpctl
-
-    config = Configuration("", parent_package, top_path)
-
-    oneapi_root = environ.get("ONEAPI_ROOT", None)
-    if not oneapi_root:
-        raise ValueError(
-            "ONEAPI_ROOT must be set, typical value is /opt/intel/oneapi"
+    See README.md for more details.
+    """,
+    license="Apache 2.0",
+    author="Intel Corporation",
+    url="https://github.com/IntelPython/dpctl",
+    ext_modules=[
+        Extension(
+            name="syclbuffer_naive",
+            sources=[
+                "_buffer_example.pyx",
+                "sycl_function.cpp",
+            ],
+            include_dirs=[".", np.get_include(), dpctl.get_include()],
+            libraries=["sycl"]
+            + [
+                "mkl_sycl",
+                "mkl_intel_ilp64",
+                "mkl_tbb_thread",
+                "mkl_core",
+                "tbb",
+                "iomp5",
+            ],
+            runtime_library_dirs=[],
+            extra_compile_args=[
+                "-Wall",
+                "-Wextra",
+                "-fsycl",
+                "-fsycl-unnamed-lambda",
+            ],
+            extra_link_args=["-fPIC"],
+            language="c++",
         )
-
-    mkl_info = {
-        "include_dirs": [join(oneapi_root, "mkl", "include")],
-        "library_dirs": [
-            join(oneapi_root, "mkl", "lib"),
-            join(oneapi_root, "mkl", "lib", "intel64"),
-        ],
-        "libraries": [
-            "mkl_sycl",
-            "mkl_intel_ilp64",
-            "mkl_tbb_thread",
-            "mkl_core",
-            "tbb",
-            "iomp5",
-        ],
-    }
-
-    mkl_include_dirs = mkl_info.get("include_dirs")
-    mkl_library_dirs = mkl_info.get("library_dirs")
-    mkl_libraries = mkl_info.get("libraries")
-
-    pdir = dirname(__file__)
-    wdir = join(pdir)
-
-    eca = ["-Wall", "-Wextra", "-fsycl", "-fsycl-unnamed-lambda"]
-
-    config.add_extension(
-        name="syclbuffer_naive",
-        sources=[
-            join(pdir, "_buffer_example.pyx"),
-            join(pdir, "sycl_function.cpp"),
-            join(pdir, "sycl_function.hpp"),
-        ],
-        include_dirs=[wdir, np.get_include(), dpctl.get_include()]
-        + mkl_include_dirs,
-        libraries=["sycl"] + mkl_libraries,
-        runtime_library_dirs=mkl_library_dirs,
-        extra_compile_args=eca,  # + ['-O0', '-g', '-ggdb'],
-        extra_link_args=["-fPIC"],
-        language="c++",
-    )
-
-    config.ext_modules = cythonize(
-        config.ext_modules, include_path=[pdir, wdir]
-    )
-    return config
-
-
-if __name__ == "__main__":
-    from numpy.distutils.core import setup
-
-    setup(configuration=configuration)
+    ],
+)

--- a/examples/cython/usm_memory/.gitignore
+++ b/examples/cython/usm_memory/.gitignore
@@ -1,0 +1,3 @@
+blackscholes.cpp
+*~
+*.cpython*.so

--- a/examples/cython/usm_memory/setup.py
+++ b/examples/cython/usm_memory/setup.py
@@ -14,74 +14,49 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from os import environ
-from os.path import dirname, join
+import numpy as np
+from setuptools import Extension, setup
 
-from Cython.Build import cythonize
+import dpctl
 
+setup(
+    name="blackscholes_usm",
+    version="0.0.0",
+    description="An example of Cython extension calling SYCL routines",
+    long_description="""
+    Example of using SYCL to work on usm allocations.
 
-def configuration(parent_package="", top_path=None):
-    import numpy as np
-    from numpy.distutils.misc_util import Configuration
-
-    import dpctl
-
-    config = Configuration("", parent_package, top_path)
-
-    oneapi_root = environ.get("ONEAPI_ROOT", None)
-    if not oneapi_root:
-        raise ValueError(
-            "ONEAPI_ROOT must be set, typical value is /opt/intel/oneapi"
+    See README.md for more details.
+    """,
+    license="Apache 2.0",
+    author="Intel Corporation",
+    url="https://github.com/IntelPython/dpctl",
+    ext_modules=[
+        Extension(
+            name="blackscholes_usm",
+            sources=[
+                "blackscholes.pyx",
+                "sycl_blackscholes.cpp",
+            ],
+            include_dirs=[".", np.get_include(), dpctl.get_include()],
+            libraries=["sycl"]
+            + [
+                "mkl_sycl",
+                "mkl_intel_ilp64",
+                "mkl_tbb_thread",
+                "mkl_core",
+                "tbb",
+                "iomp5",
+            ],
+            runtime_library_dirs=[],
+            extra_compile_args=[
+                "-Wall",
+                "-Wextra",
+                "-fsycl",
+                "-fsycl-unnamed-lambda",
+            ],
+            extra_link_args=["-fPIC"],
+            language="c++",
         )
-
-    mkl_info = {
-        "include_dirs": [join(oneapi_root, "mkl", "include")],
-        "library_dirs": [
-            join(oneapi_root, "mkl", "lib"),
-            join(oneapi_root, "mkl", "lib", "intel64"),
-        ],
-        "libraries": [
-            "mkl_sycl",
-            "mkl_intel_ilp64",
-            "mkl_tbb_thread",
-            "mkl_core",
-            "tbb",
-            "iomp5",
-        ],
-    }
-
-    mkl_include_dirs = mkl_info.get("include_dirs")
-    mkl_library_dirs = mkl_info.get("library_dirs")
-    mkl_libraries = mkl_info.get("libraries")
-
-    pdir = dirname(__file__)
-    wdir = join(pdir)
-
-    eca = ["-Wall", "-Wextra", "-fsycl", "-fsycl-unnamed-lambda"]
-
-    config.add_extension(
-        name="blackscholes_usm",
-        sources=[
-            join(pdir, "blackscholes.pyx"),
-            join(wdir, "sycl_blackscholes.cpp"),
-            join(wdir, "sycl_blackscholes.hpp"),
-        ],
-        include_dirs=[wdir, np.get_include(), dpctl.get_include()]
-        + mkl_include_dirs,
-        libraries=["sycl"] + mkl_libraries,
-        runtime_library_dirs=mkl_library_dirs,
-        extra_compile_args=eca,  # + ['-O0', '-g', '-ggdb'],
-        extra_link_args=["-fPIC"],
-        language="c++",
-    )
-
-    config.ext_modules = cythonize(
-        config.ext_modules, include_path=[pdir, wdir]
-    )
-    return config
-
-
-if __name__ == "__main__":
-    from numpy.distutils.core import setup
-
-    setup(configuration=configuration)
+    ],
+)

--- a/examples/pybind11/use_dpctl_syclqueue/pybind11_example.cpp
+++ b/examples/pybind11/use_dpctl_syclqueue/pybind11_example.cpp
@@ -130,7 +130,7 @@ offloaded_array_mod(py::object queue,
             ->submit([&](sycl::handler &cgh) {
                 sycl::accessor a_acc(a_buf, cgh, sycl::read_only);
                 sycl::accessor r_acc(r_buf, cgh, sycl::write_only,
-                                     sycl::noinit);
+                                     sycl::no_init);
 
                 cgh.parallel_for(sycl::range<1>(n), [=](sycl::id<1> idx) {
                     r_acc[idx] = a_acc[idx] % mod;

--- a/examples/python/usm_memory_allocation.py
+++ b/examples/python/usm_memory_allocation.py
@@ -34,8 +34,8 @@ mda = dpmem.MemoryUSMDevice(128, alignment=16)
 
 # allocate using given queue,
 # i.e. on the device and bound to the context stored in the queue
-mdq = dpmem.MemoryUSMDevice(256, queue=mda._queue)
+mdq = dpmem.MemoryUSMDevice(256, queue=mda.sycl_queue)
 
 # information about device associate with USM buffer
 print("Allocation performed on device:")
-mda._queue.sycl_device.print_device_info()
+mda.sycl_queue.print_device_info()


### PR DESCRIPTION
Updated deprecated SYCL code. 

Changes setup scripts to exclusively use `setuptools`, and not use `numpy.distutils` which have problems with `LLVM` toolchain.