### PR TITLE
Replaced deprecated cl::sycl namespace with sycl

### DIFF
--- a/dpctl/_backend.pxd
+++ b/dpctl/_backend.pxd
@@ -175,7 +175,6 @@ cdef extern from "syclinterface/dpctl_sycl_device_interface.h":
     cdef bool DPCTLDevice_IsCPU(const DPCTLSyclDeviceRef DRef)
     cdef bool DPCTLDevice_IsGPU(const DPCTLSyclDeviceRef DRef)
     cdef bool DPCTLDevice_IsHost(const DPCTLSyclDeviceRef DRef)
-    cdef bool DPCTLDevice_IsHostUnifiedMemory(const DPCTLSyclDeviceRef DRef)
     cdef bool DPCTLDevice_GetSubGroupIndependentForwardProgress(const DPCTLSyclDeviceRef DRef)
     cdef uint32_t DPCTLDevice_GetPreferredVectorWidthChar(const DPCTLSyclDeviceRef DRef)
     cdef uint32_t DPCTLDevice_GetPreferredVectorWidthShort(const DPCTLSyclDeviceRef DRef)

--- a/dpctl/_sycl_device.pxd
+++ b/dpctl/_sycl_device.pxd
@@ -33,7 +33,7 @@ cdef public api class _SyclDevice [
     object Py_SyclDeviceObject,
     type Py_SyclDeviceType
 ]:
-    """ A helper data-owner class to abstract a `cl::sycl::device` instance.
+    """ A helper data-owner class to abstract a `sycl::device` instance.
     """
     cdef DPCTLSyclDeviceRef _device_ref
     cdef const char *_vendor

--- a/dpctl/_sycl_device.pyx
+++ b/dpctl/_sycl_device.pyx
@@ -129,7 +129,7 @@ cdef class SyclSubDeviceCreationError(Exception):
 
 cdef class _SyclDevice:
     """
-    A helper data-owner class to abstract a cl::sycl::device instance.
+    A helper data-owner class to abstract a `sycl::device` instance.
     """
 
     def __dealloc__(self):

--- a/dpctl/_sycl_event.pxd
+++ b/dpctl/_sycl_event.pxd
@@ -36,7 +36,7 @@ cdef public api class SyclEvent(_SyclEvent) [
     object PySyclEventObject,
     type PySyclEventType
 ]:
-    """ Python wrapper class for a ``cl::sycl::event``
+    """ Python wrapper class for a ``sycl::event``
     """
     @staticmethod
     cdef SyclEvent _create (DPCTLSyclEventRef event)

--- a/dpctl/_sycl_event.pyx
+++ b/dpctl/_sycl_event.pyx
@@ -105,11 +105,11 @@ cdef class _SyclEvent:
 cdef class SyclEvent(_SyclEvent):
     """
     SyclEvent(arg=None)
-    Python class representing ``cl::sycl::event``. There are multiple
+    Python class representing ``sycl::event``. There are multiple
     ways to create a :class:`dpctl.SyclEvent` object:
 
         - Invoking the constructor with no arguments creates a ready event
-          using the default constructor of the ``cl::sycl::event``.
+          using the default constructor of the ``sycl::event``.
 
         :Example:
             .. code-block:: python
@@ -248,7 +248,7 @@ cdef class SyclEvent(_SyclEvent):
 
     def _get_capsule(self):
         """
-        Returns a copy of the underlying ``cl::sycl::event`` pointer as a void
+        Returns a copy of the underlying ``sycl::event`` pointer as a void
         pointer inside a named ``PyCapsule`` that has the name
         **SyclEventRef**. The ownership of the pointer inside the capsule is
         passed to the caller, and pointer is deleted when the capsule goes out
@@ -256,11 +256,11 @@ cdef class SyclEvent(_SyclEvent):
 
         Returns:
             :class:`pycapsule`: A capsule object storing a copy of the
-            ``cl::sycl::event`` pointer belonging to a
+            ``sycl::event`` pointer belonging to a
             :class:`dpctl.SyclEvent` instance.
         Raises:
             ValueError: If the ``DPCTLEvent_Copy`` fails to copy the
-                        ``cl::sycl::event`` pointer.
+                        ``sycl::event`` pointer.
 
         """
         cdef DPCTLSyclEventRef ERef = NULL
@@ -334,7 +334,7 @@ cdef class SyclEvent(_SyclEvent):
     def profiling_info_submit(self):
         """
         Returns the 64-bit time value in nanoseconds
-        when ``cl::sycl::command_group`` was submitted to the queue.
+        when ``sycl::command_group`` was submitted to the queue.
         """
         cdef uint64_t profiling_info_submit = 0
         profiling_info_submit = DPCTLEvent_GetProfilingInfoSubmit(
@@ -346,7 +346,7 @@ cdef class SyclEvent(_SyclEvent):
     def profiling_info_start(self):
         """
         Returns the 64-bit time value in nanoseconds
-        when ``cl::sycl::command_group`` started execution on the device.
+        when ``sycl::command_group`` started execution on the device.
         """
         cdef uint64_t profiling_info_start = 0
         profiling_info_start = DPCTLEvent_GetProfilingInfoStart(self._event_ref)
@@ -356,7 +356,7 @@ cdef class SyclEvent(_SyclEvent):
     def profiling_info_end(self):
         """
         Returns the 64-bit time value in nanoseconds
-        when ``cl::sycl::command_group`` finished execution on the device.
+        when ``sycl::command_group`` finished execution on the device.
         """
         cdef uint64_t profiling_info_end = 0
         profiling_info_end = DPCTLEvent_GetProfilingInfoEnd(self._event_ref)

--- a/dpctl/_sycl_platform.pxd
+++ b/dpctl/_sycl_platform.pxd
@@ -25,7 +25,7 @@ from ._backend cimport DPCTLSyclDeviceSelectorRef, DPCTLSyclPlatformRef
 
 
 cdef class _SyclPlatform:
-    ''' A helper metaclass to abstract a cl::sycl::platform instance.
+    ''' A helper metaclass to abstract a ``sycl::platform`` instance.
     '''
     cdef DPCTLSyclPlatformRef _platform_ref
     cdef const char *_vendor

--- a/dpctl/_sycl_platform.pyx
+++ b/dpctl/_sycl_platform.pyx
@@ -81,7 +81,7 @@ cdef void _init_helper(_SyclPlatform platform, DPCTLSyclPlatformRef PRef):
 
 cdef class SyclPlatform(_SyclPlatform):
     """ SyclPlatform(self, arg=None)
-        Python class representing ``cl::sycl::platform`` class.
+        Python class representing ``sycl::platform`` class.
 
         SyclPlatform() - create platform selected by sycl::default_selector
         SyclPlatform(filter_selector) - create platform selected by filter

--- a/dpctl/_sycl_queue.pyx
+++ b/dpctl/_sycl_queue.pyx
@@ -186,7 +186,7 @@ cdef class _SyclQueue:
 cdef class SyclQueue(_SyclQueue):
     """
     SyclQueue(*args, **kwargs)
-    Python class representing ``cl::sycl::queue``. There are multiple
+    Python class representing ``sycl::queue``. There are multiple
     ways to create a :class:`dpctl.SyclQueue` object:
 
         - Invoking the constructor with no arguments creates a context using
@@ -258,7 +258,7 @@ cdef class SyclQueue(_SyclQueue):
             context will be created from the specified device.
         dev (str, :class:`dpctl.SyclDevice`, capsule, optional): Sycl device
              to create :class:`dpctl.SyclQueue` from. If not specified, sycl
-             device selected by ``cl::sycl::default_selector`` is used.
+             device selected by ``sycl::default_selector`` is used.
              The argument must be explicitly specified if `ctxt` argument is
              provided.
 

--- a/examples/cython/sycl_direct_linkage/_buffer_example.pyx
+++ b/examples/cython/sycl_direct_linkage/_buffer_example.pyx
@@ -24,7 +24,7 @@ import numpy as np
 from cython.operator cimport dereference as deref
 
 
-cdef extern from "CL/sycl.hpp" namespace "cl::sycl":
+cdef extern from "CL/sycl.hpp" namespace "sycl":
     cdef cppclass queue nogil:
         pass
 

--- a/examples/cython/sycl_direct_linkage/_buffer_example.pyx
+++ b/examples/cython/sycl_direct_linkage/_buffer_example.pyx
@@ -31,7 +31,7 @@ cdef extern from "CL/sycl.hpp" namespace "sycl":
 
 cdef extern from "sycl_function.hpp":
     int c_columnwise_total(
-        queue& q, size_t n, size_t m, double *m, double *ct
+        queue q, size_t n, size_t m, double *m, double *ct
     ) nogil
 
 

--- a/examples/cython/sycl_direct_linkage/sycl_function.cpp
+++ b/examples/cython/sycl_direct_linkage/sycl_function.cpp
@@ -31,7 +31,7 @@
 #include <CL/sycl.hpp>
 #include <oneapi/mkl.hpp>
 
-int c_columnwise_total(sycl::queue &q,
+int c_columnwise_total(sycl::queue q,
                        size_t n,
                        size_t m,
                        double *mat,

--- a/examples/cython/sycl_direct_linkage/sycl_function.cpp
+++ b/examples/cython/sycl_direct_linkage/sycl_function.cpp
@@ -31,7 +31,7 @@
 #include <CL/sycl.hpp>
 #include <oneapi/mkl.hpp>
 
-int c_columnwise_total(cl::sycl::queue &q,
+int c_columnwise_total(sycl::queue &q,
                        size_t n,
                        size_t m,
                        double *mat,

--- a/examples/cython/sycl_direct_linkage/sycl_function.hpp
+++ b/examples/cython/sycl_direct_linkage/sycl_function.hpp
@@ -1,6 +1,6 @@
 #include <CL/sycl.hpp>
 
-int c_columnwise_total(cl::sycl::queue &,
+int c_columnwise_total(sycl::queue &,
                        size_t n,
                        size_t m,
                        double *mat,

--- a/examples/cython/sycl_direct_linkage/sycl_function.hpp
+++ b/examples/cython/sycl_direct_linkage/sycl_function.hpp
@@ -1,6 +1,6 @@
 #include <CL/sycl.hpp>
 
-int c_columnwise_total(sycl::queue &,
+int c_columnwise_total(sycl::queue,
                        size_t n,
                        size_t m,
                        double *mat,

--- a/examples/cython/usm_memory/sycl_blackscholes.cpp
+++ b/examples/cython/usm_memory/sycl_blackscholes.cpp
@@ -89,32 +89,32 @@ cpp_blackscholes(DPCTLSyclQueueRef q_ptr, size_t n_opts, T *params, T *callput)
                 data_t mr = -opt_rate,
                        sig_sig_two = two * opt_volatility * opt_volatility;
 
-                a = cl::sycl::log(opt_price / opt_strike);
+                a = sycl::log(opt_price / opt_strike);
                 b = opt_maturity * mr;
                 z = opt_maturity * sig_sig_two;
 
                 c = quarter * z;
-                e = cl::sycl::exp(b);
-                y = cl::sycl::rsqrt(z);
+                e = sycl::exp(b);
+                y = sycl::rsqrt(z);
 
                 a = b - a;
                 w1 = (a - c) * y;
                 w2 = (a + c) * y;
 
                 if (w1 < zero) {
-                    d1 = cl::sycl::erfc(w1) * half;
+                    d1 = sycl::erfc(w1) * half;
                     d1c = one - d1;
                 }
                 else {
-                    d1c = cl::sycl::erfc(-w1) * half;
+                    d1c = sycl::erfc(-w1) * half;
                     d1 = one - d1c;
                 }
                 if (w2 < zero) {
-                    d2 = cl::sycl::erfc(w2) * half;
+                    d2 = sycl::erfc(w2) * half;
                     d2c = one - d2;
                 }
                 else {
-                    d2c = cl::sycl::erfc(-w2) * half;
+                    d2c = sycl::erfc(-w2) * half;
                     d2 = one - d2c;
                 }
 

--- a/examples/python/device_selection.py
+++ b/examples/python/device_selection.py
@@ -22,7 +22,7 @@ import dpctl
 
 def create_default_device():
     """
-    Create default SyclDevice using `cl::sycl::default_selector`.
+    Create default SyclDevice using `sycl::default_selector`.
 
     Device created can be influenced by environment variable
     SYCL_DEVICE_FILTER, which determines SYCL devices seen by the

--- a/libsyclinterface/helper/include/dpctl_error_handlers.h
+++ b/libsyclinterface/helper/include/dpctl_error_handlers.h
@@ -42,7 +42,7 @@ public:
     {
     }
 
-    void operator()(const cl::sycl::exception_list &exceptions);
+    void operator()(const sycl::exception_list &exceptions);
 };
 
 enum error_level : int

--- a/libsyclinterface/helper/source/dpctl_error_handlers.cpp
+++ b/libsyclinterface/helper/source/dpctl_error_handlers.cpp
@@ -31,8 +31,7 @@
 #include <glog/logging.h>
 #endif
 
-void DPCTL_AsyncErrorHandler::operator()(
-    const cl::sycl::exception_list &exceptions)
+void DPCTL_AsyncErrorHandler::operator()(const sycl::exception_list &exceptions)
 {
     for (std::exception_ptr const &e : exceptions) {
         try {

--- a/libsyclinterface/helper/source/dpctl_utils_helper.cpp
+++ b/libsyclinterface/helper/source/dpctl_utils_helper.cpp
@@ -27,7 +27,7 @@
 #include <sstream>
 #include <string>
 
-using namespace cl::sycl;
+using namespace sycl;
 
 /*!
  * Transforms enum info::device_type to string.
@@ -164,7 +164,7 @@ DPCTLSyclDeviceType DPCTL_SyclDeviceTypeToDPCTLDeviceType(info::device_type D)
 }
 
 /*!
- * Transforms cl::sycl::aspect to string.
+ * Transforms sycl::aspect to string.
  */
 std::string DPCTL_AspectToStr(aspect aspectTy)
 {
@@ -237,7 +237,7 @@ std::string DPCTL_AspectToStr(aspect aspectTy)
 }
 
 /*!
- * Transforms string to cl::sycl::aspect.
+ * Transforms string to sycl::aspect.
  */
 aspect DPCTL_StrToAspectType(const std::string &aspectTyStr)
 {

--- a/libsyclinterface/include/dpctl_sycl_device_interface.h
+++ b/libsyclinterface/include/dpctl_sycl_device_interface.h
@@ -313,19 +313,6 @@ __dpctl_give const char *
 DPCTLDevice_GetVendor(__dpctl_keep const DPCTLSyclDeviceRef DRef);
 
 /*!
- * @brief Returns True if the device and the host share a unified memory
- * subsystem, else returns False.
- *
- * @param    DRef           Opaque pointer to a ``sycl::device``
- * @return   Boolean indicating if the device shares a unified memory subsystem
- * with the host.
- * @ingroup DeviceInterface
- */
-DPCTL_API
-bool DPCTLDevice_IsHostUnifiedMemory(
-    __dpctl_keep const DPCTLSyclDeviceRef DRef);
-
-/*!
  * @brief Checks if two DPCTLSyclDeviceRef objects point to the same
  * sycl::device.
  *

--- a/libsyclinterface/source/dpctl_sycl_context_interface.cpp
+++ b/libsyclinterface/source/dpctl_sycl_context_interface.cpp
@@ -30,7 +30,7 @@
 #include <CL/sycl.hpp>
 #include <vector>
 
-using namespace cl::sycl;
+using namespace sycl;
 
 namespace
 {

--- a/libsyclinterface/source/dpctl_sycl_device_interface.cpp
+++ b/libsyclinterface/source/dpctl_sycl_device_interface.cpp
@@ -367,20 +367,6 @@ DPCTLDevice_GetDriverVersion(__dpctl_keep const DPCTLSyclDeviceRef DRef)
     return cstr_driver;
 }
 
-bool DPCTLDevice_IsHostUnifiedMemory(__dpctl_keep const DPCTLSyclDeviceRef DRef)
-{
-    bool ret = false;
-    auto D = unwrap(DRef);
-    if (D) {
-        try {
-            ret = D->get_info<info::device::host_unified_memory>();
-        } catch (std::exception const &e) {
-            error_handler(e, __FILE__, __func__, __LINE__);
-        }
-    }
-    return ret;
-}
-
 bool DPCTLDevice_AreEq(__dpctl_keep const DPCTLSyclDeviceRef DRef1,
                        __dpctl_keep const DPCTLSyclDeviceRef DRef2)
 {

--- a/libsyclinterface/source/dpctl_sycl_device_interface.cpp
+++ b/libsyclinterface/source/dpctl_sycl_device_interface.cpp
@@ -35,7 +35,7 @@
 #include <cstring>
 #include <vector>
 
-using namespace cl::sycl;
+using namespace sycl;
 
 namespace
 {

--- a/libsyclinterface/source/dpctl_sycl_device_manager.cpp
+++ b/libsyclinterface/source/dpctl_sycl_device_manager.cpp
@@ -58,8 +58,6 @@ std::string get_device_info_str(const device &Device)
        << Device.get_info<info::device::driver_version>() << _endl
        << std::setw(4) << " " << std::left << std::setw(16) << "Vendor"
        << Device.get_info<info::device::vendor>() << _endl << std::setw(4)
-       << " " << std::left << std::setw(16) << "Profile"
-       << Device.get_info<info::device::profile>() << _endl << std::setw(4)
        << " " << std::left << std::setw(16) << "Filter string"
        << DPCTL_GetDeviceFilterString(Device) << _endl;
 

--- a/libsyclinterface/source/dpctl_sycl_device_manager.cpp
+++ b/libsyclinterface/source/dpctl_sycl_device_manager.cpp
@@ -35,7 +35,7 @@
 #include <unordered_map>
 #include <vector>
 
-using namespace cl::sycl;
+using namespace sycl;
 
 namespace
 {

--- a/libsyclinterface/source/dpctl_sycl_device_selector_interface.cpp
+++ b/libsyclinterface/source/dpctl_sycl_device_selector_interface.cpp
@@ -28,7 +28,7 @@
 #include "dpctl_error_handlers.h"
 #include <CL/sycl.hpp> /* SYCL headers   */
 
-using namespace cl::sycl;
+using namespace sycl;
 
 namespace
 {

--- a/libsyclinterface/source/dpctl_sycl_event_interface.cpp
+++ b/libsyclinterface/source/dpctl_sycl_event_interface.cpp
@@ -31,7 +31,7 @@
 #include <CL/sycl.hpp> /* SYCL headers   */
 #include <vector>
 
-using namespace cl::sycl;
+using namespace sycl;
 
 namespace
 {

--- a/libsyclinterface/source/dpctl_sycl_kernel_bundle_interface.cpp
+++ b/libsyclinterface/source/dpctl_sycl_kernel_bundle_interface.cpp
@@ -52,7 +52,7 @@
 // clang-format on
 #endif
 
-using namespace cl::sycl;
+using namespace sycl;
 
 namespace
 {

--- a/libsyclinterface/source/dpctl_sycl_kernel_interface.cpp
+++ b/libsyclinterface/source/dpctl_sycl_kernel_interface.cpp
@@ -31,7 +31,7 @@
 #include <CL/sycl.hpp> /* Sycl headers */
 #include <cstdint>
 
-using namespace cl::sycl;
+using namespace sycl;
 
 namespace
 {

--- a/libsyclinterface/source/dpctl_sycl_platform_interface.cpp
+++ b/libsyclinterface/source/dpctl_sycl_platform_interface.cpp
@@ -36,7 +36,7 @@
 #include <sstream>
 #include <vector>
 
-using namespace cl::sycl;
+using namespace sycl;
 
 namespace
 {

--- a/libsyclinterface/source/dpctl_sycl_platform_manager.cpp
+++ b/libsyclinterface/source/dpctl_sycl_platform_manager.cpp
@@ -36,7 +36,7 @@
 #include <set>
 #include <sstream>
 
-using namespace cl::sycl;
+using namespace sycl;
 
 namespace
 {

--- a/libsyclinterface/source/dpctl_sycl_queue_interface.cpp
+++ b/libsyclinterface/source/dpctl_sycl_queue_interface.cpp
@@ -34,7 +34,7 @@
 #include <exception>
 #include <stdexcept>
 
-using namespace cl::sycl;
+using namespace sycl;
 
 namespace
 {

--- a/libsyclinterface/source/dpctl_sycl_queue_manager.cpp
+++ b/libsyclinterface/source/dpctl_sycl_queue_manager.cpp
@@ -30,7 +30,7 @@
 #include <CL/sycl.hpp> /* SYCL headers   */
 #include <vector>
 
-using namespace cl::sycl;
+using namespace sycl;
 
 /*------------------------------- Private helpers ----------------------------*/
 

--- a/libsyclinterface/source/dpctl_sycl_usm_interface.cpp
+++ b/libsyclinterface/source/dpctl_sycl_usm_interface.cpp
@@ -30,7 +30,7 @@
 #include "dpctl_sycl_device_interface.h"
 #include <CL/sycl.hpp> /* SYCL headers   */
 
-using namespace cl::sycl;
+using namespace sycl;
 
 namespace
 {

--- a/libsyclinterface/tests/test_sycl_context_interface.cpp
+++ b/libsyclinterface/tests/test_sycl_context_interface.cpp
@@ -33,7 +33,7 @@
 #include <gtest/gtest.h>
 #include <vector>
 
-using namespace cl::sycl;
+using namespace sycl;
 
 namespace
 {

--- a/libsyclinterface/tests/test_sycl_device_aspects.cpp
+++ b/libsyclinterface/tests/test_sycl_device_aspects.cpp
@@ -74,40 +74,36 @@ auto build_params()
         "opencl:gpu", "opencl:cpu", "level_zero:gpu", "host");
 
     constexpr auto param_2 =
-        get_param_list<std::pair<const char *, cl::sycl::aspect>>(
-            std::make_pair("host", cl::sycl::aspect::host),
-            std::make_pair("cpu", cl::sycl::aspect::cpu),
-            std::make_pair("gpu", cl::sycl::aspect::gpu),
-            std::make_pair("accelerator", cl::sycl::aspect::accelerator),
-            std::make_pair("custom", cl::sycl::aspect::custom),
-            std::make_pair("fp16", cl::sycl::aspect::fp16),
-            std::make_pair("fp64", cl::sycl::aspect::fp64),
-            std::make_pair("atomic64", cl::sycl::aspect::atomic64),
-            std::make_pair("online_compiler",
-                           cl::sycl::aspect::online_compiler),
-            std::make_pair("online_linker", cl::sycl::aspect::online_linker),
-            std::make_pair("queue_profiling",
-                           cl::sycl::aspect::queue_profiling),
+        get_param_list<std::pair<const char *, sycl::aspect>>(
+            std::make_pair("host", sycl::aspect::host),
+            std::make_pair("cpu", sycl::aspect::cpu),
+            std::make_pair("gpu", sycl::aspect::gpu),
+            std::make_pair("accelerator", sycl::aspect::accelerator),
+            std::make_pair("custom", sycl::aspect::custom),
+            std::make_pair("fp16", sycl::aspect::fp16),
+            std::make_pair("fp64", sycl::aspect::fp64),
+            std::make_pair("atomic64", sycl::aspect::atomic64),
+            std::make_pair("online_compiler", sycl::aspect::online_compiler),
+            std::make_pair("online_linker", sycl::aspect::online_linker),
+            std::make_pair("queue_profiling", sycl::aspect::queue_profiling),
             std::make_pair("usm_device_allocations",
-                           cl::sycl::aspect::usm_device_allocations),
+                           sycl::aspect::usm_device_allocations),
             std::make_pair("usm_host_allocations",
-                           cl::sycl::aspect::usm_host_allocations),
+                           sycl::aspect::usm_host_allocations),
             std::make_pair("usm_shared_allocations",
-                           cl::sycl::aspect::usm_shared_allocations),
+                           sycl::aspect::usm_shared_allocations),
             std::make_pair("usm_restricted_shared_allocations",
-                           cl::sycl::aspect::usm_restricted_shared_allocations),
+                           sycl::aspect::usm_restricted_shared_allocations),
             std::make_pair("usm_system_allocations",
-                           cl::sycl::aspect::usm_system_allocations),
+                           sycl::aspect::usm_system_allocations),
             std::make_pair("usm_atomic_host_allocations",
-                           cl::sycl::aspect::usm_atomic_host_allocations),
+                           sycl::aspect::usm_atomic_host_allocations),
             std::make_pair("usm_atomic_shared_allocations",
-                           cl::sycl::aspect::usm_atomic_shared_allocations),
-            std::make_pair("host_debuggable",
-                           cl::sycl::aspect::host_debuggable));
+                           sycl::aspect::usm_atomic_shared_allocations),
+            std::make_pair("host_debuggable", sycl::aspect::host_debuggable));
 
     auto pairs =
-        build_param_pairs<const char *,
-                          std::pair<const char *, cl::sycl::aspect>,
+        build_param_pairs<const char *, std::pair<const char *, sycl::aspect>,
                           param_1.size(), param_2.size()>(param_1, param_2);
 
     return build_gtest_values(pairs);
@@ -117,7 +113,7 @@ auto build_params()
 
 struct TestDPCTLSyclDeviceInterfaceAspects
     : public ::testing::TestWithParam<
-          std::pair<const char *, std::pair<const char *, cl::sycl::aspect>>>
+          std::pair<const char *, std::pair<const char *, sycl::aspect>>>
 {
     DPCTLSyclDeviceSelectorRef DSRef = nullptr;
     DPCTLSyclDeviceRef DRef = nullptr;

--- a/libsyclinterface/tests/test_sycl_device_interface.cpp
+++ b/libsyclinterface/tests/test_sycl_device_interface.cpp
@@ -586,14 +586,6 @@ TEST_F(TestDPCTLSyclDeviceNullArgs, ChkDriverVersion)
     ASSERT_TRUE(driver_version == nullptr);
 }
 
-TEST_F(TestDPCTLSyclDeviceNullArgs, ChkIsHostUnifiedMemory)
-{
-    bool is_hum = true;
-    EXPECT_NO_FATAL_FAILURE(is_hum =
-                                DPCTLDevice_IsHostUnifiedMemory(Null_DRef));
-    ASSERT_FALSE(is_hum);
-}
-
 TEST_F(TestDPCTLSyclDeviceNullArgs, ChkAreEq)
 {
     bool are_eq = true;

--- a/libsyclinterface/tests/test_sycl_device_interface.cpp
+++ b/libsyclinterface/tests/test_sycl_device_interface.cpp
@@ -32,7 +32,7 @@
 #include <CL/sycl.hpp>
 #include <gtest/gtest.h>
 
-using namespace cl::sycl;
+using namespace sycl;
 
 struct TestDPCTLSyclDeviceInterface
     : public ::testing::TestWithParam<const char *>

--- a/libsyclinterface/tests/test_sycl_device_invalid_filters.cpp
+++ b/libsyclinterface/tests/test_sycl_device_invalid_filters.cpp
@@ -28,7 +28,8 @@
 #include <CL/sycl.hpp>
 #include <gtest/gtest.h>
 
-using namespace cl::sycl;
+using namespace sycl;
+
 struct TestUnsupportedFilters : public ::testing::TestWithParam<const char *>
 {
     DPCTLSyclDeviceSelectorRef DSRef = nullptr;

--- a/libsyclinterface/tests/test_sycl_device_manager.cpp
+++ b/libsyclinterface/tests/test_sycl_device_manager.cpp
@@ -186,7 +186,7 @@ struct TestGetNumDevicesForBTy : public ::testing::TestWithParam<int>
 
 TEST_P(TestGetNumDevicesForBTy, ChkGetNumDevices)
 {
-    auto platforms = cl::sycl::platform::get_platforms();
+    auto platforms = sycl::platform::get_platforms();
     size_t nDevices = 0;
     sycl::default_selector mRanker;
     for (const auto &P : platforms) {

--- a/libsyclinterface/tests/test_sycl_device_selector_interface.cpp
+++ b/libsyclinterface/tests/test_sycl_device_selector_interface.cpp
@@ -31,7 +31,7 @@
 #include <CL/sycl.hpp>
 #include <gtest/gtest.h>
 
-using namespace cl::sycl;
+using namespace sycl;
 
 namespace
 {

--- a/libsyclinterface/tests/test_sycl_device_subdevices.cpp
+++ b/libsyclinterface/tests/test_sycl_device_subdevices.cpp
@@ -35,7 +35,7 @@
 #include <CL/sycl.hpp>
 #include <gtest/gtest.h>
 
-using namespace cl::sycl;
+using namespace sycl;
 
 DEFINE_SIMPLE_CONVERSION_FUNCTIONS(device, DPCTLSyclDeviceRef);
 

--- a/libsyclinterface/tests/test_sycl_event_interface.cpp
+++ b/libsyclinterface/tests/test_sycl_event_interface.cpp
@@ -31,7 +31,7 @@
 #include <gtest/gtest.h>
 #include <vector>
 
-using namespace cl::sycl;
+using namespace sycl;
 
 namespace
 {

--- a/libsyclinterface/tests/test_sycl_kernel_bundle_interface.cpp
+++ b/libsyclinterface/tests/test_sycl_kernel_bundle_interface.cpp
@@ -40,7 +40,7 @@
 #include <fstream>
 #include <gtest/gtest.h>
 
-using namespace cl::sycl;
+using namespace sycl;
 
 struct TestDPCTLSyclKernelBundleInterface
     : public ::testing::TestWithParam<const char *>

--- a/libsyclinterface/tests/test_sycl_kernel_interface.cpp
+++ b/libsyclinterface/tests/test_sycl_kernel_interface.cpp
@@ -36,7 +36,7 @@
 #include <array>
 #include <gtest/gtest.h>
 
-using namespace cl::sycl;
+using namespace sycl;
 
 namespace
 {

--- a/libsyclinterface/tests/test_sycl_platform_interface.cpp
+++ b/libsyclinterface/tests/test_sycl_platform_interface.cpp
@@ -34,7 +34,7 @@
 #include <gtest/gtest.h>
 #include <vector>
 
-using namespace cl::sycl;
+using namespace sycl;
 
 namespace
 {

--- a/libsyclinterface/tests/test_sycl_platform_invalid_filters.cpp
+++ b/libsyclinterface/tests/test_sycl_platform_invalid_filters.cpp
@@ -29,7 +29,8 @@
 #include <CL/sycl.hpp>
 #include <gtest/gtest.h>
 
-using namespace cl::sycl;
+using namespace sycl;
+
 struct TestUnsupportedFilters : public ::testing::TestWithParam<const char *>
 {
     DPCTLSyclDeviceSelectorRef DSRef = nullptr;

--- a/libsyclinterface/tests/test_sycl_queue_interface.cpp
+++ b/libsyclinterface/tests/test_sycl_queue_interface.cpp
@@ -36,7 +36,7 @@
 #include <CL/sycl.hpp>
 #include <gtest/gtest.h>
 
-using namespace cl::sycl;
+using namespace sycl;
 
 namespace
 {

--- a/libsyclinterface/tests/test_sycl_queue_manager.cpp
+++ b/libsyclinterface/tests/test_sycl_queue_manager.cpp
@@ -35,7 +35,7 @@
 #include <thread>
 
 using namespace std;
-using namespace cl::sycl;
+using namespace sycl;
 
 namespace
 {

--- a/libsyclinterface/tests/test_sycl_usm_interface.cpp
+++ b/libsyclinterface/tests/test_sycl_usm_interface.cpp
@@ -36,7 +36,7 @@
 #include <cstring>
 #include <gtest/gtest.h>
 
-using namespace cl::sycl;
+using namespace sycl;
 
 namespace
 {


### PR DESCRIPTION
Building `dpctl` with intel/llvm DPC++ compiler one can see 

```
~/sycl_workspace/dpctl/libsyclinterface/source/dpctl_sycl_queue_interface.cpp:37:19: warning: 'cl' is deprecated: cl::sycl is deprecated, use ::sycl in
stead. [-Wdeprecated-declarations]
using namespace cl::sycl;
                  ^
```

This PR removes use of `cl::sycl` namespace in favor of recommended `sycl` namespace.

This PR also removes use of `sycl::info::device::profile` deprecated descriptor from `print_device_info` function, and removed
`DPCTLDevice_IsUnifiedHostMemory` function exposing deprecated descriptor `sycl::info::device::host_unified_memory`.

Open source compiler now compiles the code without deprecation warnings.

- [X] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [X] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
