### PR TITLE
Fix docstring for SyclTimer

### DIFF
--- a/dpctl/_sycl_timer.py
+++ b/dpctl/_sycl_timer.py
@@ -46,8 +46,13 @@ class SyclTimer:
             sycl_dt, wall_dt = timer.dt
 
     Remark:
-        The timer synchronizes the queue at the entrance and the
-        exit of the context.
+        The timer submits barriers to the queue at the entrance and the
+        exit of the context and uses profiling information from events
+        associated with these submissions to perform the timing. Thus
+        :class:`dpctl.SyclTimer` requires the queue with "enable_profiling"
+        property. In order to be able to collect the profiling information
+        the property `dt` ensures that both submitted barriers complete
+        their execution and thus effectively synchronizing the queue.
 
     Args:
         host_timer (callable): A callable such that host_timer() returns current

--- a/dpctl/_sycl_timer.py
+++ b/dpctl/_sycl_timer.py
@@ -46,14 +46,14 @@ class SyclTimer:
             sycl_dt, wall_dt = timer.dt
 
     Remark:
-       The timer synchronizes the queue at the entrance and the
-       exit of the context.
+        The timer synchronizes the queue at the entrance and the
+        exit of the context.
 
     Args:
-       host_timer (callable): A callable such that host_timer() returns current
-       host time in seconds.
-       time_scale (int, float): Ratio of the unit of time of interest and
-       one second.
+        host_timer (callable): A callable such that host_timer() returns current
+            host time in seconds.
+        time_scale (int, float): Ratio of the unit of time of interest and
+            one second.
     """
 
     def __init__(self, host_timer=timeit.default_timer, time_scale=1):


### PR DESCRIPTION
This changes docstring to avoid glitches in formatting:

![image](https://user-images.githubusercontent.com/21087696/165771120-3569ef19-7e17-42dd-ada3-3437ac826646.png)
