### PR TITLE
Fixed filter-selector-string output by lsplatform and print_device_info

### DIFF
--- a/libsyclinterface/helper/include/dpctl_utils_helper.h
+++ b/libsyclinterface/helper/include/dpctl_utils_helper.h
@@ -198,6 +198,18 @@ DPCTL_API
 int64_t DPCTL_GetRelativeDeviceId(const sycl::device &Device);
 
 /*!
+ * @brief Gives the filter string which would select given root device if
+ * used as argument to ``sycl::ext::oneapi::filter_selector``. Throws exception
+ * if filter string can not be constructed.
+ *
+ * @param    Device         A ``sycl::device`` object whose filter selector
+ *                          needs to be computed.
+ * @return   Filter selector for the device.
+ */
+DPCTL_API
+std::string DPCTL_GetDeviceFilterString(const sycl::device &Device);
+
+/*!
  * @brief Converts a ``sycl::info::event_command_status`` enum value to
  * corresponding DPCTLSyclEventStatusType enum value.
  *

--- a/libsyclinterface/helper/source/dpctl_utils_helper.cpp
+++ b/libsyclinterface/helper/source/dpctl_utils_helper.cpp
@@ -470,6 +470,38 @@ int64_t DPCTL_GetRelativeDeviceId(const device &Device)
     return relid;
 }
 
+std::string DPCTL_GetDeviceFilterString(const device &Device)
+{
+    std::stringstream ss;
+    static constexpr const char *filter_string_separator = ":";
+
+    auto be = Device.get_platform().get_backend();
+
+    switch (be) {
+    case backend::ext_oneapi_level_zero:
+        ss << "level_zero";
+        break;
+    case backend::ext_oneapi_cuda:
+        ss << "cuda";
+        break;
+    case backend::opencl:
+        ss << "opencl";
+        break;
+    case backend::host:
+        ss << "host";
+        break;
+    default:
+        ss << "unknown";
+    };
+
+    ss << filter_string_separator;
+    ss << DPCTL_DeviceTypeToStr(Device.get_info<info::device::device_type>());
+    ss << filter_string_separator;
+    ss << DPCTL_GetRelativeDeviceId(Device);
+
+    return ss.str();
+}
+
 DPCTLSyclEventStatusType
 DPCTL_SyclEventStatusToDPCTLEventStatusType(info::event_command_status E)
 {

--- a/libsyclinterface/source/dpctl_sycl_device_manager.cpp
+++ b/libsyclinterface/source/dpctl_sycl_device_manager.cpp
@@ -50,19 +50,18 @@ DEFINE_SIMPLE_CONVERSION_FUNCTIONS(context, DPCTLSyclContextRef)
 std::string get_device_info_str(const device &Device)
 {
     std::stringstream ss;
+    static constexpr const char *_endl = "\n";
 
     ss << std::setw(4) << " " << std::left << std::setw(16) << "Name"
-       << Device.get_info<info::device::name>() << '\n'
-       << std::setw(4) << " " << std::left << std::setw(16) << "Driver version"
-       << Device.get_info<info::device::driver_version>() << '\n'
+       << Device.get_info<info::device::name>() << _endl << std::setw(4) << " "
+       << std::left << std::setw(16) << "Driver version"
+       << Device.get_info<info::device::driver_version>() << _endl
        << std::setw(4) << " " << std::left << std::setw(16) << "Vendor"
-       << Device.get_info<info::device::vendor>() << '\n'
-       << std::setw(4) << " " << std::left << std::setw(16) << "Profile"
-       << Device.get_info<info::device::profile>() << '\n'
-       << std::setw(4) << " " << std::left << std::setw(16) << "Filter string"
-       << Device.get_platform().get_backend() << ":"
-       << DPCTL_DeviceTypeToStr(Device.get_info<info::device::device_type>())
-       << ":" << DPCTL_GetRelativeDeviceId(Device) << '\n';
+       << Device.get_info<info::device::vendor>() << _endl << std::setw(4)
+       << " " << std::left << std::setw(16) << "Profile"
+       << Device.get_info<info::device::profile>() << _endl << std::setw(4)
+       << " " << std::left << std::setw(16) << "Filter string"
+       << DPCTL_GetDeviceFilterString(Device) << _endl;
 
     return ss.str();
 }

--- a/libsyclinterface/source/dpctl_sycl_platform_manager.cpp
+++ b/libsyclinterface/source/dpctl_sycl_platform_manager.cpp
@@ -45,6 +45,7 @@ DEFINE_SIMPLE_CONVERSION_FUNCTIONS(platform, DPCTLSyclPlatformRef);
 std::string platform_print_info_impl(const platform &p, size_t verbosity)
 {
     std::stringstream ss;
+    static constexpr const char *_endl = "\n";
 
     if (verbosity > 2) {
         error_handler("Illegal verbosity level. Accepted values are 0, 1, or 2."
@@ -55,7 +56,7 @@ std::string platform_print_info_impl(const platform &p, size_t verbosity)
 
     if (verbosity == 0)
         ss << p.get_info<info::platform::name>() << " "
-           << p.get_info<info::platform::version>() << '\n';
+           << p.get_info<info::platform::version>() << _endl;
 
     if (verbosity > 0) {
         auto vendor = p.get_info<info::platform::vendor>();
@@ -63,37 +64,31 @@ std::string platform_print_info_impl(const platform &p, size_t verbosity)
             vendor = "unknown";
 
         ss << std::setw(4) << " " << std::left << std::setw(12) << "Name"
-           << p.get_info<info::platform::name>() << '\n'
-           << std::setw(4) << " " << std::left << std::setw(12) << "Version"
-           << p.get_info<info::platform::version>() << '\n'
-           << std::setw(4) << " " << std::left << std::setw(12) << "Vendor"
-           << vendor << '\n'
+           << p.get_info<info::platform::name>() << _endl << std::setw(4) << " "
+           << std::left << std::setw(12) << "Version"
+           << p.get_info<info::platform::version>() << _endl << std::setw(4)
+           << " " << std::left << std::setw(12) << "Vendor" << vendor << _endl
            << std::setw(4) << " " << std::left << std::setw(12) << "Backend";
         p.is_host() ? (ss << "unknown") : (ss << p.get_backend());
-        ss << '\n';
+        ss << _endl;
 
         // Get number of devices on the platform
         auto devices = p.get_devices();
         ss << std::setw(4) << " " << std::left << std::setw(12) << "Num Devices"
-           << devices.size() << '\n';
+           << devices.size() << _endl;
 
         if (verbosity == 2)
             // Print some of the device information
             for (auto dn = 0ul; dn < devices.size(); ++dn) {
-                ss << std::setw(6) << " " << std::left << "# " << dn << '\n'
+                ss << std::setw(6) << " " << std::left << "# " << dn << _endl
                    << std::setw(8) << " " << std::left << std::setw(20)
                    << "Name" << devices[dn].get_info<info::device::name>()
-                   << '\n'
-                   << std::setw(8) << " " << std::left << std::setw(20)
+                   << _endl << std::setw(8) << " " << std::left << std::setw(20)
                    << "Version"
                    << devices[dn].get_info<info::device::driver_version>()
-                   << '\n'
-                   << std::setw(8) << " " << std::left << std::setw(20)
+                   << _endl << std::setw(8) << " " << std::left << std::setw(20)
                    << "Filter string"
-                   << devices[dn].get_platform().get_backend() << ":"
-                   << DPCTL_DeviceTypeToStr(
-                          devices[dn].get_info<info::device::device_type>())
-                   << ":" << DPCTL_GetRelativeDeviceId(devices[dn]) << '\n';
+                   << DPCTL_GetDeviceFilterString(devices[dn]) << _endl;
             }
     }
 


### PR DESCRIPTION
SYCLInterface library functions used `std::to_string(sycl::backend d.get_platform().get_backend())` to produce backend section of the filter selector.  Correspondingly they produced invalid strings like `"ext_oneapi_level_zero:gpu:0"` where `"level_zero:gpu:0"` was expected.

- [X] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [X] Have you tested your changes locally for CPU and GPU devices?
- [X] Have you made sure that new changes do not introduce compiler warnings?

---

For example, now:

```
Platform  3 ::
    Name        Intel(R) Level-Zero
    Version     1.3
    Vendor      Intel(R) Corporation
    Backend     ext_oneapi_level_zero
    Num Devices 1
      # 0
        Name                Intel(R) UHD Graphics [0x9bca]
        Version             1.3.23750
        Filter string       level_zero:gpu:0
```

While previously the filter string was "ext_oneapi_level_zero:gpu:0".

Similar change for print_device_info:

```
$ SYCL_FILTER_SELECTOR=level python -c "import dpctl; dpctl.SyclDevice().print_device_info()"
    Name            Intel(R) UHD Graphics [0x9bca]
    Driver version  1.3.23750
    Vendor          Intel(R) Corporation
    Profile         FULL_PROFILE
    Filter string   level_zero:gpu:0
```

Previously the filter string used to be "ext_oneapi_level_zero:gpu:0".
