### PR TITLE
Memory api

### DIFF
--- a/dpctl/_sycl_context.pyx
+++ b/dpctl/_sycl_context.pyx
@@ -480,7 +480,7 @@ cdef class SyclContext(_SyclContext):
             &_context_capsule_deleter
         )
 
-cdef api DPCTLSyclContextRef get_context_ref(SyclContext ctx):
+cdef api DPCTLSyclContextRef SyclContext_GetContextRef(SyclContext ctx):
     """
     C-API function to get opaque context reference from
     :class:`dpctl.SyclContext` instance.
@@ -488,7 +488,7 @@ cdef api DPCTLSyclContextRef get_context_ref(SyclContext ctx):
     return ctx.get_context_ref()
 
 
-cdef api SyclContext make_SyclContext(DPCTLSyclContextRef CRef):
+cdef api SyclContext SyclContext_Make(DPCTLSyclContextRef CRef):
     """
     C-API function to create :class:`dpctl.SyclContext` instance
     from the given opaque context reference.

--- a/dpctl/_sycl_device.pyx
+++ b/dpctl/_sycl_device.pyx
@@ -1130,7 +1130,7 @@ cdef class SyclDevice(_SyclDevice):
                 else:
                     return str(relId)
 
-cdef api DPCTLSyclDeviceRef get_device_ref(SyclDevice dev):
+cdef api DPCTLSyclDeviceRef SyclDevice_GetDeviceRef(SyclDevice dev):
     """
     C-API function to get opaque device reference from
     :class:`dpctl.SyclDevice` instance.
@@ -1138,7 +1138,7 @@ cdef api DPCTLSyclDeviceRef get_device_ref(SyclDevice dev):
     return dev.get_device_ref()
 
 
-cdef api SyclDevice make_SyclDevice(DPCTLSyclDeviceRef DRef):
+cdef api SyclDevice SyclDevice_Make(DPCTLSyclDeviceRef DRef):
     """
     C-API function to create :class:`dpctl.SyclDevice` instance
     from the given opaque device reference.

--- a/dpctl/_sycl_event.pyx
+++ b/dpctl/_sycl_event.pyx
@@ -57,14 +57,14 @@ __all__ = [
 _logger = logging.getLogger(__name__)
 
 
-cdef api DPCTLSyclEventRef get_event_ref(SyclEvent ev):
+cdef api DPCTLSyclEventRef SyclEvent_GetEventRef(SyclEvent ev):
     """ C-API function to access opaque event reference from
     Python object of type :class:`dpctl.SyclEvent`.
     """
     return ev.get_event_ref()
 
 
-cdef api SyclEvent make_SyclEvent(DPCTLSyclEventRef ERef):
+cdef api SyclEvent SyclEvent_Make(DPCTLSyclEventRef ERef):
     """
     C-API function to create :class:`dpctl.SyclEvent`
     instance from opaque sycl event reference.

--- a/dpctl/_sycl_queue.pyx
+++ b/dpctl/_sycl_queue.pyx
@@ -1001,7 +1001,7 @@ cdef class SyclQueue(_SyclQueue):
         self.sycl_device.print_device_info()
 
 
-cdef api DPCTLSyclQueueRef get_queue_ref(SyclQueue q):
+cdef api DPCTLSyclQueueRef SyclQueue_GetQueueRef(SyclQueue q):
     """
     C-API function to get opaque queue reference from
     :class:`dpctl.SyclQueue` instance.
@@ -1009,7 +1009,7 @@ cdef api DPCTLSyclQueueRef get_queue_ref(SyclQueue q):
     return q.get_queue_ref()
 
 
-cdef api SyclQueue make_SyclQueue(DPCTLSyclQueueRef QRef):
+cdef api SyclQueue SyclQueue_Make(DPCTLSyclQueueRef QRef):
     """
     C-API function to create :class:`dpctl.SyclQueue` instance
     from the given opaque queue reference.

--- a/dpctl/apis/include/dpctl4pybind11.hpp
+++ b/dpctl/apis/include/dpctl4pybind11.hpp
@@ -49,8 +49,8 @@ public:
     {
         PyObject *source = src.ptr();
         if (PyObject_TypeCheck(source, &PySyclQueueType)) {
-            DPCTLSyclQueueRef QRef =
-                get_queue_ref(reinterpret_cast<PySyclQueueObject *>(source));
+            DPCTLSyclQueueRef QRef = SyclQueue_GetQueueRef(
+                reinterpret_cast<PySyclQueueObject *>(source));
             sycl::queue *q = reinterpret_cast<sycl::queue *>(QRef);
             value = *q;
             return true;
@@ -63,7 +63,7 @@ public:
 
     static handle cast(sycl::queue src, return_value_policy, handle)
     {
-        auto tmp = make_SyclQueue(reinterpret_cast<DPCTLSyclQueueRef>(&src));
+        auto tmp = SyclQueue_Make(reinterpret_cast<DPCTLSyclQueueRef>(&src));
         return handle(reinterpret_cast<PyObject *>(tmp));
     }
 };
@@ -87,8 +87,8 @@ public:
     {
         PyObject *source = src.ptr();
         if (PyObject_TypeCheck(source, &PySyclDeviceType)) {
-            DPCTLSyclDeviceRef DRef =
-                get_device_ref(reinterpret_cast<PySyclDeviceObject *>(source));
+            DPCTLSyclDeviceRef DRef = SyclDevice_GetDeviceRef(
+                reinterpret_cast<PySyclDeviceObject *>(source));
             sycl::device *d = reinterpret_cast<sycl::device *>(DRef);
             value = *d;
             return true;
@@ -101,7 +101,7 @@ public:
 
     static handle cast(sycl::device src, return_value_policy, handle)
     {
-        auto tmp = make_SyclDevice(reinterpret_cast<DPCTLSyclDeviceRef>(&src));
+        auto tmp = SyclDevice_Make(reinterpret_cast<DPCTLSyclDeviceRef>(&src));
         return handle(reinterpret_cast<PyObject *>(tmp));
     }
 };
@@ -125,7 +125,7 @@ public:
     {
         PyObject *source = src.ptr();
         if (PyObject_TypeCheck(source, &PySyclContextType)) {
-            DPCTLSyclContextRef CRef = get_context_ref(
+            DPCTLSyclContextRef CRef = SyclContext_GetContextRef(
                 reinterpret_cast<PySyclContextObject *>(source));
             sycl::context *ctx = reinterpret_cast<sycl::context *>(CRef);
             value = *ctx;
@@ -140,7 +140,7 @@ public:
     static handle cast(sycl::context src, return_value_policy, handle)
     {
         auto tmp =
-            make_SyclContext(reinterpret_cast<DPCTLSyclContextRef>(&src));
+            SyclContext_Make(reinterpret_cast<DPCTLSyclContextRef>(&src));
         return handle(reinterpret_cast<PyObject *>(tmp));
     }
 };
@@ -164,8 +164,8 @@ public:
     {
         PyObject *source = src.ptr();
         if (PyObject_TypeCheck(source, &PySyclEventType)) {
-            DPCTLSyclEventRef ERef =
-                get_event_ref(reinterpret_cast<PySyclEventObject *>(source));
+            DPCTLSyclEventRef ERef = SyclEvent_GetEventRef(
+                reinterpret_cast<PySyclEventObject *>(source));
             sycl::event *ev = reinterpret_cast<sycl::event *>(ERef);
             value = *ev;
             return true;
@@ -178,7 +178,7 @@ public:
 
     static handle cast(sycl::event src, return_value_policy, handle)
     {
-        auto tmp = make_SyclEvent(reinterpret_cast<DPCTLSyclEventRef>(&src));
+        auto tmp = SyclEvent_Make(reinterpret_cast<DPCTLSyclEventRef>(&src));
         return handle(reinterpret_cast<PyObject *>(tmp));
     }
 };

--- a/dpctl/apis/include/dpctl_capi.h
+++ b/dpctl/apis/include/dpctl_capi.h
@@ -36,6 +36,8 @@
 #include "../_sycl_event_api.h"
 #include "../_sycl_queue.h"
 #include "../_sycl_queue_api.h"
+#include "../memory/_memory.h"
+#include "../memory/_memory_api.h"
 // clang-format on
 
 /*
@@ -50,6 +52,6 @@ void import_dpctl(void)
     import_dpctl___sycl_context();
     import_dpctl___sycl_event();
     import_dpctl___sycl_queue();
-
+    import_dpctl__memory___memory();
     return;
 }

--- a/dpctl/apis/include/dpctl_capi.h
+++ b/dpctl/apis/include/dpctl_capi.h
@@ -38,6 +38,8 @@
 #include "../_sycl_queue_api.h"
 #include "../memory/_memory.h"
 #include "../memory/_memory_api.h"
+#include "../tensor/_usmarray.h"
+#include "../tensor/_usmarray_api.h"
 // clang-format on
 
 /*
@@ -53,5 +55,6 @@ void import_dpctl(void)
     import_dpctl___sycl_event();
     import_dpctl___sycl_queue();
     import_dpctl__memory___memory();
+    import_dpctl__tensor___usmarray();
     return;
 }

--- a/dpctl/memory/_memory.pyx
+++ b/dpctl/memory/_memory.pyx
@@ -751,20 +751,20 @@ def as_usm_memory(obj):
         )
 
 
-cdef api DPCTLSyclUSMRef get_usm_pointer(_Memory obj):
+cdef api DPCTLSyclUSMRef Memory_get_usm_pointer(_Memory obj):
     "Pointer of USM allocation"
     return obj.memory_ptr
 
-cdef api DPCTLSyclContextRef get_context_ref(_Memory obj):
+cdef api DPCTLSyclContextRef Memory_get_context_ref(_Memory obj):
     "Context reference to which USM allocation is bound"
     return obj.queue._context.get_context_ref()
 
-cdef api DPCTLSyclQueueRef get_queue_ref(_Memory obj):
+cdef api DPCTLSyclQueueRef Memory_get_queue_ref(_Memory obj):
     """Queue associated with this allocation, used
     for copying, population, etc."""
     return obj.queue.get_queue_ref()
 
-cdef api size_t get_nbytes(_Memory obj):
+cdef api size_t Memory_get_nbytes(_Memory obj):
     "Size of the allocation in bytes."
     return <size_t>obj.nbytes
 

--- a/dpctl/memory/_memory.pyx
+++ b/dpctl/memory/_memory.pyx
@@ -751,24 +751,24 @@ def as_usm_memory(obj):
         )
 
 
-cdef api DPCTLSyclUSMRef Memory_get_usm_pointer(_Memory obj):
+cdef api DPCTLSyclUSMRef Memory_GetUsmPointer(_Memory obj):
     "Pointer of USM allocation"
     return obj.memory_ptr
 
-cdef api DPCTLSyclContextRef Memory_get_context_ref(_Memory obj):
+cdef api DPCTLSyclContextRef Memory_GetContextRef(_Memory obj):
     "Context reference to which USM allocation is bound"
     return obj.queue._context.get_context_ref()
 
-cdef api DPCTLSyclQueueRef Memory_get_queue_ref(_Memory obj):
+cdef api DPCTLSyclQueueRef Memory_GetQueueRef(_Memory obj):
     """Queue associated with this allocation, used
     for copying, population, etc."""
     return obj.queue.get_queue_ref()
 
-cdef api size_t Memory_get_nbytes(_Memory obj):
+cdef api size_t Memory_GetNumBytes(_Memory obj):
     "Size of the allocation in bytes."
     return <size_t>obj.nbytes
 
-cdef api object make_Memory(
+cdef api object Memory_Make(
     DPCTLSyclUSMRef ptr,
     size_t nbytes,
     DPCTLSyclQueueRef QRef,

--- a/dpctl/memory/_memory.pyx
+++ b/dpctl/memory/_memory.pyx
@@ -774,6 +774,7 @@ cdef api object Memory_Make(
     DPCTLSyclQueueRef QRef,
     object owner
 ):
+    "Create _Memory Python object from preallocated memory."
     return _Memory.create_from_usm_pointer_size_qref(
         ptr, nbytes, QRef, memory_owner=owner
     )

--- a/dpctl/memory/_memory.pyx
+++ b/dpctl/memory/_memory.pyx
@@ -752,10 +752,28 @@ def as_usm_memory(obj):
 
 
 cdef api DPCTLSyclUSMRef get_usm_pointer(_Memory obj):
+    "Pointer of USM allocation"
     return obj.memory_ptr
 
-cdef api DPCTLSyclContextRef get_context(_Memory obj):
+cdef api DPCTLSyclContextRef get_context_ref(_Memory obj):
+    "Context reference to which USM allocation is bound"
     return obj.queue._context.get_context_ref()
 
+cdef api DPCTLSyclQueueRef get_queue_ref(_Memory obj):
+    """Queue associated with this allocation, used
+    for copying, population, etc."""
+    return obj.queue.get_queue_ref()
+
 cdef api size_t get_nbytes(_Memory obj):
+    "Size of the allocation in bytes."
     return <size_t>obj.nbytes
+
+cdef api object make_Memory(
+    DPCTLSyclUSMRef ptr,
+    size_t nbytes,
+    DPCTLSyclQueueRef QRef,
+    object owner
+):
+    return _Memory.create_from_usm_pointer_size_qref(
+        ptr, nbytes, QRef, memory_owner=owner
+    )

--- a/dpctl/tensor/_usmarray.pyx
+++ b/dpctl/tensor/_usmarray.pyx
@@ -1136,37 +1136,37 @@ cdef usm_ndarray _zero_like(usm_ndarray ary):
     return r
 
 
-cdef api char* usm_ndarray_get_data(usm_ndarray arr):
+cdef api char* UsmNDArray_GetData(usm_ndarray arr):
     """
     """
     return arr.get_data()
 
 
-cdef api int usm_ndarray_get_ndim(usm_ndarray arr):
+cdef api int UsmNDArray_GetNDim(usm_ndarray arr):
     """"""
     return arr.get_ndim()
 
 
-cdef api Py_ssize_t* usm_ndarray_get_shape(usm_ndarray arr):
+cdef api Py_ssize_t* UsmNDArray_GetShape(usm_ndarray arr):
     """ """
     return arr.get_shape()
 
 
-cdef api Py_ssize_t* usm_ndarray_get_strides(usm_ndarray arr):
+cdef api Py_ssize_t* UsmNDArray_GetStrides(usm_ndarray arr):
     """ """
     return arr.get_strides()
 
 
-cdef api int usm_ndarray_get_typenum(usm_ndarray arr):
+cdef api int UsmNDArray_GetTypenum(usm_ndarray arr):
     """ """
     return arr.get_typenum()
 
 
-cdef api int usm_ndarray_get_flags(usm_ndarray arr):
+cdef api int UsmNDArray_GetFlags(usm_ndarray arr):
     """ """
     return arr.get_flags()
 
 
-cdef api c_dpctl.DPCTLSyclQueueRef usm_ndarray_get_queue_ref(usm_ndarray arr):
+cdef api c_dpctl.DPCTLSyclQueueRef UsmNDArray_GetQueueRef(usm_ndarray arr):
     """ """
     return arr.get_queue_ref()

--- a/dpctl/tensor/_usmarray.pyx
+++ b/dpctl/tensor/_usmarray.pyx
@@ -1137,36 +1137,35 @@ cdef usm_ndarray _zero_like(usm_ndarray ary):
 
 
 cdef api char* UsmNDArray_GetData(usm_ndarray arr):
-    """
-    """
+    """Get allocation pointer of zero index element of array """
     return arr.get_data()
 
 
 cdef api int UsmNDArray_GetNDim(usm_ndarray arr):
-    """"""
+    """Get array rank: length of its shape"""
     return arr.get_ndim()
 
 
 cdef api Py_ssize_t* UsmNDArray_GetShape(usm_ndarray arr):
-    """ """
+    """Get host pointer to shape vector"""
     return arr.get_shape()
 
 
 cdef api Py_ssize_t* UsmNDArray_GetStrides(usm_ndarray arr):
-    """ """
+    """Get host pointer to strides vector"""
     return arr.get_strides()
 
 
 cdef api int UsmNDArray_GetTypenum(usm_ndarray arr):
-    """ """
+    """Get type number for data type of array elements"""
     return arr.get_typenum()
 
 
 cdef api int UsmNDArray_GetFlags(usm_ndarray arr):
-    """ """
+    """Get flags of array"""
     return arr.get_flags()
 
 
 cdef api c_dpctl.DPCTLSyclQueueRef UsmNDArray_GetQueueRef(usm_ndarray arr):
-    """ """
+    """Get DPCTLSyclQueueRef for queue associated with the array"""
     return arr.get_queue_ref()

--- a/dpctl/tests/test_sycl_context.py
+++ b/dpctl/tests/test_sycl_context.py
@@ -190,15 +190,15 @@ def test_context_repr():
     assert type(ctx.__repr__()) is str
 
 
-def test_cpython_api_get_context_ref():
+def test_cpython_api_SyclContext_GetContextRef():
     import ctypes
     import sys
 
     ctx = dpctl.SyclContext()
     mod = sys.modules[ctx.__class__.__module__]
-    # get capsule storign get_context_ref function ptr
-    ctx_ref_fn_cap = mod.__pyx_capi__["get_context_ref"]
-    # construct Python callable to invoke "get_context_ref"
+    # get capsule storign SyclContext_GetContextRef function ptr
+    ctx_ref_fn_cap = mod.__pyx_capi__["SyclContext_GetContextRef"]
+    # construct Python callable to invoke "SyclContext_GetContextRef"
     cap_ptr_fn = ctypes.pythonapi.PyCapsule_GetPointer
     cap_ptr_fn.restype = ctypes.c_void_p
     cap_ptr_fn.argtypes = [ctypes.py_object, ctypes.c_char_p]
@@ -213,15 +213,15 @@ def test_cpython_api_get_context_ref():
     assert r1 == r2
 
 
-def test_cpython_api_make_SyclContext():
+def test_cpython_api_SyclContext_Make():
     import ctypes
     import sys
 
     ctx = dpctl.SyclContext()
     mod = sys.modules[ctx.__class__.__module__]
-    # get capsule storign make_SyclContext function ptr
-    make_ctx_fn_cap = mod.__pyx_capi__["make_SyclContext"]
-    # construct Python callable to invoke "make_SyclContext"
+    # get capsule storign SyclContext_Make function ptr
+    make_ctx_fn_cap = mod.__pyx_capi__["SyclContext_Make"]
+    # construct Python callable to invoke "SyclContext_Make"
     cap_ptr_fn = ctypes.pythonapi.PyCapsule_GetPointer
     cap_ptr_fn.restype = ctypes.c_void_p
     cap_ptr_fn.argtypes = [ctypes.py_object, ctypes.c_char_p]

--- a/dpctl/tests/test_sycl_device.py
+++ b/dpctl/tests/test_sycl_device.py
@@ -731,15 +731,15 @@ def test_handle_no_device():
         dpctl.select_device_with_aspects("cpu", excluded_aspects="cpu")
 
 
-def test_cpython_api_get_device_ref():
+def test_cpython_api_SyclDevice_GetDeviceRef():
     import ctypes
     import sys
 
     d = dpctl.SyclDevice()
     mod = sys.modules[d.__class__.__module__]
-    # get capsule storign get_device_ref function ptr
-    d_ref_fn_cap = mod.__pyx_capi__["get_device_ref"]
-    # construct Python callable to invoke "get_device_ref"
+    # get capsule storing SyclDevice_GetDeviceRef function ptr
+    d_ref_fn_cap = mod.__pyx_capi__["SyclDevice_GetDeviceRef"]
+    # construct Python callable to invoke "SyclDevice_GetDeviceRef"
     cap_ptr_fn = ctypes.pythonapi.PyCapsule_GetPointer
     cap_ptr_fn.restype = ctypes.c_void_p
     cap_ptr_fn.argtypes = [ctypes.py_object, ctypes.c_char_p]
@@ -754,15 +754,15 @@ def test_cpython_api_get_device_ref():
     assert r1 == r2
 
 
-def test_cpython_api_make_SyclDevice():
+def test_cpython_api_SyclDevice_Make():
     import ctypes
     import sys
 
     d = dpctl.SyclDevice()
     mod = sys.modules[d.__class__.__module__]
-    # get capsule storign make_SyclContext function ptr
-    make_d_fn_cap = mod.__pyx_capi__["make_SyclDevice"]
-    # construct Python callable to invoke "make_SyclDevice"
+    # get capsule storign SyclContext_Make function ptr
+    make_d_fn_cap = mod.__pyx_capi__["SyclDevice_Make"]
+    # construct Python callable to invoke "SyclDevice_Make"
     cap_ptr_fn = ctypes.pythonapi.PyCapsule_GetPointer
     cap_ptr_fn.restype = ctypes.c_void_p
     cap_ptr_fn.argtypes = [ctypes.py_object, ctypes.c_char_p]

--- a/dpctl/tests/test_sycl_event.py
+++ b/dpctl/tests/test_sycl_event.py
@@ -234,15 +234,15 @@ def test_addressof_ref():
     assert type(ref) is int
 
 
-def test_cpython_api_get_event_ref():
+def test_cpython_api_SyclEvent_GetEventRef():
     import ctypes
     import sys
 
     ev = dpctl.SyclEvent()
     mod = sys.modules[ev.__class__.__module__]
-    # get capsule storign get_event_ref function ptr
-    ev_ref_fn_cap = mod.__pyx_capi__["get_event_ref"]
-    # construct Python callable to invoke "get_event_ref"
+    # get capsule storign SyclEvent_GetEventRef function ptr
+    ev_ref_fn_cap = mod.__pyx_capi__["SyclEvent_GetEventRef"]
+    # construct Python callable to invoke "SyclEvent_GetEventRef"
     cap_ptr_fn = ctypes.pythonapi.PyCapsule_GetPointer
     cap_ptr_fn.restype = ctypes.c_void_p
     cap_ptr_fn.argtypes = [ctypes.py_object, ctypes.c_char_p]
@@ -257,15 +257,15 @@ def test_cpython_api_get_event_ref():
     assert r1 == r2
 
 
-def test_cpython_api_make_SyclEvent():
+def test_cpython_api_SyclEvent_Make():
     import ctypes
     import sys
 
     ev = dpctl.SyclEvent()
     mod = sys.modules[ev.__class__.__module__]
-    # get capsule storing make_SyclEvent function ptr
-    make_e_fn_cap = mod.__pyx_capi__["make_SyclEvent"]
-    # construct Python callable to invoke "make_SyclDevice"
+    # get capsule storing SyclEvent_Make function ptr
+    make_e_fn_cap = mod.__pyx_capi__["SyclEvent_Make"]
+    # construct Python callable to invoke "SyclDevice_Make"
     cap_ptr_fn = ctypes.pythonapi.PyCapsule_GetPointer
     cap_ptr_fn.restype = ctypes.c_void_p
     cap_ptr_fn.argtypes = [ctypes.py_object, ctypes.c_char_p]

--- a/dpctl/tests/test_sycl_queue.py
+++ b/dpctl/tests/test_sycl_queue.py
@@ -469,12 +469,12 @@ def test_queue_capsule():
     assert q2 != []  # compare with other types
 
 
-def test_cpython_api_get_queue_ref():
+def test_cpython_api_SyclQueue_GetQueueRef():
     q = dpctl.SyclQueue()
     mod = sys.modules[q.__class__.__module__]
-    # get capsule storign get_queue_ref function ptr
-    q_ref_fn_cap = mod.__pyx_capi__["get_queue_ref"]
-    # construct Python callable to invoke "get_queue_ref"
+    # get capsule storign SyclQueue_GetQueueRef function ptr
+    q_ref_fn_cap = mod.__pyx_capi__["SyclQueue_GetQueueRef"]
+    # construct Python callable to invoke "SyclQueue_GetQueueRef"
     cap_ptr_fn = ctypes.pythonapi.PyCapsule_GetPointer
     cap_ptr_fn.restype = ctypes.c_void_p
     cap_ptr_fn.argtypes = [ctypes.py_object, ctypes.c_char_p]
@@ -489,12 +489,12 @@ def test_cpython_api_get_queue_ref():
     assert r1 == r2
 
 
-def test_cpython_api_make_SyclQueue():
+def test_cpython_api_SyclQueue_Make():
     q = dpctl.SyclQueue()
     mod = sys.modules[q.__class__.__module__]
-    # get capsule storing make_SyclQueue function ptr
-    make_SyclQueue_fn_cap = mod.__pyx_capi__["make_SyclQueue"]
-    # construct Python callable to invoke "make_SyclQueue"
+    # get capsule storing SyclQueue_Make function ptr
+    make_SyclQueue_fn_cap = mod.__pyx_capi__["SyclQueue_Make"]
+    # construct Python callable to invoke "SyclQueue_Make"
     cap_ptr_fn = ctypes.pythonapi.PyCapsule_GetPointer
     cap_ptr_fn.restype = ctypes.c_void_p
     cap_ptr_fn.argtypes = [ctypes.py_object, ctypes.c_char_p]

--- a/dpctl/tests/test_sycl_usm.py
+++ b/dpctl/tests/test_sycl_usm.py
@@ -530,11 +530,11 @@ def test_cpython_api(memory_ctor):
     mobj = memory_ctor(1024)
     mod = sys.modules[mobj.__class__.__module__]
     # get capsules storing function pointers
-    mem_ptr_fn_cap = mod.__pyx_capi__["Memory_get_usm_pointer"]
-    mem_q_ref_fn_cap = mod.__pyx_capi__["Memory_get_queue_ref"]
-    mem_ctx_ref_fn_cap = mod.__pyx_capi__["Memory_get_context_ref"]
-    mem_nby_fn_cap = mod.__pyx_capi__["Memory_get_nbytes"]
-    # construct Python callable to invoke "get_usm_pointer"
+    mem_ptr_fn_cap = mod.__pyx_capi__["Memory_GetUsmPointer"]
+    mem_q_ref_fn_cap = mod.__pyx_capi__["Memory_GetQueueRef"]
+    mem_ctx_ref_fn_cap = mod.__pyx_capi__["Memory_GetContextRef"]
+    mem_nby_fn_cap = mod.__pyx_capi__["Memory_GetNumBytes"]
+    # construct Python callable to invoke functions
     cap_ptr_fn = ctypes.pythonapi.PyCapsule_GetPointer
     cap_ptr_fn.restype = ctypes.c_void_p
     cap_ptr_fn.argtypes = [ctypes.py_object, ctypes.c_char_p]

--- a/dpctl/tests/test_sycl_usm.py
+++ b/dpctl/tests/test_sycl_usm.py
@@ -531,7 +531,7 @@ def test_cpython_api(memory_ctor):
     mod = sys.modules[mobj.__class__.__module__]
     # get capsules storing function pointers
     mem_ptr_fn_cap = mod.__pyx_capi__["get_usm_pointer"]
-    mem_ctx_fn_cap = mod.__pyx_capi__["get_context"]
+    mem_ctx_ref_fn_cap = mod.__pyx_capi__["get_context_ref"]
     mem_nby_fn_cap = mod.__pyx_capi__["get_nbytes"]
     # construct Python callable to invoke "get_usm_pointer"
     cap_ptr_fn = ctypes.pythonapi.PyCapsule_GetPointer
@@ -540,21 +540,21 @@ def test_cpython_api(memory_ctor):
     mem_ptr_fn_ptr = cap_ptr_fn(
         mem_ptr_fn_cap, b"DPCTLSyclUSMRef (struct Py_MemoryObject *)"
     )
-    mem_ctx_fn_ptr = cap_ptr_fn(
-        mem_ctx_fn_cap, b"DPCTLSyclContextRef (struct Py_MemoryObject *)"
+    mem_ctx_ref_fn_ptr = cap_ptr_fn(
+        mem_ctx_ref_fn_cap, b"DPCTLSyclContextRef (struct Py_MemoryObject *)"
     )
     mem_nby_fn_ptr = cap_ptr_fn(
         mem_nby_fn_cap, b"size_t (struct Py_MemoryObject *)"
     )
     callable_maker = ctypes.PYFUNCTYPE(ctypes.c_void_p, ctypes.py_object)
     get_ptr_fn = callable_maker(mem_ptr_fn_ptr)
-    get_ctx_fn = callable_maker(mem_ctx_fn_ptr)
+    get_ctx_ref_fn = callable_maker(mem_ctx_ref_fn_ptr)
     get_nby_fn = callable_maker(mem_nby_fn_ptr)
 
     capi_ptr = get_ptr_fn(mobj)
     direct_ptr = mobj._pointer
     assert capi_ptr == direct_ptr
-    capi_ctx_ref = get_ctx_fn(mobj)
+    capi_ctx_ref = get_ctx_ref_fn(mobj)
     direct_ctx_ref = mobj._context.addressof_ref()
     assert capi_ctx_ref == direct_ctx_ref
     capi_nbytes = get_nby_fn(mobj)

--- a/dpctl/tests/test_usm_ndarray_ctor.py
+++ b/dpctl/tests/test_usm_ndarray_ctor.py
@@ -353,7 +353,7 @@ def test_pyx_capi_get_data():
     X = dpt.usm_ndarray(17)[1::2]
     get_data_fn = _pyx_capi_fnptr_to_callable(
         X,
-        "usm_ndarray_get_data",
+        "UsmNDArray_GetData",
         b"char *(struct PyUSMArrayObject *)",
         fn_restype=ctypes.c_void_p,
     )
@@ -366,7 +366,7 @@ def test_pyx_capi_get_shape():
     X = dpt.usm_ndarray(17)[1::2]
     get_shape_fn = _pyx_capi_fnptr_to_callable(
         X,
-        "usm_ndarray_get_shape",
+        "UsmNDArray_GetShape",
         b"Py_ssize_t *(struct PyUSMArrayObject *)",
         fn_restype=ctypes.c_void_p,
     )
@@ -379,7 +379,7 @@ def test_pyx_capi_get_strides():
     X = dpt.usm_ndarray(17)[1::2]
     get_strides_fn = _pyx_capi_fnptr_to_callable(
         X,
-        "usm_ndarray_get_strides",
+        "UsmNDArray_GetStrides",
         b"Py_ssize_t *(struct PyUSMArrayObject *)",
         fn_restype=ctypes.c_void_p,
     )
@@ -395,7 +395,7 @@ def test_pyx_capi_get_ndim():
     X = dpt.usm_ndarray(17)[1::2]
     get_ndim_fn = _pyx_capi_fnptr_to_callable(
         X,
-        "usm_ndarray_get_ndim",
+        "UsmNDArray_GetNDim",
         b"int (struct PyUSMArrayObject *)",
         fn_restype=ctypes.c_int,
     )
@@ -406,7 +406,7 @@ def test_pyx_capi_get_typenum():
     X = dpt.usm_ndarray(17)[1::2]
     get_typenum_fn = _pyx_capi_fnptr_to_callable(
         X,
-        "usm_ndarray_get_typenum",
+        "UsmNDArray_GetTypenum",
         b"int (struct PyUSMArrayObject *)",
         fn_restype=ctypes.c_int,
     )
@@ -419,7 +419,7 @@ def test_pyx_capi_get_flags():
     X = dpt.usm_ndarray(17)[1::2]
     get_flags_fn = _pyx_capi_fnptr_to_callable(
         X,
-        "usm_ndarray_get_flags",
+        "UsmNDArray_GetFlags",
         b"int (struct PyUSMArrayObject *)",
         fn_restype=ctypes.c_int,
     )
@@ -431,7 +431,7 @@ def test_pyx_capi_get_queue_ref():
     X = dpt.usm_ndarray(17)[1::2]
     get_queue_ref_fn = _pyx_capi_fnptr_to_callable(
         X,
-        "usm_ndarray_get_queue_ref",
+        "UsmNDArray_GetQueueRef",
         b"DPCTLSyclQueueRef (struct PyUSMArrayObject *)",
         fn_restype=ctypes.c_void_p,
     )


### PR DESCRIPTION
This expands Python C-API public functions to work with memory objects. 

What is missing is  pybind11 casters.