### PR TITLE
Cleanup: sycl deprecation warnings, includes

### DIFF
--- a/dpctl/_backend.pxd
+++ b/dpctl/_backend.pxd
@@ -93,7 +93,7 @@ cdef extern from "syclinterface/dpctl_sycl_enum_types.h":
         _usm_host_allocations               'usm_host_allocations',
         _usm_shared_allocations             'usm_shared_allocations',
         _usm_restricted_shared_allocations  'usm_restricted_shared_allocations',
-        _usm_system_allocator               'usm_system_allocator'
+        _usm_system_allocations             'usm_system_allocations'
 
     ctypedef enum _partition_affinity_domain_type 'DPCTLPartitionAffinityDomainType':
         _not_applicable                     'not_applicable',

--- a/dpctl/_sycl_device.pyx
+++ b/dpctl/_sycl_device.pyx
@@ -441,8 +441,8 @@ cdef class SyclDevice(_SyclDevice):
         return DPCTLDevice_HasAspect(self._device_ref, AT)
 
     @property
-    def has_aspect_usm_system_allocator(self):
-        cdef _aspect_type AT = _aspect_type._usm_system_allocator
+    def has_aspect_usm_system_allocations(self):
+        cdef _aspect_type AT = _aspect_type._usm_system_allocations
         return DPCTLDevice_HasAspect(self._device_ref, AT)
 
     @property

--- a/dpctl/tests/test_sycl_device.py
+++ b/dpctl/tests/test_sycl_device.py
@@ -219,11 +219,11 @@ def check_has_aspect_usm_restricted_shared_allocations(device):
         pytest.fail("has_aspect_usm_restricted_shared_allocations call failed")
 
 
-def check_has_aspect_usm_system_allocator(device):
+def check_has_aspect_usm_system_allocations(device):
     try:
-        device.has_aspect_usm_system_allocator
+        device.has_aspect_usm_system_allocations
     except Exception:
-        pytest.fail("has_aspect_usm_system_allocator call failed")
+        pytest.fail("has_aspect_usm_system_allocations call failed")
 
 
 def check_is_accelerator(device):
@@ -520,7 +520,7 @@ list_of_checks = [
     check_has_aspect_usm_host_allocations,
     check_has_aspect_usm_shared_allocations,
     check_has_aspect_usm_restricted_shared_allocations,
-    check_has_aspect_usm_system_allocator,
+    check_has_aspect_usm_system_allocations,
     check_get_max_read_image_args,
     check_get_max_write_image_args,
     check_get_image_2d_max_width,
@@ -679,7 +679,7 @@ list_of_supported_aspects = [
     "usm_device_allocations",
     "usm_host_allocations",
     "usm_shared_allocations",
-    "usm_system_allocator",
+    "usm_system_allocations",
 ]
 
 # SYCL 2020 spec aspects not presently

--- a/dpctl/tests/test_sycl_queue.py
+++ b/dpctl/tests/test_sycl_queue.py
@@ -211,11 +211,11 @@ def check_has_aspect_usm_restricted_shared_allocations(device):
         pytest.fail("has_aspect_usm_restricted_shared_allocations call failed")
 
 
-def check_has_aspect_usm_system_allocator(device):
+def check_has_aspect_usm_system_allocations(device):
     try:
-        device.has_aspect_usm_system_allocator
+        device.has_aspect_usm_system_allocations
     except Exception:
-        pytest.fail("has_aspect_usm_system_allocator call failed")
+        pytest.fail("has_aspect_usm_system_allocations call failed")
 
 
 def check_is_accelerator(device):
@@ -273,7 +273,7 @@ list_of_checks = [
     check_has_aspect_usm_host_allocations,
     check_has_aspect_usm_shared_allocations,
     check_has_aspect_usm_restricted_shared_allocations,
-    check_has_aspect_usm_system_allocator,
+    check_has_aspect_usm_system_allocations,
 ]
 
 

--- a/libsyclinterface/helper/include/dpctl_string_utils.hpp
+++ b/libsyclinterface/helper/include/dpctl_string_utils.hpp
@@ -21,7 +21,7 @@
 /// \file
 /// Helper function to convert a C++ string to a C string.
 //===----------------------------------------------------------------------===//
-#include "../helper/include/dpctl_error_handlers.h"
+#include "dpctl_error_handlers.h"
 #include <cstring>
 #include <iostream>
 #include <string>

--- a/libsyclinterface/helper/source/dpctl_error_handlers.cpp
+++ b/libsyclinterface/helper/source/dpctl_error_handlers.cpp
@@ -39,7 +39,7 @@ void DPCTL_AsyncErrorHandler::operator()(
             std::rethrow_exception(e);
         } catch (sycl::exception const &e) {
             error_handler(e, __FILE__, __func__, __LINE__);
-            auto err_code = e.get_cl_code();
+            auto err_code = e.code();
             handler_(static_cast<int>(err_code));
         }
     }

--- a/libsyclinterface/helper/source/dpctl_error_handlers.cpp
+++ b/libsyclinterface/helper/source/dpctl_error_handlers.cpp
@@ -39,7 +39,7 @@ void DPCTL_AsyncErrorHandler::operator()(
             std::rethrow_exception(e);
         } catch (sycl::exception const &e) {
             error_handler(e, __FILE__, __func__, __LINE__);
-            auto err_code = e.code();
+            auto err_code = e.code().value();
             handler_(static_cast<int>(err_code));
         }
     }

--- a/libsyclinterface/helper/source/dpctl_utils_helper.cpp
+++ b/libsyclinterface/helper/source/dpctl_utils_helper.cpp
@@ -221,8 +221,8 @@ std::string DPCTL_AspectToStr(aspect aspectTy)
     case aspect::usm_restricted_shared_allocations:
         ss << "usm_restricted_shared_allocations";
         break;
-    case aspect::usm_system_allocator:
-        ss << "usm_system_allocator";
+    case aspect::usm_system_allocations:
+        ss << "usm_system_allocations";
         break;
     default:
         throw std::runtime_error("Unsupported aspect type");
@@ -287,8 +287,8 @@ aspect DPCTL_StrToAspectType(const std::string &aspectTyStr)
     else if (aspectTyStr == "usm_restricted_shared_allocations") {
         aspectTy = aspect::usm_restricted_shared_allocations;
     }
-    else if (aspectTyStr == "usm_system_allocator") {
-        aspectTy = aspect::usm_system_allocator;
+    else if (aspectTyStr == "usm_system_allocations") {
+        aspectTy = aspect::usm_system_allocations;
     }
     else {
         // \todo handle the error
@@ -334,8 +334,8 @@ aspect DPCTL_DPCTLAspectTypeToSyclAspect(DPCTLSyclAspectType AspectTy)
         return aspect::usm_shared_allocations;
     case DPCTLSyclAspectType::usm_restricted_shared_allocations:
         return aspect::usm_restricted_shared_allocations;
-    case DPCTLSyclAspectType::usm_system_allocator:
-        return aspect::usm_system_allocator;
+    case DPCTLSyclAspectType::usm_system_allocations:
+        return aspect::usm_system_allocations;
     default:
         throw std::runtime_error("Unsupported aspect type");
     }
@@ -378,8 +378,8 @@ DPCTLSyclAspectType DPCTL_SyclAspectToDPCTLAspectType(aspect Aspect)
         return DPCTLSyclAspectType::usm_shared_allocations;
     case aspect::usm_restricted_shared_allocations:
         return DPCTLSyclAspectType::usm_restricted_shared_allocations;
-    case aspect::usm_system_allocator:
-        return DPCTLSyclAspectType::usm_system_allocator;
+    case aspect::usm_system_allocations:
+        return DPCTLSyclAspectType::usm_system_allocations;
     default:
         throw std::runtime_error("Unsupported aspect type");
     }

--- a/libsyclinterface/helper/source/dpctl_utils_helper.cpp
+++ b/libsyclinterface/helper/source/dpctl_utils_helper.cpp
@@ -93,7 +93,7 @@ backend DPCTL_DPCTLBackendTypeToSyclBackend(DPCTLSyclBackendType BeTy)
     case DPCTLSyclBackendType::DPCTL_HOST:
         return backend::host;
     case DPCTLSyclBackendType::DPCTL_LEVEL_ZERO:
-        return backend::level_zero;
+        return backend::ext_oneapi_level_zero;
     case DPCTLSyclBackendType::DPCTL_OPENCL:
         return backend::opencl;
     case DPCTLSyclBackendType::DPCTL_ALL_BACKENDS:
@@ -110,7 +110,7 @@ DPCTLSyclBackendType DPCTL_SyclBackendToDPCTLBackendType(backend B)
         return DPCTLSyclBackendType::DPCTL_CUDA;
     case backend::host:
         return DPCTLSyclBackendType::DPCTL_HOST;
-    case backend::level_zero:
+    case backend::ext_oneapi_level_zero:
         return DPCTLSyclBackendType::DPCTL_LEVEL_ZERO;
     case backend::opencl:
         return DPCTLSyclBackendType::DPCTL_OPENCL;

--- a/libsyclinterface/include/dpctl_sycl_enum_types.h
+++ b/libsyclinterface/include/dpctl_sycl_enum_types.h
@@ -119,7 +119,7 @@ typedef enum
     usm_host_allocations,
     usm_shared_allocations,
     usm_restricted_shared_allocations,
-    usm_system_allocator
+    usm_system_allocations
 } DPCTLSyclAspectType;
 
 /*!

--- a/libsyclinterface/source/dpctl_sycl_context_interface.cpp
+++ b/libsyclinterface/source/dpctl_sycl_context_interface.cpp
@@ -25,8 +25,8 @@
 //===----------------------------------------------------------------------===//
 
 #include "dpctl_sycl_context_interface.h"
-#include "../helper/include/dpctl_error_handlers.h"
 #include "Support/CBindingWrapping.h"
+#include "dpctl_error_handlers.h"
 #include <CL/sycl.hpp>
 #include <vector>
 

--- a/libsyclinterface/source/dpctl_sycl_context_interface.cpp
+++ b/libsyclinterface/source/dpctl_sycl_context_interface.cpp
@@ -194,7 +194,7 @@ DPCTLContext_GetBackend(__dpctl_keep const DPCTLSyclContextRef CtxRef)
         return DPCTL_HOST;
     case backend::opencl:
         return DPCTL_OPENCL;
-    case backend::level_zero:
+    case backend::ext_oneapi_level_zero:
         return DPCTL_LEVEL_ZERO;
     case backend::cuda:
         return DPCTL_CUDA;

--- a/libsyclinterface/source/dpctl_sycl_device_interface.cpp
+++ b/libsyclinterface/source/dpctl_sycl_device_interface.cpp
@@ -25,11 +25,11 @@
 //===----------------------------------------------------------------------===//
 
 #include "dpctl_sycl_device_interface.h"
-#include "../helper/include/dpctl_error_handlers.h"
-#include "../helper/include/dpctl_string_utils.hpp"
-#include "../helper/include/dpctl_utils_helper.h"
 #include "Support/CBindingWrapping.h"
+#include "dpctl_error_handlers.h"
+#include "dpctl_string_utils.hpp"
 #include "dpctl_sycl_device_manager.h"
+#include "dpctl_utils_helper.h"
 #include <CL/sycl.hpp> /* SYCL headers   */
 #include <algorithm>
 #include <cstring>

--- a/libsyclinterface/source/dpctl_sycl_device_manager.cpp
+++ b/libsyclinterface/source/dpctl_sycl_device_manager.cpp
@@ -24,11 +24,11 @@
 //===----------------------------------------------------------------------===//
 
 #include "dpctl_sycl_device_manager.h"
-#include "../helper/include/dpctl_error_handlers.h"
-#include "../helper/include/dpctl_string_utils.hpp"
-#include "../helper/include/dpctl_utils_helper.h"
 #include "Support/CBindingWrapping.h"
+#include "dpctl_error_handlers.h"
+#include "dpctl_string_utils.hpp"
 #include "dpctl_sycl_enum_types.h"
+#include "dpctl_utils_helper.h"
 #include <CL/sycl.hpp> /* SYCL headers   */
 #include <iomanip>
 #include <iostream>

--- a/libsyclinterface/source/dpctl_sycl_device_selector_interface.cpp
+++ b/libsyclinterface/source/dpctl_sycl_device_selector_interface.cpp
@@ -24,8 +24,8 @@
 //===----------------------------------------------------------------------===//
 
 #include "dpctl_sycl_device_selector_interface.h"
-#include "../helper/include/dpctl_error_handlers.h"
 #include "Support/CBindingWrapping.h"
+#include "dpctl_error_handlers.h"
 #include <CL/sycl.hpp> /* SYCL headers   */
 
 using namespace cl::sycl;

--- a/libsyclinterface/source/dpctl_sycl_event_interface.cpp
+++ b/libsyclinterface/source/dpctl_sycl_event_interface.cpp
@@ -25,9 +25,9 @@
 //===----------------------------------------------------------------------===//
 
 #include "dpctl_sycl_event_interface.h"
-#include "../helper/include/dpctl_error_handlers.h"
-#include "../helper/include/dpctl_utils_helper.h"
 #include "Support/CBindingWrapping.h"
+#include "dpctl_error_handlers.h"
+#include "dpctl_utils_helper.h"
 #include <CL/sycl.hpp> /* SYCL headers   */
 #include <vector>
 

--- a/libsyclinterface/source/dpctl_sycl_kernel_interface.cpp
+++ b/libsyclinterface/source/dpctl_sycl_kernel_interface.cpp
@@ -25,9 +25,9 @@
 //===----------------------------------------------------------------------===//
 
 #include "dpctl_sycl_kernel_interface.h"
-#include "../helper/include/dpctl_error_handlers.h"
-#include "../helper/include/dpctl_string_utils.hpp"
 #include "Support/CBindingWrapping.h"
+#include "dpctl_error_handlers.h"
+#include "dpctl_string_utils.hpp"
 #include <CL/sycl.hpp> /* Sycl headers */
 
 using namespace cl::sycl;

--- a/libsyclinterface/source/dpctl_sycl_platform_interface.cpp
+++ b/libsyclinterface/source/dpctl_sycl_platform_interface.cpp
@@ -25,10 +25,10 @@
 //===----------------------------------------------------------------------===//
 
 #include "dpctl_sycl_platform_interface.h"
-#include "../helper/include/dpctl_error_handlers.h"
-#include "../helper/include/dpctl_string_utils.hpp"
-#include "../helper/include/dpctl_utils_helper.h"
 #include "Support/CBindingWrapping.h"
+#include "dpctl_error_handlers.h"
+#include "dpctl_string_utils.hpp"
+#include "dpctl_utils_helper.h"
 #include <CL/sycl.hpp>
 #include <iomanip>
 #include <iostream>

--- a/libsyclinterface/source/dpctl_sycl_platform_manager.cpp
+++ b/libsyclinterface/source/dpctl_sycl_platform_manager.cpp
@@ -25,10 +25,10 @@
 //===----------------------------------------------------------------------===//
 
 #include "dpctl_sycl_platform_manager.h"
-#include "../helper/include/dpctl_error_handlers.h"
-#include "../helper/include/dpctl_utils_helper.h"
 #include "Support/CBindingWrapping.h"
+#include "dpctl_error_handlers.h"
 #include "dpctl_sycl_platform_interface.h"
+#include "dpctl_utils_helper.h"
 #include <CL/sycl.hpp>
 #include <iomanip>
 #include <iostream>

--- a/libsyclinterface/source/dpctl_sycl_program_interface.cpp
+++ b/libsyclinterface/source/dpctl_sycl_program_interface.cpp
@@ -30,9 +30,9 @@
 #endif
 
 #include "dpctl_sycl_program_interface.h"
-#include "../helper/include/dpctl_error_handlers.h"
 #include "Config/dpctl_config.h"
 #include "Support/CBindingWrapping.h"
+#include "dpctl_error_handlers.h"
 #include <CL/cl.h>     /* OpenCL headers     */
 #include <CL/sycl.hpp> /* Sycl headers       */
 #include <CL/sycl/backend/opencl.hpp>

--- a/libsyclinterface/source/dpctl_sycl_program_interface.cpp
+++ b/libsyclinterface/source/dpctl_sycl_program_interface.cpp
@@ -223,7 +223,7 @@ DPCTLProgram_CreateFromSpirv(__dpctl_keep const DPCTLSyclContextRef CtxRef,
     case backend::opencl:
         Pref = createOpenCLInterOpProgram(*SyclCtx, IL, length, CompileOpts);
         break;
-    case backend::level_zero:
+    case backend::ext_oneapi_level_zero:
 #ifdef DPCTL_ENABLE_LO_PROGRAM_CREATION
         Pref = createLevelZeroInterOpProgram(*SyclCtx, IL, length, CompileOpts);
 #endif
@@ -274,7 +274,7 @@ DPCTLProgram_CreateFromOCLSource(__dpctl_keep const DPCTLSyclContextRef Ctx,
             return nullptr;
         }
         break;
-    case backend::level_zero:
+    case backend::ext_oneapi_level_zero:
         error_handler("CreateFromSource is not supported in Level Zero.",
                       __FILE__, __func__, __LINE__);
         delete SyclProgram;

--- a/libsyclinterface/source/dpctl_sycl_program_interface.cpp
+++ b/libsyclinterface/source/dpctl_sycl_program_interface.cpp
@@ -39,11 +39,13 @@
 #include <sstream>
 
 #ifdef DPCTL_ENABLE_LO_PROGRAM_CREATION
-#include "../helper/include/dpctl_dynamic_lib_helper.h"
-#include <zet_api.h> /* Level Zero headers */
+#include "dpctl_dynamic_lib_helper.h"
 // Note: include ze_api.h before level_zero.hpp. Make sure clang-format does
 // not reorder the includes.
-#include <CL/sycl/backend/level_zero.hpp>
+// clang-format off
+#include "ze_api.h" /* Level Zero headers */
+#include "sycl/ext/oneapi/backend/level_zero.hpp"
+// clang-format on
 #endif
 
 using namespace cl::sycl;

--- a/libsyclinterface/source/dpctl_sycl_program_interface.cpp
+++ b/libsyclinterface/source/dpctl_sycl_program_interface.cpp
@@ -146,7 +146,7 @@ createLevelZeroInterOpProgram(const context &SyclCtx,
                               size_t length,
                               const char *CompileOpts)
 {
-    auto ZeCtx = get_native<backend::level_zero>(SyclCtx);
+    auto ZeCtx = get_native<backend::ext_oneapi_level_zero>(SyclCtx);
     auto SyclDevices = SyclCtx.get_devices();
     if (SyclDevices.size() > 1) {
         error_handler("Level zero program can be created for only one device.",
@@ -168,7 +168,7 @@ createLevelZeroInterOpProgram(const context &SyclCtx,
     ZeModuleDesc.pBuildFlags = CompileOpts;
     ZeModuleDesc.pConstants = &ZeSpecConstants;
 
-    auto ZeDevice = get_native<backend::level_zero>(SyclDevices[0]);
+    auto ZeDevice = get_native<backend::ext_oneapi_level_zero>(SyclDevices[0]);
     ze_module_handle_t ZeModule;
 
     auto stZeModuleCreateF = getZeModuleCreateFn();
@@ -189,8 +189,9 @@ createLevelZeroInterOpProgram(const context &SyclCtx,
 
     // Create the Sycl program from the ZeModule
     try {
-        auto ZeProgram = new program(sycl::level_zero::make_program(
-            SyclCtx, reinterpret_cast<uintptr_t>(ZeModule)));
+        auto ZeProgram =
+            new program(sycl::ext::oneapi::level_zero::make_program(
+                SyclCtx, reinterpret_cast<uintptr_t>(ZeModule)));
         return wrap(ZeProgram);
     } catch (std::exception const &e) {
         error_handler(e, __FILE__, __func__, __LINE__);

--- a/libsyclinterface/source/dpctl_sycl_queue_interface.cpp
+++ b/libsyclinterface/source/dpctl_sycl_queue_interface.cpp
@@ -25,8 +25,8 @@
 //===----------------------------------------------------------------------===//
 
 #include "dpctl_sycl_queue_interface.h"
-#include "../helper/include/dpctl_error_handlers.h"
 #include "Support/CBindingWrapping.h"
+#include "dpctl_error_handlers.h"
 #include "dpctl_sycl_context_interface.h"
 #include "dpctl_sycl_device_interface.h"
 #include "dpctl_sycl_device_manager.h"

--- a/libsyclinterface/source/dpctl_sycl_queue_interface.cpp
+++ b/libsyclinterface/source/dpctl_sycl_queue_interface.cpp
@@ -530,7 +530,7 @@ DPCTLSyclEventRef DPCTLQueue_MemAdvise(__dpctl_keep DPCTLSyclQueueRef QRef,
     if (Q) {
         sycl::event ev;
         try {
-            ev = Q->mem_advise(Ptr, Count, static_cast<pi_mem_advice>(Advice));
+            ev = Q->mem_advise(Ptr, Count, Advice);
         } catch (std::exception const &e) {
             error_handler(e, __FILE__, __func__, __LINE__);
             return nullptr;
@@ -592,7 +592,7 @@ __dpctl_give DPCTLSyclEventRef DPCTLQueue_SubmitBarrierForEvents(
                     for (auto i = 0ul; i < NDepEvents; ++i)
                         cgh.depends_on(*unwrap(DepEvents[i]));
 
-                cgh.barrier();
+                cgh.ext_oneapi_barrier();
             });
         } catch (std::exception const &e) {
             error_handler(e, __FILE__, __func__, __LINE__);

--- a/libsyclinterface/source/dpctl_sycl_queue_manager.cpp
+++ b/libsyclinterface/source/dpctl_sycl_queue_manager.cpp
@@ -24,8 +24,8 @@
 ///
 //===----------------------------------------------------------------------===//
 #include "dpctl_sycl_queue_manager.h"
-#include "../helper/include/dpctl_error_handlers.h"
 #include "Support/CBindingWrapping.h"
+#include "dpctl_error_handlers.h"
 #include "dpctl_sycl_device_manager.h"
 #include <CL/sycl.hpp> /* SYCL headers   */
 #include <vector>

--- a/libsyclinterface/source/dpctl_sycl_usm_interface.cpp
+++ b/libsyclinterface/source/dpctl_sycl_usm_interface.cpp
@@ -25,8 +25,8 @@
 //===----------------------------------------------------------------------===//
 
 #include "dpctl_sycl_usm_interface.h"
-#include "../helper/include/dpctl_error_handlers.h"
 #include "Support/CBindingWrapping.h"
+#include "dpctl_error_handlers.h"
 #include "dpctl_sycl_device_interface.h"
 #include <CL/sycl.hpp> /* SYCL headers   */
 

--- a/libsyclinterface/source/dpctl_vector_templ.cpp
+++ b/libsyclinterface/source/dpctl_vector_templ.cpp
@@ -23,9 +23,9 @@
 /// the wrapper functions for vector operations.
 ///
 //===----------------------------------------------------------------------===//
-#include "../helper/include/dpctl_error_handlers.h"
-#include "../helper/include/dpctl_vector_macros.h"
 #include "Support/MemOwnershipAttrs.h"
+#include "dpctl_error_handlers.h"
+#include "dpctl_vector_macros.h"
 #include <type_traits>
 #include <vector>
 

--- a/libsyclinterface/tests/test_helper.cpp
+++ b/libsyclinterface/tests/test_helper.cpp
@@ -86,7 +86,7 @@ TEST_F(TestHelperFns, ChkStrToDeviceType)
 
 TEST_F(TestHelperFns, ChkDPCTLBackendTypeToSyclBackend)
 {
-    sycl::backend res = sycl::backend::level_zero;
+    sycl::backend res = sycl::backend::ext_oneapi_level_zero;
 
     EXPECT_NO_FATAL_FAILURE(res = DPCTL_DPCTLBackendTypeToSyclBackend(
                                 DPCTLSyclBackendType::DPCTL_CUDA));
@@ -102,7 +102,7 @@ TEST_F(TestHelperFns, ChkDPCTLBackendTypeToSyclBackend)
 
     EXPECT_NO_FATAL_FAILURE(res = DPCTL_DPCTLBackendTypeToSyclBackend(
                                 DPCTLSyclBackendType::DPCTL_LEVEL_ZERO));
-    ASSERT_TRUE(res == sycl::backend::level_zero);
+    ASSERT_TRUE(res == sycl::backend::ext_oneapi_level_zero);
 
     EXPECT_THROW(DPCTL_DPCTLBackendTypeToSyclBackend(
                      DPCTLSyclBackendType::DPCTL_UNKNOWN_BACKEND),
@@ -113,8 +113,8 @@ TEST_F(TestHelperFns, ChkSyclBackendToDPCTLBackendType)
 {
     DPCTLSyclBackendType DTy = DPCTLSyclBackendType::DPCTL_UNKNOWN_BACKEND;
 
-    EXPECT_NO_FATAL_FAILURE(
-        DTy = DPCTL_SyclBackendToDPCTLBackendType(sycl::backend::level_zero));
+    EXPECT_NO_FATAL_FAILURE(DTy = DPCTL_SyclBackendToDPCTLBackendType(
+                                sycl::backend::ext_oneapi_level_zero));
     ASSERT_TRUE(DTy == DPCTLSyclBackendType::DPCTL_LEVEL_ZERO);
 
     EXPECT_NO_FATAL_FAILURE(

--- a/libsyclinterface/tests/test_sycl_device_aspects.cpp
+++ b/libsyclinterface/tests/test_sycl_device_aspects.cpp
@@ -99,8 +99,8 @@ auto build_params()
                            cl::sycl::aspect::usm_shared_allocations),
             std::make_pair("usm_restricted_shared_allocations",
                            cl::sycl::aspect::usm_restricted_shared_allocations),
-            std::make_pair("usm_system_allocator",
-                           cl::sycl::aspect::usm_system_allocator));
+            std::make_pair("usm_system_allocations",
+                           cl::sycl::aspect::usm_system_allocations));
 
     auto pairs =
         build_param_pairs<const char *,
@@ -141,7 +141,7 @@ struct TestDPCTLSyclDeviceInterfaceAspects
         auto syclAspect = GetParam().second.second;
         try {
             hasAspect = D->has(syclAspect);
-        } catch (cl::sycl::runtime_error const &re) {
+        } catch (sycl::exception const &e) {
         }
     }
 

--- a/libsyclinterface/tests/test_sycl_device_subdevices.cpp
+++ b/libsyclinterface/tests/test_sycl_device_subdevices.cpp
@@ -149,7 +149,7 @@ TEST_P(TestDPCTLSyclDeviceInterface, ChkCreateSubDevicesByAffinityNotApplicable)
                 EXPECT_TRUE(DPCTLDeviceVector_Size(DVRef) == expected_size);
                 EXPECT_NO_FATAL_FAILURE(DPCTLDeviceVector_Delete(DVRef));
             }
-        } catch (runtime_error const &re) {
+        } catch (exception const &e) {
         }
     }
 }

--- a/libsyclinterface/tests/test_sycl_queue_interface.cpp
+++ b/libsyclinterface/tests/test_sycl_queue_interface.cpp
@@ -358,7 +358,7 @@ TEST_P(TestDPCTLQueueMemberFunctions, CheckGetBackend)
         EXPECT_TRUE(Backend == backend::host);
         break;
     case DPCTL_LEVEL_ZERO:
-        EXPECT_TRUE(Backend == backend::level_zero);
+        EXPECT_TRUE(Backend == backend::ext_oneapi_level_zero);
         break;
     case DPCTL_OPENCL:
         EXPECT_TRUE(Backend == backend::opencl);


### PR DESCRIPTION
Clean up for `#includes`, replacing use of `#include "../helper/include/header.h"` with `#include "header.h"`, since include directories already point to `../header/include`.

Replaced deprecated sycl declarations with their intended replacements:

```c++
  sycl::backend::level_zero -> sycl::backend::ext_oneapi_level_zero
  sycl::queue::barrier -> sycl::queue::ext_oneapi_barrier
  sycl::aspect::usm_system_allocator -> sycl::aspect::usm_system_allocations
````

Also removed uses of reprecated `sycl::runtime_error` in favor of use of `sycl::exception`.

Because of deprecation of `sycl::aspect::usm_system_allocator`, changed the name of dpctl enum entry name accordingly, which is a user visible change.