### PR TITLE
Improve type casters

### DIFF
--- a/dpctl/tensor/_device.py
+++ b/dpctl/tensor/_device.py
@@ -22,8 +22,8 @@ class Device:
 
     This is a wrapper around :class:`dpctl.SyclQueue` with custom
     formatting. The class does not have public constructor,
-    but a class method to construct it from device= keyword
-    in Array-API functions.
+    but a class method `create_device` to construct it from device= keyword
+    argument in Array-API functions.
 
     Instance can be queried for ``sycl_queue``, ``sycl_context``,
     or ``sycl_device``.
@@ -110,6 +110,12 @@ class Device:
         except TypeError:
             # This is a sub-device
             return repr(self.sycl_queue)
+
+    def wait(self):
+        """
+        Call ``wait`` method of the underlying ``sycl_queue``.
+        """
+        self.sycl_queue_.wait()
 
 
 def normalize_queue_device(sycl_queue=None, device=None):

--- a/dpctl/tensor/libtensor/source/tensor_py.cpp
+++ b/dpctl/tensor/libtensor/source/tensor_py.cpp
@@ -1946,28 +1946,34 @@ PYBIND11_MODULE(_tensor_impl, m)
           py::arg("fill_value"), py::arg("dst"), py::arg("sycl_queue"),
           py::arg("depends") = py::list());
 
-    m.def("default_device_fp_type", [](sycl::queue q) {
+    m.def("default_device_fp_type", [](sycl::queue q) -> std::string {
         return get_default_device_fp_type(q.get_device());
     });
-    m.def("default_device_fp_type",
-          [](sycl::device dev) { return get_default_device_fp_type(dev); });
+    m.def("default_device_fp_type_device", [](sycl::device dev) -> std::string {
+        return get_default_device_fp_type(dev);
+    });
 
-    m.def("default_device_int_type", [](sycl::queue q) {
+    m.def("default_device_int_type", [](sycl::queue q) -> std::string {
         return get_default_device_int_type(q.get_device());
     });
-    m.def("default_device_int_type",
-          [](sycl::device dev) { return get_default_device_int_type(dev); });
+    m.def("default_device_int_type_device",
+          [](sycl::device dev) -> std::string {
+              return get_default_device_int_type(dev);
+          });
 
-    m.def("default_device_bool_type", [](sycl::queue q) {
+    m.def("default_device_bool_type", [](sycl::queue q) -> std::string {
         return get_default_device_bool_type(q.get_device());
     });
-    m.def("default_device_bool_type",
-          [](sycl::device dev) { return get_default_device_bool_type(dev); });
+    m.def("default_device_bool_type_device",
+          [](sycl::device dev) -> std::string {
+              return get_default_device_bool_type(dev);
+          });
 
-    m.def("default_device_complex_type", [](sycl::queue q) {
+    m.def("default_device_complex_type", [](sycl::queue q) -> std::string {
         return get_default_device_complex_type(q.get_device());
     });
-    m.def("default_device_complex_type", [](sycl::device dev) {
-        return get_default_device_complex_type(dev);
-    });
+    m.def("default_device_complex_type_device",
+          [](sycl::device dev) -> std::string {
+              return get_default_device_complex_type(dev);
+          });
 }


### PR DESCRIPTION
Improved efficiency of pybind11 classes and type casters. 

Type casters in pybind11 generated with `PYBIND11_TYPE_CASTER` macro rely on default constructor of C++ type. The default constructed value is then overwritten by `load`  method. C++ types such as `sycl::device` and `sycl::queue` do non-trivial amount of work in default constructor. This work was ranking high in certain workloads (such as `example/pybind11/onemkl_gemv/sycl_timing_solver.py`).

Same applies to auto-generated type-casters for classes `dpctl::memory::usm_memory` and `dpctl::tensor::usm_ndarray`.

This PR introduces DPCTL_TYPE_CASTER macro that defines `unique_ptr` to the C++ type, rather than the type itself. This avoids superfluous call to default constructor altogether.

Instead of redefining `pyobject_caster` automatically generated for `dpctl::tensor::usm_ndarray` and `dpctl::memory::usm_memory` a singleton class `dpctl::detail::dpctl_api` is added that creates objects used by default constructors of these classes.

- [X] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [X] Have you tested your changes locally for CPU and GPU devices?
- [X] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
