### PR TITLE
Add missing api keyword in declaration of MemoryUSMDevice class

### DIFF
--- a/dpctl/memory/_memory.pxd
+++ b/dpctl/memory/_memory.pxd
@@ -75,6 +75,6 @@ cdef public api class MemoryUSMHost(_Memory) [object PyMemoryUSMHostObject,
     pass
 
 
-cdef public class MemoryUSMDevice(_Memory) [object PyMemoryUSMDeviceObject,
+cdef public api class MemoryUSMDevice(_Memory) [object PyMemoryUSMDeviceObject,
                                             type PyMemoryUSMDeviceType]:
     pass


### PR DESCRIPTION
Declaration of `MemoryUSMDevice` class was missing `api` qualifier in `_memory.pxd`.

- [X] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [X] Have you tested your changes locally for CPU and GPU devices?
- [X] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
