### PR TITLE
Bugfix/gh 728 astype

### DIFF
--- a/dpctl/tests/test_usm_ndarray_ctor.py
+++ b/dpctl/tests/test_usm_ndarray_ctor.py
@@ -600,6 +600,8 @@ def test_setitem_same_dtype(dtype, src_usm_type, dst_usm_type):
     R2 = np.broadcast_to(Xnp[0], R1.shape)
     assert R1.shape == R2.shape
     assert np.allclose(R1, R2)
+    Zusm_empty = Zusm_1d[0:0]
+    Zusm_empty[Ellipsis] = Zusm_3d[0, 0, 0:0]
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Fixes #728 


```
In [1]: import dpctl.tensor as dpt

In [2]: X = dpt.asarray([])

In [3]: dpt.astype(X, float)
Out[3]: <dpctl.tensor._usmarray.usm_ndarray at 0x7fdb48137740>

In [4]: (dpt.asnumpy(_), _.dtype, _.shape, _.strides)
Out[4]: (array([], dtype=float64), dtype('float64'), (0,), (1,))
```