### PR TITLE
Fix broken links in the libsyclinterface html pages.

### DIFF
--- a/docs/Doxyfile.in
+++ b/docs/Doxyfile.in
@@ -562,7 +562,7 @@ INTERNAL_DOCS          = NO
 # (including Cygwin) ands Mac users are advised to set this option to NO.
 # The default value is: system dependent.
 
-CASE_SENSE_NAMES       = YES
+CASE_SENSE_NAMES       = NO
 
 # If the HIDE_SCOPE_NAMES tag is set to NO then doxygen will show members with
 # their full class and namespace scopes in the documentation. If set to YES, the


### PR DESCRIPTION
  Sphinx does not support mixed case labels. To work around the issue,
  we force Doxygen to generate only lowercase labels. Refer:
  https://github.com/vovkos/doxyrest/issues/33