### PR TITLE
Fix for errors reported in #729 when reshaping 0-elems array

### DIFF
--- a/dpctl/tensor/_reshape.py
+++ b/dpctl/tensor/_reshape.py
@@ -104,7 +104,10 @@ def reshape(X, newshape, order="C"):
         newshape = [v if d == -1 else d for d in newshape]
     if X.size != np.prod(newshape):
         raise ValueError("Can not reshape into {}".format(newshape))
-    newsts = reshaped_strides(X.shape, X.strides, newshape, order=order)
+    if X.size:
+        newsts = reshaped_strides(X.shape, X.strides, newshape, order=order)
+    else:
+        newsts = (1,) * len(newshape)
     if newsts is None:
         # must perform a copy
         flat_res = dpt.usm_ndarray(

--- a/dpctl/tensor/_usmarray.pyx
+++ b/dpctl/tensor/_usmarray.pyx
@@ -428,6 +428,7 @@ cdef class usm_ndarray:
         cdef int contig_flag = 0
         cdef Py_ssize_t *shape_ptr = NULL
         cdef Py_ssize_t *strides_ptr = NULL
+        cdef Py_ssize_t size = -1
         import operator
 
         from ._reshape import reshaped_strides
@@ -439,15 +440,19 @@ cdef class usm_ndarray:
             raise TypeError(
                 "Target shape must be a finite iterable of integers"
             )
-        if not np.prod(new_shape) == shape_to_elem_count(self.nd_, self.shape_):
+        size = shape_to_elem_count(self.nd_, self.shape_)
+        if not np.prod(new_shape) == size:
             raise TypeError(
                 f"Can not reshape array of size {self.size} into {new_shape}"
             )
-        new_strides = reshaped_strides(
-            self.shape,
-            self.strides,
-            new_shape
-        )
+        if size > 0:
+            new_strides = reshaped_strides(
+               self.shape,
+               self.strides,
+               new_shape
+            )
+        else:
+            new_strides = (1,) * len(new_shape)
         if new_strides is None:
             raise AttributeError(
                 "Incompatible shape for in-place modification. "

--- a/dpctl/tests/test_usm_ndarray_ctor.py
+++ b/dpctl/tests/test_usm_ndarray_ctor.py
@@ -713,6 +713,21 @@ def test_shape_setter():
     X = dpt.usm_ndarray((4, 4), dtype="d")[::2, ::2]
     with pytest.raises(AttributeError):
         X.shape = (4,)
+    X = dpt.usm_ndarray((0,), dtype="i4")
+    X.shape = (0,)
+    X.shape = (
+        2,
+        0,
+    )
+    X.shape = (
+        0,
+        2,
+    )
+    X.shape = (
+        1,
+        0,
+        1,
+    )
 
 
 def test_len():

--- a/dpctl/tests/test_usm_ndarray_ctor.py
+++ b/dpctl/tests/test_usm_ndarray_ctor.py
@@ -816,6 +816,32 @@ def test_reshape():
     Y = dpt.reshape(X, X.shape)
     assert Y.flags == X.flags
 
+    A = dpt.usm_ndarray((0,), "i4")
+    A1 = dpt.reshape(A, (0,))
+    assert A1.shape == (0,)
+    A2 = dpt.reshape(
+        A,
+        (
+            2,
+            0,
+        ),
+    )
+    assert A2.shape == (
+        2,
+        0,
+    )
+    A3 = dpt.reshape(A, (0, 2))
+    assert A3.shape == (
+        0,
+        2,
+    )
+    A4 = dpt.reshape(A, (1, 0, 2))
+    assert A4.shape == (
+        1,
+        0,
+        2,
+    )
+
 
 def test_transpose():
     n, m = 2, 3


### PR DESCRIPTION
Fixes #729

The generated reshaped_strides routine is meant for non-empty arrays,
and so empty ones must be handled differently.

Tests added as well.