### PR TITLE
Update black to version 22.3.0 to fix issue with click

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,7 @@ repos:
     -   id: end-of-file-fixer
     -   id: trailing-whitespace
 -   repo: https://github.com/psf/black
-    rev: 22.1.0
+    rev: 22.3.0
     hooks:
     -   id: black
         exclude: "versioneer.py|dpctl/_version.py"


### PR DESCRIPTION
Updated `.pre-commit-config.yaml` to use black 22.3.0 to work around a breaking change in a dependent `click`.

See https://github.com/psf/black/issues/2964#issuecomment-1080974737