### PR TITLE
Adding dpctl.tensor.zeros

### DIFF
--- a/dpctl/tensor/__init__.py
+++ b/dpctl/tensor/__init__.py
@@ -22,7 +22,7 @@
 """
 
 from dpctl.tensor._copy_utils import asnumpy, astype, copy, from_numpy, to_numpy
-from dpctl.tensor._ctors import arange, asarray, empty
+from dpctl.tensor._ctors import arange, asarray, empty, zeros
 from dpctl.tensor._device import Device
 from dpctl.tensor._dlpack import from_dlpack
 from dpctl.tensor._manipulation_functions import (
@@ -45,6 +45,7 @@ __all__ = [
     "astype",
     "copy",
     "empty",
+    "zeros",
     "flip",
     "reshape",
     "roll",

--- a/dpctl/tests/test_usm_ndarray_ctor.py
+++ b/dpctl/tests/test_usm_ndarray_ctor.py
@@ -957,3 +957,27 @@ def test_real_imag_views():
     assert np.array_equal(dpt.to_numpy(X.imag), Xnp.imag)
     assert np.array_equal(dpt.to_numpy(X[1:].real), Xnp[1:].real)
     assert np.array_equal(dpt.to_numpy(X[1:].imag), Xnp[1:].imag)
+
+
+@pytest.mark.parametrize(
+    "dtype",
+    [
+        "b1",
+        "i1",
+        "u1",
+        "i2",
+        "u2",
+        "i4",
+        "u4",
+        "i8",
+        "u8",
+        "f2",
+        "f4",
+        "f8",
+        "c8",
+        "c16",
+    ],
+)
+def test_zeros(dtype):
+    X = dpt.zeros(10, dtype=dtype)
+    assert np.array_equal(dpt.asnumpy(X), np.zeros(10, dtype=dtype))


### PR DESCRIPTION
Implements `zeros` from [array-API specs](https://data-apis.org/array-api/latest/API_specification/generated/signatures.creation_functions.zeros.html):

```python
import dpctl
import dcptl.tensor as dpt

X = dpt.zeros(30, dtype='f4', device="gpu")
```