### PR TITLE
Hooked up _Memory.memset() method

### DIFF
--- a/dpctl/_backend.pxd
+++ b/dpctl/_backend.pxd
@@ -363,6 +363,11 @@ cdef extern from "syclinterface/dpctl_sycl_queue_interface.h":
         void *Dest,
         const void *Src,
         size_t Count)
+    cdef DPCTLSyclEventRef DPCTLQueue_Memset(
+        const DPCTLSyclQueueRef Q,
+        void *Dest,
+        int Val,
+        size_t Count)
     cdef DPCTLSyclEventRef DPCTLQueue_Prefetch(
         const DPCTLSyclQueueRef Q,
         const void *Src,

--- a/dpctl/memory/_memory.pxd
+++ b/dpctl/memory/_memory.pxd
@@ -47,6 +47,7 @@ cdef public api class _Memory [object Py_MemoryObject, type Py_MemoryType]:
     cpdef copy_to_host(self, object obj=*)
     cpdef copy_from_host(self, object obj)
     cpdef copy_from_device(self, object obj)
+    cpdef memset(self, unsigned short val=*)
 
     cpdef bytes tobytes(self)
 

--- a/dpctl/memory/_memory.pyx
+++ b/dpctl/memory/_memory.pyx
@@ -47,6 +47,7 @@ from dpctl._backend cimport (  # noqa: E211
     DPCTLQueue_Delete,
     DPCTLQueue_GetContext,
     DPCTLQueue_Memcpy,
+    DPCTLQueue_Memset,
     DPCTLSyclContextRef,
     DPCTLSyclDeviceRef,
     DPCTLSyclEventRef,
@@ -477,6 +478,27 @@ cdef class _Memory:
                 )
         else:
             raise TypeError
+
+    cpdef memset(self, unsigned short val = 0):
+        """
+        Populates this USM allocation with given value.
+        """
+        cdef DPCTLSyclEventRef ERef = NULL
+
+        ERef = DPCTLQueue_Memset(
+            self.queue.get_queue_ref(),
+            <void *>self.memory_ptr,  # destination
+            <int> val,
+            self.nbytes)
+
+        if ERef is not NULL:
+            DPCTLEvent_Wait(ERef)
+            DPCTLEvent_Delete(ERef)
+            return
+        else:
+            raise RuntimeError(
+                "Call to memset resulted in an error"
+            )
 
     cpdef bytes tobytes(self):
         """

--- a/dpctl/tests/test_sycl_usm.py
+++ b/dpctl/tests/test_sycl_usm.py
@@ -610,3 +610,28 @@ def test_memory_copy_between_contexts():
     copy_buf = bytearray(256)
     m1.copy_to_host(copy_buf)
     assert host_buf == copy_buf
+
+
+def test_memset():
+    try:
+        q = dpctl.SyclQueue()
+    except dpctl.SyclQueueCreationError:
+        pytest.skip("Default queue could not be created")
+
+    n = 4086
+    m_de = MemoryUSMDevice(n, queue=q)
+    m_sh = MemoryUSMShared(n, queue=q)
+    m_ho = MemoryUSMHost(n, queue=q)
+
+    host_buf = bytearray(n)
+    m_de.memset()
+    m_de.copy_to_host(host_buf)
+    assert host_buf == b"\x00" * n
+
+    m_sh.memset(ord("j"))
+    m_sh.copy_to_host(host_buf)
+    assert host_buf == b"j" * n
+
+    m_ho.memset(ord("7"))
+    m_ho.copy_to_host(host_buf)
+    assert host_buf == b"7" * n


### PR DESCRIPTION
`obj.memset()` fills object with zero bytes.

`obj.memset(val)` fills object with given value (expected to fit in
`unsigned short` type)