### PR TITLE
Implementation of broadcast_arrays function

### DIFF
--- a/dpctl/tensor/__init__.py
+++ b/dpctl/tensor/__init__.py
@@ -26,6 +26,7 @@ from dpctl.tensor._ctors import asarray, empty
 from dpctl.tensor._device import Device
 from dpctl.tensor._dlpack import from_dlpack
 from dpctl.tensor._manipulation_functions import (
+    broadcast_arrays,
     broadcast_to,
     expand_dims,
     permute_dims,
@@ -42,6 +43,7 @@ __all__ = [
     "copy",
     "empty",
     "reshape",
+    "broadcast_arrays",
     "broadcast_to",
     "expand_dims",
     "permute_dims",

--- a/dpctl/tests/test_usm_ndarray_manipulation.py
+++ b/dpctl/tests/test_usm_ndarray_manipulation.py
@@ -338,7 +338,9 @@ def assert_broadcast_correct(input_shapes):
     usm_arrays = [dpt.asarray(Xnp, sycl_queue=q) for Xnp in np_arrays]
     out_usm_arrays = dpt.broadcast_arrays(*usm_arrays)
     for Xnp, X in zip(out_np_arrays, out_usm_arrays):
-        assert_array_equal(Xnp, dpt.asnumpy(X))
+        assert_array_equal(
+            Xnp, dpt.asnumpy(X), err_msg=f"Failed for {input_shapes})"
+        )
 
 
 def assert_broadcast_arrays_raise(input_shapes):
@@ -462,7 +464,6 @@ def test_broadcast_arrays_different_len_shapes(shapes):
     # to the correct shape.
 
     for input_shapes in shapes:
-        print(input_shapes)
         assert_broadcast_correct(input_shapes)
         assert_broadcast_correct(input_shapes[::-1])
 
@@ -478,6 +479,5 @@ def test_broadcast_arrays_different_len_shapes(shapes):
 )
 def test_incompatible_shapes_raise_valueerror(shapes):
     for input_shapes in shapes:
-        print(input_shapes)
         assert_broadcast_arrays_raise(input_shapes)
         assert_broadcast_arrays_raise(input_shapes[::-1])


### PR DESCRIPTION
This PR adds `broadcast_arrays` functions according to [Python array API standard](https://data-apis.org/array-api/latest/API_specification/generated/signatures.data_type_functions.broadcast_arrays.html) for usm_ndarray.

