### PR TITLE
Exported keep_args_alive to dpctl4pybind11

### DIFF
--- a/dpctl/apis/include/dpctl4pybind11.hpp
+++ b/dpctl/apis/include/dpctl4pybind11.hpp
@@ -28,7 +28,9 @@
 #include "dpctl_capi.h"
 #include <CL/sycl.hpp>
 #include <complex>
+#include <memory>
 #include <pybind11/pybind11.h>
+#include <vector>
 
 namespace py = pybind11;
 
@@ -497,4 +499,38 @@ private:
 };
 
 } // end namespace tensor
+
+namespace utils
+{
+
+template <std::size_t num>
+sycl::event keep_args_alive(sycl::queue q,
+                            const py::object (&py_objs)[num],
+                            const std::vector<sycl::event> &depends = {})
+{
+    sycl::event host_task_ev = q.submit([&](sycl::handler &cgh) {
+        cgh.depends_on(depends);
+        std::array<std::shared_ptr<py::handle>, num> shp_arr;
+        for (std::size_t i = 0; i < num; ++i) {
+            shp_arr[i] = std::make_shared<py::handle>(py_objs[i]);
+            shp_arr[i]->inc_ref();
+        }
+        cgh.host_task([=]() {
+            bool guard = (Py_IsInitialized() && !_Py_IsFinalizing());
+            if (guard) {
+                PyGILState_STATE gstate;
+                gstate = PyGILState_Ensure();
+                for (std::size_t i = 0; i < num; ++i) {
+                    shp_arr[i]->dec_ref();
+                }
+                PyGILState_Release(gstate);
+            }
+        });
+    });
+
+    return host_task_ev;
+}
+
+} // end namespace utils
+
 } // end namespace dpctl


### PR DESCRIPTION
 used that in `tensor_py.cpp` and `onemkl_gemv` example.