### PR TITLE
Improve queue compatibility testing

### DIFF
--- a/dpctl/apis/include/dpctl4pybind11.hpp
+++ b/dpctl/apis/include/dpctl4pybind11.hpp
@@ -547,6 +547,19 @@ sycl::event keep_args_alive(sycl::queue q,
     return host_task_ev;
 }
 
+template <std::size_t num>
+bool queues_are_compatible(sycl::queue exec_q,
+                           const sycl::queue (&alloc_qs)[num])
+{
+    for (std::size_t i = 0; i < num; ++i) {
+
+        if (exec_q != alloc_qs[i]) {
+            return false;
+        }
+    }
+    return true;
+}
+
 } // end namespace utils
 
 } // end namespace dpctl

--- a/dpctl/tensor/libtensor/source/tensor_py.cpp
+++ b/dpctl/tensor/libtensor/source/tensor_py.cpp
@@ -707,8 +707,9 @@ copy_usm_ndarray_into_usm_ndarray(dpctl::tensor::usm_ndarray src,
                   shp_host_shape_strides->begin() + nd);
     }
 
-    sycl::event copy_shape_ev = exec_q.copy<py::ssize_t>(
-        shp_host_shape_strides->data(), shape_strides, 3 * nd);
+    sycl::event copy_shape_ev =
+        exec_q.copy<py::ssize_t>(shp_host_shape_strides->data(), shape_strides,
+                                 shp_host_shape_strides->size());
 
     exec_q.submit([&](sycl::handler &cgh) {
         cgh.depends_on(copy_shape_ev);

--- a/dpctl/tensor/libtensor/source/tensor_py.cpp
+++ b/dpctl/tensor/libtensor/source/tensor_py.cpp
@@ -524,14 +524,13 @@ copy_usm_ndarray_into_usm_ndarray(dpctl::tensor::usm_ndarray src,
         }
     }
 
-    // check same contexts
+    // check compatibility of execution queue and allocation queue
     sycl::queue src_q = src.get_queue();
     sycl::queue dst_q = dst.get_queue();
 
-    sycl::context exec_ctx = exec_q.get_context();
-    if (src_q.get_context() != exec_ctx || dst_q.get_context() != exec_ctx) {
+    if (!dpctl::utils::queues_are_compatible(exec_q, {src_q, dst_q})) {
         throw py::value_error(
-            "Execution queue context is not the same as allocation contexts");
+            "Execution queue is not compatible with allocation queues");
     }
 
     int src_typenum = src.get_typenum();
@@ -938,10 +937,9 @@ copy_usm_ndarray_for_reshape(dpctl::tensor::usm_ndarray src,
     sycl::queue src_q = src.get_queue();
     sycl::queue dst_q = dst.get_queue();
 
-    sycl::context exec_ctx = exec_q.get_context();
-    if (src_q.get_context() != exec_ctx || dst_q.get_context() != exec_ctx) {
+    if (!dpctl::utils::queues_are_compatible(exec_q, {src_q, dst_q})) {
         throw py::value_error(
-            "Execution queue context is not the same as allocation contexts");
+            "Execution queue is not compatible with allocation queues");
     }
 
     if (src_nelems == 1) {
@@ -1255,10 +1253,9 @@ void copy_numpy_ndarray_into_usm_ndarray(
 
     sycl::queue dst_q = dst.get_queue();
 
-    sycl::context exec_ctx = exec_q.get_context();
-    if (dst_q.get_context() != exec_ctx) {
-        throw py::value_error("Execution queue context is not the same as the "
-                              "allocation context");
+    if (!dpctl::utils::queues_are_compatible(exec_q, {dst_q})) {
+        throw py::value_error("Execution queue is not compatible with the "
+                              "allocation queue");
     }
 
     // here we assume that NumPy's type numbers agree with ours for types

--- a/dpctl/tests/test_usm_ndarray_ctor.py
+++ b/dpctl/tests/test_usm_ndarray_ctor.py
@@ -684,8 +684,12 @@ def test_setitem_scalar(dtype, usm_type):
 
 
 def test_setitem_errors():
-    X = dpt.usm_ndarray((4,), dtype="u1")
-    Y = dpt.usm_ndarray((4, 2), dtype="u1")
+    try:
+        q = dpctl.SyclQueue()
+    except dpctl.SyclQueueCreationError:
+        pytest.skip("Default queue could not be created")
+    X = dpt.empty((4,), dtype="u1", sycl_queue=q)
+    Y = dpt.empty((4, 2), dtype="u1", sycl_queue=q)
     with pytest.raises(ValueError):
         X[:] = Y
     with pytest.raises(ValueError):


### PR DESCRIPTION
This introduces `dpctl::utils::queues_are_compatible(exec_q, {alloc_q1, alloc_q2, ...})` and deploys it in `tensor_py.cpp`.

The check replaces notion of compatibility from queues have equal contexts to queues are equal, aligning check with the logic in `_compute_follows_data.pyx`.

Furthermore, this PR implements optimization for transfer of shape/strides from host-allocated metadata to kernels.
Previously, transfer was done with 3 or 4 calls to `exec_q.copy`. It is replaced with allocation of host temporary where necessary `std::copy` calls are made to populate it, followed by a single call to `exec_q.copy` to copy data into USM allocation for use in kernel. 

No other logic has changed.

- [X] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [X] Have you tested your changes locally for CPU and GPU devices?
- [X] Have you made sure that new changes do not introduce compiler warnings?

