### PR TITLE
Implementation of roll function

### DIFF
--- a/dpctl/tensor/__init__.py
+++ b/dpctl/tensor/__init__.py
@@ -31,6 +31,7 @@ from dpctl.tensor._manipulation_functions import (
     expand_dims,
     flip,
     permute_dims,
+    roll,
     squeeze,
 )
 from dpctl.tensor._reshape import reshape
@@ -45,6 +46,7 @@ __all__ = [
     "empty",
     "flip",
     "reshape",
+    "roll",
     "broadcast_arrays",
     "broadcast_to",
     "expand_dims",

--- a/dpctl/tensor/_manipulation_functions.py
+++ b/dpctl/tensor/_manipulation_functions.py
@@ -265,7 +265,9 @@ def roll(X, shift, axes=None):
                 (np.s_[-offset:], np.s_[:offset]),
             )
 
-    res = dpt.empty(X.shape, dtype=X.dtype, sycl_queue=X.sycl_queue)
+    res = dpt.empty(
+        X.shape, dtype=X.dtype, usm_type=X.usm_type, sycl_queue=X.sycl_queue
+    )
     hev_list = []
     for indices in product(*rolls):
         arr_index, res_index = zip(*indices)

--- a/dpctl/tensor/_manipulation_functions.py
+++ b/dpctl/tensor/_manipulation_functions.py
@@ -15,12 +15,14 @@
 #  limitations under the License.
 
 
-from itertools import chain, repeat
+from itertools import chain, product, repeat
 
 import numpy as np
 from numpy.core.numeric import normalize_axis_tuple
 
+import dpctl
 import dpctl.tensor as dpt
+import dpctl.tensor._tensor_impl as ti
 
 
 def _broadcast_strides(X_shape, X_strides, res_ndim):
@@ -228,3 +230,49 @@ def flip(X, axes=None):
             np.s_[::-1] if i in axes else np.s_[:] for i in range(X.ndim)
         )
     return X[indexer]
+
+
+def roll(X, shift, axes=None):
+    """
+    roll(X: usm_ndarray, shift: int or tuple or list,\
+         axes: int or tuple or list) -> usm_ndarray
+
+    Rolls array elements along a specified axis.
+    Array elements that roll beyond the last position are re-introduced
+    at the first position. Array elements that roll beyond the first position
+    are re-introduced at the last position.
+    returns an output array having the same data type as X and whose elements,
+    relative to X, are shifted.
+    """
+    if not isinstance(X, dpt.usm_ndarray):
+        raise TypeError(f"Expected usm_ndarray type, got {type(X)}.")
+    if axes is None:
+        return dpt.reshape(roll(dpt.reshape(X, X.size), shift, 0), X.shape)
+    axes = normalize_axis_tuple(axes, X.ndim, allow_duplicate=True)
+    broadcasted = np.broadcast(shift, axes)
+    if broadcasted.ndim > 1:
+        raise ValueError("'shift' and 'axis' should be scalars or 1D sequences")
+    shifts = {ax: 0 for ax in range(X.ndim)}
+    for sh, ax in broadcasted:
+        shifts[ax] += sh
+    rolls = [((np.s_[:], np.s_[:]),)] * X.ndim
+    for ax, offset in shifts.items():
+        offset %= X.shape[ax] or 1
+        if offset:
+            # (original, result), (original, result)
+            rolls[ax] = (
+                (np.s_[:-offset], np.s_[offset:]),
+                (np.s_[-offset:], np.s_[:offset]),
+            )
+
+    res = dpt.empty(X.shape, dtype=X.dtype, sycl_queue=X.sycl_queue)
+    hev_list = []
+    for indices in product(*rolls):
+        arr_index, res_index = zip(*indices)
+        hev, _ = ti._copy_usm_ndarray_into_usm_ndarray(
+            src=X[arr_index], dst=res[res_index], queue=X.sycl_queue
+        )
+        hev_list.append(hev)
+
+    dpctl.SyclEvent.wait_for(hev_list)
+    return res

--- a/dpctl/tests/test_usm_ndarray_manipulation.py
+++ b/dpctl/tests/test_usm_ndarray_manipulation.py
@@ -641,3 +641,87 @@ def test_flip_multiple_axes(data):
     Y = dpt.flip(X, axes)
     Ynp = np.flip(Xnp, axes)
     assert_array_equal(Ynp, dpt.asnumpy(Y))
+
+
+def test_roll_empty():
+    try:
+        q = dpctl.SyclQueue()
+    except dpctl.SyclQueueCreationError:
+        pytest.skip("Queue could not be created")
+
+    Xnp = np.empty([])
+    X = dpt.asarray(Xnp, sycl_queue=q)
+
+    Y = dpt.roll(X, 1)
+    Ynp = np.roll(Xnp, 1)
+    assert_array_equal(Ynp, dpt.asnumpy(Y))
+    pytest.raises(np.AxisError, dpt.roll, X, 1, 0)
+    pytest.raises(np.AxisError, dpt.roll, X, 1, 1)
+
+
+@pytest.mark.parametrize(
+    "data",
+    [
+        [2, None],
+        [-2, None],
+        [2, 0],
+        [-2, 0],
+        [2, ()],
+        [11, 0],
+    ],
+)
+def test_roll_1d(data):
+    try:
+        q = dpctl.SyclQueue()
+    except dpctl.SyclQueueCreationError:
+        pytest.skip("Queue could not be created")
+
+    Xnp = np.arange(10)
+    X = dpt.asarray(Xnp, sycl_queue=q)
+    sh, ax = data
+
+    Y = dpt.roll(X, sh, ax)
+    Ynp = np.roll(Xnp, sh, ax)
+    assert_array_equal(Ynp, dpt.asnumpy(Y))
+
+    Y = dpt.roll(X, sh, ax)
+    Ynp = np.roll(Xnp, sh, ax)
+    assert_array_equal(Ynp, dpt.asnumpy(Y))
+
+
+@pytest.mark.parametrize(
+    "data",
+    [
+        [1, None],
+        [1, 0],
+        [1, 1],
+        [1, ()],
+        # Roll multiple axes at once
+        [1, (0, 1)],
+        [(1, 0), (0, 1)],
+        [(-1, 0), (1, 0)],
+        [(0, 1), (0, 1)],
+        [(0, -1), (0, 1)],
+        [(1, 1), (0, 1)],
+        [(-1, -1), (0, 1)],
+        # Roll the same axis multiple times.
+        [1, (0, 0)],
+        [1, (1, 1)],
+        # Roll more than one turn in either direction.
+        [6, 1],
+        [-4, 1],
+    ],
+)
+def test_roll_2d(data):
+    try:
+        q = dpctl.SyclQueue()
+    except dpctl.SyclQueueCreationError:
+        pytest.skip("Queue could not be created")
+
+    Xnp = np.arange(10).reshape(2, 5)
+    X = dpt.asarray(Xnp, sycl_queue=q)
+    sh, ax = data
+
+    Y = dpt.roll(X, sh, ax)
+    Ynp = np.roll(Xnp, sh, ax)
+    assert_array_equal(Ynp, dpt.asnumpy(Y))


### PR DESCRIPTION
This PR adds `roll` functions according to [Python array API standard](https://data-apis.org/array-api/latest/API_specification/generated/signatures.manipulation_functions.roll.html) for usm_ndarray.