### PR TITLE
Update version of clang-format used

### DIFF
--- a/.github/workflows/cpp_style_checks.yml
+++ b/.github/workflows/cpp_style_checks.yml
@@ -18,5 +18,5 @@ jobs:
     - name: Run clang-format style check for C/C++ programs.
       uses: jidicula/clang-format-action@v3.1.0
       with:
-        clang-format-version: '11'
+        clang-format-version: '12'
         check-path: 'libsyclinterface'


### PR DESCRIPTION
Updated clang-format requested by the workflow from 11 to 12 (13 is the default version used by the action).