### PR TITLE
Fix os-llvm-sycl-build workflow

### DIFF
--- a/.github/workflows/os-llvm-sycl-build.yml
+++ b/.github/workflows/os-llvm-sycl-build.yml
@@ -41,15 +41,35 @@ jobs:
           cd /home/runner/work
           mkdir -p sycl_bundle
           cd sycl_bundle
-          export LATEST_LLVM_TAG=$(git -c 'versionsort.suffix=-' ls-remote --tags --sort='v:refname' https://github.com/intel/llvm.git | grep sycl-nightly | tail --lines=1)
-          export LATEST_LLVM_TAG_SHA=$(echo ${LATEST_LLVM_TAG} | awk '{print $1}')
-          export NIGHTLY_TAG=$(python3 -c "import sys, urllib.parse as ul; print (ul.quote_plus(sys.argv[1]))" \
-             $(echo ${LATEST_LLVM_TAG} | awk '{gsub(/^refs\/tags\//, "", $2)} {print $2}'))
-          if [[ -f bundle_id.txt && ( "$(cat bundle_id.txt)" == "${LATEST_LLVM_TAG_SHA}" ) ]]; then
-              echo "Using cached download of ${LATEST_LLVM_TAG}"
+          # get list of shas and tags from remote, filter sycl-nightly tags and reverse order
+          export LLVM_TAGS=$(git -c 'versionsort.suffix=-' ls-remote --tags --sort='v:refname' https://github.com/intel/llvm.git | \
+                       grep sycl-nightly | awk '{a[i++]=$0} END {for (j=i-1; j>=0;) print a[j--] }')
+          # initialize
+          unset DEPLOY_NIGHTLY_TAG
+          unset DEPLOY_NIGHTLY_TAG_SHA
+
+          # go through tags and find the most recent one where nighly build binary is available
+          while IFS= read -r NEXT_LLVM_TAG; do
+              export NEXT_LLVM_TAG_SHA=$(echo ${NEXT_LLVM_TAG} | awk '{print $1}')
+              export NEXT_NIGHTLY_TAG=$(python3 -c "import sys, urllib.parse as ul; print (ul.quote_plus(sys.argv[1]))" \
+                                          $(echo ${NEXT_LLVM_TAG} | awk '{gsub(/^refs\/tags\//, "", $2)} {print $2}'))
+              if [[ `wget -S --spider ${DOWNLOAD_URL_PREFIX}/${NEXT_NIGHTLY_TAG}/dpcpp-compiler.tar.gz  2>&1 | grep 'HTTP/1.1 200 OK'` ]];
+              then
+                  export DEPLOY_NIGHTLY_TAG=${NEXT_NIGHTLY_TAG}
+                  export DEPLOY_LLVM_TAG_SHA=${NEXT_LLVM_TAG_SHA}
+                  break
+              fi
+          done <<< "${LLVM_TAGS}"
+
+          [[ -n "${DEPLOY_NIGHTLY_TAG}" ]] || exit 1
+          [[ -n "${DEPLOY_LLVM_TAG_SHA}" ]] || exit 1
+          echo "Using ${m} corresponding to intel/llvm at ${DEPLOY_LLVM_TAG_SHA}"
+
+          if [[ -f bundle_id.txt && ( "$(cat bundle_id.txt)" == "${DEPLOY_LLVM_TAG_SHA}" ) ]]; then
+              echo "Using cached download of ${DEPLOY_LLVM_TAG_SHA}"
           else
               rm -rf dpcpp-compiler.tar.gz
-              wget ${DOWNLOAD_URL_PREFIX}/${NIGHTLY_TAG}/dpcpp-compiler.tar.gz && echo ${LATEST_LLVM_TAG_SHA} > bundle_id.txt || rm -rf bundle_id.txt
+              wget ${DOWNLOAD_URL_PREFIX}/${DEPLOY_NIGHTLY_TAG}/dpcpp-compiler.tar.gz && echo ${DEPLOY_LLVM_TAG_SHA} > bundle_id.txt || rm -rf bundle_id.txt
               [ -f ${OCLCPUEXP_FN} ] || wget ${DOWNLOAD_URL_PREFIX}/${DRIVER_PATH}/${OCLCPUEXP_FN} || rm -rf bundle_id.txt
               [ -f ${FPGAEMU_FN} ] || wget ${DOWNLOAD_URL_PREFIX}/${DRIVER_PATH}/${FPGAEMU_FN} || rm -rf bundle_id.txt
               [ -f ${TBB_FN} ] || wget ${TBB_URL}/${TBB_FN} || rm -rf bundle_id.txt


### PR DESCRIPTION
Since some sycl-nightly tags do no thave associated binaries attached the workflow was failing.

This commit enhances the download logic to go through recent tags until one is where where binary file is available.

- [X] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
