### PR TITLE
Implementation of GLog

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -13,6 +13,7 @@ exclude =
     .git
 
 per-file-ignores =
+    dpctl/_dev.pyx: E999
     dpctl/_sycl_context.pyx: E999, E225, E227
     dpctl/_sycl_device.pyx: E999, E225
     dpctl/_sycl_device_factory.pyx: E999, E225

--- a/.flake8
+++ b/.flake8
@@ -13,7 +13,7 @@ exclude =
     .git
 
 per-file-ignores =
-    dpctl/_dev.pyx: E999
+    dpctl/_diagnostics.pyx: E999
     dpctl/_sycl_context.pyx: E999, E225, E227
     dpctl/_sycl_device.pyx: E999, E225
     dpctl/_sycl_device_factory.pyx: E999, E225

--- a/dpctl/_dev.pyx
+++ b/dpctl/_dev.pyx
@@ -1,0 +1,77 @@
+#                      Data Parallel Control (dpctl)
+#
+# Copyright 2020-2021 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# distutils: language = c++
+# cython: language_level=3
+# cython: linetrace=True
+
+""" Implements developer utilities.
+"""
+import contextlib
+import os
+
+
+cdef extern from "syclinterface/dpctl_service.h":
+   cdef void DPCTLService_InitLogger(const char *, const char *)
+   cdef void DPCTLService_ShutdownLogger()
+
+
+def init_logger(log_dir=None):
+    """Initialize logger to use given directory to save logs.
+
+    The call has no effect if `dpctl` was not built to use logger.
+    """
+    cdef bytes p = b""
+    cdef const char *app_name = "dpctl"
+    if log_dir is None:
+        log_dir = os.getcwd()
+    if not os.path.exists(log_dir):
+        raise ValueError(f"Path {log_dir} does not exist")
+    if isinstance(log_dir, str):
+        p = bytes(log_dir, "utf-8")
+    else:
+        p = bytes(log_dir)
+    DPCTLService_InitLogger(app_name, <char *>p)
+
+
+def fini_logger():
+    """Finilize logger.
+
+    The call has no effect if `dpctl` was not built to use logger.
+    """
+    DPCTLService_ShutdownLogger()
+
+
+@contextlib.contextmanager
+def verbose(verbosity="warning", log_dir=None):
+    """Context manager that activate verbosity"""
+    _allowed_verbosity = ["warning", "error"]
+    if not verbosity in _allowed_verbosity:
+        raise ValueError(
+            f"Verbosity argument not understood. "
+            f"Permitted values are {_allowed_verbosity}"
+        )
+    init_logger(log_dir=log_dir)
+    _saved = os.environ.get("DPCTL_VERBOSITY", None)
+    os.environ["DPCTL_VERBOSITY"] = verbosity
+    try:
+        yield
+    finally:
+        fini_logger()
+        if _saved:
+            os.environ["DPCTL_VERBOSITY"] = _saved
+        else:
+            del os.environ["DPCTL_VERBOSITY"]

--- a/dpctl/tests/test_service.py
+++ b/dpctl/tests/test_service.py
@@ -107,3 +107,20 @@ def test___version__():
         r"0|[1-9][0-9]*))?(\+.*)?$"
     )
     assert re.match(reg_expr, dpctl_ver) is not None
+
+
+def test_dev_utils():
+    import dpctl._dev as dd
+
+    with dd.verbose():
+        dpctl.SyclDevice().parent_device
+    with dd.verbose(verbosity="error"):
+        dpctl.SyclDevice().parent_device
+    with pytest.raises(ValueError):
+        with dd.verbose(verbosity="blah"):
+            dpctl.SyclDevice().parent_device
+    with dd.verbose(log_dir="/tmp"):
+        dpctl.SyclDevice().parent_device
+    with pytest.raises(ValueError):
+        with dd.verbose(log_dir="/not_a_dir"):
+            dpctl.SyclDevice().parent_device

--- a/dpctl/tests/test_service.py
+++ b/dpctl/tests/test_service.py
@@ -110,17 +110,22 @@ def test___version__():
 
 
 def test_dev_utils():
-    import dpctl._dev as dd
+    import tempfile
 
-    with dd.verbose():
+    import dpctl._diagnostics as dd
+
+    ctx_mngr = dd.syclinterface_diagnostics
+
+    with ctx_mngr():
         dpctl.SyclDevice().parent_device
-    with dd.verbose(verbosity="error"):
+    with ctx_mngr(verbosity="error"):
         dpctl.SyclDevice().parent_device
     with pytest.raises(ValueError):
-        with dd.verbose(verbosity="blah"):
+        with ctx_mngr(verbosity="blah"):
             dpctl.SyclDevice().parent_device
-    with dd.verbose(log_dir="/tmp"):
-        dpctl.SyclDevice().parent_device
+    with tempfile.TemporaryDirectory() as temp_dir:
+        with ctx_mngr(log_dir=temp_dir):
+            dpctl.SyclDevice().parent_device
     with pytest.raises(ValueError):
-        with dd.verbose(log_dir="/not_a_dir"):
+        with ctx_mngr(log_dir="/not_a_dir"):
             dpctl.SyclDevice().parent_device

--- a/libsyclinterface/CMakeLists.txt
+++ b/libsyclinterface/CMakeLists.txt
@@ -38,6 +38,11 @@ option(DPCTL_BUILD_CAPI_TESTS
     "Build dpctl C API google tests"
     OFF
 )
+# Option to turn on logging support for dpctl C API
+option(DPCTL_ENABLE_GLOG
+    "Enable the Google logging module"
+    OFF
+)
 
 # Minimum version requirement only when oneAPI dpcpp is used.
 if(DPCTL_DPCPP_FROM_ONEAPI)
@@ -166,11 +171,24 @@ target_include_directories(DPCTLSyclInterface
     ${CMAKE_CURRENT_SOURCE_DIR}/helper/include/
     ${IntelSycl_SYCL_INCLUDE_DIR}
 )
-
 target_link_libraries(DPCTLSyclInterface
-    PRIVATE ${IntelSycl_SYCL_LIBRARY}
-    PRIVATE ${IntelSycl_OPENCL_LIBRARY}
+  PRIVATE ${IntelSycl_SYCL_LIBRARY}
+  PRIVATE ${IntelSycl_OPENCL_LIBRARY}
 )
+
+if(DPCTL_ENABLE_GLOG)
+    find_package(glog REQUIRED)
+
+    target_include_directories(DPCTLSyclInterface
+        PRIVATE
+        glog::glog
+    )
+    target_compile_definitions(DPCTLSyclInterface PRIVATE ENABLE_GLOG)
+    target_link_libraries(DPCTLSyclInterface
+        PRIVATE glog::glog
+    )
+endif()
+
 
 include(GetProjectVersion)
 # the get_version function is defined in the GetProjectVersion module and

--- a/libsyclinterface/helper/source/dpctl_error_handlers.cpp
+++ b/libsyclinterface/helper/source/dpctl_error_handlers.cpp
@@ -65,21 +65,30 @@ int requested_verbosity_level(void)
     return requested_level;
 }
 
-void output_message(std::string ss_str, [[maybe_unused]] error_level error_type)
+void output_message(std::string ss_str, error_level error_type)
 {
 #ifdef ENABLE_GLOG
     switch (error_type) {
     case error_level::error:
-        LOG(ERROR) << ss_str;
+        LOG(ERROR) << "[ERR] " << ss_str;
         break;
     case error_level::warning:
-        LOG(WARNING) << ss_str;
+        LOG(WARNING) << "[WARN] " << ss_str;
         break;
     default:
-        LOG(FATAL) << ss_str;
+        LOG(FATAL) << "[FATAL] " << ss_str;
     }
 #else
-    std::cerr << ss_str;
+    switch (error_type) {
+    case error_level::error:
+        std::cerr << "[ERR] " << ss_str;
+        break;
+    case error_level::warning:
+        std::cerr << "[WARN] " << ss_str;
+        break;
+    default:
+        std::cerr << "[FATAL] " << ss_str;
+    }
 #endif
 }
 

--- a/libsyclinterface/helper/source/dpctl_error_handlers.cpp
+++ b/libsyclinterface/helper/source/dpctl_error_handlers.cpp
@@ -24,7 +24,12 @@
 //===----------------------------------------------------------------------===//
 
 #include "dpctl_error_handlers.h"
+#include "dpctl_service.h"
 #include <cstring>
+#include <sstream>
+#ifdef ENABLE_GLOG
+#include <glog/logging.h>
+#endif
 
 void DPCTL_AsyncErrorHandler::operator()(
     const cl::sycl::exception_list &exceptions)
@@ -59,6 +64,25 @@ int requested_verbosity_level(void)
 
     return requested_level;
 }
+
+void output_message(std::string ss_str, [[maybe_unused]] error_level error_type)
+{
+#ifdef ENABLE_GLOG
+    switch (error_type) {
+    case error_level::error:
+        LOG(ERROR) << ss_str;
+        break;
+    case error_level::warning:
+        LOG(WARNING) << ss_str;
+        break;
+    default:
+        LOG(FATAL) << ss_str;
+    }
+#else
+    std::cerr << ss_str;
+#endif
+}
+
 } // namespace
 
 void error_handler(const std::exception &e,
@@ -70,9 +94,14 @@ void error_handler(const std::exception &e,
     int requested_level = requested_verbosity_level();
     int error_level = static_cast<int>(error_type);
 
-    if (requested_level >= error_level) {
-        std::cerr << e.what() << " in " << func_name << " at " << file_name
-                  << ":" << line_num << std::endl;
+    bool to_output = requested_level >= error_level;
+
+    if (to_output) {
+        std::stringstream ss;
+        ss << e.what() << " in " << func_name << " at " << file_name << ":"
+           << line_num << std::endl;
+
+        output_message(ss.str(), error_type);
     }
 }
 
@@ -85,8 +114,13 @@ void error_handler(const std::string &what,
     int requested_level = requested_verbosity_level();
     int error_level = static_cast<int>(error_type);
 
-    if (requested_level >= error_level) {
-        std::cerr << what << " In " << func_name << " at " << file_name << ":"
-                  << line_num << std::endl;
+    bool to_output = requested_level >= error_level;
+
+    if (to_output) {
+        std::stringstream ss;
+        ss << what << " in " << func_name << " at " << file_name << ":"
+           << line_num << std::endl;
+
+        output_message(ss.str(), error_type);
     }
 }

--- a/libsyclinterface/include/dpctl_service.h
+++ b/libsyclinterface/include/dpctl_service.h
@@ -43,8 +43,22 @@ DPCTL_C_EXTERN_C_BEGIN
 DPCTL_API
 __dpctl_give const char *DPCTLService_GetDPCPPVersion(void);
 
-DPCTL_C_EXTERN_C_END
-
+/*!
+ * @brief Initialize logger if compiled to use logger, no-op otherwise.
+ *
+ * @param app_name  C-string for application name reflected in the log.
+ * @paral log_dir   C-string for directory where log files are placed.
+ * @ingroup Service
+ */
+DPCTL_API
 void DPCTLService_InitLogger(const char *app_name, const char *log_dir);
 
+/*!
+ * @brief Finilize logger if enabled, no-op otherwise.
+ *
+ * @ingroup Service
+ */
+DPCTL_API
 void DPCTLService_ShutdownLogger(void);
+
+DPCTL_C_EXTERN_C_END

--- a/libsyclinterface/include/dpctl_service.h
+++ b/libsyclinterface/include/dpctl_service.h
@@ -44,3 +44,7 @@ DPCTL_API
 __dpctl_give const char *DPCTLService_GetDPCPPVersion(void);
 
 DPCTL_C_EXTERN_C_END
+
+void DPCTLService_InitLogger(const char *app_name, const char *log_dir);
+
+void DPCTLService_ShutdownLogger(void);

--- a/libsyclinterface/source/dpctl_service.cpp
+++ b/libsyclinterface/source/dpctl_service.cpp
@@ -30,8 +30,8 @@
 #include <algorithm>
 #include <cstring>
 #include <iostream>
-#include <sys/stat.h>
 #ifdef ENABLE_GLOG
+#include <filesystem>
 #include <glog/logging.h>
 #endif
 
@@ -50,8 +50,12 @@ void DPCTLService_InitLogger(const char *app_name, const char *log_dir)
     google::InstallFailureSignalHandler();
     FLAGS_colorlogtostderr = true;
     FLAGS_stderrthreshold = google::FATAL;
-    struct stat buffer;
-    if (stat(log_dir, &buffer) != 0) {
+
+    namespace fs = std::filesystem;
+    const fs::path path(log_dir);
+    std::error_code ec;
+
+    if (fs::is_directory(path, ec)) {
         FLAGS_log_dir = log_dir;
     }
     else {

--- a/libsyclinterface/source/dpctl_service.cpp
+++ b/libsyclinterface/source/dpctl_service.cpp
@@ -46,21 +46,22 @@ __dpctl_give const char *DPCTLService_GetDPCPPVersion(void)
 void DPCTLService_InitLogger(const char *app_name, const char *log_dir)
 {
     google::InitGoogleLogging(app_name);
-    google::EnableLogCleaner(0);
     google::InstallFailureSignalHandler();
-    FLAGS_colorlogtostderr = true;
-    FLAGS_stderrthreshold = google::FATAL;
 
-    namespace fs = std::filesystem;
-    const fs::path path(log_dir);
-    std::error_code ec;
+    if (log_dir) {
+        namespace fs = std::filesystem;
+        const fs::path path(log_dir);
+        std::error_code ec;
 
-    if (fs::is_directory(path, ec)) {
-        FLAGS_log_dir = log_dir;
+        if (fs::is_directory(path, ec)) {
+            google::EnableLogCleaner(0);
+            FLAGS_log_dir = log_dir;
+        }
     }
     else {
-        std::cerr << "Directory not found. Log files will be created in the "
-                     "default logging directory.\n";
+        FLAGS_colorlogtostderr = true;
+        FLAGS_stderrthreshold = google::FATAL;
+        FLAGS_logtostderr = 1;
     }
 }
 

--- a/scripts/build_backend.py
+++ b/scripts/build_backend.py
@@ -19,7 +19,7 @@
 
 
 def build_backend(
-    l0_support=False, code_coverage=False, sycl_compiler_prefix=None
+    l0_support=False, code_coverage=False, glog=False, sycl_compiler_prefix=None
 ):
     import glob
     import os
@@ -99,6 +99,8 @@ def build_backend(
                 "-DCMAKE_CXX_COMPILER:PATH="
                 + os.path.join(DPCPP_ROOT, "bin", "clang++"),
             ]
+        if glog:
+            cmake_compiler_args.append("-DDPCTL_ENABLE_GLOG=ON")
         if code_coverage:
             cmake_args = (
                 [
@@ -177,6 +179,8 @@ def build_backend(
                 "-DCMAKE_CXX_COMPILER:PATH="
                 + os.path.join(DPCPP_ROOT, "bin", "clang++.exe"),
             ]
+        if glog:
+            cmake_compiler_args.append("-DDPCTL_ENABLE_GLOG=ON")
         cmake_args = (
             [
                 "cmake",

--- a/scripts/build_locally.py
+++ b/scripts/build_locally.py
@@ -10,6 +10,7 @@ def run(
     level_zero=True,
     compiler_root=None,
     cmake_executable=None,
+    use_glog=False,
 ):
     IS_LIN = False
 
@@ -43,6 +44,7 @@ def run(
         "-DCMAKE_CXX_COMPILER:PATH=" + cxx_compiler,
         "-DDPCTL_ENABLE_LO_PROGRAM_CREATION=" + ("ON" if level_zero else "OFF"),
         "-DDPCTL_DPCPP_FROM_ONEAPI:BOOL=" + ("ON" if use_oneapi else "OFF"),
+        "-DDPCTL_ENABLE_GLOG:BOOL=" + ("ON" if use_glog else "OFF"),
     ]
     if compiler_root:
         cmake_args += [
@@ -82,6 +84,12 @@ if __name__ == "__main__":
         dest="level_zero",
         action="store_false",
     )
+    driver.add_argument(
+        "--glog",
+        help="DPCTLSyclInterface uses Google logger",
+        dest="glog",
+        action="store_true",
+    )
     args = parser.parse_args()
 
     if args.oneapi:
@@ -112,4 +120,5 @@ if __name__ == "__main__":
         level_zero=args.level_zero,
         compiler_root=args.compiler_root,
         cmake_executable=args.cmake_executable,
+        use_glog=args.glog,
     )


### PR DESCRIPTION
This PR contains the primary implementation of using GLog in dpctl.

The implementation used Glog 5.0
`conda install glog`

Added the `--glog` flag for setup in development mode
`python setup.py develop --glog=True`

Implemented 2 functions for initialization and deinitialization of GLog
`void DPCTLService_InitLogger` and `void DPCTLService_ShutdownLogger`

