### PR TITLE
Fix dpctl.lsplatform() to output in jupyter notebook

### DIFF
--- a/dpctl/_backend.pxd
+++ b/dpctl/_backend.pxd
@@ -263,6 +263,7 @@ cdef extern from "syclinterface/dpctl_sycl_platform_manager.h":
         DPCTLPlatformVectorRef,
         size_t index)
     cdef void DPCTLPlatformMgr_PrintInfo(const DPCTLSyclPlatformRef, size_t)
+    cdef const char *DPCTLPlatformMgr_GetInfo(const DPCTLSyclPlatformRef, size_t)
 
 
 cdef extern from "syclinterface/dpctl_sycl_platform_interface.h":

--- a/dpctl/_sycl_platform.pyx
+++ b/dpctl/_sycl_platform.pyx
@@ -34,6 +34,7 @@ from ._backend cimport (  # noqa: E211
     DPCTLPlatform_GetPlatforms,
     DPCTLPlatform_GetVendor,
     DPCTLPlatform_GetVersion,
+    DPCTLPlatformMgr_GetInfo,
     DPCTLPlatformMgr_PrintInfo,
     DPCTLPlatformVector_Delete,
     DPCTLPlatformVector_GetAt,
@@ -323,6 +324,7 @@ def lsplatform(verbosity=0):
     cdef DPCTLPlatformVectorRef PVRef = NULL
     cdef size_t v = 0
     cdef size_t size = 0
+    cdef const char * info_str = NULL
     cdef DPCTLSyclPlatformRef PRef = NULL
 
     if not isinstance(verbosity, int):
@@ -347,8 +349,11 @@ def lsplatform(verbosity=0):
             if v != 0:
                 print("Platform ", i, "::")
             PRef = DPCTLPlatformVector_GetAt(PVRef, i)
-            DPCTLPlatformMgr_PrintInfo(PRef, v)
+            info_str = DPCTLPlatformMgr_GetInfo(PRef,v)
+            py_info = <bytes> info_str
+            DPCTLCString_Delete(info_str)
             DPCTLPlatform_Delete(PRef)
+            print(py_info.decode("utf-8"),end='')
     DPCTLPlatformVector_Delete(PVRef)
 
 

--- a/libsyclinterface/include/dpctl_sycl_platform_manager.h
+++ b/libsyclinterface/include/dpctl_sycl_platform_manager.h
@@ -64,6 +64,30 @@ DPCTL_API
 void DPCTLPlatformMgr_PrintInfo(__dpctl_keep const DPCTLSyclPlatformRef PRef,
                                 size_t verbosity);
 
+/*!
+ * @brief Returns a set of platform info attributes as a string.
+ *
+ * The helper function is used to get metadata about a given platform. The
+ * amount of information received is controlled by the verbosity level.
+ *
+ * Verbosity level 0: Returns only the name of the platform.
+ * Verbosity level 1: Returns the name, version, vendor, backend, number of
+ *                    devices in the platform.
+ * Verbosity level 2: Returns everything in level 1 and also returns the name,
+ *                    version, and filter string for each device in the
+ *                    platform.
+ *
+ * @param    PRef           A #DPCTLSyclPlatformRef opaque pointer.
+ * @param    verbosity      Verbosilty level to control how much information is
+ *                          printed out.
+ * @return   A formatted C string capturing the information about the
+ *           sycl::platform argument.
+ */
+DPCTL_API
+__dpctl_give const char *
+DPCTLPlatformMgr_GetInfo(__dpctl_keep const DPCTLSyclPlatformRef PRef,
+                         size_t verbosity);
+
 /*! @} */
 
 DPCTL_C_EXTERN_C_END

--- a/libsyclinterface/source/dpctl_sycl_platform_manager.cpp
+++ b/libsyclinterface/source/dpctl_sycl_platform_manager.cpp
@@ -27,6 +27,7 @@
 #include "dpctl_sycl_platform_manager.h"
 #include "Support/CBindingWrapping.h"
 #include "dpctl_error_handlers.h"
+#include "dpctl_string_utils.hpp"
 #include "dpctl_sycl_platform_interface.h"
 #include "dpctl_utils_helper.h"
 #include <CL/sycl.hpp>
@@ -41,7 +42,7 @@ namespace
 {
 DEFINE_SIMPLE_CONVERSION_FUNCTIONS(platform, DPCTLSyclPlatformRef);
 
-void platform_print_info_impl(const platform &p, size_t verbosity)
+std::string platform_print_info_impl(const platform &p, size_t verbosity)
 {
     std::stringstream ss;
 
@@ -96,7 +97,7 @@ void platform_print_info_impl(const platform &p, size_t verbosity)
             }
     }
 
-    std::cout << ss.str();
+    return ss.str();
 }
 
 } // namespace
@@ -111,10 +112,27 @@ void DPCTLPlatformMgr_PrintInfo(__dpctl_keep const DPCTLSyclPlatformRef PRef,
 {
     auto p = unwrap(PRef);
     if (p) {
-        platform_print_info_impl(*p, verbosity);
+        std::cout << platform_print_info_impl(*p, verbosity);
     }
     else {
         error_handler("Platform reference is NULL.", __FILE__, __func__,
                       __LINE__);
     }
+}
+
+__dpctl_give const char *
+DPCTLPlatformMgr_GetInfo(__dpctl_keep const DPCTLSyclPlatformRef PRef,
+                         size_t verbosity)
+{
+    const char *cstr_info = nullptr;
+    auto p = unwrap(PRef);
+    if (p) {
+        auto infostr = platform_print_info_impl(*p, verbosity);
+        cstr_info = dpctl::helper::cstring_from_string(infostr);
+    }
+    else {
+        error_handler("Platform reference is NULL.", __FILE__, __func__,
+                      __LINE__);
+    }
+    return cstr_info;
 }

--- a/libsyclinterface/tests/test_sycl_platform_interface.cpp
+++ b/libsyclinterface/tests/test_sycl_platform_interface.cpp
@@ -295,6 +295,14 @@ TEST_F(TestDPCTLSyclDefaultPlatform, ChkGetInfo3)
     EXPECT_NO_FATAL_FAILURE(DPCTLCString_Delete(info_str));
 }
 
+TEST_F(TestDPCTLSyclDefaultPlatform, ChkGetInfoNull)
+{
+    const char *info_str = nullptr;
+    DPCTLSyclPlatformRef NullPRef = nullptr;
+    EXPECT_NO_FATAL_FAILURE(info_str = DPCTLPlatformMgr_GetInfo(NullPRef, 0));
+    ASSERT_TRUE(info_str == nullptr);
+}
+
 TEST_F(TestDPCTLSyclDefaultPlatform, ChkPrintInfo0)
 {
     EXPECT_NO_FATAL_FAILURE(DPCTLPlatformMgr_PrintInfo(PRef, 0));

--- a/libsyclinterface/tests/test_sycl_platform_interface.cpp
+++ b/libsyclinterface/tests/test_sycl_platform_interface.cpp
@@ -224,6 +224,14 @@ TEST_P(TestDPCTLSyclPlatformInterface, ChkCopyNullArg)
     EXPECT_NO_FATAL_FAILURE(DPCTLPlatform_Delete(Copied_PRef));
 }
 
+TEST_P(TestDPCTLSyclPlatformInterface, ChkGetInfo)
+{
+    const char *info_str = nullptr;
+    EXPECT_NO_FATAL_FAILURE(info_str = DPCTLPlatformMgr_GetInfo(PRef, 0));
+    ASSERT_TRUE(info_str != nullptr);
+    EXPECT_NO_FATAL_FAILURE(DPCTLCString_Delete(info_str));
+}
+
 TEST_P(TestDPCTLSyclPlatformInterface, ChkPrintInfo)
 {
     EXPECT_NO_FATAL_FAILURE(DPCTLPlatformMgr_PrintInfo(PRef, 0));
@@ -253,6 +261,38 @@ TEST_F(TestDPCTLSyclDefaultPlatform, ChkGetVersion)
 TEST_F(TestDPCTLSyclDefaultPlatform, ChkGetBackend)
 {
     check_platform_backend(PRef);
+}
+
+TEST_F(TestDPCTLSyclDefaultPlatform, ChkGetInfo0)
+{
+    const char *info_str = nullptr;
+    EXPECT_NO_FATAL_FAILURE(info_str = DPCTLPlatformMgr_GetInfo(PRef, 0));
+    ASSERT_TRUE(info_str != nullptr);
+    EXPECT_NO_FATAL_FAILURE(DPCTLCString_Delete(info_str));
+}
+
+TEST_F(TestDPCTLSyclDefaultPlatform, ChkGetInfo1)
+{
+    const char *info_str = nullptr;
+    EXPECT_NO_FATAL_FAILURE(info_str = DPCTLPlatformMgr_GetInfo(PRef, 1));
+    ASSERT_TRUE(info_str != nullptr);
+    EXPECT_NO_FATAL_FAILURE(DPCTLCString_Delete(info_str));
+}
+
+TEST_F(TestDPCTLSyclDefaultPlatform, ChkGetInfo2)
+{
+    const char *info_str = nullptr;
+    EXPECT_NO_FATAL_FAILURE(info_str = DPCTLPlatformMgr_GetInfo(PRef, 2));
+    ASSERT_TRUE(info_str != nullptr);
+    EXPECT_NO_FATAL_FAILURE(DPCTLCString_Delete(info_str));
+}
+
+TEST_F(TestDPCTLSyclDefaultPlatform, ChkGetInfo3)
+{
+    const char *info_str = nullptr;
+    EXPECT_NO_FATAL_FAILURE(info_str = DPCTLPlatformMgr_GetInfo(PRef, 3));
+    ASSERT_TRUE(info_str != nullptr);
+    EXPECT_NO_FATAL_FAILURE(DPCTLCString_Delete(info_str));
 }
 
 TEST_F(TestDPCTLSyclDefaultPlatform, ChkPrintInfo0)


### PR DESCRIPTION
Closes #796 

This PR changes `DPCTLPlatformMgr_PrintInfo` function to return `char *` instead of outputting it in `libsyclinterface` , and use that to print using CPython.