### PR TITLE
Remove deprecated aspects related to atomics, added supported aspects

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -13,7 +13,7 @@ build:
 requirements:
     build:
         - {{ compiler('cxx') }}
-        - {{ compiler('dpcpp') }}  # [not osx]
+        - {{ compiler('dpcpp') }}  >=2022.1  # [not osx]
     host:
         - setuptools
         - cython

--- a/dpctl/_backend.pxd
+++ b/dpctl/_backend.pxd
@@ -83,8 +83,7 @@ cdef extern from "syclinterface/dpctl_sycl_enum_types.h":
         _custom                             'custom',
         _fp16                               'fp16',
         _fp64                               'fp64',
-        _int64_base_atomics                 'int64_base_atomics',
-        _int64_extended_atomics             'int64_extended_atomics',
+        _atomic64                           'atomic64',
         _image                              'image',
         _online_compiler                    'online_compiler',
         _online_linker                      'online_linker',
@@ -93,7 +92,10 @@ cdef extern from "syclinterface/dpctl_sycl_enum_types.h":
         _usm_host_allocations               'usm_host_allocations',
         _usm_shared_allocations             'usm_shared_allocations',
         _usm_restricted_shared_allocations  'usm_restricted_shared_allocations',
-        _usm_system_allocations             'usm_system_allocations'
+        _usm_system_allocations             'usm_system_allocations',
+        _usm_atomic_host_allocations        'usm_atomic_host_allocations',
+        _usm_atomic_shared_allocations      'usm_atomic_shared_allocations',
+        _host_debuggable                    'host_debuggable',
 
     ctypedef enum _partition_affinity_domain_type 'DPCTLPartitionAffinityDomainType':
         _not_applicable                     'not_applicable',

--- a/dpctl/_sycl_device.pyx
+++ b/dpctl/_sycl_device.pyx
@@ -420,13 +420,8 @@ cdef class SyclDevice(_SyclDevice):
         return DPCTLDevice_HasAspect(self._device_ref, AT)
 
     @property
-    def has_aspect_int64_base_atomics(self):
-        cdef _aspect_type AT = _aspect_type._int64_base_atomics
-        return DPCTLDevice_HasAspect(self._device_ref, AT)
-
-    @property
-    def has_aspect_int64_extended_atomics(self):
-        cdef _aspect_type AT = _aspect_type._int64_extended_atomics
+    def has_aspect_atomic64(self):
+        cdef _aspect_type AT = _aspect_type._atomic64
         return DPCTLDevice_HasAspect(self._device_ref, AT)
 
     @property
@@ -472,6 +467,21 @@ cdef class SyclDevice(_SyclDevice):
     @property
     def has_aspect_usm_system_allocations(self):
         cdef _aspect_type AT = _aspect_type._usm_system_allocations
+        return DPCTLDevice_HasAspect(self._device_ref, AT)
+
+    @property
+    def has_aspect_usm_atomic_host_allocations(self):
+        cdef _aspect_type AT = _aspect_type._usm_atomic_host_allocations
+        return DPCTLDevice_HasAspect(self._device_ref, AT)
+
+    @property
+    def has_aspect_usm_atomic_shared_allocations(self):
+        cdef _aspect_type AT = _aspect_type._usm_atomic_shared_allocations
+        return DPCTLDevice_HasAspect(self._device_ref, AT)
+
+    @property
+    def has_aspect_host_debuggable(self):
+        cdef _aspect_type AT = _aspect_type._host_debuggable
         return DPCTLDevice_HasAspect(self._device_ref, AT)
 
     @property

--- a/dpctl/tests/test_sycl_device.py
+++ b/dpctl/tests/test_sycl_device.py
@@ -149,18 +149,11 @@ def check_has_aspect_fp64(device):
         pytest.fail("has_aspect_fp64 call failed")
 
 
-def check_has_aspect_int64_base_atomics(device):
+def check_has_aspect_atomic64(device):
     try:
-        device.has_aspect_int64_base_atomics
+        device.has_aspect_atomic64
     except Exception:
-        pytest.fail("has_aspect_int64_base_atomics call failed")
-
-
-def check_has_aspect_int64_extended_atomics(device):
-    try:
-        device.has_aspect_int64_extended_atomics
-    except Exception:
-        pytest.fail("has_aspect_int64_extended_atomics call failed")
+        pytest.fail("has_aspect_atomic64 call failed")
 
 
 def check_has_aspect_image(device):
@@ -224,6 +217,27 @@ def check_has_aspect_usm_system_allocations(device):
         device.has_aspect_usm_system_allocations
     except Exception:
         pytest.fail("has_aspect_usm_system_allocations call failed")
+
+
+def check_has_aspect_usm_atomic_host_allocations(device):
+    try:
+        device.has_aspect_usm_atomic_host_allocations
+    except Exception:
+        pytest.fail("has_aspect_usm_atomic_host_allocations call failed")
+
+
+def check_has_aspect_usm_atomic_shared_allocations(device):
+    try:
+        device.has_aspect_usm_atomic_shared_allocations
+    except Exception:
+        pytest.fail("has_aspect_usm_atomic_shared_allocations call failed")
+
+
+def check_has_aspect_host_debuggable(device):
+    try:
+        device.has_aspect_host_debuggable
+    except Exception:
+        pytest.fail("has_aspect_host_debuggable call failed")
 
 
 def check_is_accelerator(device):
@@ -526,8 +540,7 @@ list_of_checks = [
     check_has_aspect_custom,
     check_has_aspect_fp16,
     check_has_aspect_fp64,
-    check_has_aspect_int64_base_atomics,
-    check_has_aspect_int64_extended_atomics,
+    check_has_aspect_atomic64,
     check_has_aspect_image,
     check_has_aspect_online_compiler,
     check_has_aspect_online_linker,
@@ -537,6 +550,9 @@ list_of_checks = [
     check_has_aspect_usm_shared_allocations,
     check_has_aspect_usm_restricted_shared_allocations,
     check_has_aspect_usm_system_allocations,
+    check_has_aspect_usm_atomic_host_allocations,
+    check_has_aspect_usm_atomic_shared_allocations,
+    check_has_aspect_host_debuggable,
     check_get_max_read_image_args,
     check_get_max_write_image_args,
     check_get_image_2d_max_width,
@@ -703,16 +719,16 @@ list_of_supported_aspects = [
     "usm_host_allocations",
     "usm_shared_allocations",
     "usm_system_allocations",
+    "host_debuggable",
+    "atomic64",
+    "usm_atomic_host_allocations",
+    "usm_atomic_shared_allocations",
 ]
 
 # SYCL 2020 spec aspects not presently
 # supported in DPC++, and dpctl
 list_of_unsupported_aspects = [
     "emulated",
-    "host_debuggable",
-    "atomic64",
-    "usm_atomic_host_allocations",
-    "usm_atomic_shared_allocations",
 ]
 
 

--- a/dpctl/tests/test_sycl_queue.py
+++ b/dpctl/tests/test_sycl_queue.py
@@ -141,18 +141,11 @@ def check_has_aspect_fp64(device):
         pytest.fail("has_aspect_fp64 call failed")
 
 
-def check_has_aspect_int64_base_atomics(device):
+def check_has_aspect_atomic64(device):
     try:
-        device.has_aspect_int64_base_atomics
+        device.has_aspect_atomic64
     except Exception:
-        pytest.fail("has_aspect_int64_base_atomics call failed")
-
-
-def check_has_aspect_int64_extended_atomics(device):
-    try:
-        device.has_aspect_int64_extended_atomics
-    except Exception:
-        pytest.fail("has_aspect_int64_extended_atomics call failed")
+        pytest.fail("has_aspect_atomic64 call failed")
 
 
 def check_has_aspect_image(device):
@@ -218,6 +211,27 @@ def check_has_aspect_usm_system_allocations(device):
         pytest.fail("has_aspect_usm_system_allocations call failed")
 
 
+def check_has_aspect_usm_atomic_host_allocations(device):
+    try:
+        device.has_aspect_usm_atomic_host_allocations
+    except Exception:
+        pytest.fail("has_aspect_usm_atomic_host_allocations call failed")
+
+
+def check_has_aspect_usm_atomic_shared_allocations(device):
+    try:
+        device.has_aspect_usm_atomic_shared_allocations
+    except Exception:
+        pytest.fail("has_aspect_usm_atomic_shared_allocations call failed")
+
+
+def check_has_aspect_host_debuggable(device):
+    try:
+        device.has_aspect_host_debuggable
+    except Exception:
+        pytest.fail("has_aspect_host_debuggable call failed")
+
+
 def check_is_accelerator(device):
     try:
         device.is_accelerator
@@ -263,8 +277,7 @@ list_of_checks = [
     check_has_aspect_custom,
     check_has_aspect_fp16,
     check_has_aspect_fp64,
-    check_has_aspect_int64_base_atomics,
-    check_has_aspect_int64_extended_atomics,
+    check_has_aspect_atomic64,
     check_has_aspect_image,
     check_has_aspect_online_compiler,
     check_has_aspect_online_linker,
@@ -274,6 +287,9 @@ list_of_checks = [
     check_has_aspect_usm_shared_allocations,
     check_has_aspect_usm_restricted_shared_allocations,
     check_has_aspect_usm_system_allocations,
+    check_has_aspect_usm_atomic_host_allocations,
+    check_has_aspect_usm_atomic_shared_allocations,
+    check_has_aspect_host_debuggable,
 ]
 
 

--- a/libsyclinterface/helper/source/dpctl_utils_helper.cpp
+++ b/libsyclinterface/helper/source/dpctl_utils_helper.cpp
@@ -191,11 +191,8 @@ std::string DPCTL_AspectToStr(aspect aspectTy)
     case aspect::fp64:
         ss << "fp64";
         break;
-    case aspect::int64_base_atomics:
-        ss << "int64_base_atomics";
-        break;
-    case aspect::int64_extended_atomics:
-        ss << "int64_extended_atomics";
+    case aspect::atomic64:
+        ss << "atomic64";
         break;
     case aspect::image:
         ss << "image";
@@ -223,6 +220,15 @@ std::string DPCTL_AspectToStr(aspect aspectTy)
         break;
     case aspect::usm_system_allocations:
         ss << "usm_system_allocations";
+        break;
+    case aspect::usm_atomic_host_allocations:
+        ss << "usm_atomic_host_allocations";
+        break;
+    case aspect::usm_atomic_shared_allocations:
+        ss << "usm_atomic_shared_allocations";
+        break;
+    case aspect::host_debuggable:
+        ss << "host_debuggable";
         break;
     default:
         throw std::runtime_error("Unsupported aspect type");
@@ -257,11 +263,8 @@ aspect DPCTL_StrToAspectType(const std::string &aspectTyStr)
     else if (aspectTyStr == "fp64") {
         aspectTy = aspect::fp64;
     }
-    else if (aspectTyStr == "int64_base_atomics") {
-        aspectTy = aspect::int64_base_atomics;
-    }
-    else if (aspectTyStr == "int64_extended_atomics") {
-        aspectTy = aspect::int64_extended_atomics;
+    else if (aspectTyStr == "atomic64") {
+        aspectTy = aspect::atomic64;
     }
     else if (aspectTyStr == "image") {
         aspectTy = aspect::image;
@@ -290,6 +293,15 @@ aspect DPCTL_StrToAspectType(const std::string &aspectTyStr)
     else if (aspectTyStr == "usm_system_allocations") {
         aspectTy = aspect::usm_system_allocations;
     }
+    else if (aspectTyStr == "usm_atomic_host_allocations") {
+        aspectTy = aspect::usm_atomic_host_allocations;
+    }
+    else if (aspectTyStr == "usm_atomic_shared_allocations") {
+        aspectTy = aspect::usm_atomic_shared_allocations;
+    }
+    else if (aspectTyStr == "host_debuggable") {
+        aspectTy = aspect::host_debuggable;
+    }
     else {
         // \todo handle the error
         throw std::runtime_error("Unsupported aspect type");
@@ -314,10 +326,8 @@ aspect DPCTL_DPCTLAspectTypeToSyclAspect(DPCTLSyclAspectType AspectTy)
         return aspect::fp16;
     case DPCTLSyclAspectType::fp64:
         return aspect::fp64;
-    case DPCTLSyclAspectType::int64_base_atomics:
-        return aspect::int64_base_atomics;
-    case DPCTLSyclAspectType::int64_extended_atomics:
-        return aspect::int64_extended_atomics;
+    case DPCTLSyclAspectType::atomic64:
+        return aspect::atomic64;
     case DPCTLSyclAspectType::image:
         return aspect::image;
     case DPCTLSyclAspectType::online_compiler:
@@ -336,6 +346,12 @@ aspect DPCTL_DPCTLAspectTypeToSyclAspect(DPCTLSyclAspectType AspectTy)
         return aspect::usm_restricted_shared_allocations;
     case DPCTLSyclAspectType::usm_system_allocations:
         return aspect::usm_system_allocations;
+    case DPCTLSyclAspectType::usm_atomic_host_allocations:
+        return aspect::usm_atomic_host_allocations;
+    case DPCTLSyclAspectType::usm_atomic_shared_allocations:
+        return aspect::usm_atomic_shared_allocations;
+    case DPCTLSyclAspectType::host_debuggable:
+        return aspect::host_debuggable;
     default:
         throw std::runtime_error("Unsupported aspect type");
     }
@@ -358,10 +374,8 @@ DPCTLSyclAspectType DPCTL_SyclAspectToDPCTLAspectType(aspect Aspect)
         return DPCTLSyclAspectType::fp16;
     case aspect::fp64:
         return DPCTLSyclAspectType::fp64;
-    case aspect::int64_base_atomics:
-        return DPCTLSyclAspectType::int64_base_atomics;
-    case aspect::int64_extended_atomics:
-        return DPCTLSyclAspectType::int64_extended_atomics;
+    case aspect::atomic64:
+        return DPCTLSyclAspectType::atomic64;
     case aspect::image:
         return DPCTLSyclAspectType::image;
     case aspect::online_compiler:
@@ -380,6 +394,12 @@ DPCTLSyclAspectType DPCTL_SyclAspectToDPCTLAspectType(aspect Aspect)
         return DPCTLSyclAspectType::usm_restricted_shared_allocations;
     case aspect::usm_system_allocations:
         return DPCTLSyclAspectType::usm_system_allocations;
+    case aspect::usm_atomic_host_allocations:
+        return DPCTLSyclAspectType::usm_atomic_host_allocations;
+    case aspect::usm_atomic_shared_allocations:
+        return DPCTLSyclAspectType::usm_atomic_shared_allocations;
+    case aspect::host_debuggable:
+        return DPCTLSyclAspectType::host_debuggable;
     default:
         throw std::runtime_error("Unsupported aspect type");
     }

--- a/libsyclinterface/include/dpctl_sycl_enum_types.h
+++ b/libsyclinterface/include/dpctl_sycl_enum_types.h
@@ -109,8 +109,7 @@ typedef enum
     custom,
     fp16,
     fp64,
-    int64_base_atomics,
-    int64_extended_atomics,
+    atomic64,
     image,
     online_compiler,
     online_linker,
@@ -119,7 +118,10 @@ typedef enum
     usm_host_allocations,
     usm_shared_allocations,
     usm_restricted_shared_allocations,
-    usm_system_allocations
+    usm_system_allocations,
+    usm_atomic_host_allocations,
+    usm_atomic_shared_allocations,
+    host_debuggable,
 } DPCTLSyclAspectType;
 
 /*!

--- a/libsyclinterface/tests/test_sycl_device_aspects.cpp
+++ b/libsyclinterface/tests/test_sycl_device_aspects.cpp
@@ -82,10 +82,7 @@ auto build_params()
             std::make_pair("custom", cl::sycl::aspect::custom),
             std::make_pair("fp16", cl::sycl::aspect::fp16),
             std::make_pair("fp64", cl::sycl::aspect::fp64),
-            std::make_pair("int64_base_atomics",
-                           cl::sycl::aspect::int64_base_atomics),
-            std::make_pair("int64_extended_atomics",
-                           cl::sycl::aspect::int64_extended_atomics),
+            std::make_pair("atomic64", cl::sycl::aspect::atomic64),
             std::make_pair("online_compiler",
                            cl::sycl::aspect::online_compiler),
             std::make_pair("online_linker", cl::sycl::aspect::online_linker),
@@ -100,7 +97,13 @@ auto build_params()
             std::make_pair("usm_restricted_shared_allocations",
                            cl::sycl::aspect::usm_restricted_shared_allocations),
             std::make_pair("usm_system_allocations",
-                           cl::sycl::aspect::usm_system_allocations));
+                           cl::sycl::aspect::usm_system_allocations),
+            std::make_pair("usm_atomic_host_allocations",
+                           cl::sycl::aspect::usm_atomic_host_allocations),
+            std::make_pair("usm_atomic_shared_allocations",
+                           cl::sycl::aspect::usm_atomic_shared_allocations),
+            std::make_pair("host_debuggable",
+                           cl::sycl::aspect::host_debuggable));
 
     auto pairs =
         build_param_pairs<const char *,


### PR DESCRIPTION
From gh-309 only emulated aspect remains unsupported.

The following aspects from gh-309 are now supported

```c++
   sycl::aspect::host_debuggable,
   sycl::aspect::atomic64,
   sycl::aspect::usm_atomic_host_allocations,
   sycl::aspect::usm_atomic_shared_allocations,
```

Removed (due to deprecation in DPC++) aspects are

```c++
    int64_base_atomics
    int64_extended_atomics
```
- [X] Verified that neither `numba-dpex` for `dpnp` make use of removed aspects.

----

- [X] Have you provided a meaningful PR description?
- [X] Have you added a test, reproducer or referred to an issue with a reproducer?
- [X] Have you tested your changes locally for CPU and GPU devices?
- [X] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
