### PR TITLE
Host task used by submit must ensure interpreter is not shutting down

### DIFF
--- a/dpctl/_host_task_util.hpp
+++ b/dpctl/_host_task_util.hpp
@@ -56,7 +56,7 @@ int async_dec_ref(DPCTLSyclQueueRef QRef,
             }
             cgh.host_task([obj_array_size, obj_vec]() {
                 // if the main thread has not finilized the interpreter yet
-                if (Py_IsInitialized()) {
+                if (Py_IsInitialized() && !_Py_IsFinalizing()) {
                     PyGILState_STATE gstate;
                     gstate = PyGILState_Ensure();
                     for (size_t i = 0; i < obj_array_size; ++i) {


### PR DESCRIPTION
Clean up task can call `PyGILState_Ensure` if interpreter has started and if it is not finilizing/shutting-down