### PR TITLE
Fixed type in utility `_memory_overlap`.

### DIFF
--- a/dpctl/tensor/_copy_utils.py
+++ b/dpctl/tensor/_copy_utils.py
@@ -75,7 +75,8 @@ def _has_memory_overlap(x1, x2):
             p1_end = p1_beg + m1.nbytes
             p2_beg = m2._pointer
             p2_end = p2_beg + m2.nbytes
-            return p1_beg > p2_end or p2_beg < p1_end
+            # may intersect if not ((p1_beg >= p2_end) or (p2_beg >= p2_end))
+            return (p1_beg < p2_end) and (p2_beg < p1_end)
         else:
             return False
     else:


### PR DESCRIPTION
To intervals `[B1..E1)` and `[B2..E2)` do not overlap when
`E1 <= B2 || E2 <= B1` <=> `B1 >= E2 || B2 >= E1`.

The typo in the code was the reason why the coverage was jumping
around.

The overlap may occur only if `(B1 < E2) and (B2 < E1)`.