### PR TITLE
Added license text to IntelDPCPPConfig.cmake

### DIFF
--- a/cmake/IntelDPCPPConfig.cmake
+++ b/cmake/IntelDPCPPConfig.cmake
@@ -1,3 +1,16 @@
+#
+# Modifications, Copyright (C) 2021 Intel Corporation
+#
+# This software and the related documents are Intel copyrighted materials, and
+# your use of them is governed by the express license under which they were
+# provided to you ("License"). Unless the License provides otherwise, you may not
+# use, modify, copy, publish, distribute, disclose or transmit this software or
+# the related documents without Intel's prior written permission.
+#
+# This software and the related documents are provided as is, with no express
+# or implied warranties, other than those that are expressly stated in the
+# License.
+#
 # Distributed under the OSI-approved BSD 3-Clause License.  See accompanying
 # file Copyright.txt or https://cmake.org/licensing for details.
 


### PR DESCRIPTION
Added license text to IntelDPCPPConfig.cmake to align it with what's is oneAPI DPC++

No functional changes.

- [X] Have you provided a meaningful PR description?
