### PR TITLE
Add example for select_device_with_aspects.

### DIFF
--- a/examples/python/device_selection.py
+++ b/examples/python/device_selection.py
@@ -20,17 +20,6 @@
 import dpctl
 
 
-def print_device(d):
-    "Display information about given device argument."
-    if type(d) is not dpctl.SyclDevice:
-        raise ValueError
-    print("Name: ", d.name)
-    print("Vendor: ", d.vendor)
-    print("Driver version: ", d.driver_version)
-    print("Backend: ", d.backend)
-    print("Max EU: ", d.max_compute_units)
-
-
 def create_default_device():
     """
     Create default SyclDevice using `cl::sycl::default_selector`.
@@ -42,7 +31,7 @@ def create_default_device():
     d1 = dpctl.SyclDevice()
     d2 = dpctl.select_default_device()
     assert d1 == d2
-    print_device(d1)
+    d1.print_device_info()
     return d1
 
 
@@ -58,7 +47,7 @@ def create_gpu_device():
         d1 = dpctl.SyclDevice("gpu")
         d2 = dpctl.select_gpu_device()
         assert d1 == d2
-        print_device(d1)
+        d1.print_device_info()
     except ValueError:
         print("A GPU device is not available on the system")
 
@@ -96,10 +85,22 @@ def custom_select_device():
             max_score = d.default_selector_score
             selected_dev = d
     if selected_dev:
-        print_device(selected_dev)
+        selected_dev.print_device_info()
     else:
         print("No device with half-precision support is available.")
     return selected_dev
+
+
+def create_device_with_aspects():
+    """
+    Programmatically select a device based on specific set of aspects.
+
+    Demonstrate the usage of :func:`dpctl.select_device_with_aspects()`.
+    """
+    dev = dpctl.select_device_with_aspects(
+        required_aspects=["fp64", "gpu", "usm_shared_allocations"]
+    )
+    dev.print_device_info()
 
 
 if __name__ == "__main__":

--- a/examples/python/filter_selection.py
+++ b/examples/python/filter_selection.py
@@ -20,17 +20,6 @@
 import dpctl
 
 
-def print_device(d):
-    "Display information about given device argument."
-    if type(d) is not dpctl.SyclDevice:
-        raise ValueError
-    print("Name: ", d.name)
-    print("Vendor: ", d.vendor)
-    print("Driver version: ", d.driver_version)
-    print("Backend: ", d.backend)
-    print("Max EU: ", d.max_compute_units)
-
-
 def select_using_filter():
     """
     Demonstrate the usage of a filter string to create a SyclDevice.
@@ -38,22 +27,22 @@ def select_using_filter():
     """
     try:
         d1 = dpctl.SyclDevice("cpu")
-        print_device(d1)
+        d1.print_device_info()
     except ValueError:
         print("A CPU type device is not available on the system")
 
     try:
         d1 = dpctl.SyclDevice("opencl:cpu:0")
-        print_device(d1)
+        d1.print_device_info()
     except ValueError:
         print("An OpenCL CPU driver needs to be installed on the system")
 
     d1 = dpctl.SyclDevice("0")
-    print_device(d1)
+    d1.print_device_info()
 
     try:
         d1 = dpctl.SyclDevice("gpu")
-        print_device(d1)
+        d1.print_device_info()
     except ValueError:
         print("A GPU type device is not available on the system")
 


### PR DESCRIPTION
Added an example for `select_device_with_aspects`. 
We do not need a custom function for printing device information, use `SyclDevice.print_device_info`.