### PR TITLE
Addressed gh-891, improved SyclDevice ctor error message

### DIFF
--- a/dpctl/_sycl_device.pyx
+++ b/dpctl/_sycl_device.pyx
@@ -293,7 +293,8 @@ cdef class SyclDevice(_SyclDevice):
             ret = self._init_from_selector(DSRef)
             if ret == -1:
                 raise SyclDeviceCreationError(
-                    "Could not create a SyclDevice with the selector string"
+                    "Could not create a SyclDevice with the selector string "
+		    "'{selector_string}'".format(selector_string=arg)
                 )
         elif isinstance(arg, _SyclDevice):
             ret = self._init_from__SyclDevice(arg)


### PR DESCRIPTION
Improved exception message when SyclDevice could not created from invalid filter string. Closes #891

```
In [1]: import dpctl

In [2]: dpctl.SyclDevice("invalid")
---------------------------------------------------------------------------
SyclDeviceCreationError                   Traceback (most recent call last)
Input In [2], in <cell line: 1>()
----> 1 dpctl.SyclDevice("invalid")

File ~/repos/dpctl/dpctl/_sycl_device.pyx:295, in dpctl._sycl_device.SyclDevice.__cinit__()
    293             ret = self._init_from_selector(DSRef)
    294             if ret == -1:
--> 295                 raise SyclDeviceCreationError(
    296                     "Could not create a SyclDevice with the selector string "
    297                     "'{selector_string}'".format(selector_string=arg)

SyclDeviceCreationError: Could not create a SyclDevice with the selector string 'invalid'
```

- [X] Have you provided a meaningful PR description?
- [X] Have you added a test, reproducer or referred to an issue with a reproducer?
- [X] Have you tested your changes locally for CPU and GPU devices?
- [X] Have you made sure that new changes do not introduce compiler warnings?
