### PR TITLE
Fixed bug in dpctl.tensor.arange, streamlined tests

### DIFF
--- a/dpctl/tensor/_ctors.py
+++ b/dpctl/tensor/_ctors.py
@@ -547,7 +547,8 @@ def arange(
     )
     _step = (start + step) - start
     _step = dt.type(_step)
-    hev, _ = ti._linspace_step(start, _step, res, sycl_queue)
+    _start = dt.type(start)
+    hev, _ = ti._linspace_step(_start, _step, res, sycl_queue)
     hev.wait()
     return res
 

--- a/dpctl/tests/test_usm_ndarray_ctor.py
+++ b/dpctl/tests/test_usm_ndarray_ctor.py
@@ -985,11 +985,13 @@ def test_arange(dt):
     elif np.issubdtype(dt, np.complexfloating):
         assert complex(X[47]) == 47.0 + 0.0j
 
-    X1 = dpt.arange(4, dtype=dt, sycl_queue=q)
-    assert X1.shape == (4,)
+    # choose size larger than maximal value that u1/u2 can accomodate
+    sz = int(np.iinfo(np.int16).max) + 1
+    X1 = dpt.arange(sz, dtype=dt, sycl_queue=q)
+    assert X1.shape == (sz,)
 
-    X2 = dpt.arange(4, 0, -1, dtype=dt, sycl_queue=q)
-    assert X2.shape == (4,)
+    X2 = dpt.arange(sz, 0, -1, dtype=dt, sycl_queue=q)
+    assert X2.shape == (sz,)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
While modifying tests to use `dpctl.tensor.arange` I encountered exception when starting value was outside of the range of the elemental data-type, e.g. `dpctl.tensor.arange(128, 0, -1, dtype='i1')`.

This PR fixes the issue by coercing the starting point to the elemental data-type scalar. 
A test of `arange` was modified to cover such input. 

Tests in `test_sycl_event` and `test_sycl_kernel_submit` were modified to use `dpctl.tensor.arange` as opposed to using `numpy.arange` and copying the content into a `MemoryUSMShared` allocation.

- [X] Have you provided a meaningful PR description?
- [X] Have you added a test, reproducer or referred to an issue with a reproducer?
- [X] Have you tested your changes locally for CPU and GPU devices?
- [X] Have you made sure that new changes do not introduce compiler warnings?
