### PR TITLE
Fixes #698

### DIFF
--- a/dpctl/tensor/_ctors.py
+++ b/dpctl/tensor/_ctors.py
@@ -388,7 +388,7 @@ def asarray(
         _, dt, devs = _array_info_sequence(obj)
         if devs == _host_set:
             return _asarray_from_numpy_ndarray(
-                np.asarray(obj, dt, order=order),
+                np.asarray(obj, dtype=dtype, order=order),
                 dtype=dtype,
                 usm_type=usm_type,
                 sycl_queue=sycl_queue,


### PR DESCRIPTION
Fixes #698 

When processing sequence of sequences, pass requested array data type
to numpy converter to ensure that the expected `ValueError` is raised:

```
In [2]: import dpctl.tensor as dpt

In [3]: dpt.asarray([float("nan"), -1, 1], dtype="i8")
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
<ipython-input-3-5393cc22ddff> in <module>
----> 1 dpt.asarray([float("nan"), -1, 1], dtype="i8")

/.../dpctl/dpctl/tensor/_ctors.py in asarray(obj, dtype, device, copy, usm_type, sycl_queue, order)
    389         if devs == _host_set:
    390             return _asarray_from_numpy_ndarray(
--> 391                 np.asarray(obj, dtype=dtype, order=order),
    392                 dtype=dtype,
    393                 usm_type=usm_type,

~/..../site-packages/numpy/core/_asarray.py in asarray(a, dtype, order, like)
    100         return _asarray_with_like(a, dtype=dtype, order=order, like=like)
    101
--> 102     return array(a, dtype, copy=False, order=order)
    103
    104

ValueError: cannot convert float NaN to integer

In [4]: quit
```