### PR TITLE
Type dispatch fix

### DIFF
--- a/dpctl/tensor/libtensor/include/utils/type_dispatch.hpp
+++ b/dpctl/tensor/libtensor/include/utils/type_dispatch.hpp
@@ -228,9 +228,22 @@ struct usm_ndarray_types
         else if (typenum == UAR_HALF_) {
             return static_cast<int>(typenum_t::HALF);
         }
+        else if (typenum == UAR_INT || typenum == UAR_UINT) {
+            switch (sizeof(int)) {
+            case sizeof(std::int32_t):
+                return ((typenum == UAR_INT)
+                            ? static_cast<int>(typenum_t::INT32)
+                            : static_cast<int>(typenum_t::UINT32));
+            case sizeof(std::int64_t):
+                return ((typenum == UAR_INT)
+                            ? static_cast<int>(typenum_t::INT64)
+                            : static_cast<int>(typenum_t::UINT64));
+            default:
+                throw_unrecognized_typenum_error(typenum);
+            }
+        }
         else {
-            throw std::runtime_error("Unrecogized typenum " +
-                                     std::to_string(typenum) + " encountered.");
+            throw_unrecognized_typenum_error(typenum);
         }
     }
 
@@ -285,6 +298,12 @@ private:
         types.init_constants();
 
         return types;
+    }
+
+    void throw_unrecognized_typenum_error(int typenum)
+    {
+        throw std::runtime_error("Unrecogized typenum " +
+                                 std::to_string(typenum) + " encountered.");
     }
 };
 

--- a/dpctl/tests/test_usm_ndarray_ctor.py
+++ b/dpctl/tests/test_usm_ndarray_ctor.py
@@ -708,6 +708,23 @@ def test_setitem_different_dtypes(src_dt, dst_dt):
     assert np.allclose(dpt.asnumpy(Z), np.tile(np.array([1, 0], Z.dtype), 10))
 
 
+def test_setitem_wingaps():
+    try:
+        q = dpctl.SyclQueue()
+    except dpctl.SyclQueueCreationError:
+        pytest.skip("Default queue could not be created")
+    if np.dtype("intc").itemsize == np.dtype("int32").itemsize:
+        dpt_dst = dpt.empty(4, dtype="int32", sycl_queue=q)
+        np_src = np.arange(4, dtype="intc")
+        dpt_dst[:] = np_src  # should not raise exceptions
+        assert np.array_equal(dpt.asnumpy(dpt_dst), np_src)
+    if np.dtype("long").itemsize == np.dtype("longlong").itemsize:
+        dpt_dst = dpt.empty(4, dtype="longlong", sycl_queue=q)
+        np_src = np.arange(4, dtype="long")
+        dpt_dst[:] = np_src  # should not raise exceptions
+        assert np.array_equal(dpt.asnumpy(dpt_dst), np_src)
+
+
 def test_shape_setter():
     def cc_strides(sh):
         return np.empty(sh, dtype="u1").strides


### PR DESCRIPTION
The utilities that maps array's `typenum` to `type_id` for function pointer look-up need to understand not only computed disjoint types, but only shadowed types which are not mapped to the disjoin types.

```python
import dpctl.tensor as dpt, numpy as np
dpt_dst = dpt.empty((10,), dtype=np.int32)

dpt_dst[:] = np.arange(10, dtype='intc')   # used to raise RuntimeError of unrecognized 
                                           # type number 5 (corresponding to intc)
```

Test added.

- [X] Have you provided a meaningful PR description?
- [X] Have you added a test, reproducer or referred to an issue with a reproducer?
- [X] Have you tested your changes locally for CPU and GPU devices?
- [X] Have you made sure that new changes do not introduce compiler warnings?
