### PR TITLE
Fix c interface

### DIFF
--- a/.github/workflows/conda-package.yml
+++ b/.github/workflows/conda-package.yml
@@ -393,7 +393,7 @@ jobs:
           conda install -n examples -y ninja $CHANNELS || exit 1
           conda install -n examples -y pybind11 cython scikit-build $CHANNELS || exit 1
           conda install -n examples -y mkl-dpcpp mkl-devel-dpcpp dpcpp_cpp_rt $CHANNELS || exit 1
-          conda create -y -n build_env -c intel dpcpp_linux-64
+          conda create -y -n build_env -c intel gcc_linux-64 gxx_linux-64 dpcpp_linux-64
       - name: Install dpctl
         shell: bash -l {0}
         run: |
@@ -424,7 +424,7 @@ jobs:
                     -DMKL_INCLUDE_DIR=${MKLROOT}/include \
                     -DTBB_INCLUDE_DIR=${TBBROOT}/include || exit 1
             else
-               CC=dpcpp CXX=dpcpp LD_SHARED="dpcpp -shared" \
+               CC=dpcpp CXX=dpcpp LDSHARED="dpcpp -shared" \
                     python setup.py build_ext --inplace || exit 1
             fi
             conda deactivate
@@ -441,10 +441,20 @@ jobs:
           do
             pushd $d
             conda activate --stack build_env
-            CC=dpcpp CXX=dpcpp LD_SHARED="dpcpp -shared" \
+            CC=dpcpp CXX=dpcpp LDSHARED="dpcpp -shared" \
                    python setup.py build_ext --inplace || exit 1
             conda deactivate
             LD_LIBRARY_PATH=${CONDA_PREFIX}/lib python run.py || exit 1
+            popd
+          done
+          cd ../c
+          for d in $(ls)
+          do
+            pushd $d
+            conda activate --stack build_env
+            python setup.py build_ext --inplace || exit 1
+            conda deactivate
+            python -m pytest tests || exit 1
             popd
           done
       - name: Run Python examples

--- a/dpctl/_sycl_platform.pyx
+++ b/dpctl/_sycl_platform.pyx
@@ -349,7 +349,7 @@ def lsplatform(verbosity=0):
     cdef DPCTLSyclPlatformRef PRef = NULL
 
     if not isinstance(verbosity, int):
-        print(
+        warnings.warn(
             "Illegal verbosity level. Accepted values are 0, 1, or 2. "
             "Using the default verbosity level of 0."
         )

--- a/examples/c/py_sycl_ls/py_sycl_ls/__init__.py
+++ b/examples/c/py_sycl_ls/py_sycl_ls/__init__.py
@@ -1,0 +1,21 @@
+#                      Data Parallel Control (dpctl)
+#
+# Copyright 2022 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from ._py_sycl_ls import sycl_ls
+
+__all__ = [
+    "sycl_ls",
+]

--- a/examples/c/py_sycl_ls/py_sycl_ls/__main__.py
+++ b/examples/c/py_sycl_ls/py_sycl_ls/__main__.py
@@ -1,0 +1,20 @@
+#                      Data Parallel Control (dpctl)
+#
+# Copyright 2020-2021 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from py_sycl_ls import sycl_ls
+
+if __name__ == "__main__":
+    sycl_ls()

--- a/examples/c/py_sycl_ls/setup.py
+++ b/examples/c/py_sycl_ls/setup.py
@@ -1,0 +1,61 @@
+#                      Data Parallel Control (dpctl)
+#
+# Copyright 2022 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os.path
+import sysconfig
+
+from setuptools import Extension, setup
+
+import dpctl
+
+setup(
+    name="py_sycl_ls",
+    version="0.0.1",
+    description="An example of C extension calling SYCLInterface routines",
+    long_description="""
+    Example of using SYCLInterface.
+
+    See README.md for more details.
+    """,
+    license="Apache 2.0",
+    author="Intel Corporation",
+    url="https://github.com/IntelPython/dpctl",
+    ext_modules=[
+        Extension(
+            name="py_sycl_ls._py_sycl_ls",
+            sources=[
+                "src/py_sycl-ls.c",
+            ],
+            include_dirs=[
+                dpctl.get_include(),
+                os.path.join(sysconfig.get_paths()["include"], ".."),
+            ],
+            library_dirs=[
+                os.path.join(dpctl.get_include(), ".."),
+            ],
+            libraries=["DPCTLSyclInterface"],
+            runtime_library_dirs=[
+                os.path.join(dpctl.get_include(), ".."),
+            ],
+            extra_compile_args=[
+                "-Wall",
+                "-Wextra",
+            ],
+            extra_link_args=["-fPIC"],
+            language="c",
+        )
+    ],
+)

--- a/examples/c/py_sycl_ls/src/py_sycl-ls.c
+++ b/examples/c/py_sycl_ls/src/py_sycl-ls.c
@@ -1,0 +1,89 @@
+//==- py_sycl-ls.c - Example of C extension working with                -===//
+//  DPCTLSyclInterface C-interface library.
+//
+//                      Data Parallel Control (dpctl)
+//
+// Copyright 2022 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// This file implements C Python extension using DPCTLSyclInterface library.
+///
+//===----------------------------------------------------------------------===//
+
+// clang-format off
+#include "Python.h"
+#include "dpctl_capi.h"
+#include "syclinterface/dpctl_sycl_platform_interface.h"
+#include "syclinterface/dpctl_sycl_platform_manager.h"
+#include "syclinterface/dpctl_utils.h"
+// clang-format on
+
+PyObject *sycl_ls(PyObject *self_unused, PyObject *args)
+{
+    DPCTLPlatformVectorRef PVRef = NULL;
+    size_t psz = 0;
+
+    (void)(self_unused); // avoid unused arguments warning
+    (void)(args);
+    PVRef = DPCTLPlatform_GetPlatforms();
+
+    if (PVRef) {
+        psz = DPCTLPlatformVector_Size(PVRef);
+
+        for (size_t i = 0; i < psz; ++i) {
+            DPCTLSyclPlatformRef PRef = DPCTLPlatformVector_GetAt(PVRef, i);
+            const char *pl_info = DPCTLPlatformMgr_GetInfo(PRef, 2);
+
+            printf("Platform: %ld::\n%s\n", i, pl_info);
+
+            DPCTLCString_Delete(pl_info);
+            DPCTLPlatform_Delete(PRef);
+        }
+
+        DPCTLPlatformVector_Delete(PVRef);
+    }
+
+    Py_RETURN_NONE;
+}
+
+static PyMethodDef SyclLSMethods[] = {
+    {"sycl_ls", sycl_ls, METH_NOARGS, "Output information about SYCL platform"},
+    {NULL, NULL, 0, NULL} /* Sentinel */
+};
+
+static struct PyModuleDef syclls_module = {
+    PyModuleDef_HEAD_INIT,
+    "_py_sycl_ls", /* name of module */
+    "",            /* module documentation, may be NULL */
+    -1,            /* size of per-interpreter state of the module,
+                      or -1 if the module keeps state in global variables. */
+    SyclLSMethods,
+    NULL,
+    NULL,
+    NULL,
+    NULL};
+
+PyMODINIT_FUNC PyInit__py_sycl_ls(void)
+{
+    PyObject *m;
+
+    import_dpctl();
+
+    m = PyModule_Create(&syclls_module);
+
+    return m;
+}

--- a/examples/c/py_sycl_ls/tests/test_sycl_ls.py
+++ b/examples/c/py_sycl_ls/tests/test_sycl_ls.py
@@ -1,0 +1,26 @@
+#                      Data Parallel Control (dpctl)
+#
+# Copyright 2022 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import subprocess
+import sys
+
+
+def test_sycl_ls():
+    r = subprocess.run(
+        [sys.executable, "-m", "py_sycl_ls"], capture_output=True, check=True
+    )
+    assert r.stdout
+    assert not r.stderr

--- a/examples/cython/sycl_buffer/setup.py
+++ b/examples/cython/sycl_buffer/setup.py
@@ -48,6 +48,9 @@ setup(
                 dpctl.get_include(),
                 os.path.join(sysconfig.get_paths()["include"], ".."),
             ],
+            library_dirs=[
+                os.path.join(sysconfig.get_paths()["stdlib"], ".."),
+            ],
             libraries=["sycl"]
             + [
                 "mkl_sycl",
@@ -55,7 +58,6 @@ setup(
                 "mkl_tbb_thread",
                 "mkl_core",
                 "tbb",
-                "iomp5",
             ],
             runtime_library_dirs=[],
             extra_compile_args=[

--- a/examples/cython/sycl_buffer/use_sycl_buffer.cpp
+++ b/examples/cython/sycl_buffer/use_sycl_buffer.cpp
@@ -60,8 +60,7 @@ int c_columnwise_total(DPCTLSyclQueueRef q_ref,
             ev.wait_and_throw();
         } catch (sycl::exception const &e) {
             std::cout << "\t\tCaught synchronous SYCL exception during fill:\n"
-                      << e.what() << std::endl
-                      << "OpenCL status: " << e.get_cl_code() << std::endl;
+                      << e.what() << std::endl;
             goto cleanup;
         }
 
@@ -72,8 +71,7 @@ int c_columnwise_total(DPCTLSyclQueueRef q_ref,
             q.wait();
         } catch (sycl::exception const &e) {
             std::cout << "\t\tCaught synchronous SYCL exception during GEMV:\n"
-                      << e.what() << std::endl
-                      << "OpenCL status: " << e.get_cl_code() << std::endl;
+                      << e.what() << std::endl;
             goto cleanup;
         }
     }
@@ -128,8 +126,8 @@ int c_columnwise_total_no_mkl(DPCTLSyclQueueRef q_ref,
                     std::plus<double>());
                 if (it.get_local_id(0) == 0) {
                     sycl::ext::oneapi::atomic_ref<
-                        double, sycl::ext::oneapi::memory_order::relaxed,
-                        sycl::ext::oneapi::memory_scope::system,
+                        double, sycl::memory_order::relaxed,
+                        sycl::memory_scope::system,
                         sycl::access::address_space::global_space>(ct_acc[j]) +=
                         group_sum;
                 }

--- a/examples/cython/sycl_buffer/use_sycl_buffer.cpp
+++ b/examples/cython/sycl_buffer/use_sycl_buffer.cpp
@@ -125,11 +125,10 @@ int c_columnwise_total_no_mkl(DPCTLSyclQueueRef q_ref,
                     it.get_group(), (i < n) ? mat_acc[it.get_global_id()] : 0.0,
                     std::plus<double>());
                 if (it.get_local_id(0) == 0) {
-                    sycl::ext::oneapi::atomic_ref<
-                        double, sycl::memory_order::relaxed,
-                        sycl::memory_scope::system,
-                        sycl::access::address_space::global_space>(ct_acc[j]) +=
-                        group_sum;
+                    sycl::atomic_ref<double, sycl::memory_order::relaxed,
+                                     sycl::memory_scope::system,
+                                     sycl::access::address_space::global_space>(
+                        ct_acc[j]) += group_sum;
                 }
             });
     });

--- a/examples/cython/sycl_direct_linkage/setup.py
+++ b/examples/cython/sycl_direct_linkage/setup.py
@@ -52,6 +52,9 @@ setup(
                 dpctl.get_include(),
                 os.path.join(sysconfig.get_paths()["include"], ".."),
             ],
+            library_dirs=[
+                os.path.join(sysconfig.get_paths()["stdlib"], ".."),
+            ],
             libraries=["sycl"]
             + [
                 "mkl_sycl",
@@ -59,7 +62,6 @@ setup(
                 "mkl_tbb_thread",
                 "mkl_core",
                 "tbb",
-                "iomp5",
             ],
             runtime_library_dirs=[],
             extra_compile_args=[

--- a/examples/cython/sycl_direct_linkage/sycl_function.cpp
+++ b/examples/cython/sycl_direct_linkage/sycl_function.cpp
@@ -56,8 +56,7 @@ int c_columnwise_total(cl::sycl::queue &q,
             ev.wait_and_throw();
         } catch (sycl::exception const &e) {
             std::cout << "\t\tCaught synchronous SYCL exception during fill:\n"
-                      << e.what() << std::endl
-                      << "OpenCL status: " << e.get_cl_code() << std::endl;
+                      << e.what() << std::endl;
             goto cleanup;
         }
 
@@ -68,8 +67,7 @@ int c_columnwise_total(cl::sycl::queue &q,
             q.wait();
         } catch (sycl::exception const &e) {
             std::cout << "\t\tCaught synchronous SYCL exception during GEMV:\n"
-                      << e.what() << std::endl
-                      << "OpenCL status: " << e.get_cl_code() << std::endl;
+                      << e.what() << std::endl;
             goto cleanup;
         }
     }

--- a/examples/cython/usm_memory/setup.py
+++ b/examples/cython/usm_memory/setup.py
@@ -47,6 +47,9 @@ setup(
                 dpctl.get_include(),
                 os.path.join(sysconfig.get_paths()["include"], ".."),
             ],
+            library_dirs=[
+                os.path.join(sysconfig.get_paths()["stdlib"], ".."),
+            ],
             libraries=["sycl"]
             + [
                 "mkl_sycl",
@@ -54,7 +57,6 @@ setup(
                 "mkl_tbb_thread",
                 "mkl_core",
                 "tbb",
-                "iomp5",
             ],
             runtime_library_dirs=[],
             extra_compile_args=[

--- a/libsyclinterface/include/dpctl_sycl_device_interface.h
+++ b/libsyclinterface/include/dpctl_sycl_device_interface.h
@@ -250,11 +250,9 @@ DPCTLDevice_GetMaxWorkItemSizes3d(__dpctl_keep const DPCTLSyclDeviceRef DRef);
  * @return   Returns the valid result if device exists else returns NULL.
  * @ingroup DeviceInterface
  */
-DPCTL_API
-__dpctl_keep size_t *
-DPCTLDevice_GetMaxWorkItemSizes(__dpctl_keep const DPCTLSyclDeviceRef DRef)
-    __attribute__((deprecated("DPCTLDevice_GetMaxWorkItemSizes is deprecated ",
-                              "Use DPCTLDevice_WorkItemSizes3d instead")));
+[[deprecated("Use DPCTLDevice_WorkItemSizes3d instead")]] DPCTL_API
+    __dpctl_keep size_t *
+    DPCTLDevice_GetMaxWorkItemSizes(__dpctl_keep const DPCTLSyclDeviceRef DRef);
 
 /*!
  * @brief Wrapper for get_info<info::device::max_work_group_size>().


### PR DESCRIPTION
One of DPCTLSyclInterface function was deprecated in #876, and `__attributes__((deprecated(what, repl))` was used.

This broke building of C extensions using the library. This PR uses `[[deprecated(msg)]]` instead, which is understood by both the gcc and icx.

An example of native Python extension written in C and that is using DPCTLSyclInterface is added. It is being compiled in the workflow `conda-package.yml` workflow when testing that examples can be compiled on Linux.

Incidentally, `dpctl.lsplatform` implementation replaced informational `print` with seemingly more appropriate use of `warnings.warn`.

- [X] Have you provided a meaningful PR description?
- [X] Have you added a test, reproducer or referred to an issue with a reproducer?
- [X] Have you tested your changes locally for CPU and GPU devices?
- [X] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?

@mingjie-intel