### PR TITLE
Add arange function

### DIFF
--- a/dpctl/tensor/__init__.py
+++ b/dpctl/tensor/__init__.py
@@ -22,7 +22,7 @@
 """
 
 from dpctl.tensor._copy_utils import asnumpy, astype, copy, from_numpy, to_numpy
-from dpctl.tensor._ctors import asarray, empty
+from dpctl.tensor._ctors import arange, asarray, empty
 from dpctl.tensor._device import Device
 from dpctl.tensor._dlpack import from_dlpack
 from dpctl.tensor._manipulation_functions import (
@@ -40,6 +40,7 @@ from dpctl.tensor._usmarray import usm_ndarray
 __all__ = [
     "Device",
     "usm_ndarray",
+    "arange",
     "asarray",
     "astype",
     "copy",

--- a/dpctl/tests/test_usm_ndarray_manipulation.py
+++ b/dpctl/tests/test_usm_ndarray_manipulation.py
@@ -725,3 +725,37 @@ def test_roll_2d(data):
     Y = dpt.roll(X, sh, ax)
     Ynp = np.roll(Xnp, sh, ax)
     assert_array_equal(Ynp, dpt.asnumpy(Y))
+
+
+@pytest.mark.parametrize(
+    "dt",
+    [
+        "u1",
+        "i1",
+        "u2",
+        "i2",
+        "u4",
+        "i4",
+        "u8",
+        "i8",
+        "f2",
+        "f4",
+        "f8",
+        "c8",
+        "c16",
+    ],
+)
+def test_arange(dt):
+    try:
+        q = dpctl.SyclQueue()
+    except dpctl.SyclQueueCreationError:
+        pytest.skip("Queue could not be created")
+
+    X = dpt.arange(0, 123, dtype=dt, sycl_queue=q)
+    dt = np.dtype(dt)
+    if np.issubdtype(dt, np.integer):
+        assert int(X[47]) == 47
+    elif np.issubdtype(dt, np.floating):
+        assert float(X[47]) == 47.0
+    elif np.issubdtype(dt, np.complexfloating):
+        assert complex(X[47]) == 47.0 + 0.0j

--- a/dpctl/tests/test_usm_ndarray_manipulation.py
+++ b/dpctl/tests/test_usm_ndarray_manipulation.py
@@ -759,3 +759,6 @@ def test_arange(dt):
         assert float(X[47]) == 47.0
     elif np.issubdtype(dt, np.complexfloating):
         assert complex(X[47]) == 47.0 + 0.0j
+
+    X1 = dpt.arange(4, dtype=dt, sycl_queue=q)
+    assert X1.shape == (4,)

--- a/dpctl/tests/test_utils.py
+++ b/dpctl/tests/test_utils.py
@@ -94,3 +94,20 @@ def test_get_coerced_usm_type():
     assert dpctl.utils.get_coerced_usm_type([]) is None
     with pytest.raises(TypeError):
         dpctl.utils.get_coerced_usm_type(dict())
+
+
+def validate_usm_type_arg():
+    _t = ["device", "shared", "host"]
+
+    for i in range(len(_t)):
+        dpctl.utils.validate_usm_type(_t[i])
+        dpctl.utils.validate_usm_type(_t[i], allow_none=False)
+    dpctl.utils.validate_usm_type(None, allow_none=True)
+    with pytest.raises(TypeError):
+        dpctl.utils.validate_usm_type(dict(), allow_none=True)
+    with pytest.raises(TypeError):
+        dpctl.utils.validate_usm_type(dict(), allow_none=False)
+    with pytest.raises(ValueError):
+        dpctl.utils.validate_usm_type("inv", allow_none=True)
+    with pytest.raises(ValueError):
+        dpctl.utils.validate_usm_type("inv", allow_none=False)

--- a/dpctl/utils/__init__.py
+++ b/dpctl/utils/__init__.py
@@ -18,9 +18,14 @@
 A collection of utility functions.
 """
 
-from ._compute_follows_data import get_coerced_usm_type, get_execution_queue
+from ._compute_follows_data import (
+    get_coerced_usm_type,
+    get_execution_queue,
+    validate_usm_type,
+)
 
 __all__ = [
     "get_execution_queue",
     "get_coerced_usm_type",
+    "validate_usm_type",
 ]

--- a/dpctl/utils/_compute_follows_data.pyx
+++ b/dpctl/utils/_compute_follows_data.pyx
@@ -81,3 +81,39 @@ def get_coerced_usm_type(usm_types):
             return None
         res = min(res, _m[t])
     return _k[res]
+
+
+def _validate_usm_type_allow_none(usm_type):
+    "Validates usm_type argument"
+    if usm_type is not None:
+        if isinstance(usm_type, str):
+            if usm_type not in ["device", "shared", "host"]:
+                raise ValueError(
+                    f"Unrecognized value of usm_type={usm_type}, "
+                    "expected 'device', 'shared', 'host', or None."
+                )
+        else:
+            raise TypeError(
+                f"Expected usm_type to be a str or None, got {type(usm_type)}"
+            )
+
+def _validate_usm_type_disallow_none(usm_type):
+    "Validates usm_type argument"
+    if isinstance(usm_type, str):
+        if usm_type not in ["device", "shared", "host"]:
+            raise ValueError(
+                f"Unrecognized value of usm_type={usm_type}, "
+                "expected 'device', 'shared', or 'host'."
+            )
+    else:
+        raise TypeError(
+            f"Expected usm_type to be a str, got {type(usm_type)}"
+        )
+
+
+def validate_usm_type(usm_type, allow_none=True):
+    "Validates usm_type argument"
+    if allow_none:
+        _validate_usm_type_allow_none(usm_type)
+    else:
+        _validate_usm_type_disallow_none(usm_type)


### PR DESCRIPTION
Adds implementation of `dpctl.tensor.arange` per [array API spec](https://data-apis.org/array-api/latest/API_specification/generated/signatures.creation_functions.arange.html).

Also adds a kernel to be later used for implementation of `linspace` function of the spec.

Adds a test.