### PR TITLE
dpctl.tensor.asarray must check numpy array data-type

### DIFF
--- a/.github/workflows/os-llvm-sycl-build.yml
+++ b/.github/workflows/os-llvm-sycl-build.yml
@@ -41,7 +41,7 @@ jobs:
           cd /home/runner/work
           mkdir -p sycl_bundle
           cd sycl_bundle
-          export LATEST_LLVM_TAG=$(git -c 'versionsort.suffix=-' ls-remote --tags --sort='v:refname' https://github.com/intel/llvm.git | tail --lines=1)
+          export LATEST_LLVM_TAG=$(git -c 'versionsort.suffix=-' ls-remote --tags --sort='v:refname' https://github.com/intel/llvm.git | grep sycl-nightly | tail --lines=1)
           export LATEST_LLVM_TAG_SHA=$(echo ${LATEST_LLVM_TAG} | awk '{print $1}')
           export NIGHTLY_TAG=$(python3 -c "import sys, urllib.parse as ul; print (ul.quote_plus(sys.argv[1]))" \
              $(echo ${LATEST_LLVM_TAG} | awk '{gsub(/^refs\/tags\//, "", $2)} {print $2}'))

--- a/dpctl/tensor/_ctors.py
+++ b/dpctl/tensor/_ctors.py
@@ -44,7 +44,7 @@ def _get_dtype(dtype, sycl_obj, ref_type=None):
             dtype = ti.default_device_complex_type(sycl_obj)
             return np.dtype(dtype)
         else:
-            raise ValueError(f"Reference type {ref_type} not recognized.")
+            raise TypeError(f"Reference type {ref_type} not recognized.")
     else:
         return np.dtype(dtype)
 
@@ -199,6 +199,11 @@ def _asarray_from_numpy_ndarray(
     if usm_type is None:
         usm_type = "device"
     copy_q = normalize_queue_device(sycl_queue=None, device=sycl_queue)
+    if ary.dtype.char not in "?bBhHiIlLqQefdFD":
+        raise TypeError(
+            f"Numpy array of data type {ary.dtype} is not supported. "
+            "Please convert the input to an array with numeric data type."
+        )
     if dtype is None:
         ary_dtype = ary.dtype
         dtype = _get_dtype(dtype, copy_q, ref_type=ary_dtype)

--- a/dpctl/tests/test_tensor_asarray.py
+++ b/dpctl/tests/test_tensor_asarray.py
@@ -220,3 +220,13 @@ def test_asarray_copy_false():
     assert Y6 is Xf
     with pytest.raises(ValueError):
         dpt.asarray(Xf, copy=False, order="C")
+
+
+def test_asarray_invalid_dtype():
+    try:
+        q = dpctl.SyclQueue()
+    except dpctl.SyclQueueCreationError:
+        pytest.skip("Could not create a queue")
+    Xnp = np.array([1, 2, 3], dtype=object)
+    with pytest.raises(TypeError):
+        dpt.asarray(Xnp, sycl_queue=q)

--- a/dpctl/tests/test_tensor_asarray.py
+++ b/dpctl/tests/test_tensor_asarray.py
@@ -177,11 +177,17 @@ def test_asarray_scalars():
     Y = dpt.asarray(5)
     assert Y.dtype == np.dtype(int)
     Y = dpt.asarray(5.2)
-    assert Y.dtype == np.dtype(float)
+    if Y.sycl_device.has_aspect_fp64:
+        assert Y.dtype == np.dtype(float)
+    else:
+        assert Y.dtype == np.dtype(np.float32)
     Y = dpt.asarray(np.float32(2.3))
     assert Y.dtype == np.dtype(np.float32)
     Y = dpt.asarray(1.0j)
-    assert Y.dtype == np.dtype(complex)
+    if Y.sycl_device.has_aspect_fp64:
+        assert Y.dtype == np.dtype(complex)
+    else:
+        assert Y.dtype == np.dtype(np.complex64)
     Y = dpt.asarray(ctypes.c_int(8))
     assert Y.dtype == np.dtype(ctypes.c_int)
 


### PR DESCRIPTION
This PR addresses a test failure in `dpnp` caused by lack of data-type checking in `dpctl.tensor.asarray(numpy_array)`.

```python
import numpy as np, dpctl.tensor as dpt

dpt.asarray(np.array([1,2,3], dtype=object)) # now raises TypeError
```

- [X] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [X] Have you tested your changes locally for CPU and GPU devices?
- [X] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
