### PR TITLE
endfunction must use matching name or warnings

### DIFF
--- a/libsyclinterface/cmake/modules/FindIntelSycl.cmake
+++ b/libsyclinterface/cmake/modules/FindIntelSycl.cmake
@@ -79,7 +79,7 @@ function(versions_greater_equal VERSION_STR1 VERSION_STR2 OUTPUT)
             set(${OUTPUT} TRUE PARENT_SCOPE)
         endif()
     endforeach()
-endfunction(compare_versions)
+endfunction(versions_greater_equal)
 
 # Check if dpcpp is available
 execute_process(


### PR DESCRIPTION
This fixes CMake dev-warnings about mismatch in the name at the beginning of the function definition, and used in `endfunction`. 

Any CMake run would reproduce the warning.


- [X] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [X] Have you tested your changes locally for CPU and GPU devices?
- [X] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
