### PR TITLE
Implementation of memset function in libSyclInterface 

### DIFF
--- a/libsyclinterface/include/dpctl_sycl_queue_interface.h
+++ b/libsyclinterface/include/dpctl_sycl_queue_interface.h
@@ -464,10 +464,11 @@ DPCTLSyclEventRef DPCTLQueue_Fill64(__dpctl_keep const DPCTLSyclQueueRef QRef,
  *           ``sycl::queue::fill`` function.
  * @ingroup QueueInterface
  */
+/*
 DPCTL_API
 DPCTLSyclEventRef DPCTLQueue_Fill128(__dpctl_keep const DPCTLSyclQueueRef QRef,
                                      void *USMRef,
                                      uint64_t *Value,
                                      size_t Count);
-
+*/
 DPCTL_C_EXTERN_C_END

--- a/libsyclinterface/include/dpctl_sycl_queue_interface.h
+++ b/libsyclinterface/include/dpctl_sycl_queue_interface.h
@@ -430,12 +430,13 @@ DPCTLSyclEventRef DPCTLQueue_Fill16(__dpctl_keep const DPCTLSyclQueueRef QRef,
  *           ``sycl::queue::fill`` function.
  * @ingroup QueueInterface
  */
+/*
 DPCTL_API
 DPCTLSyclEventRef DPCTLQueue_Fill32(__dpctl_keep const DPCTLSyclQueueRef QRef,
                                     void *USMRef,
                                     uint32_t Value,
                                     size_t Count);
-
+*/
 /*!
  * @brief C-API wrapper for ``sycl::queue::fill``.
  *
@@ -447,12 +448,13 @@ DPCTLSyclEventRef DPCTLQueue_Fill32(__dpctl_keep const DPCTLSyclQueueRef QRef,
  *           ``sycl::queue::fill`` function.
  * @ingroup QueueInterface
  */
+/*
 DPCTL_API
 DPCTLSyclEventRef DPCTLQueue_Fill64(__dpctl_keep const DPCTLSyclQueueRef QRef,
                                     void *USMRef,
                                     uint64_t Value,
                                     size_t Count);
-
+*/
 /*!
  * @brief C-API wrapper for ``sycl::queue::fill``.
  *

--- a/libsyclinterface/include/dpctl_sycl_queue_interface.h
+++ b/libsyclinterface/include/dpctl_sycl_queue_interface.h
@@ -385,4 +385,89 @@ DPCTLSyclEventRef DPCTLQueue_SubmitBarrierForEvents(
     __dpctl_keep const DPCTLSyclEventRef *DepEvents,
     size_t NDepEvents);
 
+/*!
+ * @brief C-API wrapper for ``sycl::queue::fill``.
+ *
+ * @param    QRef           An opaque pointer to the ``sycl::queue``.
+ * @param    USMRef         An USM pointer to the memory to fill.
+ * @param    Value          A value to fill.
+ * @param    Count          A number of uint8_t elements to fill.
+ * @return   An opaque pointer to the ``sycl::event`` returned by the
+ *           ``sycl::queue::fill`` function.
+ * @ingroup QueueInterface
+ */
+DPCTL_API
+DPCTLSyclEventRef DPCTLQueue_Fill8(__dpctl_keep const DPCTLSyclQueueRef QRef,
+                                   void *USMRef,
+                                   uint8_t Value,
+                                   size_t Count);
+
+/*!
+ * @brief C-API wrapper for ``sycl::queue::fill``.
+ *
+ * @param    QRef           An opaque pointer to the ``sycl::queue``.
+ * @param    USMRef         An USM pointer to the memory to fill.
+ * @param    Value          A value to fill.
+ * @param    Count          A number of uint16_t elements to fill.
+ * @return   An opaque pointer to the ``sycl::event`` returned by the
+ *           ``sycl::queue::fill`` function.
+ * @ingroup QueueInterface
+ */
+DPCTL_API
+DPCTLSyclEventRef DPCTLQueue_Fill16(__dpctl_keep const DPCTLSyclQueueRef QRef,
+                                    void *USMRef,
+                                    uint16_t Value,
+                                    size_t Count);
+
+/*!
+ * @brief C-API wrapper for ``sycl::queue::fill``.
+ *
+ * @param    QRef           An opaque pointer to the ``sycl::queue``.
+ * @param    USMRef         An USM pointer to the memory to fill.
+ * @param    Value          A value to fill.
+ * @param    Count          A number of uint32_t elements to fill.
+ * @return   An opaque pointer to the ``sycl::event`` returned by the
+ *           ``sycl::queue::fill`` function.
+ * @ingroup QueueInterface
+ */
+DPCTL_API
+DPCTLSyclEventRef DPCTLQueue_Fill32(__dpctl_keep const DPCTLSyclQueueRef QRef,
+                                    void *USMRef,
+                                    uint32_t Value,
+                                    size_t Count);
+
+/*!
+ * @brief C-API wrapper for ``sycl::queue::fill``.
+ *
+ * @param    QRef           An opaque pointer to the ``sycl::queue``.
+ * @param    USMRef         An USM pointer to the memory to fill.
+ * @param    Value          A value to fill.
+ * @param    Count          A number of uint64_t elements to fill.
+ * @return   An opaque pointer to the ``sycl::event`` returned by the
+ *           ``sycl::queue::fill`` function.
+ * @ingroup QueueInterface
+ */
+DPCTL_API
+DPCTLSyclEventRef DPCTLQueue_Fill64(__dpctl_keep const DPCTLSyclQueueRef QRef,
+                                    void *USMRef,
+                                    uint64_t Value,
+                                    size_t Count);
+
+/*!
+ * @brief C-API wrapper for ``sycl::queue::fill``.
+ *
+ * @param    QRef           An opaque pointer to the ``sycl::queue``.
+ * @param    USMRef         An USM pointer to the memory to fill.
+ * @param    Value          A value to fill.
+ * @param    Count          A number of 128-bit elements to fill.
+ * @return   An opaque pointer to the ``sycl::event`` returned by the
+ *           ``sycl::queue::fill`` function.
+ * @ingroup QueueInterface
+ */
+DPCTL_API
+DPCTLSyclEventRef DPCTLQueue_Fill128(__dpctl_keep const DPCTLSyclQueueRef QRef,
+                                     void *USMRef,
+                                     uint64_t *Value,
+                                     size_t Count);
+
 DPCTL_C_EXTERN_C_END

--- a/libsyclinterface/include/dpctl_sycl_queue_interface.h
+++ b/libsyclinterface/include/dpctl_sycl_queue_interface.h
@@ -386,7 +386,7 @@ DPCTLSyclEventRef DPCTLQueue_SubmitBarrierForEvents(
     size_t NDepEvents);
 
 /*!
- * @brief C-API wrapper for ``sycl::queue::fill``.
+ * @brief C-API wrapper for ``sycl::queue::memset``.
  *
  * @param    QRef           An opaque pointer to the ``sycl::queue``.
  * @param    USMRef         An USM pointer to the memory to fill.
@@ -397,80 +397,9 @@ DPCTLSyclEventRef DPCTLQueue_SubmitBarrierForEvents(
  * @ingroup QueueInterface
  */
 DPCTL_API
-DPCTLSyclEventRef DPCTLQueue_Fill8(__dpctl_keep const DPCTLSyclQueueRef QRef,
-                                   void *USMRef,
-                                   uint8_t Value,
-                                   size_t Count);
-
-/*!
- * @brief C-API wrapper for ``sycl::queue::fill``.
- *
- * @param    QRef           An opaque pointer to the ``sycl::queue``.
- * @param    USMRef         An USM pointer to the memory to fill.
- * @param    Value          A value to fill.
- * @param    Count          A number of uint16_t elements to fill.
- * @return   An opaque pointer to the ``sycl::event`` returned by the
- *           ``sycl::queue::fill`` function.
- * @ingroup QueueInterface
- */
-DPCTL_API
-DPCTLSyclEventRef DPCTLQueue_Fill16(__dpctl_keep const DPCTLSyclQueueRef QRef,
+DPCTLSyclEventRef DPCTLQueue_Memset(__dpctl_keep const DPCTLSyclQueueRef QRef,
                                     void *USMRef,
-                                    uint16_t Value,
+                                    uint8_t Value,
                                     size_t Count);
 
-/*!
- * @brief C-API wrapper for ``sycl::queue::fill``.
- *
- * @param    QRef           An opaque pointer to the ``sycl::queue``.
- * @param    USMRef         An USM pointer to the memory to fill.
- * @param    Value          A value to fill.
- * @param    Count          A number of uint32_t elements to fill.
- * @return   An opaque pointer to the ``sycl::event`` returned by the
- *           ``sycl::queue::fill`` function.
- * @ingroup QueueInterface
- */
-/*
-DPCTL_API
-DPCTLSyclEventRef DPCTLQueue_Fill32(__dpctl_keep const DPCTLSyclQueueRef QRef,
-                                    void *USMRef,
-                                    uint32_t Value,
-                                    size_t Count);
-*/
-/*!
- * @brief C-API wrapper for ``sycl::queue::fill``.
- *
- * @param    QRef           An opaque pointer to the ``sycl::queue``.
- * @param    USMRef         An USM pointer to the memory to fill.
- * @param    Value          A value to fill.
- * @param    Count          A number of uint64_t elements to fill.
- * @return   An opaque pointer to the ``sycl::event`` returned by the
- *           ``sycl::queue::fill`` function.
- * @ingroup QueueInterface
- */
-/*
-DPCTL_API
-DPCTLSyclEventRef DPCTLQueue_Fill64(__dpctl_keep const DPCTLSyclQueueRef QRef,
-                                    void *USMRef,
-                                    uint64_t Value,
-                                    size_t Count);
-*/
-/*!
- * @brief C-API wrapper for ``sycl::queue::fill``.
- *
- * @param    QRef           An opaque pointer to the ``sycl::queue``.
- * @param    USMRef         An USM pointer to the memory to fill.
- * @param    Value          A value to fill.
- * @param    Count          A number of 128-bit elements to fill.
- * @return   An opaque pointer to the ``sycl::event`` returned by the
- *           ``sycl::queue::fill`` function.
- * @ingroup QueueInterface
- */
-/*
-DPCTL_API
-DPCTLSyclEventRef DPCTLQueue_Fill128(__dpctl_keep const DPCTLSyclQueueRef QRef,
-                                     void *USMRef,
-                                     uint64_t *Value,
-                                     size_t Count);
-*/
 DPCTL_C_EXTERN_C_END

--- a/libsyclinterface/source/dpctl_sycl_queue_interface.cpp
+++ b/libsyclinterface/source/dpctl_sycl_queue_interface.cpp
@@ -612,3 +612,127 @@ DPCTLQueue_SubmitBarrier(__dpctl_keep const DPCTLSyclQueueRef QRef)
 {
     return DPCTLQueue_SubmitBarrierForEvents(QRef, nullptr, 0);
 }
+
+DPCTLSyclEventRef DPCTLQueue_Fill8(__dpctl_keep const DPCTLSyclQueueRef QRef,
+                                   DPCTLSyclUSMRef *USMRef,
+                                   uint8_t Value,
+                                   size_t Count)
+{
+    auto Q = unwrap(QRef);
+    if (Q && USMRef) {
+        sycl::event ev;
+        try {
+            ev = Q->memset(USMRef, Value, Count);
+        } catch (std::exception const &e) {
+            error_handler(e, __FILE__, __func__, __LINE__);
+            return nullptr;
+        }
+        return wrap(new event(ev));
+    }
+    else {
+        error_handler("QRef or USMRef passed to fill8 were NULL.", __FILE__,
+                      __func__, __LINE__);
+        return nullptr;
+    }
+}
+
+DPCTLSyclEventRef DPCTLQueue_Fill16(__dpctl_keep const DPCTLSyclQueueRef QRef,
+                                    void *USMRef,
+                                    uint16_t Value,
+                                    size_t Count)
+{
+    auto Q = unwrap(QRef);
+    if (Q && USMRef) {
+        sycl::event ev;
+        try {
+            ev = Q->fill<uint16_t>(USMRef, Value, Count);
+        } catch (std::exception const &e) {
+            error_handler(e, __FILE__, __func__, __LINE__);
+            return nullptr;
+        }
+        return wrap(new event(ev));
+    }
+    else {
+        error_handler("QRef or USMRef passed to fill16 were NULL.", __FILE__,
+                      __func__, __LINE__);
+        return nullptr;
+    }
+}
+
+DPCTLSyclEventRef DPCTLQueue_Fill32(__dpctl_keep const DPCTLSyclQueueRef QRef,
+                                    void *USMRef,
+                                    uint32_t Value,
+                                    size_t Count)
+{
+    auto Q = unwrap(QRef);
+    if (Q && USMRef) {
+        sycl::event ev;
+        try {
+            ev = Q->fill<uint32_t>(USMRef, Value, Count);
+        } catch (std::exception const &e) {
+            error_handler(e, __FILE__, __func__, __LINE__);
+            return nullptr;
+        }
+        return wrap(new event(ev));
+    }
+    else {
+        error_handler("QRef or USMRef passed to fill32 were NULL.", __FILE__,
+                      __func__, __LINE__);
+        return nullptr;
+    }
+}
+
+DPCTLSyclEventRef DPCTLQueue_Fill64(__dpctl_keep const DPCTLSyclQueueRef QRef,
+                                    void *USMRef,
+                                    uint64_t Value,
+                                    size_t Count)
+{
+    auto Q = unwrap(QRef);
+    if (Q && USMRef) {
+        sycl::event ev;
+        try {
+            ev = Q->fill<uint64_t>(USMRef, Value, Count);
+        } catch (std::exception const &e) {
+            error_handler(e, __FILE__, __func__, __LINE__);
+            return nullptr;
+        }
+        return wrap(new event(ev));
+    }
+    else {
+        error_handler("QRef or USMRef passed to fill64 were NULL.", __FILE__,
+                      __func__, __LINE__);
+        return nullptr;
+    }
+}
+
+typedef struct complex
+{
+    uint64_t real;
+    uint64_t imag;
+} coplexNumber;
+
+DPCTLSyclEventRef DPCTLQueue_Fill128(__dpctl_keep const DPCTLSyclQueueRef QRef,
+                                     void *USMRef,
+                                     uint64_t *Value,
+                                     size_t Count)
+{
+    auto Q = unwrap(QRef);
+    if (Q && USMRef) {
+        sycl::event ev;
+        try {
+            coplexNumber Val;
+            Val.real = Value[0];
+            Val.imag = Value[1];
+            ev = Q->fill(USMRef, Val, Count);
+        } catch (std::exception const &e) {
+            error_handler(e, __FILE__, __func__, __LINE__);
+            return nullptr;
+        }
+        return wrap(new event(ev));
+    }
+    else {
+        error_handler("QRef or USMRef passed to fill128 were NULL.", __FILE__,
+                      __func__, __LINE__);
+        return nullptr;
+    }
+}

--- a/libsyclinterface/source/dpctl_sycl_queue_interface.cpp
+++ b/libsyclinterface/source/dpctl_sycl_queue_interface.cpp
@@ -614,7 +614,7 @@ DPCTLQueue_SubmitBarrier(__dpctl_keep const DPCTLSyclQueueRef QRef)
 }
 
 DPCTLSyclEventRef DPCTLQueue_Fill8(__dpctl_keep const DPCTLSyclQueueRef QRef,
-                                   DPCTLSyclUSMRef *USMRef,
+                                   void *USMRef,
                                    uint8_t Value,
                                    size_t Count)
 {
@@ -659,6 +659,7 @@ DPCTLSyclEventRef DPCTLQueue_Fill16(__dpctl_keep const DPCTLSyclQueueRef QRef,
     }
 }
 
+#if 0
 DPCTLSyclEventRef DPCTLQueue_Fill32(__dpctl_keep const DPCTLSyclQueueRef QRef,
                                     void *USMRef,
                                     uint32_t Value,
@@ -739,3 +740,4 @@ DPCTLSyclEventRef DPCTLQueue_Fill128(__dpctl_keep const DPCTLSyclQueueRef QRef,
         return nullptr;
     }
 }
+#endif

--- a/libsyclinterface/source/dpctl_sycl_queue_interface.cpp
+++ b/libsyclinterface/source/dpctl_sycl_queue_interface.cpp
@@ -613,10 +613,10 @@ DPCTLQueue_SubmitBarrier(__dpctl_keep const DPCTLSyclQueueRef QRef)
     return DPCTLQueue_SubmitBarrierForEvents(QRef, nullptr, 0);
 }
 
-DPCTLSyclEventRef DPCTLQueue_Fill8(__dpctl_keep const DPCTLSyclQueueRef QRef,
-                                   void *USMRef,
-                                   uint8_t Value,
-                                   size_t Count)
+DPCTLSyclEventRef DPCTLQueue_Memset(__dpctl_keep const DPCTLSyclQueueRef QRef,
+                                    void *USMRef,
+                                    uint8_t Value,
+                                    size_t Count)
 {
     auto Q = unwrap(QRef);
     if (Q && USMRef) {
@@ -635,109 +635,3 @@ DPCTLSyclEventRef DPCTLQueue_Fill8(__dpctl_keep const DPCTLSyclQueueRef QRef,
         return nullptr;
     }
 }
-
-DPCTLSyclEventRef DPCTLQueue_Fill16(__dpctl_keep const DPCTLSyclQueueRef QRef,
-                                    void *USMRef,
-                                    uint16_t Value,
-                                    size_t Count)
-{
-    auto Q = unwrap(QRef);
-    if (Q && USMRef) {
-        sycl::event ev;
-        try {
-            ev = Q->fill<uint16_t>(USMRef, Value, Count);
-        } catch (std::exception const &e) {
-            error_handler(e, __FILE__, __func__, __LINE__);
-            return nullptr;
-        }
-        return wrap(new event(ev));
-    }
-    else {
-        error_handler("QRef or USMRef passed to fill16 were NULL.", __FILE__,
-                      __func__, __LINE__);
-        return nullptr;
-    }
-}
-
-#if 0
-DPCTLSyclEventRef DPCTLQueue_Fill32(__dpctl_keep const DPCTLSyclQueueRef QRef,
-                                    void *USMRef,
-                                    uint32_t Value,
-                                    size_t Count)
-{
-    auto Q = unwrap(QRef);
-    if (Q && USMRef) {
-        sycl::event ev;
-        try {
-            ev = Q->fill<uint32_t>(USMRef, Value, Count);
-        } catch (std::exception const &e) {
-            error_handler(e, __FILE__, __func__, __LINE__);
-            return nullptr;
-        }
-        return wrap(new event(ev));
-    }
-    else {
-        error_handler("QRef or USMRef passed to fill32 were NULL.", __FILE__,
-                      __func__, __LINE__);
-        return nullptr;
-    }
-}
-
-DPCTLSyclEventRef DPCTLQueue_Fill64(__dpctl_keep const DPCTLSyclQueueRef QRef,
-                                    void *USMRef,
-                                    uint64_t Value,
-                                    size_t Count)
-{
-    auto Q = unwrap(QRef);
-    if (Q && USMRef) {
-        sycl::event ev;
-        try {
-            ev = Q->fill<uint64_t>(USMRef, Value, Count);
-        } catch (std::exception const &e) {
-            error_handler(e, __FILE__, __func__, __LINE__);
-            return nullptr;
-        }
-        return wrap(new event(ev));
-    }
-    else {
-        error_handler("QRef or USMRef passed to fill64 were NULL.", __FILE__,
-                      __func__, __LINE__);
-        return nullptr;
-    }
-}
-
-namespace
-{
-struct value128_t
-{
-    uint64_t first;
-    uint64_t second;
-    value128_t(uint64_t v0, uint64_t v1) : first(v0), second(v1) {}
-};
-static_assert(sizeof(value128_t) == 2 * sizeof(uint64_t));
-} // namespace
-
-DPCTLSyclEventRef DPCTLQueue_Fill128(__dpctl_keep const DPCTLSyclQueueRef QRef,
-                                     void *USMRef,
-                                     uint64_t *Value,
-                                     size_t Count)
-{
-    auto Q = unwrap(QRef);
-    if (Q && USMRef) {
-        sycl::event ev;
-        try {
-            value128_t Val{Value[0], Value[1]};
-            ev = Q->fill<value128_t>(USMRef, Val, Count);
-        } catch (std::exception const &e) {
-            error_handler(e, __FILE__, __func__, __LINE__);
-            return nullptr;
-        }
-        return wrap(new event(ev));
-    }
-    else {
-        error_handler("QRef or USMRef passed to fill128 were NULL.", __FILE__,
-                      __func__, __LINE__);
-        return nullptr;
-    }
-}
-#endif

--- a/libsyclinterface/tests/test_sycl_queue_interface.cpp
+++ b/libsyclinterface/tests/test_sycl_queue_interface.cpp
@@ -414,27 +414,28 @@ TEST(TestDPCTLSyclQueueInterface, CheckFillNullQRef)
     uint8_t val8 = 0;
     uint16_t val16 = 0;
     uint32_t val32 = 0;
-    uint64_t val128[2] = {0, 0};
+    uint64_t val64 = 0;
+    /*
+      uint64_t val128[2] = {0, 0}; */
     DPCTLSyclEventRef ERef = nullptr;
 
-    ASSERT_NO_FATAL_FAILURE(ERef = DPCTLQueue_Fill8(QRef, p, val, sizeof(val)));
+    ASSERT_NO_FATAL_FAILURE(ERef = DPCTLQueue_Fill8(QRef, p, val8, 1));
     ASSERT_FALSE(bool(ERef));
 
-    ASSERT_NO_FATAL_FAILURE(ERef =
-                                DPCTLQueue_Fill16(QRef, p, val, sizeof(val)));
+    ASSERT_NO_FATAL_FAILURE(ERef = DPCTLQueue_Fill16(QRef, p, val16, 1));
     ASSERT_FALSE(bool(ERef));
 
-    ASSERT_NO_FATAL_FAILURE(ERef =
-                                DPCTLQueue_Fill32(QRef, p, val, sizeof(val)));
+    ASSERT_NO_FATAL_FAILURE(ERef = DPCTLQueue_Fill32(QRef, p, val32, 1));
     ASSERT_FALSE(bool(ERef));
 
-    ASSERT_NO_FATAL_FAILURE(ERef =
-                                DPCTLQueue_Fill64(QRef, p, val, sizeof(val)));
+    ASSERT_NO_FATAL_FAILURE(ERef = DPCTLQueue_Fill64(QRef, p, val64, 1));
     ASSERT_FALSE(bool(ERef));
 
+    /*
     ASSERT_NO_FATAL_FAILURE(ERef =
-                                DPCTLQueue_Fill128(QRef, p, val, sizeof(val)));
+                                DPCTLQueue_Fill128(QRef, p, val128, 1));
     ASSERT_FALSE(bool(ERef));
+    */
 }
 
 INSTANTIATE_TEST_SUITE_P(

--- a/libsyclinterface/tests/test_sycl_queue_interface.cpp
+++ b/libsyclinterface/tests/test_sycl_queue_interface.cpp
@@ -413,10 +413,11 @@ TEST(TestDPCTLSyclQueueInterface, CheckFillNullQRef)
     void *p = nullptr;
     uint8_t val8 = 0;
     uint16_t val16 = 0;
+    /*
     uint32_t val32 = 0;
     uint64_t val64 = 0;
-    /*
-      uint64_t val128[2] = {0, 0}; */
+    uint64_t val128[2] = {0, 0};
+    */
     DPCTLSyclEventRef ERef = nullptr;
 
     ASSERT_NO_FATAL_FAILURE(ERef = DPCTLQueue_Fill8(QRef, p, val8, 1));
@@ -425,13 +426,13 @@ TEST(TestDPCTLSyclQueueInterface, CheckFillNullQRef)
     ASSERT_NO_FATAL_FAILURE(ERef = DPCTLQueue_Fill16(QRef, p, val16, 1));
     ASSERT_FALSE(bool(ERef));
 
+    /*
     ASSERT_NO_FATAL_FAILURE(ERef = DPCTLQueue_Fill32(QRef, p, val32, 1));
     ASSERT_FALSE(bool(ERef));
 
     ASSERT_NO_FATAL_FAILURE(ERef = DPCTLQueue_Fill64(QRef, p, val64, 1));
     ASSERT_FALSE(bool(ERef));
 
-    /*
     ASSERT_NO_FATAL_FAILURE(ERef =
                                 DPCTLQueue_Fill128(QRef, p, val128, 1));
     ASSERT_FALSE(bool(ERef));

--- a/libsyclinterface/tests/test_sycl_queue_interface.cpp
+++ b/libsyclinterface/tests/test_sycl_queue_interface.cpp
@@ -407,6 +407,37 @@ TEST_P(TestDPCTLQueueMemberFunctions, CheckMemOpsNullPtr)
     }
 }
 
+TEST(TestDPCTLSyclQueueInterface, CheckFillNullQRef)
+{
+    DPCTLSyclQueueRef QRef = nullptr;
+    void *p = nullptr;
+    uint8_t val8 = 0;
+    uint16_t val16 = 0;
+    uint32_t val32 = 0;
+    uint64_t val128[2] = {0, 0};
+    DPCTLSyclEventRef ERef = nullptr;
+
+    ASSERT_NO_FATAL_FAILURE(ERef =
+                                DPCTLQueue_Fill8(QRef, p, val8, sizeof(val8)));
+    ASSERT_FALSE(bool(ERef));
+
+    ASSERT_NO_FATAL_FAILURE(
+        ERef = DPCTLQueue_Fill16(QRef, p, val16, sizeof(val16)));
+    ASSERT_FALSE(bool(ERef));
+
+    ASSERT_NO_FATAL_FAILURE(
+        ERef = DPCTLQueue_Fill32(QRef, p, val32, sizeof(val32)));
+    ASSERT_FALSE(bool(ERef));
+
+    ASSERT_NO_FATAL_FAILURE(
+        ERef = DPCTLQueue_Fill64(QRef, p, val64, sizeof(val64)));
+    ASSERT_FALSE(bool(ERef));
+
+    ASSERT_NO_FATAL_FAILURE(
+        ERef = DPCTLQueue_Fill128(QRef, p, val128, sizeof(val128)));
+    ASSERT_FALSE(bool(ERef));
+}
+
 INSTANTIATE_TEST_SUITE_P(
     DPCTLQueueMemberFuncTests,
     TestDPCTLQueueMemberFunctions,

--- a/libsyclinterface/tests/test_sycl_queue_interface.cpp
+++ b/libsyclinterface/tests/test_sycl_queue_interface.cpp
@@ -417,24 +417,23 @@ TEST(TestDPCTLSyclQueueInterface, CheckFillNullQRef)
     uint64_t val128[2] = {0, 0};
     DPCTLSyclEventRef ERef = nullptr;
 
+    ASSERT_NO_FATAL_FAILURE(ERef = DPCTLQueue_Fill8(QRef, p, val, sizeof(val)));
+    ASSERT_FALSE(bool(ERef));
+
     ASSERT_NO_FATAL_FAILURE(ERef =
-                                DPCTLQueue_Fill8(QRef, p, val8, sizeof(val8)));
+                                DPCTLQueue_Fill16(QRef, p, val, sizeof(val)));
     ASSERT_FALSE(bool(ERef));
 
-    ASSERT_NO_FATAL_FAILURE(
-        ERef = DPCTLQueue_Fill16(QRef, p, val16, sizeof(val16)));
+    ASSERT_NO_FATAL_FAILURE(ERef =
+                                DPCTLQueue_Fill32(QRef, p, val, sizeof(val)));
     ASSERT_FALSE(bool(ERef));
 
-    ASSERT_NO_FATAL_FAILURE(
-        ERef = DPCTLQueue_Fill32(QRef, p, val32, sizeof(val32)));
+    ASSERT_NO_FATAL_FAILURE(ERef =
+                                DPCTLQueue_Fill64(QRef, p, val, sizeof(val)));
     ASSERT_FALSE(bool(ERef));
 
-    ASSERT_NO_FATAL_FAILURE(
-        ERef = DPCTLQueue_Fill64(QRef, p, val64, sizeof(val64)));
-    ASSERT_FALSE(bool(ERef));
-
-    ASSERT_NO_FATAL_FAILURE(
-        ERef = DPCTLQueue_Fill128(QRef, p, val128, sizeof(val128)));
+    ASSERT_NO_FATAL_FAILURE(ERef =
+                                DPCTLQueue_Fill128(QRef, p, val, sizeof(val)));
     ASSERT_FALSE(bool(ERef));
 }
 

--- a/libsyclinterface/tests/test_sycl_queue_interface.cpp
+++ b/libsyclinterface/tests/test_sycl_queue_interface.cpp
@@ -32,6 +32,7 @@
 #include "dpctl_sycl_event_interface.h"
 #include "dpctl_sycl_queue_interface.h"
 #include "dpctl_sycl_queue_manager.h"
+#include "dpctl_sycl_usm_interface.h"
 #include <CL/sycl.hpp>
 #include <gtest/gtest.h>
 
@@ -407,36 +408,49 @@ TEST_P(TestDPCTLQueueMemberFunctions, CheckMemOpsNullPtr)
     }
 }
 
-TEST(TestDPCTLSyclQueueInterface, CheckFillNullQRef)
+TEST(TestDPCTLSyclQueueInterface, CheckMemsetNullQRef)
 {
     DPCTLSyclQueueRef QRef = nullptr;
     void *p = nullptr;
     uint8_t val8 = 0;
-    uint16_t val16 = 0;
-    /*
-    uint32_t val32 = 0;
-    uint64_t val64 = 0;
-    uint64_t val128[2] = {0, 0};
-    */
     DPCTLSyclEventRef ERef = nullptr;
 
-    ASSERT_NO_FATAL_FAILURE(ERef = DPCTLQueue_Fill8(QRef, p, val8, 1));
+    ASSERT_NO_FATAL_FAILURE(ERef = DPCTLQueue_Memset(QRef, p, val8, 1));
     ASSERT_FALSE(bool(ERef));
+}
 
-    ASSERT_NO_FATAL_FAILURE(ERef = DPCTLQueue_Fill16(QRef, p, val16, 1));
-    ASSERT_FALSE(bool(ERef));
+TEST_P(TestDPCTLQueueMemberFunctions, CheckMemset)
+{
+    DPCTLSyclUSMRef p = nullptr;
+    DPCTLSyclEventRef ERef = nullptr;
+    uint8_t val = 73;
+    size_t nbytes = 256;
+    uint8_t *host_arr = new uint8_t[nbytes];
 
-    /*
-    ASSERT_NO_FATAL_FAILURE(ERef = DPCTLQueue_Fill32(QRef, p, val32, 1));
-    ASSERT_FALSE(bool(ERef));
+    ASSERT_FALSE(host_arr == nullptr);
 
-    ASSERT_NO_FATAL_FAILURE(ERef = DPCTLQueue_Fill64(QRef, p, val64, 1));
-    ASSERT_FALSE(bool(ERef));
+    ASSERT_NO_FATAL_FAILURE(p = DPCTLmalloc_device(nbytes, QRef));
+    ASSERT_FALSE(p == nullptr);
+
+    ASSERT_NO_FATAL_FAILURE(
+        ERef = DPCTLQueue_Memset(QRef, (void *)p, val, nbytes));
+    ASSERT_NO_FATAL_FAILURE(DPCTLEvent_Wait(ERef));
+    ASSERT_NO_FATAL_FAILURE(DPCTLEvent_Delete(ERef));
+
+    ERef = nullptr;
 
     ASSERT_NO_FATAL_FAILURE(ERef =
-                                DPCTLQueue_Fill128(QRef, p, val128, 1));
-    ASSERT_FALSE(bool(ERef));
-    */
+                                DPCTLQueue_Memcpy(QRef, host_arr, p, nbytes));
+    ASSERT_NO_FATAL_FAILURE(DPCTLEvent_Wait(ERef));
+    ASSERT_NO_FATAL_FAILURE(DPCTLEvent_Delete(ERef));
+
+    ASSERT_NO_FATAL_FAILURE(DPCTLfree_with_queue(p, QRef));
+
+    bool equal = true;
+    for (size_t i = 0; i < nbytes; ++i) {
+        ASSERT_TRUE(host_arr[i] == val);
+    }
+    delete[] host_arr;
 }
 
 INSTANTIATE_TEST_SUITE_P(


### PR DESCRIPTION
This PR:
1. Implements of `DPCTLQueue_Memset` function.
2. Adds test to 'libsyclinterface/tests' to test this function.