### PR TITLE
Implementation of broadcast_to function

### DIFF
--- a/dpctl/tensor/__init__.py
+++ b/dpctl/tensor/__init__.py
@@ -26,6 +26,7 @@ from dpctl.tensor._ctors import asarray, empty
 from dpctl.tensor._device import Device
 from dpctl.tensor._dlpack import from_dlpack
 from dpctl.tensor._manipulation_functions import (
+    broadcast_to,
     expand_dims,
     permute_dims,
     squeeze,
@@ -41,8 +42,9 @@ __all__ = [
     "copy",
     "empty",
     "reshape",
-    "permute_dims",
+    "broadcast_to",
     "expand_dims",
+    "permute_dims",
     "squeeze",
     "from_numpy",
     "to_numpy",

--- a/dpctl/tensor/_manipulation_functions.py
+++ b/dpctl/tensor/_manipulation_functions.py
@@ -15,9 +15,27 @@
 #  limitations under the License.
 
 
+import numpy as np
 from numpy.core.numeric import normalize_axis_tuple
 
 import dpctl.tensor as dpt
+
+
+def _broadcast_strides(X_shape, X_strides, res_ndim):
+    """
+    Broadcasts strides to match the given dimensions;
+    returns tuple type strides.
+    """
+    out_strides = [0] * res_ndim
+    X_shape_len = len(X_shape)
+    str_dim = -X_shape_len
+    for i in range(X_shape_len):
+        shape_value = X_shape[i]
+        if not shape_value == 1:
+            out_strides[str_dim] = X_strides[i]
+        str_dim += 1
+
+    return tuple(out_strides)
 
 
 def permute_dims(X, axes):
@@ -102,3 +120,29 @@ def squeeze(X, axes=None):
         return X
     else:
         return dpt.reshape(X, new_shape)
+
+
+def broadcast_to(X, shape):
+    """
+    broadcast_to(X: usm_ndarray, shape: tuple or list) -> usm_ndarray
+
+    Broadcast an array to a new shape; returns the broadcasted
+    array as a view.
+    """
+    if not isinstance(X, dpt.usm_ndarray):
+        raise TypeError(f"Expected usm_ndarray type, got {type(X)}.")
+
+    # Use numpy.broadcast_to to check the validity of the input
+    # parametr 'shape'. Raise ValueError if 'X' is not compatible
+    # with 'shape' according to NumPy's broadcasting rules.
+    new_array = np.broadcast_to(
+        np.broadcast_to(np.empty(tuple(), dtype="u1"), X.shape), shape
+    )
+    new_sts = _broadcast_strides(X.shape, X.strides, new_array.ndim)
+    return dpt.usm_ndarray(
+        shape=new_array.shape,
+        dtype=X.dtype,
+        buffer=X,
+        strides=new_sts,
+        offset=X.__sycl_usm_array_interface__.get("offset", 0),
+    )


### PR DESCRIPTION
This PR adds `broadcast_to` functions according to [Python array API standard](https://data-apis.org/array-api/latest/API_specification/generated/signatures.data_type_functions.broadcast_to.html) for usm_ndarray.