### PR TITLE
Make sure to fail worfklow step in doc generation of make Sphinx errs

### DIFF
--- a/.github/workflows/generate-docs.yml
+++ b/.github/workflows/generate-docs.yml
@@ -75,7 +75,7 @@ jobs:
           cmake .. -DDPCTL_USE_MULTIVERSION_TEMPLATE=ON \
                    -DDPCTL_ENABLE_DOXYREST=ON \
                    -DDoxyrest_DIR=`pwd`/doxyrest-2.1.2-linux-amd64
-          make Sphinx
+          make Sphinx || exit 1
           cd ..
           mv generated_docs/docs ~/docs
           git clean -dfx
@@ -90,7 +90,7 @@ jobs:
           echo `pwd`
           cd master
           git rm -rf *
-          mv ~/docs/* .
+          mv ~/docs/* . || exot 1
           git add .
           git config --global user.name 'github-actions[doc-deploy-bot]'
           git config --global user.email 'github-actions[doc-deploy-bot]@users.noreply.github.com'

--- a/.github/workflows/generate-docs.yml
+++ b/.github/workflows/generate-docs.yml
@@ -90,7 +90,7 @@ jobs:
           echo `pwd`
           cd master
           git rm -rf *
-          mv ~/docs/* . || exot 1
+          mv ~/docs/* . || exit 1
           git add .
           git config --global user.name 'github-actions[doc-deploy-bot]'
           git config --global user.email 'github-actions[doc-deploy-bot]@users.noreply.github.com'


### PR DESCRIPTION
Use `make Sphinx || exit 1`.

See https://stackoverflow.com/a/57907146/594376

Were this change in place, it would have prevented #704 docs generation job from succeeding and erasing existing directory.