### PR TITLE
Updated setup's classifiers keyword argument

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -492,8 +492,8 @@ setup(
     keywords="dpctl",
     classifiers=[
         "Development Status :: 3 - Alpha",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
     ],
 )


### PR DESCRIPTION
Remove declaration for support for Python 3.6, added declaration of support for Python 3.9