### PR TITLE
Catch exceptions that sycl::program::program can throw

### DIFF
--- a/libsyclinterface/source/dpctl_sycl_program_interface.cpp
+++ b/libsyclinterface/source/dpctl_sycl_program_interface.cpp
@@ -256,7 +256,12 @@ DPCTLProgram_CreateFromOCLSource(__dpctl_keep const DPCTLSyclContextRef Ctx,
     }
 
     SyclCtx = unwrap(Ctx);
-    SyclProgram = new program(*SyclCtx);
+    try {
+        SyclProgram = new program(*SyclCtx);
+    } catch (std::exception const &e) {
+        error_handler(e, __FILE__, __func__, __LINE__);
+        return nullptr;
+    }
     std::string source = Source;
 
     if (CompileOpts) {


### PR DESCRIPTION
Since call to `sycl::program` constructor can throw exceptions, use try/catch around the call.

One exception I encountered was when using a multi-device context, which is not supported by the deprecated `sycl::program` class.

- [X] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [X] Have you tested your changes locally for CPU and GPU devices?
- [X] Have you made sure that new changes do not introduce compiler warnings?
