### PR TITLE
Use pytest.warns instead of fixure filterwarning

### DIFF
--- a/dpctl/tests/_device_attributes_checks.py
+++ b/dpctl/tests/_device_attributes_checks.py
@@ -90,9 +90,9 @@ def check_max_work_item_sizes3d(device):
         assert size is not None
 
 
-@pytest.mark.filterwarnings("DeprecationWarning:")
 def check_max_work_item_sizes(device):
-    max_work_item_sizes = device.max_work_item_sizes
+    with pytest.warns(DeprecationWarning):
+        max_work_item_sizes = device.max_work_item_sizes
     for size in max_work_item_sizes:
         assert size is not None
 


### PR DESCRIPTION
Improved `check_max_work_item_sizes` to use `pytest.warns` context manager instead of `pytest.marks.filterwarnings` decorator.

This is better since it assers that warning is issues, and filters it out, so test run of `test_sycl_device.py` is green, rather than darker-yellow.

- [X] Have you provided a meaningful PR description?
- [X] Have you added a test, reproducer or referred to an issue with a reproducer?
- [X] Have you tested your changes locally for CPU and GPU devices?
- [X] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
