### PR TITLE
array_info_sequence handles empty sequences as host data

### DIFF
--- a/dpctl/tensor/_ctors.py
+++ b/dpctl/tensor/_ctors.py
@@ -63,6 +63,9 @@ def _array_info_sequence(li):
             raise ValueError(
                 "Inconsistent dimensions, {} and {}".format(dim, el_dim)
             )
+    if dim is None:
+        dim = tuple()
+        device = _host_set
     return (n,) + dim, dt, device
 
 

--- a/dpctl/tests/test_tensor_asarray.py
+++ b/dpctl/tests/test_tensor_asarray.py
@@ -80,6 +80,12 @@ def test_asarray_from_sequence():
     Y = dpt.asarray(X, usm_type="device")
     assert type(Y) is dpt.usm_ndarray
     assert Y.ndim == 2
+    assert Y.shape == (len(X), 2)
+
+    X = []
+    Y = dpt.asarray(X, usm_type="device")
+    assert type(Y) is dpt.usm_ndarray
+    assert Y.shape == (0,)
 
 
 def test_asarray_from_object_with_suai():


### PR DESCRIPTION
Closes #687.

`_array_info_sequence` should handle empty sequences as host data. Added a test for this input.