### PR TITLE
Fixed stray use of deprecated SYCL-2020 quantifier in dpctl_c_api tests

### DIFF
--- a/libsyclinterface/tests/test_sycl_event_interface.cpp
+++ b/libsyclinterface/tests/test_sycl_event_interface.cpp
@@ -40,7 +40,7 @@ sycl::event produce_event(sycl::queue &Q, sycl::buffer<int> &data)
     int N = data.get_range()[0];
 
     auto e1 = Q.submit([&](sycl::handler &h) {
-        sycl::accessor a{data, h, sycl::write_only, sycl::noinit};
+        sycl::accessor a{data, h, sycl::write_only, sycl::no_init};
         h.parallel_for(N, [=](sycl::id<1> i) { a[i] = 1; });
     });
 


### PR DESCRIPTION
Use of `sycl::noinit` in `libsyclinterface/tests/test_sycl_event_interface.cpp` was producing deprecation warnings during coverage build. 

This change replaces `sycl::noinit` with suggested `sycl::no_init` addressing the warning.

- [X] Have you provided a meaningful PR description?
- [X] Have you added a test, reproducer or referred to an issue with a reproducer?
- [X] Have you tested your changes locally for CPU and GPU devices?
- [X] Have you made sure that new changes do not introduce compiler warnings?
