### PR TITLE
usm_ndarray API extended by GetOffset function

### DIFF
--- a/dpctl/tensor/_usmarray.pxd
+++ b/dpctl/tensor/_usmarray.pxd
@@ -4,27 +4,27 @@
 cimport dpctl
 
 
-cdef public int USM_ARRAY_C_CONTIGUOUS
-cdef public int USM_ARRAY_F_CONTIGUOUS
-cdef public int USM_ARRAY_WRITEABLE
+cdef public api int USM_ARRAY_C_CONTIGUOUS
+cdef public api int USM_ARRAY_F_CONTIGUOUS
+cdef public api int USM_ARRAY_WRITEABLE
 
-cdef public int UAR_BOOL
-cdef public int UAR_BYTE
-cdef public int UAR_UBYTE
-cdef public int UAR_SHORT
-cdef public int UAR_USHORT
-cdef public int UAR_INT
-cdef public int UAR_UINT
-cdef public int UAR_LONG
-cdef public int UAR_ULONG
-cdef public int UAR_LONGLONG
-cdef public int UAR_ULONGLONG
-cdef public int UAR_FLOAT
-cdef public int UAR_DOUBLE
-cdef public int UAR_CFLOAT
-cdef public int UAR_CDOUBLE
-cdef public int UAR_TYPE_SENTINEL
-cdef public int UAR_HALF
+cdef public api int UAR_BOOL
+cdef public api int UAR_BYTE
+cdef public api int UAR_UBYTE
+cdef public api int UAR_SHORT
+cdef public api int UAR_USHORT
+cdef public api int UAR_INT
+cdef public api int UAR_UINT
+cdef public api int UAR_LONG
+cdef public api int UAR_ULONG
+cdef public api int UAR_LONGLONG
+cdef public api int UAR_ULONGLONG
+cdef public api int UAR_FLOAT
+cdef public api int UAR_DOUBLE
+cdef public api int UAR_CFLOAT
+cdef public api int UAR_CDOUBLE
+cdef public api int UAR_TYPE_SENTINEL
+cdef public api int UAR_HALF
 
 
 cdef api class usm_ndarray [object PyUSMArrayObject, type PyUSMArrayType]:

--- a/dpctl/tensor/_usmarray.pyx
+++ b/dpctl/tensor/_usmarray.pyx
@@ -1174,3 +1174,9 @@ cdef api int UsmNDArray_GetFlags(usm_ndarray arr):
 cdef api c_dpctl.DPCTLSyclQueueRef UsmNDArray_GetQueueRef(usm_ndarray arr):
     """Get DPCTLSyclQueueRef for queue associated with the array"""
     return arr.get_queue_ref()
+
+
+cdef api Py_ssize_t UsmNDArray_GetOffset(usm_ndarray arr):
+    """Get offset of zero-index array element from the beginning of the USM
+    allocation."""
+    return arr.get_offset()

--- a/dpctl/tests/test_usm_ndarray_ctor.py
+++ b/dpctl/tests/test_usm_ndarray_ctor.py
@@ -427,6 +427,19 @@ def test_pyx_capi_get_flags():
     assert type(flags) is int and flags == X.flags
 
 
+def test_pyx_capi_get_offset():
+    X = dpt.usm_ndarray(17)[1::2]
+    get_offset_fn = _pyx_capi_fnptr_to_callable(
+        X,
+        "UsmNDArray_GetOffset",
+        b"Py_ssize_t (struct PyUSMArrayObject *)",
+        fn_restype=ctypes.c_longlong,
+    )
+    offset = get_offset_fn(X)
+    assert type(offset) is int
+    assert offset == X.__sycl_usm_array_interface__["offset"]
+
+
 def test_pyx_capi_get_queue_ref():
     X = dpt.usm_ndarray(17)[1::2]
     get_queue_ref_fn = _pyx_capi_fnptr_to_callable(


### PR DESCRIPTION
Made type constants (e.g `UAR_DOUBLE`) and flags (e.g. `USM_ARRAY_C_CONTIGUOUS`) API symbols as well, so that
pybind11 extensions can use them.

`UsmNDArray_GetOffset` api function added to API, and a test added to excercise it. 