### PR TITLE
fixed typo in setup call: extra_require->extras_require

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -97,7 +97,7 @@ skbuild.setup(
     install_requires=[
         "numpy",
     ],
-    extra_require={
+    extras_require={
         "docs": [
             "Cython",
             "sphinx",


### PR DESCRIPTION
`extra_require` renamed to `extras_require`.

This resolves one of `dist.py:274: UserWarning: Unknown distribution option` see during building.