### PR TITLE
[FIX] versioneer 0.21 regression fixed in vendored file

### DIFF
--- a/dpctl/tests/test_service.py
+++ b/dpctl/tests/test_service.py
@@ -100,6 +100,7 @@ def test___version__():
     dpctl_ver = getattr(dpctl, "__version__", None)
     assert type(dpctl_ver) is str
     assert "unknown" not in dpctl_ver
+    assert "untagged" not in dpctl_ver
     # Reg expr from PEP-440, relaxed to allow for semantic variant
     # 0.9.0dev0 allowed, vs. PEP-440 compliant 0.9.0.dev0
     reg_expr = (

--- a/versioneer.py
+++ b/versioneer.py
@@ -1165,7 +1165,7 @@ def git_pieces_from_vcs(tag_prefix, root, verbose, runner=run_command):
     TAG_PREFIX_REGEX = "*"
     if sys.platform == "win32":
         GITS = ["git.cmd", "git.exe"]
-        TAG_PREFIX_REGEX = r"\*"
+        TAG_PREFIX_REGEX = r"*"  # r"\*"  - using escape on windows breaks tag extraction
 
     _, rc = runner(GITS, ["rev-parse", "--git-dir"], cwd=root,
                    hide_stderr=True)


### PR DESCRIPTION
This change makes changes to the versioneer.py installed into the codebase. 

Versioneer 0.21 added escape character to the match option of git
describe. 

> * FIX: Escape asterisk in `git describe` call on Windows, see python-versionseer/python-versioneer#262

Similar change was made upstream too: 

https://github.com/python-versioneer/python-versioneer/pull/283/files

but it has been made it into the released version yet.

```
(base) C:\Users\opavlyk\devel\dpctl>git describe --tags --dirty --always --long --match "\*"
3bd37749

(base) C:\Users\opavlyk\devel\dpctl>git describe --tags --dirty --always --long --match "\\*"
3bd37749

(base) C:\Users\opavlyk\devel\dpctl>git describe --tags --dirty --always --long --match "*"
0.12.0dev3-33-g3bd37749
```