### PR TITLE
Refine gemv example

### DIFF
--- a/examples/pybind11/onemkl_gemv/sycl_gemm/_onemkl.cpp
+++ b/examples/pybind11/onemkl_gemv/sycl_gemm/_onemkl.cpp
@@ -497,6 +497,7 @@ py::object py_dot_blocking(sycl::queue q,
             reinterpret_cast<const T *>(v2_typeless_ptr), 1, res_usm, depends);
         T res_v{};
         q.copy<T>(res_usm, &res_v, 1, {dot_ev}).wait_and_throw();
+        sycl::free(res_usm, q);
         res = py::float_(res_v);
     }
     else if (v1_typenum == UAR_FLOAT) {
@@ -507,6 +508,7 @@ py::object py_dot_blocking(sycl::queue q,
             reinterpret_cast<const T *>(v2_typeless_ptr), 1, res_usm, depends);
         T res_v(0);
         q.copy<T>(res_usm, &res_v, 1, {dot_ev}).wait_and_throw();
+        sycl::free(res_usm, q);
         res = py::float_(res_v);
     }
     else if (v1_typenum == UAR_CDOUBLE) {
@@ -517,6 +519,7 @@ py::object py_dot_blocking(sycl::queue q,
             reinterpret_cast<const T *>(v2_typeless_ptr), 1, res_usm, depends);
         T res_v{};
         q.copy<T>(res_usm, &res_v, 1, {dotc_ev}).wait_and_throw();
+        sycl::free(res_usm, q);
         res = py::cast(res_v);
     }
     else if (v1_typenum == UAR_CFLOAT) {
@@ -527,6 +530,7 @@ py::object py_dot_blocking(sycl::queue q,
             reinterpret_cast<const T *>(v2_typeless_ptr), 1, res_usm, depends);
         T res_v{};
         q.copy<T>(res_usm, &res_v, 1, {dotc_ev}).wait_and_throw();
+        sycl::free(res_usm, q);
         res = py::cast(res_v);
     }
     else {


### PR DESCRIPTION
This PR modifies `pybind11/onemkl_gemv` example by 
    - plugging a device memory leak
    - fixing `cg_solve` in solve.py to create temporaries using the same allocation queue as input arrays
    - renaming C++ variables for clarity in `cg_solver.hpp`
    - restructuring `sycl_timing_solver.py` to easily allow to comment out python/cpp portion invocations.

- [X] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [X] Have you tested your changes locally for CPU and GPU devices?
- [X] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
