### PR TITLE
No need to link DPCTLSyclInterface with OpenCL library

### DIFF
--- a/libsyclinterface/CMakeLists.txt
+++ b/libsyclinterface/CMakeLists.txt
@@ -170,6 +170,12 @@ target_include_directories(DPCTLSyclInterface
 target_link_libraries(DPCTLSyclInterface
     PRIVATE ${IntelSycl_SYCL_LIBRARY}
 )
+if(WIN32)
+    target_link_libraries(DPCTLSyclInterface
+        PRIVATE ${IntelSycl_OPENCL_LIBRARY}
+    )
+endif()
+
 
 include(GetProjectVersion)
 # the get_version function is defined in the GetProjectVersion module and

--- a/libsyclinterface/CMakeLists.txt
+++ b/libsyclinterface/CMakeLists.txt
@@ -169,7 +169,6 @@ target_include_directories(DPCTLSyclInterface
 
 target_link_libraries(DPCTLSyclInterface
     PRIVATE ${IntelSycl_SYCL_LIBRARY}
-    PRIVATE ${IntelSycl_OPENCL_LIBRARY}
 )
 
 include(GetProjectVersion)


### PR DESCRIPTION
That linkage is redundant as this PR shows.