### PR TITLE
Generate coverage should ignore tests from dpctl/tensor/libtensor/tests

### DIFF
--- a/.github/workflows/generate-coverage.yaml
+++ b/.github/workflows/generate-coverage.yaml
@@ -87,22 +87,24 @@ jobs:
           source /opt/intel/oneapi/setvars.sh
           export _SAVED_PATH=${PATH}
           export PATH=$(dirname $(dirname $(which icx)))/bin-llvm:${PATH}
-          python setup.py develop --                                           \
-          -G "Ninja"                                                           \
-          -DCMAKE_BUILD_TYPE=Debug                                             \
-          -DCMAKE_C_COMPILER:PATH=icx                                          \
-          -DCMAKE_CXX_COMPILER:PATH=icpx                                       \
-          -DDPCTL_ENABLE_LO_PROGRAM_CREATION=ON                                \
-          -DDPCTL_GENERATE_COVERAGE=ON                                         \
-          -DDPCTL_BUILD_CAPI_TESTS=ON                                          \
-          -DDPCTL_COVERAGE_REPORT_OUTPUT_DIR=$(pwd)
+          python setup.py develop --                                               \
+              -G "Ninja"                                                           \
+              -DCMAKE_BUILD_TYPE=Debug                                             \
+              -DCMAKE_C_COMPILER:PATH=icx                                          \
+              -DCMAKE_CXX_COMPILER:PATH=icpx                                       \
+              -DDPCTL_ENABLE_LO_PROGRAM_CREATION=ON                                \
+              -DDPCTL_GENERATE_COVERAGE=ON                                         \
+              -DDPCTL_BUILD_CAPI_TESTS=ON                                          \
+              -DDPCTL_COVERAGE_REPORT_OUTPUT_DIR=$(pwd)
           pushd $(find _skbuild -name cmake-build)
           cmake --build . --target lcov-genhtml || exit 1
           popd
           export PATH=${_SAVED_PATH}
           unset _SAVED_PATH
           python -c "import dpctl; print(dpctl.__version__); dpctl.lsplatform()" || exit 1
-          pytest -q -ra --disable-warnings --cov-config pyproject.toml --cov dpctl --cov-report term-missing --pyargs dpctl -vv
+          pytest -q -ra --disable-warnings --cov-config pyproject.toml --cov dpctl \
+              --cov-report term-missing --pyargs dpctl -vv                         \
+              --ignore=dpctl/tensor/libtensor/tests
 
       - name: Install coverall dependencies
         shell: bash -l {0}

--- a/scripts/gen_coverage.py
+++ b/scripts/gen_coverage.py
@@ -99,6 +99,7 @@ def run(
             "--pyargs",
             "dpctl",
             "-vv",
+            "--ignore=dpctl/tensor/libtensor/tests",
         ],
         cwd=setup_dir,
         shell=False,


### PR DESCRIPTION
Those are internal, lengthy tests and do not contribute to coverage report.