### PR TITLE
Use latest Cython>=3.* to generate coverage to address #767

### DIFF
--- a/.github/workflows/generate-coverage.yaml
+++ b/.github/workflows/generate-coverage.yaml
@@ -79,7 +79,8 @@ jobs:
       - name: Install dpctl dependencies
         shell: bash -l {0}
         run: |
-          pip install numpy cython setuptools pytest pytest-cov scikit-build coverage[toml]
+          pip install "Cython>=3.*"
+          pip install numpy setuptools pytest pytest-cov scikit-build coverage[toml]
 
       - name: Build dpctl with coverage
         shell: bash -l {0}


### PR DESCRIPTION
Closes #767 

Cython 3, currently in alpha release, generates better code for which compiler does not generate this warning.