### PR TITLE
Using quotes for dpctl/CMakeLists.txt per Anton's feedback

### DIFF
--- a/dpctl/CMakeLists.txt
+++ b/dpctl/CMakeLists.txt
@@ -2,7 +2,7 @@
 find_package(PythonExtensions REQUIRED)
 find_package(NumPy REQUIRED)
 
-set(CYTHON_FLAGS "-t -w ${CMAKE_SOURCE_DIR}")
+set(CYTHON_FLAGS "-t -w \"${CMAKE_SOURCE_DIR}\"")
 find_package(Cython REQUIRED)
 
 if(WIN32)


### PR DESCRIPTION
If the absolute path for `dpctl` checkout contains spaces the lack of quotes around working directory argument to Cython causes trouble. 

This change adds the quotes. 


- [X] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
