### PR TITLE
Profiling timer resolution device property

### DIFF
--- a/dpctl/_backend.pxd
+++ b/dpctl/_backend.pxd
@@ -190,6 +190,7 @@ cdef extern from "syclinterface/dpctl_sycl_device_interface.h":
         const DPCTLSyclDeviceRef DRef,
         _partition_affinity_domain_type PartitionAffinityDomainTy)
     cdef DPCTLSyclDeviceRef DPCTLDevice_GetParentDevice(const DPCTLSyclDeviceRef DRef)
+    cdef size_t DPCTLDevice_GetProfilingTimerResolution(const DPCTLSyclDeviceRef DRef)
 
 
 cdef extern from "syclinterface/dpctl_sycl_device_manager.h":

--- a/dpctl/_sycl_device.pyx
+++ b/dpctl/_sycl_device.pyx
@@ -57,6 +57,7 @@ from ._backend cimport (  # noqa: E211
     DPCTLDevice_GetPreferredVectorWidthInt,
     DPCTLDevice_GetPreferredVectorWidthLong,
     DPCTLDevice_GetPreferredVectorWidthShort,
+    DPCTLDevice_GetProfilingTimerResolution,
     DPCTLDevice_GetSubGroupIndependentForwardProgress,
     DPCTLDevice_GetVendor,
     DPCTLDevice_HasAspect,
@@ -923,6 +924,19 @@ cdef class SyclDevice(_SyclDevice):
         if (pDRef is NULL):
             return None
         return SyclDevice._create(pDRef)
+
+    @property
+    def profiling_timer_resolution(self):
+        """ Profiling timer resolution.
+
+        Returns:
+            int: The resolution of device timer in nanoseconds.
+        """
+        cdef size_t timer_res = 0
+        timer_res = DPCTLDevice_GetProfilingTimerResolution(self._device_ref)
+        if (timer_res == 0):
+            raise RuntimeError("Failed to get device timer resolution.")
+        return timer_res
 
     cdef cpp_bool equals(self, SyclDevice other):
         """ Returns ``True`` if the :class:`dpctl.SyclDevice` argument has the

--- a/dpctl/tests/test_sycl_device.py
+++ b/dpctl/tests/test_sycl_device.py
@@ -485,6 +485,17 @@ def check_repr(device):
     assert type(repr(device)) is str
 
 
+def check_profiling_timer_resolution(device):
+    try:
+        resol = device.profiling_timer_resolution
+    except Exception:
+        pytest.fail(
+            "Encountered an exception inside "
+            "profiling_timer_resolution property."
+        )
+    assert isinstance(resol, int) and resol > 0
+
+
 list_of_checks = [
     check_get_max_compute_units,
     check_get_max_work_item_dims,

--- a/libsyclinterface/include/dpctl_sycl_device_interface.h
+++ b/libsyclinterface/include/dpctl_sycl_device_interface.h
@@ -587,3 +587,14 @@ DPCTLDevice_GetParentDevice(__dpctl_keep const DPCTLSyclDeviceRef DRef);
  */
 DPCTL_API
 size_t DPCTLDevice_Hash(__dpctl_keep const DPCTLSyclDeviceRef DRef);
+
+/*!
+ * @brief Wrapper over
+ * device.get_info<info::device::profiling_timer_resolution>
+ *
+ * @param    DRef           Opaque pointer to a sycl::device
+ * @return   Returns the resolution of device timer in nanoseconds.
+ */
+DPCTL_API
+size_t DPCTLDevice_GetProfilingTimerResolution(
+    __dpctl_keep const DPCTLSyclDeviceRef DRef);

--- a/libsyclinterface/source/dpctl_sycl_device_interface.cpp
+++ b/libsyclinterface/source/dpctl_sycl_device_interface.cpp
@@ -648,3 +648,16 @@ size_t DPCTLDevice_Hash(__dpctl_keep const DPCTLSyclDeviceRef DRef)
         return 0;
     }
 }
+
+size_t DPCTLDevice_GetProfilingTimerResolution(
+    __dpctl_keep const DPCTLSyclDeviceRef DRef)
+{
+    if (DRef) {
+        auto D = unwrap(DRef);
+        return D->get_info<info::device::profiling_timer_resolution>();
+    }
+    else {
+        error_handler("Argument DRef is null", __FILE__, __func__, __LINE__);
+        return 0;
+    }
+}

--- a/libsyclinterface/tests/test_sycl_device_interface.cpp
+++ b/libsyclinterface/tests/test_sycl_device_interface.cpp
@@ -375,6 +375,14 @@ TEST_P(TestDPCTLSyclDeviceInterface, ChkGetParentDevice)
     EXPECT_TRUE(pDRef == nullptr);
 }
 
+TEST_P(TestDPCTLSyclDeviceInterface, ChkGetProfilingTimerResolution)
+{
+    size_t res = 0;
+    EXPECT_NO_FATAL_FAILURE(res =
+                                DPCTLDevice_GetProfilingTimerResolution(DRef));
+    EXPECT_TRUE(res != 0);
+}
+
 INSTANTIATE_TEST_SUITE_P(DPCTLDeviceFns,
                          TestDPCTLSyclDeviceInterface,
                          ::testing::Values("opencl",
@@ -672,4 +680,12 @@ TEST_F(TestDPCTLSyclDeviceNullArgs, ChkHash)
     size_t hash = 0;
     EXPECT_NO_FATAL_FAILURE(hash = DPCTLDevice_Hash(Null_DRef));
     ASSERT_TRUE(hash == 0);
+}
+
+TEST_F(TestDPCTLSyclDeviceNullArgs, ChkGetProfilingTimerResolution)
+{
+    size_t res = 1;
+    EXPECT_NO_FATAL_FAILURE(
+        res = DPCTLDevice_GetProfilingTimerResolution(Null_DRef));
+    ASSERT_TRUE(res == 0);
 }


### PR DESCRIPTION
This adds a `DPCTLDevice_GetProfilingTimerResolution` public function to export `device::get_info<info::device::profiling_timer_resolution>()`.

Expose this property to `dpctl.SyclDevice`. Added tests to both SyclInterface library and pytest,