### PR TITLE
Get coerced usm type

### DIFF
--- a/dpctl/tests/test_usm_ndarray_ctor.py
+++ b/dpctl/tests/test_usm_ndarray_ctor.py
@@ -320,9 +320,11 @@ def test_datapi_device():
         dev_t()
     dev_t.create_device(X.device)
     dev_t.create_device(X.sycl_queue)
-    dev_t.create_device(X.sycl_device)
-    dev_t.create_device(X.sycl_device.filter_string)
-    dev_t.create_device(None)
+    d1 = dev_t.create_device(X.sycl_device)
+    d2 = dev_t.create_device(X.sycl_device.filter_string)
+    d3 = dev_t.create_device(None)
+    assert d1.sycl_queue == d2.sycl_queue
+    assert d1.sycl_queue == d3.sycl_queue
     X.device.sycl_context
     X.device.sycl_queue
     X.device.sycl_device

--- a/dpctl/tests/test_utils.py
+++ b/dpctl/tests/test_utils.py
@@ -54,7 +54,17 @@ def test_get_execution_queue():
             q,
         )
     )
-    assert exec_q is q
+    assert exec_q is None
+    q_c = dpctl.SyclQueue(q._get_capsule())
+    assert q == q_c
+    exec_q = dpctl.utils.get_execution_queue(
+        (
+            q,
+            q_c,
+            q,
+        )
+    )
+    assert exec_q == q
 
 
 def test_get_execution_queue_nonequiv():
@@ -69,3 +79,18 @@ def test_get_execution_queue_nonequiv():
 
     exec_q = dpctl.utils.get_execution_queue((q, q1, q2))
     assert exec_q is None
+
+
+def test_get_coerced_usm_type():
+    _t = ["device", "shared", "host"]
+
+    for i1 in range(len(_t)):
+        for i2 in range(len(_t)):
+            assert (
+                dpctl.utils.get_coerced_usm_type([_t[i1], _t[i2]])
+                == _t[min(i1, i2)]
+            )
+
+    assert dpctl.utils.get_coerced_usm_type([]) is None
+    with pytest.raises(TypeError):
+        dpctl.utils.get_coerced_usm_type(dict())

--- a/dpctl/utils/__init__.py
+++ b/dpctl/utils/__init__.py
@@ -18,8 +18,9 @@
 A collection of utility functions.
 """
 
-from ._compute_follows_data import get_execution_queue
+from ._compute_follows_data import get_coerced_usm_type, get_execution_queue
 
 __all__ = [
     "get_execution_queue",
+    "get_coerced_usm_type",
 ]


### PR DESCRIPTION
Adds `dpctl.utils.get_coerced_usm_type` to deduce the usm type for the output array based on usm types of input arrays.

Also modified behavior of `dpctl.utils.get_execution_queue`. The notion of equivalency has changed. Now two queues are equivalent if they compare equal, i.e. `q1 == q2`. This is true when the underlying C++ class instances are copies of the same underlying instance.

Note that `dpctl.SyclQueue() == dpctl.SyclQueue()` returns `False`, and so would `dpctl.SyclQueue("cpu") == dpctl.SyclQueue("cpu")`.

To bring two arrays to equivalent queues, do `Yc = Y.to_device(X.device)`, and then `foo(X, Yc)` if `foo(X, Y)` was raising due to incompatible queues.