### PR TITLE
Update build_locally.py for Windows support and compilation mode selection

### DIFF
--- a/scripts/build_locally.py
+++ b/scripts/build_locally.py
@@ -5,6 +5,7 @@ import sys
 
 def run(
     use_oneapi=True,
+    build_type="Relese",
     c_compiler=None,
     cxx_compiler=None,
     level_zero=True,
@@ -34,7 +35,7 @@ def run(
         "--",
         "-G",
         build_system,
-        "-DCMAKE_BUILD_TYPE=Debug",
+        "-DCMAKE_BUILD_TYPE=" + build_type,
         "-DCMAKE_C_COMPILER:PATH=" + c_compiler,
         "-DCMAKE_CXX_COMPILER:PATH=" + cxx_compiler,
         "-DDPCTL_ENABLE_LO_PROGRAM_CREATION=" + ("ON" if level_zero else "OFF"),
@@ -65,6 +66,13 @@ if __name__ == "__main__":
         help="Is one-API installation",
         dest="oneapi",
         action="store_true",
+    )
+    driver.add_argument(
+        "--debug",
+        default="Release",
+        const="Debug",
+        action="store_const",
+        help="Set the compilation mode to debugging",
     )
     driver.add_argument(
         "--compiler-root", type=str, help="Path to compiler home directory"
@@ -103,6 +111,7 @@ if __name__ == "__main__":
 
     run(
         use_oneapi=args.oneapi,
+        build_type=args.debug,
         c_compiler=args.c_compiler,
         cxx_compiler=args.cxx_compiler,
         level_zero=args.level_zero,

--- a/scripts/build_locally.py
+++ b/scripts/build_locally.py
@@ -5,7 +5,7 @@ import sys
 
 def run(
     use_oneapi=True,
-    build_type="Relese",
+    build_type="Release",
     c_compiler=None,
     cxx_compiler=None,
     level_zero=True,

--- a/scripts/build_locally.py
+++ b/scripts/build_locally.py
@@ -11,19 +11,15 @@ def run(
     compiler_root=None,
     cmake_executable=None,
 ):
-    IS_LIN = False
+    build_system = None
 
     if "linux" in sys.platform:
-        IS_LIN = True
+        build_system = "Unix Makefiles"
     elif sys.platform in ["win32", "cygwin"]:
-        pass
+        build_system = "Ninja"
     else:
         assert False, sys.platform + " not supported"
 
-    if not IS_LIN:
-        raise RuntimeError(
-            "This scripts only supports coverage collection on Linux"
-        )
     setup_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
     cmake_args = [
         sys.executable,
@@ -37,7 +33,7 @@ def run(
     cmake_args += [
         "--",
         "-G",
-        "Unix Makefiles",
+        build_system,
         "-DCMAKE_BUILD_TYPE=Debug",
         "-DCMAKE_C_COMPILER:PATH=" + c_compiler,
         "-DCMAKE_CXX_COMPILER:PATH=" + cxx_compiler,
@@ -86,7 +82,7 @@ if __name__ == "__main__":
 
     if args.oneapi:
         args.c_compiler = "icx"
-        args.cxx_compiler = "icpx"
+        args.cxx_compiler = "icpx" if "linux" in sys.platform else "icx"
         args.compiler_root = None
     else:
         args_to_validate = [


### PR DESCRIPTION
This PR adds Windows OS support for build_locally.py and adds a command line argument `--dubug` to change the compilation mode