### PR TITLE
Tests on iris xe

### DIFF
--- a/dpctl/tensor/_usmarray.pyx
+++ b/dpctl/tensor/_usmarray.pyx
@@ -937,7 +937,7 @@ cdef class usm_ndarray:
                 except Exception:
                     raise ValueError(
                         f"Input of type {type(val)} could not be "
-                        "converted to numpy.ndarray"
+                        "converted to usm_ndarray"
                     )
 
     def __sub__(first, other):

--- a/dpctl/tests/test_usm_ndarray_ctor.py
+++ b/dpctl/tests/test_usm_ndarray_ctor.py
@@ -588,7 +588,10 @@ _all_dtypes = [
 )
 @pytest.mark.parametrize("usm_type", ["device", "shared", "host"])
 def test_tofrom_numpy(shape, dtype, usm_type):
-    q = dpctl.SyclQueue()
+    try:
+        q = dpctl.SyclQueue()
+    except dpctl.SyclQueueCreationError:
+        pytest.skip("Could nto create default SyclQueue")
     Xnp = np.zeros(shape, dtype=dtype)
     Xusm = dpt.from_numpy(Xnp, usm_type=usm_type, sycl_queue=q)
     Ynp = np.ones(shape, dtype=dtype)

--- a/dpctl/tests/test_usm_ndarray_manipulation.py
+++ b/dpctl/tests/test_usm_ndarray_manipulation.py
@@ -965,7 +965,6 @@ def test_stack_2arrays(data):
     Y = dpt.asarray(Ynp, sycl_queue=q)
 
     Znp = np.stack([Xnp, Ynp], axis=axis)
-    print(Znp.shape)
     Z = dpt.stack([X, Y], axis=axis)
 
     assert_array_equal(Znp, dpt.asnumpy(Z))

--- a/dpctl/tests/test_usm_ndarray_operators.py
+++ b/dpctl/tests/test_usm_ndarray_operators.py
@@ -49,7 +49,7 @@ class Dummy:
 
 @pytest.mark.parametrize("namespace", [None, Dummy()])
 def test_fp_ops(namespace):
-    X = dpt.usm_ndarray(1, "d")
+    X = dpt.ones(1)
     X._set_namespace(namespace)
     assert X.__array_namespace__() is namespace
     X[0] = -2.5


### PR DESCRIPTION
This is the set of changes that get test suite to run clean on Iris Xe hardware.

Also removed stray print statement in the test for stack_2d. Improved exception text for `usm_ndarray`.

- [X] Have you provided a meaningful PR description?
- [X] Have you tested your changes locally for CPU and GPU devices?
- [X] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?

The test suite was run as follows from within WSL:

```bash
for f in $(find dpctl/tests -name "test_*.py" -type f); do python -m pytest ${f}; done
```

using [NEO 23852](https://github.com/intel/compute-runtime/releases/tag/22.31.23852).