### PR TITLE
cpp_style_check workflow use ubuntu 20.04

### DIFF
--- a/.github/workflows/cpp_style_checks.yml
+++ b/.github/workflows/cpp_style_checks.yml
@@ -16,7 +16,12 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Run clang-format style check for C/C++ programs.
-      uses: jidicula/clang-format-action@v3.1.0
+      uses: jidicula/clang-format-action@v3.5.1
       with:
         clang-format-version: '11'
         check-path: 'libsyclinterface'
+    - name: Run clang-format style check for api headers.
+      uses: jidicula/clang-format-action@v3.5.1
+      with:
+        clang-format-version: '11'
+        check-path: 'dpctl/apis'


### PR DESCRIPTION
Also check "dpctl/apis" folder, containing header files.