### PR TITLE
Changes from testing dpctl under wsl on a laptop with Iris Xe

### DIFF
--- a/dpctl/tests/test_sycl_kernel_submit.py
+++ b/dpctl/tests/test_sycl_kernel_submit.py
@@ -45,6 +45,10 @@ def test_create_program_from_source(ctype_str, dtype, ctypes_ctor):
         q = dpctl.SyclQueue("opencl", property="enable_profiling")
     except dpctl.SyclQueueCreationError:
         pytest.skip("OpenCL queue could not be created")
+    if dtype == np.dtype("f8") and q.sycl_device.has_aspect_fp64 is False:
+        pytest.skip(
+            "Device does not support double precision floating point type"
+        )
     # OpenCL conventions for indexing global_id is opposite to
     # that of SYCL (and DPCTL)
     oclSrc = (

--- a/dpctl/tests/test_sycl_queue_memcpy.py
+++ b/dpctl/tests/test_sycl_queue_memcpy.py
@@ -24,9 +24,9 @@ import dpctl
 import dpctl.memory
 
 
-def _create_memory():
+def _create_memory(q):
     nbytes = 1024
-    mobj = dpctl.memory.MemoryUSMShared(nbytes)
+    mobj = dpctl.memory.MemoryUSMShared(nbytes, queue=q)
     return mobj
 
 
@@ -35,9 +35,9 @@ def _create_memory():
     reason="No SYCL devices except the default host device.",
 )
 def test_memcpy_copy_usm_to_usm():
-    mobj1 = _create_memory()
-    mobj2 = _create_memory()
     q = dpctl.SyclQueue()
+    mobj1 = _create_memory(q)
+    mobj2 = _create_memory(q)
 
     mv1 = memoryview(mobj1)
     mv2 = memoryview(mobj2)
@@ -54,8 +54,8 @@ def test_memcpy_copy_usm_to_usm():
 #    reason="No SYCL devices except the default host device."
 # )
 def test_memcpy_type_error():
-    mobj = _create_memory()
-    q = mobj._queue
+    q = dpctl.SyclQueue()
+    mobj = _create_memory(q)
 
     with pytest.raises(TypeError) as cm:
         q.memcpy(None, mobj, 3)

--- a/libsyclinterface/source/dpctl_sycl_event_interface.cpp
+++ b/libsyclinterface/source/dpctl_sycl_event_interface.cpp
@@ -60,8 +60,12 @@ void DPCTLEvent_Wait(__dpctl_keep DPCTLSyclEventRef ERef)
 {
     if (ERef) {
         auto SyclEvent = unwrap(ERef);
-        if (SyclEvent)
-            SyclEvent->wait();
+        try {
+            if (SyclEvent)
+                SyclEvent->wait();
+        } catch (std::exception const &e) {
+            error_handler(e, __FILE__, __func__, __LINE__);
+        }
     }
     else {
         error_handler("Cannot wait for the event. DPCTLSyclEventRef as "
@@ -74,8 +78,12 @@ void DPCTLEvent_WaitAndThrow(__dpctl_keep DPCTLSyclEventRef ERef)
 {
     if (ERef) {
         auto SyclEvent = unwrap(ERef);
-        if (SyclEvent)
-            SyclEvent->wait_and_throw();
+        try {
+            if (SyclEvent)
+                SyclEvent->wait_and_throw();
+        } catch (std::exception const &e) {
+            error_handler(e, __FILE__, __func__, __LINE__);
+        }
     }
     else {
         error_handler("Cannot wait_and_throw for the event. DPCTLSyclEventRef "


### PR DESCRIPTION
Several changes made during running test suite in WSL on a machine with Iris Xe.

1. Turns out calls to `sycl::event::wait` can throw SYCL exceptions, e.g. `CL_DEVICE_NOT_FOUND` and these need to be intercepted.
2. In the test for `test_sycl_queue_memcpy.py` be explicit about the allocation queue.
3. Since Iris Xe does not natively support double precision type, I added the logic to not submit the kernel built for double precision if the HW does not support it.

- [X] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [X] Have you tested your changes locally for CPU and GPU devices?
- [X] Have you made sure that new changes do not introduce compiler warnings?
