### PR TITLE
Only call PyThread_Ensure from host_task if the main-thread interpreter is initialized

### DIFF
--- a/dpctl/_host_task_util.hpp
+++ b/dpctl/_host_task_util.hpp
@@ -55,7 +55,8 @@ int async_dec_ref(DPCTLSyclQueueRef QRef,
                     *(reinterpret_cast<sycl::event *>(ERefs[ev_id])));
             }
             cgh.host_task([obj_array_size, obj_vec]() {
-                {
+                // if the main thread has not finilized the interpreter yet
+                if (Py_IsInitialized()) {
                     PyGILState_STATE gstate;
                     gstate = PyGILState_Ensure();
                     for (size_t i = 0; i < obj_array_size; ++i) {


### PR DESCRIPTION
This PR applies the solution worked out in a toy POC

Host tasks are executed in a separate threads from
the main thread which submitted the kernel and incremented
reference counts.

When kernel submission occurs near the end of the script,
the CPython interpreter may have begun finalization process
by the time the kernel completes the execution.

`PyThread_Ensure` would crash in that case. So execute the host
task only if `Py_IsInitialized()`.

The only testing of this scenario is to submit the kernel at
the end and not call queue synchronization.