### PR TITLE
Synchronization functions and USM allocations functions release GIL

### DIFF
--- a/dpctl/_backend.pxd
+++ b/dpctl/_backend.pxd
@@ -227,8 +227,8 @@ cdef extern from "syclinterface/dpctl_sycl_device_selector_interface.h":
 cdef extern from "syclinterface/dpctl_sycl_event_interface.h":
     cdef DPCTLSyclEventRef DPCTLEvent_Create()
     cdef DPCTLSyclEventRef DPCTLEvent_Copy(const DPCTLSyclEventRef ERef)
-    cdef void DPCTLEvent_Wait(DPCTLSyclEventRef ERef)
-    cdef void DPCTLEvent_WaitAndThrow(DPCTLSyclEventRef ERef)
+    cdef void DPCTLEvent_Wait(DPCTLSyclEventRef ERef) nogil
+    cdef void DPCTLEvent_WaitAndThrow(DPCTLSyclEventRef ERef) nogil
     cdef void DPCTLEvent_Delete(DPCTLSyclEventRef ERef)
     cdef _event_status_type DPCTLEvent_GetCommandExecutionStatus(DPCTLSyclEventRef ERef)
     cdef _backend_type DPCTLEvent_GetBackend(DPCTLSyclEventRef ERef)
@@ -356,7 +356,7 @@ cdef extern from "syclinterface/dpctl_sycl_queue_interface.h":
         size_t NDims,
         const DPCTLSyclEventRef *DepEvents,
         size_t NDepEvents)
-    cdef void DPCTLQueue_Wait(const DPCTLSyclQueueRef QRef)
+    cdef void DPCTLQueue_Wait(const DPCTLSyclQueueRef QRef) nogil
     cdef DPCTLSyclEventRef DPCTLQueue_Memcpy(
         const DPCTLSyclQueueRef Q,
         void *Dest,

--- a/dpctl/_backend.pxd
+++ b/dpctl/_backend.pxd
@@ -394,23 +394,25 @@ cdef extern from "syclinterface/dpctl_sycl_queue_manager.h":
 cdef extern from "syclinterface/dpctl_sycl_usm_interface.h":
     cdef DPCTLSyclUSMRef DPCTLmalloc_shared(
         size_t size,
-        DPCTLSyclQueueRef QRef)
+        DPCTLSyclQueueRef QRef) nogil
     cdef DPCTLSyclUSMRef DPCTLmalloc_host(
         size_t size,
-        DPCTLSyclQueueRef QRef)
-    cdef DPCTLSyclUSMRef DPCTLmalloc_device(size_t size, DPCTLSyclQueueRef QRef)
+        DPCTLSyclQueueRef QRef) nogil
+    cdef DPCTLSyclUSMRef DPCTLmalloc_device(
+        size_t size,
+        DPCTLSyclQueueRef QRef) nogil
     cdef DPCTLSyclUSMRef DPCTLaligned_alloc_shared(
         size_t alignment,
         size_t size,
-        DPCTLSyclQueueRef QRef)
+        DPCTLSyclQueueRef QRef) nogil
     cdef DPCTLSyclUSMRef DPCTLaligned_alloc_host(
         size_t alignment,
         size_t size,
-        DPCTLSyclQueueRef QRef)
+        DPCTLSyclQueueRef QRef) nogil
     cdef DPCTLSyclUSMRef DPCTLaligned_alloc_device(
         size_t alignment,
         size_t size,
-        DPCTLSyclQueueRef QRef)
+        DPCTLSyclQueueRef QRef) nogil
     cdef void DPCTLfree_with_queue(
         DPCTLSyclUSMRef MRef,
         DPCTLSyclQueueRef QRef)

--- a/dpctl/_sycl_event.pyx
+++ b/dpctl/_sycl_event.pyx
@@ -98,8 +98,7 @@ cdef class _SyclEvent:
 
     def __dealloc__(self):
         if (self._event_ref):
-            with nogil:
-                DPCTLEvent_Wait(self._event_ref)
+            with nogil: DPCTLEvent_Wait(self._event_ref)
             DPCTLEvent_Delete(self._event_ref)
         self._event_ref = NULL
         self.args = None
@@ -225,8 +224,7 @@ cdef class SyclEvent(_SyclEvent):
 
     @staticmethod
     cdef void _wait(SyclEvent event):
-        with nogil:
-            DPCTLEvent_WaitAndThrow(event._event_ref)
+        with nogil: DPCTLEvent_WaitAndThrow(event._event_ref)
 
     @staticmethod
     def wait_for(event):
@@ -372,5 +370,4 @@ cdef class SyclEvent(_SyclEvent):
 
     cpdef void wait(self):
         "Synchronously wait for completion of this event."
-        with nogil:
-            DPCTLEvent_Wait(self._event_ref)
+        with nogil: DPCTLEvent_Wait(self._event_ref)

--- a/dpctl/_sycl_event.pyx
+++ b/dpctl/_sycl_event.pyx
@@ -98,7 +98,8 @@ cdef class _SyclEvent:
 
     def __dealloc__(self):
         if (self._event_ref):
-            DPCTLEvent_Wait(self._event_ref)
+            with nogil:
+                DPCTLEvent_Wait(self._event_ref)
             DPCTLEvent_Delete(self._event_ref)
         self._event_ref = NULL
         self.args = None
@@ -224,7 +225,8 @@ cdef class SyclEvent(_SyclEvent):
 
     @staticmethod
     cdef void _wait(SyclEvent event):
-        DPCTLEvent_WaitAndThrow(event._event_ref)
+        with nogil:
+            DPCTLEvent_WaitAndThrow(event._event_ref)
 
     @staticmethod
     def wait_for(event):
@@ -370,4 +372,5 @@ cdef class SyclEvent(_SyclEvent):
 
     cpdef void wait(self):
         "Synchronously wait for completion of this event."
-        DPCTLEvent_Wait(self._event_ref)
+        with nogil:
+            DPCTLEvent_Wait(self._event_ref)

--- a/dpctl/_sycl_queue.pyx
+++ b/dpctl/_sycl_queue.pyx
@@ -824,7 +824,8 @@ cdef class SyclQueue(_SyclQueue):
         return SyclEvent._create(Eref, args)
 
     cpdef void wait(self):
-        DPCTLQueue_Wait(self._queue_ref)
+        with nogil:
+            DPCTLQueue_Wait(self._queue_ref)
 
     cpdef memcpy(self, dest, src, size_t count):
         cdef void *c_dest
@@ -846,7 +847,8 @@ cdef class SyclQueue(_SyclQueue):
             raise RuntimeError(
                 "SyclQueue.memcpy operation encountered an error"
             )
-        DPCTLEvent_Wait(ERef)
+        with nogil:
+            DPCTLEvent_Wait(ERef)
         DPCTLEvent_Delete(ERef)
 
     cpdef prefetch(self, mem, size_t count=0):
@@ -866,7 +868,8 @@ cdef class SyclQueue(_SyclQueue):
             raise RuntimeError(
                 "SyclQueue.prefetch encountered an error"
             )
-        DPCTLEvent_Wait(ERef)
+        with nogil:
+            DPCTLEvent_Wait(ERef)
         DPCTLEvent_Delete(ERef)
 
     cpdef mem_advise(self, mem, size_t count, int advice):
@@ -886,7 +889,8 @@ cdef class SyclQueue(_SyclQueue):
             raise RuntimeError(
                 "SyclQueue.mem_advise operation encountered an error"
             )
-        DPCTLEvent_Wait(ERef)
+        with nogil:
+            DPCTLEvent_Wait(ERef)
         DPCTLEvent_Delete(ERef)
 
     @property

--- a/dpctl/_sycl_queue.pyx
+++ b/dpctl/_sycl_queue.pyx
@@ -824,8 +824,7 @@ cdef class SyclQueue(_SyclQueue):
         return SyclEvent._create(Eref, args)
 
     cpdef void wait(self):
-        with nogil:
-            DPCTLQueue_Wait(self._queue_ref)
+        with nogil: DPCTLQueue_Wait(self._queue_ref)
 
     cpdef memcpy(self, dest, src, size_t count):
         cdef void *c_dest
@@ -847,8 +846,7 @@ cdef class SyclQueue(_SyclQueue):
             raise RuntimeError(
                 "SyclQueue.memcpy operation encountered an error"
             )
-        with nogil:
-            DPCTLEvent_Wait(ERef)
+        with nogil: DPCTLEvent_Wait(ERef)
         DPCTLEvent_Delete(ERef)
 
     cpdef prefetch(self, mem, size_t count=0):
@@ -868,8 +866,7 @@ cdef class SyclQueue(_SyclQueue):
             raise RuntimeError(
                 "SyclQueue.prefetch encountered an error"
             )
-        with nogil:
-            DPCTLEvent_Wait(ERef)
+        with nogil: DPCTLEvent_Wait(ERef)
         DPCTLEvent_Delete(ERef)
 
     cpdef mem_advise(self, mem, size_t count, int advice):
@@ -889,8 +886,7 @@ cdef class SyclQueue(_SyclQueue):
             raise RuntimeError(
                 "SyclQueue.mem_advise operation encountered an error"
             )
-        with nogil:
-            DPCTLEvent_Wait(ERef)
+        with nogil: DPCTLEvent_Wait(ERef)
         DPCTLEvent_Delete(ERef)
 
     @property

--- a/dpctl/memory/_memory.pyx
+++ b/dpctl/memory/_memory.pyx
@@ -94,8 +94,7 @@ cdef void copy_via_host(void *dest_ptr, SyclQueue dest_queue,
         src_ptr,
         nbytes
     )
-    with nogil:
-        DPCTLEvent_Wait(E1Ref)
+    with nogil: DPCTLEvent_Wait(E1Ref)
 
     E2Ref = DPCTLQueue_Memcpy(
         dest_queue.get_queue_ref(),
@@ -103,8 +102,7 @@ cdef void copy_via_host(void *dest_ptr, SyclQueue dest_queue,
         <void *>&host_buf[0],
         nbytes
     )
-    with nogil:
-        DPCTLEvent_Wait(E2Ref)
+    with nogil: DPCTLEvent_Wait(E2Ref)
     DPCTLEvent_Delete(E1Ref)
     DPCTLEvent_Delete(E2Ref)
 
@@ -400,8 +398,7 @@ cdef class _Memory:
             <void *>self.memory_ptr,  # source
             <size_t>self.nbytes
         )
-        with nogil:
-            DPCTLEvent_Wait(ERef)
+        with nogil: DPCTLEvent_Wait(ERef)
         DPCTLEvent_Delete(ERef)
 
         return obj
@@ -426,8 +423,7 @@ cdef class _Memory:
             <void *>&host_buf[0],     # source
             <size_t>buf_len
         )
-        with nogil:
-            DPCTLEvent_Wait(ERef)
+        with nogil: DPCTLEvent_Wait(ERef)
         DPCTLEvent_Delete(ERef)
 
     cpdef copy_from_device(self, object sycl_usm_ary):
@@ -469,8 +465,7 @@ cdef class _Memory:
                     <void *>src_buf.p,
                     <size_t>src_buf.nbytes
                 )
-                with nogil:
-                    DPCTLEvent_Wait(ERef)
+                with nogil: DPCTLEvent_Wait(ERef)
                 DPCTLEvent_Delete(ERef)
             else:
                 copy_via_host(

--- a/dpctl/memory/_memory.pyx
+++ b/dpctl/memory/_memory.pyx
@@ -94,7 +94,8 @@ cdef void copy_via_host(void *dest_ptr, SyclQueue dest_queue,
         src_ptr,
         nbytes
     )
-    DPCTLEvent_Wait(E1Ref)
+    with nogil:
+        DPCTLEvent_Wait(E1Ref)
 
     E2Ref = DPCTLQueue_Memcpy(
         dest_queue.get_queue_ref(),
@@ -102,7 +103,8 @@ cdef void copy_via_host(void *dest_ptr, SyclQueue dest_queue,
         <void *>&host_buf[0],
         nbytes
     )
-    DPCTLEvent_Wait(E2Ref)
+    with nogil:
+        DPCTLEvent_Wait(E2Ref)
     DPCTLEvent_Delete(E1Ref)
     DPCTLEvent_Delete(E2Ref)
 
@@ -398,7 +400,8 @@ cdef class _Memory:
             <void *>self.memory_ptr,  # source
             <size_t>self.nbytes
         )
-        DPCTLEvent_Wait(ERef)
+        with nogil:
+            DPCTLEvent_Wait(ERef)
         DPCTLEvent_Delete(ERef)
 
         return obj
@@ -423,7 +426,8 @@ cdef class _Memory:
             <void *>&host_buf[0],     # source
             <size_t>buf_len
         )
-        DPCTLEvent_Wait(ERef)
+        with nogil:
+            DPCTLEvent_Wait(ERef)
         DPCTLEvent_Delete(ERef)
 
     cpdef copy_from_device(self, object sycl_usm_ary):
@@ -465,7 +469,8 @@ cdef class _Memory:
                     <void *>src_buf.p,
                     <size_t>src_buf.nbytes
                 )
-                DPCTLEvent_Wait(ERef)
+                with nogil:
+                    DPCTLEvent_Wait(ERef)
                 DPCTLEvent_Delete(ERef)
             else:
                 copy_via_host(

--- a/dpctl/memory/_memory.pyx
+++ b/dpctl/memory/_memory.pyx
@@ -142,6 +142,7 @@ cdef class _Memory:
     cdef _cinit_alloc(self, Py_ssize_t alignment, Py_ssize_t nbytes,
                       bytes ptr_type, SyclQueue queue):
         cdef DPCTLSyclUSMRef p = NULL
+        cdef DPCTLSyclQueueRef QRef = NULL
 
         self._cinit_empty()
 
@@ -149,27 +150,28 @@ cdef class _Memory:
             if queue is None:
                 queue = dpctl.SyclQueue()
 
+            QRef = queue.get_queue_ref()
             if (ptr_type == b"shared"):
                 if alignment > 0:
-                    p = DPCTLaligned_alloc_shared(
-                        alignment, nbytes, queue.get_queue_ref()
+                    with nogil: p = DPCTLaligned_alloc_shared(
+                        alignment, nbytes, QRef
                     )
                 else:
-                    p = DPCTLmalloc_shared(nbytes, queue.get_queue_ref())
+                    with nogil: p = DPCTLmalloc_shared(nbytes, QRef)
             elif (ptr_type == b"host"):
                 if alignment > 0:
-                    p = DPCTLaligned_alloc_host(
-                        alignment, nbytes, queue.get_queue_ref()
+                    with nogil: p = DPCTLaligned_alloc_host(
+                        alignment, nbytes, QRef
                     )
                 else:
-                    p = DPCTLmalloc_host(nbytes, queue.get_queue_ref())
+                    with nogil: p = DPCTLmalloc_host(nbytes, QRef)
             elif (ptr_type == b"device"):
                 if (alignment > 0):
-                    p = DPCTLaligned_alloc_device(
-                        alignment, nbytes, queue.get_queue_ref()
+                    with nogil: p = DPCTLaligned_alloc_device(
+                        alignment, nbytes, QRef
                     )
                 else:
-                    p = DPCTLmalloc_device(nbytes, queue.get_queue_ref())
+                    with nogil: p = DPCTLmalloc_device(nbytes, QRef)
             else:
                 raise RuntimeError(
                     "Pointer type is unknown: {}".format(


### PR DESCRIPTION
`DPCTLQueue_Wait` and friends are declared nogil, and their use
is moved into `with nogil` context.

This allows us to use `sycl::host_task` to manipulate reference count on a Python object without introducing a deadlock.

Since USM allocation functions are also synchronous and can take some time for 
large allocations, we release GIL for them too. We may perhaps revisit this in the future, only release GIL for large enough allocations.