### PR TITLE
update expected exception type when creating devices

### DIFF
--- a/examples/python/device_selection.py
+++ b/examples/python/device_selection.py
@@ -48,7 +48,7 @@ def create_gpu_device():
         d2 = dpctl.select_gpu_device()
         assert d1 == d2
         d1.print_device_info()
-    except ValueError:
+    except dpctl.SyclDeviceCreationError:
         print("A GPU device is not available on the system")
 
 

--- a/examples/python/filter_selection.py
+++ b/examples/python/filter_selection.py
@@ -28,13 +28,13 @@ def select_using_filter():
     try:
         d1 = dpctl.SyclDevice("cpu")
         d1.print_device_info()
-    except ValueError:
+    except dpctl.SyclDeviceCreationError:
         print("A CPU type device is not available on the system")
 
     try:
         d1 = dpctl.SyclDevice("opencl:cpu:0")
         d1.print_device_info()
-    except ValueError:
+    except dpctl.SyclDeviceCreationError:
         print("An OpenCL CPU driver needs to be installed on the system")
 
     d1 = dpctl.SyclDevice("0")
@@ -43,7 +43,7 @@ def select_using_filter():
     try:
         d1 = dpctl.SyclDevice("gpu")
         d1.print_device_info()
-    except ValueError:
+    except dpctl.SyclDeviceCreationError:
         print("A GPU type device is not available on the system")
 
 


### PR DESCRIPTION
#826 has modified the type of exception raised when `dpctl.SyclDevice` could not be created from `ValueError` to `dpctl.SyclDeviceCreationError`. 

Python examples were not updated. Hence the output of the script shows errors on the [manual page about device selection](https://intelpython.github.io/dpctl/latest/docfiles/user_guides/manual/dpctl/device_selection.html).

This PR updates two affected Python example files, `device_selection.py` and `filter_selection.py`.

- [X] Have you provided a meaningful PR description?
- [X] Have you tested your changes locally for CPU and GPU devices?
