### PR TITLE
scripts/build_locally.py now supports --cmake-opts option

### DIFF
--- a/scripts/build_locally.py
+++ b/scripts/build_locally.py
@@ -28,6 +28,7 @@ def run(
     compiler_root=None,
     cmake_executable=None,
     use_glog=False,
+    cmake_opts="",
 ):
     build_system = None
 
@@ -57,6 +58,8 @@ def run(
         "-DDPCTL_ENABLE_L0_PROGRAM_CREATION=" + ("ON" if level_zero else "OFF"),
         "-DDPCTL_ENABLE_GLOG:BOOL=" + ("ON" if use_glog else "OFF"),
     ]
+    if cmake_opts:
+        cmake_args += cmake_opts.split()
     subprocess.check_call(
         cmake_args, shell=False, cwd=setup_dir, env=os.environ
     )
@@ -109,6 +112,13 @@ if __name__ == "__main__":
         help="DPCTLSyclInterface uses Google logger",
         dest="glog",
         action="store_true",
+    )
+    driver.add_argument(
+        "--cmake-opts",
+        help="DPCTLSyclInterface uses Google logger",
+        dest="cmake_opts",
+        default="",
+        type=str,
     )
     args = parser.parse_args()
 
@@ -163,4 +173,5 @@ if __name__ == "__main__":
         compiler_root=args.compiler_root,
         cmake_executable=args.cmake_executable,
         use_glog=args.glog,
+        cmake_opts=args.cmake_opts,
     )


### PR DESCRIPTION
Added support for --cmake-opts option inspired by LLVM configure script. This can be used to experiment with adding of additional options to cmake. For example, to try gold linker I used

```
python scripts/build_locally.py --cmake-opts="-DCMAKE_EXE_LINKER_FLAGS=-use-gold-plugin -DCMAKE_CXX_FLAGS=-flto"
```

- [X] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
