### PR TITLE
Test iris xe part2

### DIFF
--- a/dpctl/tests/test_tensor_asarray.py
+++ b/dpctl/tests/test_tensor_asarray.py
@@ -191,7 +191,9 @@ def test_asarray_copy_false():
         q = dpctl.SyclQueue()
     except dpctl.SyclQueueCreationError:
         pytest.skip("Could not create a queue")
-    X = dpt.from_numpy(np.random.randn(10, 4), usm_type="device", sycl_queue=q)
+    rng = np.random.default_rng()
+    Xnp = rng.integers(low=-255, high=255, size=(10, 4), dtype=np.int64)
+    X = dpt.from_numpy(Xnp, usm_type="device", sycl_queue=q)
     Y1 = dpt.asarray(X, copy=False, order="K")
     assert Y1 is X
     Y1c = dpt.asarray(X, copy=True, order="K")


### PR DESCRIPTION
Modified test suite to not exercise calls that would result in JIT-compiling kernels with double precision floating point types on hardware such as Intel Iris Xe which does not have HW support for the double precision floating point type.

- [X] Have you provided a meaningful PR description?
- [X] Have you added a test, reproducer or referred to an issue with a reproducer?
- [X] Have you tested your changes locally for CPU and GPU devices?
- [X] Have you made sure that new changes do not introduce compiler warnings?
