### PR TITLE
Remove unnecessary arg member of SyclEvent/_SyclEvent classes

### DIFF
--- a/dpctl/_sycl_event.pxd
+++ b/dpctl/_sycl_event.pxd
@@ -30,7 +30,6 @@ cdef public api class _SyclEvent [
     """ Data owner for SyclEvent
     """
     cdef DPCTLSyclEventRef _event_ref
-    cdef object args
 
 
 cdef public api class SyclEvent(_SyclEvent) [
@@ -40,7 +39,7 @@ cdef public api class SyclEvent(_SyclEvent) [
     """ Python wrapper class for a ``cl::sycl::event``
     """
     @staticmethod
-    cdef SyclEvent _create (DPCTLSyclEventRef event, object args=*)
+    cdef SyclEvent _create (DPCTLSyclEventRef event)
     cdef int _init_event_default(self)
     cdef int _init_event_from__SyclEvent(self, _SyclEvent other)
     cdef int _init_event_from_capsule(self, object caps)

--- a/dpctl/_sycl_event.pyx
+++ b/dpctl/_sycl_event.pyx
@@ -100,7 +100,6 @@ cdef class _SyclEvent:
         if (self._event_ref):
             DPCTLEvent_Delete(self._event_ref)
         self._event_ref = NULL
-        self.args = None
 
 
 cdef class SyclEvent(_SyclEvent):
@@ -140,7 +139,7 @@ cdef class SyclEvent(_SyclEvent):
     """
 
     @staticmethod
-    cdef SyclEvent _create(DPCTLSyclEventRef eref, object args=None):
+    cdef SyclEvent _create(DPCTLSyclEventRef eref):
         """"
         This function calls DPCTLEvent_Delete(eref).
 
@@ -149,21 +148,18 @@ cdef class SyclEvent(_SyclEvent):
         """
         cdef _SyclEvent ret = _SyclEvent.__new__(_SyclEvent)
         _init_helper(ret, eref)
-        ret.args=args
         return SyclEvent(ret)
 
     cdef int _init_event_default(self):
         self._event_ref = DPCTLEvent_Create()
         if (self._event_ref is NULL):
             return -1
-        self.args=None
         return 0
 
     cdef int _init_event_from__SyclEvent(self, _SyclEvent other):
         self._event_ref = DPCTLEvent_Copy(other._event_ref)
         if (self._event_ref is NULL):
             return -1
-        self.args = other.args
         return 0
 
     cdef int _init_event_from_capsule(self, object cap):
@@ -183,7 +179,6 @@ cdef class SyclEvent(_SyclEvent):
             if (ERef_copy is NULL):
                 return -3
             self._event_ref = ERef_copy
-            self.args = None
             return 0
         else:
             return -128
@@ -331,7 +326,7 @@ cdef class SyclEvent(_SyclEvent):
         events = []
         for i in range(num_events):
             ERef = DPCTLEventVector_GetAt(EVRef, i)
-            events.append(SyclEvent._create(ERef, args=None))
+            events.append(SyclEvent._create(ERef))
         DPCTLEventVector_Delete(EVRef)
         return events
 

--- a/dpctl/_sycl_queue.pyx
+++ b/dpctl/_sycl_queue.pyx
@@ -845,7 +845,7 @@ cdef class SyclQueue(_SyclQueue):
         # free memory
         free(arg_objects)
 
-        return SyclEvent._create(Eref, [])
+        return SyclEvent._create(Eref)
 
     cpdef void wait(self):
         with nogil: DPCTLQueue_Wait(self._queue_ref)
@@ -996,7 +996,7 @@ cdef class SyclQueue(_SyclQueue):
                 "Barrier submission to Sycl queue failed."
             )
 
-        return SyclEvent._create(ERef, [])
+        return SyclEvent._create(ERef)
 
     @property
     def name(self):


### PR DESCRIPTION
This used to solve the problem of keeps Python arguments that
SYCL kernels work on to stay "alive" for the duration of kernel
execution.

This mechanism was them changed to use host_task, but args member
was not removed.

This should lower the overhead of constructing/destroying SyclEvent
objects.