### PR TITLE
operator.pos(ums_ndarray) is always an identity

### DIFF
--- a/dpctl/tensor/_usmarray.pyx
+++ b/dpctl/tensor/_usmarray.pyx
@@ -857,7 +857,7 @@ cdef class usm_ndarray:
         return NotImplemented
 
     def __pos__(self):
-        return _dispatch_unary_elementwise(self, "positive")
+        return self  # _dispatch_unary_elementwise(self, "positive")
 
     def __pow__(first, other, mod):
         "See comment in __add__"


### PR DESCRIPTION
Since `dpnp.positive` is not implemented, to unblock integration testing implemented ``usm_ndarray.__pos__`` to return self.