### PR TITLE
Feature/refactor program

### DIFF
--- a/.github/workflows/generate-coverage.yaml
+++ b/.github/workflows/generate-coverage.yaml
@@ -85,7 +85,7 @@ jobs:
         shell: bash -l {0}
         run: |
           source /opt/intel/oneapi/setvars.sh
-          python scripts/gen_coverage.py
+          SYCL_ENABLE_HOST_DEVICE=1 python scripts/gen_coverage.py
 
       - name: Install coverall dependencies
         shell: bash -l {0}

--- a/dpctl/_backend.pxd
+++ b/dpctl/_backend.pxd
@@ -250,7 +250,6 @@ cdef extern from "syclinterface/dpctl_sycl_event_interface.h":
 
 
 cdef extern from "syclinterface/dpctl_sycl_kernel_interface.h":
-    cdef const char* DPCTLKernel_GetFunctionName(const DPCTLSyclKernelRef KRef)
     cdef size_t DPCTLKernel_GetNumArgs(const DPCTLSyclKernelRef KRef)
     cdef void DPCTLKernel_Delete(DPCTLSyclKernelRef KRef)
 

--- a/dpctl/_backend.pxd
+++ b/dpctl/_backend.pxd
@@ -120,7 +120,7 @@ cdef extern from "syclinterface/dpctl_sycl_types.h":
     cdef struct DPCTLOpaqueSyclEvent
     cdef struct DPCTLOpaqueSyclKernel
     cdef struct DPCTLOpaqueSyclPlatform
-    cdef struct DPCTLOpaqueSyclProgram
+    cdef struct DPCTLOpaqueSyclKernelBundle
     cdef struct DPCTLOpaqueSyclQueue
     cdef struct DPCTLOpaqueSyclUSM
 
@@ -130,7 +130,7 @@ cdef extern from "syclinterface/dpctl_sycl_types.h":
     ctypedef DPCTLOpaqueSyclEvent          *DPCTLSyclEventRef
     ctypedef DPCTLOpaqueSyclKernel         *DPCTLSyclKernelRef
     ctypedef DPCTLOpaqueSyclPlatform       *DPCTLSyclPlatformRef
-    ctypedef DPCTLOpaqueSyclProgram        *DPCTLSyclProgramRef
+    ctypedef DPCTLOpaqueSyclKernelBundle   *DPCTLSyclKernelBundleRef
     ctypedef DPCTLOpaqueSyclQueue          *DPCTLSyclQueueRef
     ctypedef DPCTLOpaqueSyclUSM            *DPCTLSyclUSMRef
 
@@ -305,21 +305,23 @@ cdef extern from "syclinterface/dpctl_sycl_context_interface.h":
 
 
 cdef extern from "syclinterface/dpctl_sycl_program_interface.h":
-    cdef DPCTLSyclProgramRef DPCTLProgram_CreateFromSpirv(
+    cdef DPCTLSyclKernelBundleRef DPCTLKernelBundle_CreateFromSpirv(
         const DPCTLSyclContextRef Ctx,
+        const DPCTLSyclDeviceRef Dev,
         const void *IL,
         size_t Length,
         const char *CompileOpts)
-    cdef DPCTLSyclProgramRef DPCTLProgram_CreateFromOCLSource(
+    cdef DPCTLSyclKernelBundleRef DPCTLKernelBundle_CreateFromOCLSource(
         const DPCTLSyclContextRef Ctx,
+        const DPCTLSyclDeviceRef Dev,
         const char *Source,
         const char *CompileOpts)
-    cdef DPCTLSyclKernelRef DPCTLProgram_GetKernel(
-        DPCTLSyclProgramRef PRef,
+    cdef DPCTLSyclKernelRef DPCTLKernelBundle_GetKernel(
+        DPCTLSyclKernelBundleRef KBRef,
         const char *KernelName)
-    cdef bool DPCTLProgram_HasKernel(DPCTLSyclProgramRef PRef,
+    cdef bool DPCTLKernelBundle_HasKernel(DPCTLSyclKernelBundleRef KBRef,
                                      const char *KernelName)
-    cdef void DPCTLProgram_Delete(DPCTLSyclProgramRef PRef)
+    cdef void DPCTLKernelBundle_Delete(DPCTLSyclKernelBundleRef KBRef)
 
 
 cdef extern from "syclinterface/dpctl_sycl_queue_interface.h":

--- a/dpctl/_backend.pxd
+++ b/dpctl/_backend.pxd
@@ -304,7 +304,7 @@ cdef extern from "syclinterface/dpctl_sycl_context_interface.h":
     cdef void DPCTLContext_Delete(DPCTLSyclContextRef CtxRef)
 
 
-cdef extern from "syclinterface/dpctl_sycl_program_interface.h":
+cdef extern from "syclinterface/dpctl_sycl_kernel_bundle_interface.h":
     cdef DPCTLSyclKernelBundleRef DPCTLKernelBundle_CreateFromSpirv(
         const DPCTLSyclContextRef Ctx,
         const DPCTLSyclDeviceRef Dev,

--- a/dpctl/program/_program.pxd
+++ b/dpctl/program/_program.pxd
@@ -33,11 +33,11 @@ cdef class SyclKernel:
         kernel.
     '''
     cdef DPCTLSyclKernelRef _kernel_ref
-    cdef const char *_function_name
+    cdef str _function_name
     cdef DPCTLSyclKernelRef get_kernel_ref (self)
 
     @staticmethod
-    cdef SyclKernel _create (DPCTLSyclKernelRef kref)
+    cdef SyclKernel _create (DPCTLSyclKernelRef kref, str name)
 
 
 cdef class SyclProgram:

--- a/dpctl/program/_program.pxd
+++ b/dpctl/program/_program.pxd
@@ -41,7 +41,7 @@ cdef class SyclKernel:
 
 
 cdef class SyclProgram:
-    ''' Wraps a sycl::kernel_bundle<sycl::bundle_state::executable> object created from
+    ''' Wraps a sycl::kernel_bundle<sycl::bundle_state::executable> object created by
         using SYCL interoperability layer for OpenCL and Level-Zero backends.
 
         SyclProgram exposes the C API from dpctl_sycl_kernel_bundle_interface.h. A

--- a/dpctl/program/_program.pxd
+++ b/dpctl/program/_program.pxd
@@ -44,7 +44,7 @@ cdef class SyclProgram:
     ''' Wraps a sycl::kernel_bundle<sycl::bundle_state::executable> object created from
         using SYCL interoperability layer for OpenCL and Level-Zero backends.
 
-        SyclProgram exposes the C API from dpctl_sycl_program_interface.h. A
+        SyclProgram exposes the C API from dpctl_sycl_kernel_bundle_interface.h. A
         SyclProgram can be created from either a source string or a SPIR-V
         binary file.
     '''

--- a/dpctl/program/_program.pxd
+++ b/dpctl/program/_program.pxd
@@ -22,7 +22,7 @@
 """
 
 
-from .._backend cimport DPCTLSyclKernelRef, DPCTLSyclProgramRef
+from .._backend cimport DPCTLSyclKernelBundleRef, DPCTLSyclKernelRef
 from .._sycl_context cimport SyclContext
 from .._sycl_device cimport SyclDevice
 from .._sycl_queue cimport SyclQueue
@@ -41,18 +41,18 @@ cdef class SyclKernel:
 
 
 cdef class SyclProgram:
-    ''' Wraps a sycl::program object created from an OpenCL interoperability
-        program.
+    ''' Wraps a sycl::kernel_bundle<sycl::bundle_state::executable> object created from
+        using SYCL interoperability layer for OpenCL and Level-Zero backends.
 
         SyclProgram exposes the C API from dpctl_sycl_program_interface.h. A
         SyclProgram can be created from either a source string or a SPIR-V
         binary file.
     '''
-    cdef DPCTLSyclProgramRef _program_ref
+    cdef DPCTLSyclKernelBundleRef _program_ref
 
     @staticmethod
-    cdef  SyclProgram _create (DPCTLSyclProgramRef pref)
-    cdef  DPCTLSyclProgramRef get_program_ref (self)
+    cdef  SyclProgram _create (DPCTLSyclKernelBundleRef pref)
+    cdef  DPCTLSyclKernelBundleRef get_program_ref (self)
     cpdef SyclKernel get_sycl_kernel(self, str kernel_name)
 
 

--- a/dpctl/program/_program.pyx
+++ b/dpctl/program/_program.pyx
@@ -30,7 +30,6 @@ cimport cython.array
 from dpctl._backend cimport (  # noqa: E211, E402
     DPCTLCString_Delete,
     DPCTLKernel_Delete,
-    DPCTLKernel_GetFunctionName,
     DPCTLKernel_GetNumArgs,
     DPCTLProgram_CreateFromOCLSource,
     DPCTLProgram_CreateFromSpirv,
@@ -61,20 +60,19 @@ cdef class SyclKernel:
     """
     """
     @staticmethod
-    cdef SyclKernel _create(DPCTLSyclKernelRef kref):
+    cdef SyclKernel _create(DPCTLSyclKernelRef kref, str name):
         cdef SyclKernel ret = SyclKernel.__new__(SyclKernel)
         ret._kernel_ref = kref
-        ret._function_name = DPCTLKernel_GetFunctionName(kref)
+        ret._function_name = name
         return ret
 
     def __dealloc__(self):
         DPCTLKernel_Delete(self._kernel_ref)
-        DPCTLCString_Delete(self._function_name)
 
     def get_function_name(self):
         """ Returns the name of the ``sycl::kernel`` function.
         """
-        return self._function_name.decode()
+        return self._function_name
 
     def get_num_args(self):
         """ Returns the number of arguments for this kernel function.
@@ -121,7 +119,7 @@ cdef class SyclProgram:
     cpdef SyclKernel get_sycl_kernel(self, str kernel_name):
         name = kernel_name.encode('utf8')
         return SyclKernel._create(DPCTLProgram_GetKernel(self._program_ref,
-                                                         name))
+                                                         name), kernel_name)
 
     def has_sycl_kernel(self, str kernel_name):
         name = kernel_name.encode('utf8')

--- a/dpctl/program/_program.pyx
+++ b/dpctl/program/_program.pyx
@@ -97,12 +97,13 @@ cdef class SyclKernel:
 
 
 cdef class SyclProgram:
-    """ Wraps a ``sycl::program`` object created from an OpenCL interoperability
-        program.
+    """ Wraps a ``sycl::kernel_bundle<sycl::bundle_state::executable>`` object
+    created using SYCL interoperability layer with underlying backends. Only the
+    OpenCL and Level-Zero backends are currently supported.
 
-        SyclProgram exposes the C API from ``dpctl_sycl_program_interface.h``. A
-        SyclProgram can be created from either a source string or a SPIR-V
-        binary file.
+    SyclProgram exposes the C API from ``dpctl_sycl_kernel_bundle_interface.h``.
+    A SyclProgram can be created from either a source string or a SPIR-V
+    binary file.
     """
 
     @staticmethod

--- a/dpctl/program/_program.pyx
+++ b/dpctl/program/_program.pyx
@@ -31,14 +31,15 @@ from dpctl._backend cimport (  # noqa: E211, E402
     DPCTLCString_Delete,
     DPCTLKernel_Delete,
     DPCTLKernel_GetNumArgs,
-    DPCTLProgram_CreateFromOCLSource,
-    DPCTLProgram_CreateFromSpirv,
-    DPCTLProgram_Delete,
-    DPCTLProgram_GetKernel,
-    DPCTLProgram_HasKernel,
+    DPCTLKernelBundle_CreateFromOCLSource,
+    DPCTLKernelBundle_CreateFromSpirv,
+    DPCTLKernelBundle_Delete,
+    DPCTLKernelBundle_GetKernel,
+    DPCTLKernelBundle_HasKernel,
     DPCTLSyclContextRef,
+    DPCTLSyclDeviceRef,
+    DPCTLSyclKernelBundleRef,
     DPCTLSyclKernelRef,
-    DPCTLSyclProgramRef,
 )
 
 __all__ = [
@@ -50,8 +51,8 @@ __all__ = [
 ]
 
 cdef class SyclProgramCompilationError(Exception):
-    """This exception is raised when a ``sycl::program`` could not be built from
-       either a SPIR-V binary file or a string source.
+    """This exception is raised when a ``sycl::kernel_bundle`` could not be
+       built from either a SPIR-V binary file or a string source.
     """
     pass
 
@@ -105,33 +106,35 @@ cdef class SyclProgram:
     """
 
     @staticmethod
-    cdef SyclProgram _create(DPCTLSyclProgramRef pref):
+    cdef SyclProgram _create(DPCTLSyclKernelBundleRef KBRef):
         cdef SyclProgram ret = SyclProgram.__new__(SyclProgram)
-        ret._program_ref = pref
+        ret._program_ref = KBRef
         return ret
 
     def __dealloc__(self):
-        DPCTLProgram_Delete(self._program_ref)
+        DPCTLKernelBundle_Delete(self._program_ref)
 
-    cdef DPCTLSyclProgramRef get_program_ref(self):
+    cdef DPCTLSyclKernelBundleRef get_program_ref(self):
         return self._program_ref
 
     cpdef SyclKernel get_sycl_kernel(self, str kernel_name):
         name = kernel_name.encode('utf8')
-        return SyclKernel._create(DPCTLProgram_GetKernel(self._program_ref,
-                                                         name), kernel_name)
+        return SyclKernel._create(
+            DPCTLKernelBundle_GetKernel(self._program_ref, name),
+            kernel_name
+        )
 
     def has_sycl_kernel(self, str kernel_name):
         name = kernel_name.encode('utf8')
-        return DPCTLProgram_HasKernel(self._program_ref, name)
+        return DPCTLKernelBundle_HasKernel(self._program_ref, name)
 
     def addressof_ref(self):
-        """Returns the address of the C API DPCTLSyclProgramRef pointer
+        """Returns the address of the C API DPCTLSyclKernelBundleRef pointer
         as a long.
 
         Returns:
-            The address of the ``DPCTLSyclProgramRef`` pointer used to create
-            this :class:`dpctl.SyclProgram` object cast to a ``size_t``.
+            The address of the ``DPCTLSyclKernelBundleRef`` pointer used to
+            create this :class:`dpctl.SyclProgram` object cast to a ``size_t``.
         """
         return int(<size_t>self._program_ref)
 
@@ -140,9 +143,10 @@ cpdef create_program_from_source(SyclQueue q, unicode src, unicode copts=""):
     """
         Creates a Sycl interoperability program from an OpenCL source string.
 
-        We use the ``DPCTLProgram_CreateFromOCLSource()`` C API function to
-        create a ``sycl::program`` from an OpenCL source program that can
-        contain multiple kernels. Note currently only supported for OpenCL.
+        We use the ``DPCTLKernelBundle_CreateFromOCLSource()`` C API function
+        to create a ``sycl::kernel_bundle<sycl::bundle_state::executable>``
+        from an OpenCL source program that can contain multiple kernels.
+        Note: This function is currently only supported for the OpenCL backend.
 
         Parameters:
             q (SyclQueue)   : The :class:`SyclQueue` for which the
@@ -153,24 +157,27 @@ cpdef create_program_from_source(SyclQueue q, unicode src, unicode copts=""):
 
         Returns:
             program (SyclProgram): A :class:`SyclProgram` object wrapping the
-            ``sycl::program`` returned by the C API.
+            ``sycl::kernel_bundle<sycl::bundle_state::executable>`` returned
+            by the C API.
 
         Raises:
-            SyclProgramCompilationError: If a SYCL program could not be created.
+            SyclProgramCompilationError: If a SYCL kernel bundle could not be
+            created.
     """
 
-    cdef DPCTLSyclProgramRef Pref
+    cdef DPCTLSyclKernelBundleRef KBref
     cdef bytes bSrc = src.encode('utf8')
     cdef bytes bCOpts = copts.encode('utf8')
     cdef const char *Src = <const char*>bSrc
     cdef const char *COpts = <const char*>bCOpts
     cdef DPCTLSyclContextRef CRef = q.get_sycl_context().get_context_ref()
-    Pref = DPCTLProgram_CreateFromOCLSource(CRef, Src, COpts)
+    cdef DPCTLSyclDeviceRef DRef = q.get_sycl_device().get_device_ref()
+    KBref = DPCTLKernelBundle_CreateFromOCLSource(CRef, DRef, Src, COpts)
 
-    if Pref is NULL:
+    if KBref is NULL:
         raise SyclProgramCompilationError()
 
-    return SyclProgram._create(Pref)
+    return SyclProgram._create(KBref)
 
 
 cpdef create_program_from_spirv(SyclQueue q, const unsigned char[:] IL,
@@ -178,8 +185,9 @@ cpdef create_program_from_spirv(SyclQueue q, const unsigned char[:] IL,
     """
         Creates a Sycl interoperability program from an SPIR-V binary.
 
-        We use the ``DPCTLProgram_CreateFromOCLSpirv()`` C API function to
-        create a ``sycl::program`` object from an compiled SPIR-V binary file.
+        We use the ``DPCTLKernelBundle_CreateFromOCLSpirv()`` C API function to
+        create a ``sycl::kernel_bundle<sycl::bundle_state::executable>`` object
+        from an compiled SPIR-V binary file.
 
         Parameters:
             q (SyclQueue): The :class:`SyclQueue` for which the
@@ -190,20 +198,25 @@ cpdef create_program_from_spirv(SyclQueue q, const unsigned char[:] IL,
 
         Returns:
             program (SyclProgram): A :class:`SyclProgram` object wrapping the
-            ``sycl::program`` returned by the C API.
+            ``sycl::kernel_bundle<sycl::bundle_state::executable>`` returned by
+            the C API.
 
         Raises:
-            SyclProgramCompilationError: If a SYCL program could not be created.
+            SyclProgramCompilationError: If a SYCL kernel bundle could not be
+            created.
     """
 
-    cdef DPCTLSyclProgramRef Pref
+    cdef DPCTLSyclKernelBundleRef KBref
     cdef const unsigned char *dIL = &IL[0]
     cdef DPCTLSyclContextRef CRef = q.get_sycl_context().get_context_ref()
+    cdef DPCTLSyclDeviceRef DRef = q.get_sycl_device().get_device_ref()
     cdef size_t length = IL.shape[0]
     cdef bytes bCOpts = copts.encode('utf8')
     cdef const char *COpts = <const char*>bCOpts
-    Pref = DPCTLProgram_CreateFromSpirv(CRef, <const void*>dIL, length, COpts)
-    if Pref is NULL:
+    KBref = DPCTLKernelBundle_CreateFromSpirv(
+        CRef, DRef, <const void*>dIL, length, COpts
+    )
+    if KBref is NULL:
         raise SyclProgramCompilationError()
 
-    return SyclProgram._create(Pref)
+    return SyclProgram._create(KBref)

--- a/examples/pybind11/external_usm_allocation/CMakeLists.txt
+++ b/examples/pybind11/external_usm_allocation/CMakeLists.txt
@@ -28,7 +28,6 @@ pybind11_add_module(${py_module_name}
     external_usm_allocation/_usm_alloc_example.cpp
 )
 target_include_directories(${py_module_name} PUBLIC ${Dpctl_INCLUDE_DIRS})
-target_compile_options(${py_module_name} PRIVATE -Wno-deprecated-declarations)
 install(TARGETS ${py_module_name}
   DESTINATION external_usm_allocation
 )

--- a/examples/pybind11/onemkl_gemv/CMakeLists.txt
+++ b/examples/pybind11/onemkl_gemv/CMakeLists.txt
@@ -50,7 +50,7 @@ target_include_directories(${py_module_name} PUBLIC ${Dpctl_INCLUDE_DIRS})
 get_target_property(_sycl_gemm_sources ${py_module_name} SOURCES)
 set_source_files_properties(${_sycl_gemm_sources}
   PROPERTIES
-  COMPILE_OPTIONS "-O3;-Wno-deprecated-declarations"
+  COMPILE_OPTIONS "-O3"
 )
 
 add_executable(standalone_cpp

--- a/examples/pybind11/use_dpctl_syclqueue/CMakeLists.txt
+++ b/examples/pybind11/use_dpctl_syclqueue/CMakeLists.txt
@@ -28,7 +28,6 @@ pybind11_add_module(${py_module_name}
     use_queue_device/_example.cpp
 )
 target_include_directories(${py_module_name} PUBLIC ${Dpctl_INCLUDE_DIRS})
-target_compile_options(${py_module_name} PRIVATE -Wno-deprecated-declarations)
 install(TARGETS ${py_module_name}
   DESTINATION use_queue_device
 )

--- a/libsyclinterface/CMakeLists.txt
+++ b/libsyclinterface/CMakeLists.txt
@@ -71,6 +71,23 @@ if(DPCTL_ENABLE_L0_PROGRAM_CREATION)
     endif()
 endif()
 
+if (UNIX)
+  find_library(PI_OPENCL_LIB
+      NAMES pi_opencl
+      HINTS ${IntelSycl_LIBRARY_DIR}
+  )
+  find_program(READELF_PROG readelf)
+  find_program(GREP_PROG grep)
+  execute_process(
+    COMMAND ${READELF_PROG} -d ${PI_OPENCL_LIB}
+    COMMAND ${GREP_PROG} OpenCL
+    COMMAND ${GREP_PROG} -Po "libOpenCL[^\]]*"
+    OUTPUT_VARIABLE LIBCL_LOADER_FILENAME
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    ERROR_STRIP_TRAILING_WHITESPACE
+  )
+endif()
+
 configure_file(
     ${CMAKE_CURRENT_SOURCE_DIR}/include/Config/dpctl_config.h.in
     ${CMAKE_CURRENT_SOURCE_DIR}/include/Config/dpctl_config.h
@@ -193,7 +210,6 @@ target_include_directories(DPCTLSyclInterface
 )
 target_link_libraries(DPCTLSyclInterface
   PRIVATE ${IntelSycl_SYCL_LIBRARY}
-  PRIVATE ${IntelSycl_OPENCL_LIBRARY}
 )
 
 if(DPCTL_ENABLE_GLOG)

--- a/libsyclinterface/CMakeLists.txt
+++ b/libsyclinterface/CMakeLists.txt
@@ -104,7 +104,6 @@ if(WIN32)
         "-Wunused-function "
         "-Wuninitialized "
         "-Wmissing-declarations "
-        "-Wno-deprecated-declarations "
     )
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${WARNING_FLAGS}")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${WARNING_FLAGS}")
@@ -123,7 +122,6 @@ elseif(UNIX)
         "-Wuninitialized "
         "-Wmissing-declarations "
         "-fdiagnostics-color=auto "
-        "-Wno-deprecated-declarations "
     )
     string(CONCAT SDL_FLAGS
         "-fstack-protector "

--- a/libsyclinterface/helper/include/dpctl_dynamic_lib_helper.h
+++ b/libsyclinterface/helper/include/dpctl_dynamic_lib_helper.h
@@ -75,13 +75,13 @@ public:
         void *sym = dlsym(_handle, symName);
         char *error = dlerror();
 
-        if (NULL != error) {
+        if (nullptr != error) {
             return nullptr;
         }
 #elif defined(_WIN32) || defined(_WIN64)
         void *sym = (void *)GetProcAddress((HMODULE)_handle, symName);
 
-        if (NULL == sym) {
+        if (nullptr == sym) {
             return nullptr;
         }
 #endif

--- a/libsyclinterface/helper/source/dpctl_utils_helper.cpp
+++ b/libsyclinterface/helper/source/dpctl_utils_helper.cpp
@@ -89,7 +89,7 @@ backend DPCTL_DPCTLBackendTypeToSyclBackend(DPCTLSyclBackendType BeTy)
 {
     switch (BeTy) {
     case DPCTLSyclBackendType::DPCTL_CUDA:
-        return backend::cuda;
+        return backend::ext_oneapi_cuda;
     case DPCTLSyclBackendType::DPCTL_HOST:
         return backend::host;
     case DPCTLSyclBackendType::DPCTL_LEVEL_ZERO:
@@ -106,7 +106,7 @@ backend DPCTL_DPCTLBackendTypeToSyclBackend(DPCTLSyclBackendType BeTy)
 DPCTLSyclBackendType DPCTL_SyclBackendToDPCTLBackendType(backend B)
 {
     switch (B) {
-    case backend::cuda:
+    case backend::ext_oneapi_cuda:
         return DPCTLSyclBackendType::DPCTL_CUDA;
     case backend::host:
         return DPCTLSyclBackendType::DPCTL_HOST;

--- a/libsyclinterface/include/Config/dpctl_config.h.in
+++ b/libsyclinterface/include/Config/dpctl_config.h.in
@@ -26,9 +26,11 @@
 #pragma once
 
 /* Defined when dpctl was built with level zero program creation enabled. */
-#cmakedefine DPCTL_ENABLE_L0_PROGRAM_CREATION @DPCTL_ENABLE_L0_PROGRAM_CREATION@
+#cmakedefine DPCTL_ENABLE_L0_PROGRAM_CREATION                                  \
+    @DPCTL_ENABLE_L0_PROGRAM_CREATION @
 
 /* The DPCPP version used to build dpctl */
 #define DPCTL_DPCPP_VERSION "@IntelSycl_VERSION@"
 
 #define DPCTL_LIBZE_LOADER_FILENAME "@LIBZE_LOADER_FILENAME@"
+#define DPCTL_LIBCL_LOADER_FILENAME "@LIBCL_LOADER_FILENAME@"

--- a/libsyclinterface/include/dpctl_sycl_kernel_bundle_interface.h
+++ b/libsyclinterface/include/dpctl_sycl_kernel_bundle_interface.h
@@ -1,4 +1,5 @@
-//===- dpctl_sycl_program_interface.h - C API for sycl::program  -*-C++-*- ===//
+//===- dpctl_sycl_kernel_bundle_interface.h - C API for
+//     sycl::kernel_bundle<sycl::bundle_state::executable>      -*-C++-*- ===//
 //
 //                      Data Parallel Control (dpctl)
 //
@@ -84,7 +85,7 @@ __dpctl_give DPCTLSyclKernelBundleRef DPCTLKernelBundle_CreateFromOCLSource(
  * @brief Returns the SyclKernel with given name from the program, if not found
  * then return NULL.
  *
- * @param    PRef           Opaque pointer to a sycl::program
+ * @param    KBRef          Opaque pointer to a sycl::kernel_bundle
  * @param    KernelName     Name of kernel
  * @return   A SyclKernel reference if the kernel exists, else NULL
  * @ingroup KernelBundleInterface
@@ -98,7 +99,7 @@ DPCTLKernelBundle_GetKernel(__dpctl_keep DPCTLSyclKernelBundleRef KBRef,
  * @brief Return True if a SyclKernel with given name exists in the program, if
  * not found then returns False.
  *
- * @param    PRef           Opaque pointer to a sycl::program
+ * @param    KBRef          Opaque pointer to a sycl::kernel_bundle
  * @param    KernelName     Name of kernel
  * @return   True if the kernel exists, else False
  * @ingroup KernelBundleInterface

--- a/libsyclinterface/include/dpctl_sycl_kernel_interface.h
+++ b/libsyclinterface/include/dpctl_sycl_kernel_interface.h
@@ -39,19 +39,6 @@ DPCTL_C_EXTERN_C_BEGIN
  */
 
 /*!
- * @brief Returns a C string for the kernel name.
- *
- * @param    KRef           DPCTLSyclKernelRef pointer to an OpenCL
- *                          interoperability kernel.
- * @return   If a kernel name exists then returns it as a C string, else
- *           returns a nullptr.
- * @ingroup KernelInterface
- */
-DPCTL_API
-__dpctl_give const char *
-DPCTLKernel_GetFunctionName(__dpctl_keep const DPCTLSyclKernelRef KRef);
-
-/*!
  * @brief Returns the number of arguments for the OpenCL kernel.
  *
  * @param    KRef           DPCTLSyclKernelRef pointer to an OpenCL

--- a/libsyclinterface/include/dpctl_sycl_program_interface.h
+++ b/libsyclinterface/include/dpctl_sycl_program_interface.h
@@ -35,52 +35,50 @@
 DPCTL_C_EXTERN_C_BEGIN
 
 /**
- * @defgroup ProgramInterface Program class C wrapper
+ * @defgroup KernelBundleInterface Kernel_bundle class C wrapper
  */
 
 /*!
- * @brief Create a Sycl program from an OpenCL SPIR-V binary file.
+ * @brief Create a Sycl kernel_bundle from an OpenCL SPIR-V binary file.
  *
- * Sycl 1.2 does not expose any method to create a sycl::program from a SPIR-V
- * IL file. To get around this limitation, we first creare a SYCL
- * interoperability program and then create a SYCL program from the
- * interoperability program. Currently, interoperability programs can be created
- * for OpenCL and Level-0 backends.
- *
- * The feature to create a Sycl kernel from a SPIR-V IL binary will be available
- * in Sycl 2.0 at which point this function may become deprecated.
+ * Uses SYCL2020 interoperability layer to create sycl::kernel_bundle object
+ * in executable state for OpenCL and Level-Zero backends from SPIR-V binary.
  *
  * @param    Ctx            An opaque pointer to a sycl::context
+ * @param    Dev            An opaque pointer to a sycl::device
  * @param    IL             SPIR-V binary
  * @param    Length         The size of the IL binary in bytes.
  * @param    CompileOpts    Optional compiler flags used when compiling the
  *                          SPIR-V binary.
- * @return   A new SyclProgramRef pointer if the program creation succeeded,
- *           else returns NULL.
- * @ingroup ProgramInterface
+ * @return   A new SyclKernelBundleRef pointer if the kernel_bundle creation
+ * succeeded, else returns NULL.
+ * @ingroup KernelBundleInterface
  */
 DPCTL_API
-__dpctl_give DPCTLSyclProgramRef
-DPCTLProgram_CreateFromSpirv(__dpctl_keep const DPCTLSyclContextRef Ctx,
-                             __dpctl_keep const void *IL,
-                             size_t Length,
-                             const char *CompileOpts);
+__dpctl_give DPCTLSyclKernelBundleRef
+DPCTLKernelBundle_CreateFromSpirv(__dpctl_keep const DPCTLSyclContextRef Ctx,
+                                  __dpctl_keep const DPCTLSyclDeviceRef Dev,
+                                  __dpctl_keep const void *IL,
+                                  size_t Length,
+                                  const char *CompileOpts);
 
 /*!
- * @brief Create a Sycl program from an OpenCL kernel source string.
+ * @brief Create a Sycl kernel bundle from an OpenCL kernel source string.
  *
  * @param    Ctx            An opaque pointer to a sycl::context
+ * @param    Dev            An opaque pointer to a sycl::device
  * @param    Source         OpenCL source string
  * @param    CompileOpts    Extra compiler flags (refer Sycl spec.)
- * @return   A new SyclProgramRef pointer if the program creation succeeded,
- *           else returns NULL.
- * @ingroup ProgramInterface
+ * @return   A new SyclKernelBundleRef pointer if the program creation
+ * succeeded, else returns NULL.
+ * @ingroup KernelBundleInterface
  */
 DPCTL_API
-__dpctl_give DPCTLSyclProgramRef
-DPCTLProgram_CreateFromOCLSource(__dpctl_keep const DPCTLSyclContextRef Ctx,
-                                 __dpctl_keep const char *Source,
-                                 __dpctl_keep const char *CompileOpts);
+__dpctl_give DPCTLSyclKernelBundleRef DPCTLKernelBundle_CreateFromOCLSource(
+    __dpctl_keep const DPCTLSyclContextRef Ctx,
+    __dpctl_keep const DPCTLSyclDeviceRef Dev,
+    __dpctl_keep const char *Source,
+    __dpctl_keep const char *CompileOpts);
 
 /*!
  * @brief Returns the SyclKernel with given name from the program, if not found
@@ -89,12 +87,12 @@ DPCTLProgram_CreateFromOCLSource(__dpctl_keep const DPCTLSyclContextRef Ctx,
  * @param    PRef           Opaque pointer to a sycl::program
  * @param    KernelName     Name of kernel
  * @return   A SyclKernel reference if the kernel exists, else NULL
- * @ingroup ProgramInterface
+ * @ingroup KernelBundleInterface
  */
 DPCTL_API
 __dpctl_give DPCTLSyclKernelRef
-DPCTLProgram_GetKernel(__dpctl_keep DPCTLSyclProgramRef PRef,
-                       __dpctl_keep const char *KernelName);
+DPCTLKernelBundle_GetKernel(__dpctl_keep DPCTLSyclKernelBundleRef KBRef,
+                            __dpctl_keep const char *KernelName);
 
 /*!
  * @brief Return True if a SyclKernel with given name exists in the program, if
@@ -103,19 +101,19 @@ DPCTLProgram_GetKernel(__dpctl_keep DPCTLSyclProgramRef PRef,
  * @param    PRef           Opaque pointer to a sycl::program
  * @param    KernelName     Name of kernel
  * @return   True if the kernel exists, else False
- * @ingroup ProgramInterface
+ * @ingroup KernelBundleInterface
  */
 DPCTL_API
-bool DPCTLProgram_HasKernel(__dpctl_keep DPCTLSyclProgramRef PRef,
-                            __dpctl_keep const char *KernelName);
+bool DPCTLKernelBundle_HasKernel(__dpctl_keep DPCTLSyclKernelBundleRef KBRef,
+                                 __dpctl_keep const char *KernelName);
 
 /*!
- * @brief Frees the DPCTLSyclProgramRef pointer.
+ * @brief Frees the DPCTLSyclKernelBundleRef pointer.
  *
- * @param    PRef           Opaque pointer to a sycl::program
- * @ingroup ProgramInterface
+ * @param    PRef           Opaque pointer to a sycl::kernel_bundle
+ * @ingroup KernelBundleInterface
  */
 DPCTL_API
-void DPCTLProgram_Delete(__dpctl_take DPCTLSyclProgramRef PRef);
+void DPCTLKernelBundle_Delete(__dpctl_take DPCTLSyclKernelBundleRef KBRef);
 
 DPCTL_C_EXTERN_C_END

--- a/libsyclinterface/include/dpctl_sycl_types.h
+++ b/libsyclinterface/include/dpctl_sycl_types.h
@@ -60,16 +60,16 @@ typedef struct DPCTLOpaqueSyclEvent *DPCTLSyclEventRef;
 typedef struct DPCTLOpaqueSyclKernel *DPCTLSyclKernelRef;
 
 /*!
+ * @brief Opaque pointer to a ``sycl::kernel_bundle``
+ *
+ */
+typedef struct DPCTLOpaqueSyclKernelBundle *DPCTLSyclKernelBundleRef;
+
+/*!
  * @brief Opaque pointer to a ``sycl::platform``
  *
  */
 typedef struct DPCTLOpaqueSyclPlatform *DPCTLSyclPlatformRef;
-
-/*!
- * @brief Opaque pointer to a ``sycl::program``
- *
- */
-typedef struct DPCTLOpaqueSyclProgram *DPCTLSyclProgramRef;
 
 /*!
  * @brief Opaque pointer to a ``sycl::queue``

--- a/libsyclinterface/source/dpctl_sycl_context_interface.cpp
+++ b/libsyclinterface/source/dpctl_sycl_context_interface.cpp
@@ -196,7 +196,7 @@ DPCTLContext_GetBackend(__dpctl_keep const DPCTLSyclContextRef CtxRef)
         return DPCTL_OPENCL;
     case backend::ext_oneapi_level_zero:
         return DPCTL_LEVEL_ZERO;
-    case backend::cuda:
+    case backend::ext_oneapi_cuda:
         return DPCTL_CUDA;
     default:
         return DPCTL_UNKNOWN_BACKEND;

--- a/libsyclinterface/source/dpctl_sycl_kernel_bundle_interface.cpp
+++ b/libsyclinterface/source/dpctl_sycl_kernel_bundle_interface.cpp
@@ -147,15 +147,8 @@ typedef cl_kernel (*clCreateKernelFT)(cl_program, const char *, cl_int *);
 const char *clCreateKernel_Name = "clCreateKernel";
 clCreateKernelFT get_clCreateKernel()
 {
-    static dpctl::DynamicLibHelper clLib(clLoaderName, clLibLoadFlags);
-    if (!clLib.opened()) {
-        error_handler("The OpenCL loader dynamic library could not "
-                      "be opened.",
-                      __FILE__, __func__, __LINE__);
-        return nullptr;
-    }
     static auto st_clCreateKernelF =
-        clLib.getSymbol<clCreateKernelFT>(clCreateKernel_Name);
+        cl_loader::get().getSymbol<clCreateKernelFT>(clCreateKernel_Name);
 
     return st_clCreateKernelF;
 }

--- a/libsyclinterface/source/dpctl_sycl_kernel_bundle_interface.cpp
+++ b/libsyclinterface/source/dpctl_sycl_kernel_bundle_interface.cpp
@@ -1,5 +1,5 @@
-//===- dpctl_sycl_program_interface.cpp - Implements C API for
-// sycl::kernel_bundle<sycl::bundle_state::executable> =//
+//===- dpctl_sycl_kernel_bundle_interface.cpp - Implements C API for
+//    sycl::kernel_bundle<sycl::bundle_state::executable>  ---------------===//
 //
 //                      Data Parallel Control (dpctl)
 //
@@ -21,11 +21,11 @@
 ///
 /// \file
 /// This file implements the functions declared in
-/// dpctl_sycl_program_interface.h.
+/// dpctl_sycl_kernel_bundle_interface.h.
 ///
 //===----------------------------------------------------------------------===//
 
-#include "dpctl_sycl_program_interface.h"
+#include "dpctl_sycl_kernel_bundle_interface.h"
 #include "Config/dpctl_config.h"
 #include "Support/CBindingWrapping.h"
 #include "dpctl_dynamic_lib_helper.h"

--- a/libsyclinterface/source/dpctl_sycl_kernel_bundle_interface.cpp
+++ b/libsyclinterface/source/dpctl_sycl_kernel_bundle_interface.cpp
@@ -594,6 +594,11 @@ DPCTLKernelBundle_CreateFromSpirv(__dpctl_keep const DPCTLSyclContextRef CtxRef,
                       __FILE__, __func__, __LINE__);
         return KBRef;
     }
+    if ((!IL) || (length == 0)) {
+        error_handler("Cannot create program from null SPIR-V buffer.",
+                      __FILE__, __func__, __LINE__);
+        return KBRef;
+    }
 
     context *SyclCtx = unwrap(CtxRef);
     device *SyclDev = unwrap(DevRef);

--- a/libsyclinterface/source/dpctl_sycl_kernel_bundle_interface.cpp
+++ b/libsyclinterface/source/dpctl_sycl_kernel_bundle_interface.cpp
@@ -64,6 +64,13 @@ static const int clLibLoadFlags = 0;
 #error "OpenCL program compilation is unavailable for this platform"
 #endif
 
+#define CodeStringSuffix(code)                                                 \
+    std::string(" (code=") + std::to_string(static_cast<int>(code)) + ")"
+
+#define EnumCaseString(code)                                                   \
+    case code:                                                                 \
+        return std::string(#code) + CodeStringSuffix(code)
+
 constexpr backend cl_be = backend::opencl;
 
 struct cl_loader
@@ -155,41 +162,18 @@ clCreateKernelFT get_clCreateKernel()
 
 std::string _GetErrorCode_ocl_impl(cl_int code)
 {
-    if (code == CL_BUILD_PROGRAM_FAILURE) {
-        return "CL_BUILD_PROGRAM_FAILURE (code=" +
-               std::to_string(static_cast<int>(code)) + ")";
+    switch (code) {
+        EnumCaseString(CL_BUILD_PROGRAM_FAILURE);
+        EnumCaseString(CL_INVALID_CONTEXT);
+        EnumCaseString(CL_INVALID_DEVICE);
+        EnumCaseString(CL_INVALID_VALUE);
+        EnumCaseString(CL_OUT_OF_RESOURCES);
+        EnumCaseString(CL_OUT_OF_HOST_MEMORY);
+        EnumCaseString(CL_INVALID_OPERATION);
+        EnumCaseString(CL_INVALID_BINARY);
+    default:
+        return "<< ERROR CODE UNRECOGNIZED >>" + CodeStringSuffix(code);
     }
-    else if (code == CL_INVALID_CONTEXT) {
-        return "CL_INVALID_CONTEXT (code=" +
-               std::to_string(static_cast<int>(code)) + ")";
-    }
-    else if (code == CL_INVALID_DEVICE) {
-        return "CL_INVALID_DEVICE (code=" +
-               std::to_string(static_cast<int>(code)) + ")";
-    }
-    else if (code == CL_INVALID_VALUE) {
-        return "CL_INVALID_VALUE (code=" +
-               std::to_string(static_cast<int>(code)) + ")";
-    }
-    else if (code == CL_OUT_OF_RESOURCES) {
-        return "CL_OUT_OF_RESOURCES (code=" +
-               std::to_string(static_cast<int>(code)) + ")";
-    }
-    else if (code == CL_OUT_OF_HOST_MEMORY) {
-        return "CL_OUT_OF_HOST_MEMORY (code=" +
-               std::to_string(static_cast<int>(code)) + ")";
-    }
-    else if (code == CL_INVALID_OPERATION) {
-        return "CL_INVALID_OPERATION (code=" +
-               std::to_string(static_cast<int>(code)) + ")";
-    }
-    else if (code == CL_INVALID_BINARY) {
-        return "CL_INVALID_BINARY (code=" +
-               std::to_string(static_cast<int>(code)) + ")";
-    }
-
-    return "<< ERROR CODE UNRECOGNIZED >> (code=" +
-           std::to_string(static_cast<int>(code)) + ")";
 }
 
 DPCTLSyclKernelBundleRef
@@ -426,53 +410,21 @@ zeKernelCreateFT get_zeKernelCreate()
 
 std::string _GetErrorCode_ze_impl(ze_result_t code)
 {
-    if (code == ZE_RESULT_ERROR_UNINITIALIZED) {
-        return "ZE_RESULT_ERROR_UNINITIALIZED (code=" +
-               std::to_string(static_cast<int>(code)) + ")";
+    switch (code) {
+        EnumCaseString(ZE_RESULT_ERROR_UNINITIALIZED);
+        EnumCaseString(ZE_RESULT_ERROR_DEVICE_LOST);
+        EnumCaseString(ZE_RESULT_ERROR_INVALID_NULL_HANDLE);
+        EnumCaseString(ZE_RESULT_ERROR_INVALID_NULL_POINTER);
+        EnumCaseString(ZE_RESULT_ERROR_INVALID_ENUMERATION);
+        EnumCaseString(ZE_RESULT_ERROR_INVALID_NATIVE_BINARY);
+        EnumCaseString(ZE_RESULT_ERROR_INVALID_SIZE);
+        EnumCaseString(ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY);
+        EnumCaseString(ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY);
+        EnumCaseString(ZE_RESULT_ERROR_MODULE_BUILD_FAILURE);
+        EnumCaseString(ZE_RESULT_ERROR_INVALID_MODULE_UNLINKED);
+    default:
+        return "<< UNRECOGNIZED ZE_RESULT_T CODE >> " + CodeStringSuffix(code);
     }
-    else if (code == ZE_RESULT_ERROR_DEVICE_LOST) {
-        return "ZE_RESULT_ERROR_DEVICE_LOST (code=" +
-               std::to_string(static_cast<int>(code)) + ")";
-    }
-    else if (code == ZE_RESULT_ERROR_INVALID_NULL_HANDLE) {
-        return "ZE_RESULT_ERROR_INVALID_NULL_HANDLE (code=" +
-               std::to_string(static_cast<int>(code)) + ")";
-    }
-    else if (code == ZE_RESULT_ERROR_INVALID_NULL_POINTER) {
-        return "ZE_RESULT_ERROR_INVALID_NULL_POINTER (code=" +
-               std::to_string(static_cast<int>(code)) + ")";
-    }
-    else if (code == ZE_RESULT_ERROR_INVALID_ENUMERATION) {
-        return "ZE_RESULT_ERROR_INVALID_ENUMERATION (code=" +
-               std::to_string(static_cast<int>(code)) + ")";
-    }
-    else if (code == ZE_RESULT_ERROR_INVALID_NATIVE_BINARY) {
-        return "ZE_RESULT_ERROR_INVALID_NATIVE_BINARY (code=" +
-               std::to_string(static_cast<int>(code)) + ")";
-    }
-    else if (code == ZE_RESULT_ERROR_INVALID_SIZE) {
-        return "ZE_RESULT_ERROR_INVALID_SIZE (code=" +
-               std::to_string(static_cast<int>(code)) + ")";
-    }
-    else if (code == ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY) {
-        return "ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY (code=" +
-               std::to_string(static_cast<int>(code)) + ")";
-    }
-    else if (code == ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY) {
-        return "ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY (code=" +
-               std::to_string(static_cast<int>(code)) + ")";
-    }
-    else if (code == ZE_RESULT_ERROR_MODULE_BUILD_FAILURE) {
-        return "ZE_RESULT_ERROR_MODULE_BUILD_FAILURE (code=" +
-               std::to_string(static_cast<int>(code)) + ")";
-    }
-    else if (code == ZE_RESULT_ERROR_INVALID_MODULE_UNLINKED) {
-        return "ZE_RESULT_ERROR_INVALID_MODULE_UNLINKED (code=" +
-               std::to_string(static_cast<int>(code)) + ")";
-    }
-
-    return "<< UNRECOGNIZE ZE_RESULT_T CODE >> (code=" +
-           std::to_string(static_cast<int>(code)) + ")";
 }
 
 __dpctl_give DPCTLSyclKernelBundleRef

--- a/libsyclinterface/source/dpctl_sycl_kernel_bundle_interface.cpp
+++ b/libsyclinterface/source/dpctl_sycl_kernel_bundle_interface.cpp
@@ -178,7 +178,7 @@ _CreateKernelBundle_common_ocl_impl(cl_program clProgram,
     backend_traits<cl_be>::return_type<device> clDevice;
     clDevice = get_native<cl_be>(dev);
 
-    // Last to pointers are notification function pointer and user-data pointer
+    // Last two pointers are notification function pointer and user-data pointer
     // that can be passed to the notification function.
     auto clBuildProgramF = get_clBuldProgram();
     if (clBuildProgramF == nullptr) {

--- a/libsyclinterface/source/dpctl_sycl_kernel_interface.cpp
+++ b/libsyclinterface/source/dpctl_sycl_kernel_interface.cpp
@@ -39,23 +39,6 @@ DEFINE_SIMPLE_CONVERSION_FUNCTIONS(kernel, DPCTLSyclKernelRef)
 
 } /* end of anonymous namespace */
 
-__dpctl_give const char *
-DPCTLKernel_GetFunctionName(__dpctl_keep const DPCTLSyclKernelRef Kernel)
-{
-    if (!Kernel) {
-        error_handler("Cannot get the number of arguments "
-                      "as input is a nullptr.",
-                      __FILE__, __func__, __LINE__);
-        return nullptr;
-    }
-
-    auto SyclKernel = unwrap(Kernel);
-    auto kernel_name = SyclKernel->get_info<info::kernel::function_name>();
-    if (kernel_name.empty())
-        return nullptr;
-    return dpctl::helper::cstring_from_string(kernel_name);
-}
-
 size_t DPCTLKernel_GetNumArgs(__dpctl_keep const DPCTLSyclKernelRef Kernel)
 {
     if (!Kernel) {

--- a/libsyclinterface/tests/test_helper.cpp
+++ b/libsyclinterface/tests/test_helper.cpp
@@ -90,7 +90,7 @@ TEST_F(TestHelperFns, ChkDPCTLBackendTypeToSyclBackend)
 
     EXPECT_NO_FATAL_FAILURE(res = DPCTL_DPCTLBackendTypeToSyclBackend(
                                 DPCTLSyclBackendType::DPCTL_CUDA));
-    ASSERT_TRUE(res == sycl::backend::cuda);
+    ASSERT_TRUE(res == sycl::backend::ext_oneapi_cuda);
 
     EXPECT_NO_FATAL_FAILURE(res = DPCTL_DPCTLBackendTypeToSyclBackend(
                                 DPCTLSyclBackendType::DPCTL_HOST));
@@ -125,8 +125,8 @@ TEST_F(TestHelperFns, ChkSyclBackendToDPCTLBackendType)
         DTy = DPCTL_SyclBackendToDPCTLBackendType(sycl::backend::host));
     ASSERT_TRUE(DTy == DPCTLSyclBackendType::DPCTL_HOST);
 
-    EXPECT_NO_FATAL_FAILURE(
-        DTy = DPCTL_SyclBackendToDPCTLBackendType(sycl::backend::cuda));
+    EXPECT_NO_FATAL_FAILURE(DTy = DPCTL_SyclBackendToDPCTLBackendType(
+                                sycl::backend::ext_oneapi_cuda));
     ASSERT_TRUE(DTy == DPCTLSyclBackendType::DPCTL_CUDA);
 
     EXPECT_NO_FATAL_FAILURE(

--- a/libsyclinterface/tests/test_sycl_kernel_interface.cpp
+++ b/libsyclinterface/tests/test_sycl_kernel_interface.cpp
@@ -85,17 +85,17 @@ TEST_P(TestDPCTLSyclKernelInterface, CheckGetNumArgs)
 {
     auto QueueRef = DPCTLQueue_CreateForDevice(DRef, nullptr, 0);
     auto CtxRef = DPCTLQueue_GetContext(QueueRef);
-    auto PRef =
-        DPCTLProgram_CreateFromOCLSource(CtxRef, CLProgramStr, CompileOpts);
-    auto AddKernel = DPCTLProgram_GetKernel(PRef, "add");
-    auto AxpyKernel = DPCTLProgram_GetKernel(PRef, "axpy");
+    auto KBRef = DPCTLKernelBundle_CreateFromOCLSource(
+        CtxRef, DRef, CLProgramStr, CompileOpts);
+    auto AddKernel = DPCTLKernelBundle_GetKernel(KBRef, "add");
+    auto AxpyKernel = DPCTLKernelBundle_GetKernel(KBRef, "axpy");
 
     ASSERT_EQ(DPCTLKernel_GetNumArgs(AddKernel), 3ul);
     ASSERT_EQ(DPCTLKernel_GetNumArgs(AxpyKernel), 4ul);
 
     DPCTLQueue_Delete(QueueRef);
     DPCTLContext_Delete(CtxRef);
-    DPCTLProgram_Delete(PRef);
+    DPCTLKernelBundle_Delete(KBRef);
     DPCTLKernel_Delete(AddKernel);
     DPCTLKernel_Delete(AxpyKernel);
 }

--- a/libsyclinterface/tests/test_sycl_kernel_interface.cpp
+++ b/libsyclinterface/tests/test_sycl_kernel_interface.cpp
@@ -1,4 +1,4 @@
-//===-- test_sycl_program_interface.cpp - Test cases for kernel interface ===//
+//===-- test_sycl_kernel_interface.cpp - Test cases for kernel interface  ===//
 //
 //                      Data Parallel Control (dpctl)
 //
@@ -27,8 +27,8 @@
 #include "dpctl_sycl_context_interface.h"
 #include "dpctl_sycl_device_interface.h"
 #include "dpctl_sycl_device_selector_interface.h"
+#include "dpctl_sycl_kernel_bundle_interface.h"
 #include "dpctl_sycl_kernel_interface.h"
-#include "dpctl_sycl_program_interface.h"
 #include "dpctl_sycl_queue_interface.h"
 #include "dpctl_sycl_queue_manager.h"
 #include "dpctl_utils.h"

--- a/libsyclinterface/tests/test_sycl_kernel_interface.cpp
+++ b/libsyclinterface/tests/test_sycl_kernel_interface.cpp
@@ -81,31 +81,6 @@ struct TestDPCTLSyclKernelInterface
 };
 } // namespace
 
-TEST_P(TestDPCTLSyclKernelInterface, CheckGetFunctionName)
-{
-    auto QueueRef = DPCTLQueue_CreateForDevice(DRef, nullptr, 0);
-    auto CtxRef = DPCTLQueue_GetContext(QueueRef);
-    auto PRef =
-        DPCTLProgram_CreateFromOCLSource(CtxRef, CLProgramStr, CompileOpts);
-    auto AddKernel = DPCTLProgram_GetKernel(PRef, "add");
-    auto AxpyKernel = DPCTLProgram_GetKernel(PRef, "axpy");
-
-    auto fnName1 = DPCTLKernel_GetFunctionName(AddKernel);
-    auto fnName2 = DPCTLKernel_GetFunctionName(AxpyKernel);
-
-    ASSERT_STREQ("add", fnName1);
-    ASSERT_STREQ("axpy", fnName2);
-
-    DPCTLCString_Delete(fnName1);
-    DPCTLCString_Delete(fnName2);
-
-    DPCTLQueue_Delete(QueueRef);
-    DPCTLContext_Delete(CtxRef);
-    DPCTLProgram_Delete(PRef);
-    DPCTLKernel_Delete(AddKernel);
-    DPCTLKernel_Delete(AxpyKernel);
-}
-
 TEST_P(TestDPCTLSyclKernelInterface, CheckGetNumArgs)
 {
     auto QueueRef = DPCTLQueue_CreateForDevice(DRef, nullptr, 0);
@@ -130,7 +105,6 @@ TEST_P(TestDPCTLSyclKernelInterface, CheckNullPtrArg)
     DPCTLSyclKernelRef AddKernel = nullptr;
 
     ASSERT_EQ(DPCTLKernel_GetNumArgs(AddKernel), -1);
-    ASSERT_EQ(DPCTLKernel_GetFunctionName(AddKernel), nullptr);
 }
 
 INSTANTIATE_TEST_SUITE_P(TestKernelInterfaceFunctions,

--- a/libsyclinterface/tests/test_sycl_program_interface.cpp
+++ b/libsyclinterface/tests/test_sycl_program_interface.cpp
@@ -1,4 +1,5 @@
-//===-- test_sycl_program_interface.cpp - Test cases for module interface -===//
+//===- test_sycl_kernel_bundle_interface.cpp -
+//                                      Test cases for module interface -===//
 //
 //                      Data Parallel Control (dpctl)
 //
@@ -29,8 +30,8 @@
 #include "dpctl_sycl_device_interface.h"
 #include "dpctl_sycl_device_manager.h"
 #include "dpctl_sycl_device_selector_interface.h"
+#include "dpctl_sycl_kernel_bundle_interface.h"
 #include "dpctl_sycl_kernel_interface.h"
-#include "dpctl_sycl_program_interface.h"
 #include "dpctl_sycl_queue_interface.h"
 #include "dpctl_sycl_queue_manager.h"
 #include <CL/sycl.hpp>

--- a/libsyclinterface/tests/test_sycl_queue_interface.cpp
+++ b/libsyclinterface/tests/test_sycl_queue_interface.cpp
@@ -353,7 +353,7 @@ TEST_P(TestDPCTLQueueMemberFunctions, CheckGetBackend)
     auto Bty = DPCTLQueue_GetBackend(QRef);
     switch (Bty) {
     case DPCTL_CUDA:
-        EXPECT_TRUE(Backend == backend::cuda);
+        EXPECT_TRUE(Backend == backend::ext_oneapi_cuda);
         break;
     case DPCTL_HOST:
         EXPECT_TRUE(Backend == backend::host);

--- a/libsyclinterface/tests/test_sycl_queue_submit.cpp
+++ b/libsyclinterface/tests/test_sycl_queue_submit.cpp
@@ -28,8 +28,8 @@
 #include "dpctl_sycl_device_interface.h"
 #include "dpctl_sycl_device_selector_interface.h"
 #include "dpctl_sycl_event_interface.h"
+#include "dpctl_sycl_kernel_bundle_interface.h"
 #include "dpctl_sycl_kernel_interface.h"
-#include "dpctl_sycl_program_interface.h"
 #include "dpctl_sycl_queue_interface.h"
 #include "dpctl_sycl_usm_interface.h"
 #include <CL/sycl.hpp>

--- a/libsyclinterface/tests/test_sycl_queue_submit.cpp
+++ b/libsyclinterface/tests/test_sycl_queue_submit.cpp
@@ -79,11 +79,11 @@ TEST_F(TestQueueSubmit, CheckSubmitRange_saxpy)
     ASSERT_TRUE(QRef);
     auto CRef = DPCTLQueue_GetContext(QRef);
     ASSERT_TRUE(CRef);
-    auto PRef = DPCTLProgram_CreateFromSpirv(CRef, spirvBuffer.data(),
-                                             spirvFileSize, nullptr);
-    ASSERT_TRUE(PRef != nullptr);
-    ASSERT_TRUE(DPCTLProgram_HasKernel(PRef, "axpy"));
-    auto AxpyKernel = DPCTLProgram_GetKernel(PRef, "axpy");
+    auto KBRef = DPCTLKernelBundle_CreateFromSpirv(
+        CRef, DRef, spirvBuffer.data(), spirvFileSize, nullptr);
+    ASSERT_TRUE(KBRef != nullptr);
+    ASSERT_TRUE(DPCTLKernelBundle_HasKernel(KBRef, "axpy"));
+    auto AxpyKernel = DPCTLKernelBundle_GetKernel(KBRef, "axpy");
 
     // Create the input args
     auto a = DPCTLmalloc_shared(SIZE * sizeof(float), QRef);
@@ -120,7 +120,7 @@ TEST_F(TestQueueSubmit, CheckSubmitRange_saxpy)
     DPCTLfree_with_queue((DPCTLSyclUSMRef)c, QRef);
     DPCTLQueue_Delete(QRef);
     DPCTLContext_Delete(CRef);
-    DPCTLProgram_Delete(PRef);
+    DPCTLKernelBundle_Delete(KBRef);
     DPCTLDevice_Delete(DRef);
     DPCTLDeviceSelector_Delete(DSRef);
 }
@@ -139,11 +139,11 @@ TEST_F(TestQueueSubmit, CheckSubmitNDRange_saxpy)
     ASSERT_TRUE(QRef);
     auto CRef = DPCTLQueue_GetContext(QRef);
     ASSERT_TRUE(CRef);
-    auto PRef = DPCTLProgram_CreateFromSpirv(CRef, spirvBuffer.data(),
-                                             spirvFileSize, nullptr);
-    ASSERT_TRUE(PRef != nullptr);
-    ASSERT_TRUE(DPCTLProgram_HasKernel(PRef, "axpy"));
-    auto AxpyKernel = DPCTLProgram_GetKernel(PRef, "axpy");
+    auto KBRef = DPCTLKernelBundle_CreateFromSpirv(
+        CRef, DRef, spirvBuffer.data(), spirvFileSize, nullptr);
+    ASSERT_TRUE(KBRef != nullptr);
+    ASSERT_TRUE(DPCTLKernelBundle_HasKernel(KBRef, "axpy"));
+    auto AxpyKernel = DPCTLKernelBundle_GetKernel(KBRef, "axpy");
 
     // Create the input args
     auto a = DPCTLmalloc_shared(SIZE * sizeof(float), QRef);
@@ -185,7 +185,7 @@ TEST_F(TestQueueSubmit, CheckSubmitNDRange_saxpy)
     DPCTLfree_with_queue((DPCTLSyclUSMRef)c, QRef);
     DPCTLQueue_Delete(QRef);
     DPCTLContext_Delete(CRef);
-    DPCTLProgram_Delete(PRef);
+    DPCTLKernelBundle_Delete(KBRef);
     DPCTLDevice_Delete(DRef);
     DPCTLDeviceSelector_Delete(DSRef);
 }


### PR DESCRIPTION
This change does away with use of deprecated ``sycl::program`` class replacing it with use of ``sycl::kernel_bundle<sycl::bundle_state::executable>`` instead.

`DPCTLSyclProgramRef` has been removed, but `DPCTLSyclKernelBundleRef` introduced, being an opaque reference to the executable kernel bundle as stated above.

Functions `DPCTLProgram_*` are renamed to `DPCTLKernelBundle_*`. 

Free functions `DPCTLKernelBundle_Create*` now take context and device references (previously only took `DPCTLSyclContextRef` argument).

Implementation of `dpctl_sycl_program_interface` no longer directly uses OpenCL symbols, uses dynamic_Lib helper class to load them dynamically. Thus SyclInterface library no longer links with OpenCL library.

- [X] Have you provided a meaningful PR description?
- [X] Have you added a test, reproducer or referred to an issue with a reproducer?
- [X] Have you tested your changes locally for CPU and GPU devices?
- [X] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
