### PR TITLE
Fix errors and warnings in asserts

### DIFF
--- a/dpctl/tensor/libtensor/include/utils/type_dispatch.hpp
+++ b/dpctl/tensor/libtensor/include/utils/type_dispatch.hpp
@@ -80,7 +80,7 @@ private:
             factory<funcPtrT, dstTy, double>{}.get(),
             factory<funcPtrT, dstTy, std::complex<float>>{}.get(),
             factory<funcPtrT, dstTy, std::complex<double>>{}.get()};
-        assert(per_dsTy.size() == _num_types);
+        assert(per_dstTy.size() == _num_types);
         return per_dstTy;
     }
 

--- a/dpctl/tensor/libtensor/source/tensor_py.cpp
+++ b/dpctl/tensor/libtensor/source/tensor_py.cpp
@@ -411,9 +411,9 @@ void simplify_iteration_space(int &nd,
             }
         }
 
-        assert(simplified_shape.size() == nd);
-        assert(simplified_src_strides.size() == nd);
-        assert(simplified_dst_strides.size() == nd);
+        assert(simplified_shape.size() == static_cast<size_t>(nd));
+        assert(simplified_src_strides.size() == static_cast<size_t>(nd));
+        assert(simplified_dst_strides.size() == static_cast<size_t>(nd));
         int contracted_nd = simplify_iteration_two_strides(
             nd, simplified_shape.data(), simplified_src_strides.data(),
             simplified_dst_strides.data(),
@@ -472,9 +472,9 @@ void simplify_iteration_space(int &nd,
             simplified_dst_strides.push_back(dst_strides[0]);
         }
 
-        assert(simplified_shape.size() == nd);
-        assert(simplified_src_strides.size() == nd);
-        assert(simplified_dst_strides.size() == nd);
+        assert(simplified_shape.size() == static_cast<size_t>(nd));
+        assert(simplified_src_strides.size() == static_cast<size_t>(nd));
+        assert(simplified_dst_strides.size() == static_cast<size_t>(nd));
     }
 }
 
@@ -1329,9 +1329,9 @@ void copy_numpy_ndarray_into_usm_ndarray(
                              simplified_shape, simplified_src_strides,
                              simplified_dst_strides, src_offset, dst_offset);
 
-    assert(simplified_shape.size() == nd);
-    assert(simplified_src_strides.size() == nd);
-    assert(simplified_dst_strides.size() == nd);
+    assert(simplified_shape.size() == static_cast<size_t>(nd));
+    assert(simplified_src_strides.size() == static_cast<size_t>(nd));
+    assert(simplified_dst_strides.size() == static_cast<size_t>(nd));
 
     // handle nd == 0
     if (nd == 0) {


### PR DESCRIPTION
There was a typo in one of the assertions, and numerous comparisons between signed and unsigned types.
Recent fix to build_locally.py (#835) uncovered these, and this PR fixes the error and addresses the warnings,

- [X] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [X] Have you tested your changes locally for CPU and GPU devices?
- [X] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
