### PR TITLE
Added support for stream other than None

### DIFF
--- a/dpctl/tests/test_usm_ndarray_dlpack.py
+++ b/dpctl/tests/test_usm_ndarray_dlpack.py
@@ -79,6 +79,18 @@ def test_dlpack_exporter(typestr, usm_type):
         assert caps_fn(caps2, b"dltensor")
 
 
+def test_dlpack_exporter_stream():
+    try:
+        q1 = dpctl.SyclQueue()
+        q2 = dpctl.SyclQueue()
+    except dpctl.SyclQueueCreationError:
+        pytest.skip("Could not create default queues")
+    X = dpt.empty((64,), dtype="u1", sycl_queue=q1)
+    cap1 = X.__dlpack__(stream=q1)
+    cap2 = X.__dlpack__(stream=q2)
+    assert type(cap1) is type(cap2)
+
+
 @pytest.mark.parametrize("shape", [tuple(), (2,), (3, 0, 1), (2, 2, 2)])
 def test_from_dlpack(shape, typestr, usm_type):
     all_root_devices = dpctl.get_devices()


### PR DESCRIPTION
If `stream` keyword argument has type `dpctl.SyclQueue`, then submit a barrier into `self.sycl_queue`, and than submit another barrier into stream with dependency on the event returned by submission of the barrier into `self.sycl_queue`:

```python
   ev = self.sycl_queue.submit_barrier()
   stream.submit_barrier(dependent_events=[ev])
```

All other types of stream are ignored, in particular integer values of stream.

- [X] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?


-- 

With this PR, MPI transfer of `usm_ndarray` allocated using level-zero backend becomes possible:

```python
from mpi4py import MPI
import dpctl.tensor as dpt
import numpy as np

comm = MPI.COMM_WORLD
rank = comm.Get_rank()

# automatic MPI datatype discovery
if rank == 0:
    data = dpt.arange(100, dtype="float64")
    comm.Send(data, dest=1, tag=13)
elif rank == 1:
    data = dpt.empty(100, dtype="float64")
    comm.Recv(data, source=0, tag=13)
    X = dpt.asnumpy(data)
    print("From rank=1, received: ", X)
```

The example run using `mpi4py` built using Intel(R) MPI from oneAPI basekit:

```
$ I_MPI_OFFLOAD=2 mpirun -n 2 python mpi_exchange.py
From rank=1, received:  [ 0.  1.  2.  3.  4.  5.  6.  7.  8.  9. 10. 11. 12. 13. 14. 15. 16. 17.
 18. 19. 20. 21. 22. 23. 24. 25. 26. 27. 28. 29. 30. 31. 32. 33. 34. 35.
 36. 37. 38. 39. 40. 41. 42. 43. 44. 45. 46. 47. 48. 49. 50. 51. 52. 53.
 54. 55. 56. 57. 58. 59. 60. 61. 62. 63. 64. 65. 66. 67. 68. 69. 70. 71.
 72. 73. 74. 75. 76. 77. 78. 79. 80. 81. 82. 83. 84. 85. 86. 87. 88. 89.
 90. 91. 92. 93. 94. 95. 96. 97. 98. 99.]
```