### PR TITLE
Include intersphinx extension to generate objects inventory

### DIFF
--- a/docs/conf.in
+++ b/docs/conf.in
@@ -55,6 +55,7 @@ extensions = [
     "sphinx.ext.autosummary",
     "sphinx.ext.coverage",
     "sphinx.ext.extlinks",
+    "sphinx.ext.intersphinx",
     "sphinx.ext.githubpages",
     "sphinx.ext.napoleon",
     "sphinx.ext.todo",

--- a/dpctl/_sycl_platform.pyx
+++ b/dpctl/_sycl_platform.pyx
@@ -298,7 +298,7 @@ def lsplatform(verbosity=0):
         On a system with an OpenCL CPU driver, OpenCL GPU driver,
         Level Zero GPU driver, running the command. ::
 
-        $python -c "import dpctl; dpctl.lsplatform()"
+            $ python -c "import dpctl; dpctl.lsplatform()"
 
         returns ::
 


### PR DESCRIPTION
Use `sphinx.ext.intersphinx` Sphinx extension to generate inventory of objects in the docs web-page to cross-referencing. 

Also addressed warnings coming from docstring of `dpctl.lsplatform`.

- [X] Have you provided a meaningful PR description?
- [X] Have you made sure that new changes do not introduce compiler warnings?
