### PR TITLE
Removed extraneous argument in __lrshift__ special method

### DIFF
--- a/dpctl/tensor/_usmarray.pyx
+++ b/dpctl/tensor/_usmarray.pyx
@@ -961,7 +961,7 @@ cdef class usm_ndarray:
     def __rfloordiv__(self, other):
         return _dispatch_binary_elementwise2(other, "floor_divide", self)
 
-    def __rlshift__(self, other, mod):
+    def __rlshift__(self, other):
         return _dispatch_binary_elementwise2(other, "left_shift", self)
 
     def __rmatmul__(self, other):
@@ -976,10 +976,10 @@ cdef class usm_ndarray:
     def __ror__(self, other):
         return _dispatch_binary_elementwise(self, "logical_or", other)
 
-    def __rpow__(self, other, mod):
+    def __rpow__(self, other):
         return _dispatch_binary_elementwise2(other, "power", self)
 
-    def __rrshift__(self, other, mod):
+    def __rrshift__(self, other):
         return _dispatch_binary_elementwise2(other, "right_shift", self)
 
     def __rsub__(self, other):


### PR DESCRIPTION
This PR fixes extraneous argument in `__lrshift__` special method which was revealed by changes in Cython 0.29.29 and caught by existing tests.

- [X] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [X] Have you tested your changes locally for CPU and GPU devices?
- [X] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
