### PR TITLE
Use [[deprecated("msg")]] annotation only for C++ builds

### DIFF
--- a/libsyclinterface/include/dpctl_sycl_device_interface.h
+++ b/libsyclinterface/include/dpctl_sycl_device_interface.h
@@ -250,9 +250,11 @@ DPCTLDevice_GetMaxWorkItemSizes3d(__dpctl_keep const DPCTLSyclDeviceRef DRef);
  * @return   Returns the valid result if device exists else returns NULL.
  * @ingroup DeviceInterface
  */
-[[deprecated("Use DPCTLDevice_WorkItemSizes3d instead")]] DPCTL_API
-    __dpctl_keep size_t *
-    DPCTLDevice_GetMaxWorkItemSizes(__dpctl_keep const DPCTLSyclDeviceRef DRef);
+#if __cplusplus
+[[deprecated("Use DPCTLDevice_WorkItemSizes3d instead")]]
+#endif
+DPCTL_API __dpctl_keep size_t *
+DPCTLDevice_GetMaxWorkItemSizes(__dpctl_keep const DPCTLSyclDeviceRef DRef);
 
 /*!
  * @brief Wrapper for get_info<info::device::max_work_group_size>().

--- a/libsyclinterface/include/dpctl_sycl_device_interface.h
+++ b/libsyclinterface/include/dpctl_sycl_device_interface.h
@@ -250,7 +250,7 @@ DPCTLDevice_GetMaxWorkItemSizes3d(__dpctl_keep const DPCTLSyclDeviceRef DRef);
  * @return   Returns the valid result if device exists else returns NULL.
  * @ingroup DeviceInterface
  */
-#if __cplusplus
+#if __cplusplus || (defined(__GNUC__) && __GNUC__ > 10)
 [[deprecated("Use DPCTLDevice_WorkItemSizes3d instead")]]
 #endif
 DPCTL_API __dpctl_keep size_t *


### PR DESCRIPTION
Changed `libsyclinterface/include/dpctl_sycl_device_interface.h` to only use `[[deprecated("msg")]]` annotation for C++ builds.

This fixes build of numba-dpex's native extension. This remained broken despite claim to the contrary in #879.

- [X] Have you provided a meaningful PR description?

@mingjie-intel

