### PR TITLE
Implementation of expand_dims function

### DIFF
--- a/dpctl/tensor/__init__.py
+++ b/dpctl/tensor/__init__.py
@@ -25,7 +25,7 @@ from dpctl.tensor._copy_utils import asnumpy, astype, copy, from_numpy, to_numpy
 from dpctl.tensor._ctors import asarray, empty
 from dpctl.tensor._device import Device
 from dpctl.tensor._dlpack import from_dlpack
-from dpctl.tensor._manipulation_functions import permute_dims
+from dpctl.tensor._manipulation_functions import expand_dims, permute_dims
 from dpctl.tensor._reshape import reshape
 from dpctl.tensor._usmarray import usm_ndarray
 
@@ -38,6 +38,7 @@ __all__ = [
     "empty",
     "reshape",
     "permute_dims",
+    "expand_dims",
     "from_numpy",
     "to_numpy",
     "asnumpy",

--- a/dpctl/tensor/_manipulation_functions.py
+++ b/dpctl/tensor/_manipulation_functions.py
@@ -81,6 +81,6 @@ def expand_dims(X, axes):
     axes = normalize_axis_tuple(axes, out_ndim)
 
     shape_it = iter(X.shape)
-    shape = [1 if ax in axes else next(shape_it) for ax in range(out_ndim)]
+    shape = tuple(1 if ax in axes else next(shape_it) for ax in range(out_ndim))
 
     return dpt.reshape(X, shape)

--- a/dpctl/tensor/_manipulation_functions.py
+++ b/dpctl/tensor/_manipulation_functions.py
@@ -16,6 +16,7 @@
 
 
 import numpy as np
+from numpy.core.numeric import normalize_axis_tuple
 
 import dpctl.tensor as dpt
 
@@ -61,3 +62,25 @@ def permute_dims(X, axes):
         strides=newstrides,
         offset=X.__sycl_usm_array_interface__.get("offset", 0),
     )
+
+
+def expand_dims(X, axes):
+    """
+    expand_dims(X: usm_ndarray, axes: int or tuple or list) -> usm_ndarray
+
+    Expands the shape of an array by inserting a new axis (dimension)
+    of size one at the position specified by axes; returns a view, if possible,
+    a copy otherwise with the number of dimensions increased.
+    """
+    if not isinstance(X, dpt.usm_ndarray):
+        raise TypeError(f"Expected usm_ndarray type, got {type(X)}.")
+    if not isinstance(axes, (tuple, list)):
+        axes = (axes,)
+
+    out_ndim = len(axes) + X.ndim
+    axes = normalize_axis_tuple(axes, out_ndim)
+
+    shape_it = iter(X.shape)
+    shape = [1 if ax in axes else next(shape_it) for ax in range(out_ndim)]
+
+    return dpt.reshape(X, shape)


### PR DESCRIPTION
This PR adds `expand_dims` functions according to [Python array API standard](https://data-apis.org/array-api/latest/API_specification/generated/signatures.manipulation_functions.expand_dims.html) for usm_ndarray.