### PR TITLE
Fixed type inferencing for nest sequences with no elements

### DIFF
--- a/dpctl/tensor/_ctors.py
+++ b/dpctl/tensor/_ctors.py
@@ -67,6 +67,7 @@ def _array_info_sequence(li):
             )
     if dim is None:
         dim = tuple()
+        dt = float
         device = _host_set
     return (n,) + dim, dt, device
 

--- a/dpctl/tests/test_tensor_asarray.py
+++ b/dpctl/tests/test_tensor_asarray.py
@@ -87,6 +87,11 @@ def test_asarray_from_sequence():
     assert type(Y) is dpt.usm_ndarray
     assert Y.shape == (0,)
 
+    X = [[], []]
+    Y = dpt.asarray(X, usm_type="device")
+    assert type(Y) is dpt.usm_ndarray
+    assert Y.shape == (2, 0)
+
     X = [True, False]
     Y = dpt.asarray(X, usm_type="device")
     assert type(Y) is dpt.usm_ndarray


### PR DESCRIPTION
Fixed #696

```python
In [3]: import dpctl.tensor as dpt

In [4]: dpt.asarray( [[],]*2)
Out[4]: <dpctl.tensor._usmarray.usm_ndarray at 0x7fe5c92a8450>

In [5]: Out[4].dtype
Out[5]: dtype('float64')
```