### PR TITLE
[cleanup/tensor, step 3] Implement dpctl_capi loader in dpctl4pybind11 header file

### DIFF
--- a/dpctl/apis/include/dpctl4pybind11.hpp
+++ b/dpctl/apis/include/dpctl4pybind11.hpp
@@ -179,9 +179,15 @@ private:
         : default_sycl_queue{}, default_usm_memory{}, default_usm_ndarray{},
           as_usm_memory{}
     {
-        // Import Cython CAPI for dpctl
+        // Import Cython-generated C-API for dpctl
+        // This imports python modules and initializes
+        // static variables such as function pointers for C-API,
+        // e.g. SyclDevice_GetDeviceRef, etc.
+        // pointers to Python types, i.e. PySyclDeviceType, etc.
+        // and exported constants, i.e. USM_ARRAY_C_CONTIGUOUS, etc.
         import_dpctl();
 
+        // Python type objects for classes implemented by dpctl
         this->Py_SyclDeviceType_ = &Py_SyclDeviceType;
         this->PySyclDeviceType_ = &PySyclDeviceType;
         this->Py_SyclContextType_ = &Py_SyclContextType;
@@ -212,12 +218,14 @@ private:
         this->SyclQueue_GetQueueRef_ = SyclQueue_GetQueueRef;
         this->SyclQueue_Make_ = SyclQueue_Make;
 
+        // dpctl.memory API
         this->Memory_GetUsmPointer_ = Memory_GetUsmPointer;
         this->Memory_GetContextRef_ = Memory_GetContextRef;
         this->Memory_GetQueueRef_ = Memory_GetQueueRef;
         this->Memory_GetNumBytes_ = Memory_GetNumBytes;
         this->Memory_Make_ = Memory_Make;
 
+        // dpctl.tensor.usm_ndarray API
         this->UsmNDArray_GetData_ = UsmNDArray_GetData;
         this->UsmNDArray_GetNDim_ = UsmNDArray_GetNDim;
         this->UsmNDArray_GetShape_ = UsmNDArray_GetShape;
@@ -228,6 +236,7 @@ private:
         this->UsmNDArray_GetQueueRef_ = UsmNDArray_GetQueueRef;
         this->UsmNDArray_GetOffset_ = UsmNDArray_GetOffset;
 
+        // constants
         this->USM_ARRAY_C_CONTIGUOUS_ = USM_ARRAY_C_CONTIGUOUS;
         this->USM_ARRAY_F_CONTIGUOUS_ = USM_ARRAY_F_CONTIGUOUS;
         this->USM_ARRAY_WRITABLE_ = USM_ARRAY_WRITABLE;
@@ -247,6 +256,7 @@ private:
         this->UAR_TYPE_SENTINEL_ = UAR_TYPE_SENTINEL;
         this->UAR_HALF_ = UAR_HALF;
 
+        // deduced disjoint types
         this->UAR_INT8_ = UAR_BYTE;
         this->UAR_UINT8_ = UAR_UBYTE;
         this->UAR_INT16_ = UAR_SHORT;
@@ -266,6 +276,8 @@ private:
                                    unsigned long long, unsigned int>(
                 UAR_ULONG, UAR_ULONGLONG, UAR_UINT);
 
+        // create shared pointers to python objects used in type-casters
+        // for dpctl::memory::usm_memory and dpctl::tensor::usm_ndarray
         sycl::queue q_{};
         PySyclQueueObject *py_q_tmp =
             SyclQueue_Make(reinterpret_cast<DPCTLSyclQueueRef>(&q_));

--- a/dpctl/apis/include/dpctl4pybind11.hpp
+++ b/dpctl/apis/include/dpctl4pybind11.hpp
@@ -34,6 +34,283 @@
 
 namespace py = pybind11;
 
+namespace dpctl
+{
+namespace detail
+{
+
+// Lookup a type according to its size, and return a value corresponding to the
+// NumPy typenum.
+template <typename Concrete> constexpr int platform_typeid_lookup()
+{
+    return -1;
+}
+
+template <typename Concrete, typename T, typename... Ts, typename... Ints>
+constexpr int platform_typeid_lookup(int I, Ints... Is)
+{
+    return sizeof(Concrete) == sizeof(T)
+               ? I
+               : platform_typeid_lookup<Concrete, Ts...>(Is...);
+}
+
+struct dpctl_capi
+{
+
+    // dpctl type objects
+    PyTypeObject *Py_SyclDeviceType_;
+    PyTypeObject *PySyclDeviceType_;
+    PyTypeObject *Py_SyclContextType_;
+    PyTypeObject *PySyclContextType_;
+    PyTypeObject *Py_SyclEventType_;
+    PyTypeObject *PySyclEventType_;
+    PyTypeObject *Py_SyclQueueType_;
+    PyTypeObject *PySyclQueueType_;
+    PyTypeObject *Py_MemoryType_;
+    PyTypeObject *PyMemoryUSMDeviceType_;
+    PyTypeObject *PyMemoryUSMSharedType_;
+    PyTypeObject *PyMemoryUSMHostType_;
+    PyTypeObject *PyUSMArrayType_;
+
+    DPCTLSyclDeviceRef (*SyclDevice_GetDeviceRef_)(PySyclDeviceObject *);
+    PySyclDeviceObject *(*SyclDevice_Make_)(DPCTLSyclDeviceRef);
+
+    DPCTLSyclContextRef (*SyclContext_GetContextRef_)(PySyclContextObject *);
+    PySyclContextObject *(*SyclContext_Make_)(DPCTLSyclContextRef);
+
+    DPCTLSyclEventRef (*SyclEvent_GetEventRef_)(PySyclEventObject *);
+    PySyclEventObject *(*SyclEvent_Make_)(DPCTLSyclEventRef);
+
+    DPCTLSyclQueueRef (*SyclQueue_GetQueueRef_)(PySyclQueueObject *);
+    PySyclQueueObject *(*SyclQueue_Make_)(DPCTLSyclQueueRef);
+
+    // memory
+    DPCTLSyclUSMRef (*Memory_GetUsmPointer_)(Py_MemoryObject *);
+    DPCTLSyclContextRef (*Memory_GetContextRef_)(Py_MemoryObject *);
+    DPCTLSyclQueueRef (*Memory_GetQueueRef_)(Py_MemoryObject *);
+    size_t (*Memory_GetNumBytes_)(Py_MemoryObject *);
+    PyObject *(*Memory_Make_)(DPCTLSyclUSMRef,
+                              size_t,
+                              DPCTLSyclQueueRef,
+                              PyObject *);
+
+    // tensor
+    char *(*UsmNDArray_GetData_)(PyUSMArrayObject *);
+    int (*UsmNDArray_GetNDim_)(PyUSMArrayObject *);
+    py::ssize_t *(*UsmNDArray_GetShape_)(PyUSMArrayObject *);
+    py::ssize_t *(*UsmNDArray_GetStrides_)(PyUSMArrayObject *);
+    int (*UsmNDArray_GetTypenum_)(PyUSMArrayObject *);
+    int (*UsmNDArray_GetElementSize_)(PyUSMArrayObject *);
+    int (*UsmNDArray_GetFlags_)(PyUSMArrayObject *);
+    DPCTLSyclQueueRef (*UsmNDArray_GetQueueRef_)(PyUSMArrayObject *);
+    py::ssize_t (*UsmNDArray_GetOffset_)(PyUSMArrayObject *);
+
+    int USM_ARRAY_C_CONTIGUOUS_;
+    int USM_ARRAY_F_CONTIGUOUS_;
+    int USM_ARRAY_WRITABLE_;
+    int UAR_BOOL_, UAR_BYTE_, UAR_UBYTE_, UAR_SHORT_, UAR_USHORT_, UAR_INT_,
+        UAR_UINT_, UAR_LONG_, UAR_ULONG_, UAR_LONGLONG_, UAR_ULONGLONG_,
+        UAR_FLOAT_, UAR_DOUBLE_, UAR_CFLOAT_, UAR_CDOUBLE_, UAR_TYPE_SENTINEL_,
+        UAR_HALF_;
+    int UAR_INT8_, UAR_UINT8_, UAR_INT16_, UAR_UINT16_, UAR_INT32_, UAR_UINT32_,
+        UAR_INT64_, UAR_UINT64_;
+
+    bool PySyclDevice_Check_(PyObject *obj) const
+    {
+        return PyObject_TypeCheck(obj, PySyclDeviceType_) != 0;
+    }
+    bool PySyclContext_Check_(PyObject *obj) const
+    {
+        return PyObject_TypeCheck(obj, PySyclContextType_) != 0;
+    }
+    bool PySyclEvent_Check_(PyObject *obj) const
+    {
+        return PyObject_TypeCheck(obj, PySyclEventType_) != 0;
+    }
+    bool PySyclQueue_Check_(PyObject *obj) const
+    {
+        return PyObject_TypeCheck(obj, PySyclQueueType_) != 0;
+    }
+
+    ~dpctl_capi(){};
+
+    static auto &get()
+    {
+        static dpctl_capi api = lookup();
+        return api;
+    }
+
+    py::object default_sycl_queue_pyobj()
+    {
+        return *default_sycl_queue;
+    }
+    py::object default_usm_memory_pyobj()
+    {
+        return *default_usm_memory;
+    }
+    py::object default_usm_ndarray_pyobj()
+    {
+        return *default_usm_ndarray;
+    }
+    py::object as_usm_memory_pyobj()
+    {
+        return *as_usm_memory;
+    }
+
+private:
+    struct Deleter
+    {
+        void operator()(py::object *p) const
+        {
+            bool guard = (Py_IsInitialized() && !_Py_IsFinalizing());
+
+            if (guard) {
+                delete p;
+            }
+        }
+    };
+
+    std::shared_ptr<py::object> default_sycl_queue;
+    std::shared_ptr<py::object> default_usm_memory;
+    std::shared_ptr<py::object> default_usm_ndarray;
+    std::shared_ptr<py::object> as_usm_memory;
+
+    dpctl_capi()
+        : default_sycl_queue{}, default_usm_memory{}, default_usm_ndarray{},
+          as_usm_memory{}
+    {
+        // Import Cython CAPI for dpctl
+        import_dpctl();
+
+        this->Py_SyclDeviceType_ = &Py_SyclDeviceType;
+        this->PySyclDeviceType_ = &PySyclDeviceType;
+        this->Py_SyclContextType_ = &Py_SyclContextType;
+        this->PySyclContextType_ = &PySyclContextType;
+        this->Py_SyclEventType_ = &Py_SyclEventType;
+        this->PySyclEventType_ = &PySyclEventType;
+        this->Py_SyclQueueType_ = &Py_SyclQueueType;
+        this->PySyclQueueType_ = &PySyclQueueType;
+        this->Py_MemoryType_ = &Py_MemoryType;
+        this->PyMemoryUSMDeviceType_ = &PyMemoryUSMDeviceType;
+        this->PyMemoryUSMSharedType_ = &PyMemoryUSMSharedType;
+        this->PyMemoryUSMHostType_ = &PyMemoryUSMHostType;
+        this->PyUSMArrayType_ = &PyUSMArrayType;
+
+        // SyclDevice API
+        this->SyclDevice_GetDeviceRef_ = SyclDevice_GetDeviceRef;
+        this->SyclDevice_Make_ = SyclDevice_Make;
+
+        // SyclContext API
+        this->SyclContext_GetContextRef_ = SyclContext_GetContextRef;
+        this->SyclContext_Make_ = SyclContext_Make;
+
+        // SyclEvent API
+        this->SyclEvent_GetEventRef_ = SyclEvent_GetEventRef;
+        this->SyclEvent_Make_ = SyclEvent_Make;
+
+        // SyclQueue API
+        this->SyclQueue_GetQueueRef_ = SyclQueue_GetQueueRef;
+        this->SyclQueue_Make_ = SyclQueue_Make;
+
+        this->Memory_GetUsmPointer_ = Memory_GetUsmPointer;
+        this->Memory_GetContextRef_ = Memory_GetContextRef;
+        this->Memory_GetQueueRef_ = Memory_GetQueueRef;
+        this->Memory_GetNumBytes_ = Memory_GetNumBytes;
+        this->Memory_Make_ = Memory_Make;
+
+        this->UsmNDArray_GetData_ = UsmNDArray_GetData;
+        this->UsmNDArray_GetNDim_ = UsmNDArray_GetNDim;
+        this->UsmNDArray_GetShape_ = UsmNDArray_GetShape;
+        this->UsmNDArray_GetStrides_ = UsmNDArray_GetStrides;
+        this->UsmNDArray_GetTypenum_ = UsmNDArray_GetTypenum;
+        this->UsmNDArray_GetElementSize_ = UsmNDArray_GetElementSize;
+        this->UsmNDArray_GetFlags_ = UsmNDArray_GetFlags;
+        this->UsmNDArray_GetQueueRef_ = UsmNDArray_GetQueueRef;
+        this->UsmNDArray_GetOffset_ = UsmNDArray_GetOffset;
+
+        this->USM_ARRAY_C_CONTIGUOUS_ = USM_ARRAY_C_CONTIGUOUS;
+        this->USM_ARRAY_F_CONTIGUOUS_ = USM_ARRAY_F_CONTIGUOUS;
+        this->USM_ARRAY_WRITABLE_ = USM_ARRAY_WRITABLE;
+        this->UAR_BOOL_ = UAR_BOOL;
+        this->UAR_SHORT_ = UAR_SHORT;
+        this->UAR_USHORT_ = UAR_USHORT;
+        this->UAR_INT_ = UAR_INT;
+        this->UAR_UINT_ = UAR_UINT;
+        this->UAR_LONG_ = UAR_LONG;
+        this->UAR_ULONG_ = UAR_ULONG;
+        this->UAR_LONGLONG_ = UAR_LONGLONG;
+        this->UAR_ULONGLONG_ = UAR_ULONGLONG;
+        this->UAR_FLOAT_ = UAR_FLOAT;
+        this->UAR_DOUBLE_ = UAR_DOUBLE;
+        this->UAR_CFLOAT_ = UAR_CFLOAT;
+        this->UAR_CDOUBLE_ = UAR_CDOUBLE;
+        this->UAR_TYPE_SENTINEL_ = UAR_TYPE_SENTINEL;
+        this->UAR_HALF_ = UAR_HALF;
+
+        this->UAR_INT8_ = UAR_BYTE;
+        this->UAR_UINT8_ = UAR_UBYTE;
+        this->UAR_INT16_ = UAR_SHORT;
+        this->UAR_UINT16_ = UAR_USHORT;
+        this->UAR_INT32_ =
+            platform_typeid_lookup<std::int32_t, long, int, short>(
+                UAR_LONG, UAR_INT, UAR_SHORT);
+        this->UAR_UINT32_ =
+            platform_typeid_lookup<std::uint32_t, unsigned long, unsigned int,
+                                   unsigned short>(UAR_ULONG, UAR_UINT,
+                                                   UAR_USHORT);
+        this->UAR_INT64_ =
+            platform_typeid_lookup<std::int64_t, long, long long, int>(
+                UAR_LONG, UAR_LONGLONG, UAR_INT);
+        this->UAR_UINT64_ =
+            platform_typeid_lookup<std::uint64_t, unsigned long,
+                                   unsigned long long, unsigned int>(
+                UAR_ULONG, UAR_ULONGLONG, UAR_UINT);
+
+        sycl::queue q_{};
+        PySyclQueueObject *py_q_tmp =
+            SyclQueue_Make(reinterpret_cast<DPCTLSyclQueueRef>(&q_));
+        py::object py_sycl_queue = py::reinterpret_steal<py::object>(
+            reinterpret_cast<PyObject *>(py_q_tmp));
+
+        default_sycl_queue = std::shared_ptr<py::object>(
+            new py::object(py_sycl_queue), Deleter{});
+
+        py::module_ mod_memory = py::module_::import("dpctl.memory");
+        py::object py_as_usm_memory = mod_memory.attr("as_usm_memory");
+        as_usm_memory = std::shared_ptr<py::object>(
+            new py::object{py_as_usm_memory}, Deleter{});
+
+        auto mem_kl = mod_memory.attr("MemoryUSMHost");
+        py::object py_default_usm_memory =
+            mem_kl(1, py::arg("queue") = py_sycl_queue);
+        default_usm_memory = std::shared_ptr<py::object>(
+            new py::object{py_default_usm_memory}, Deleter{});
+
+        py::module_ mod_usmarray =
+            py::module_::import("dpctl.tensor._usmarray");
+        auto tensor_kl = mod_usmarray.attr("usm_ndarray");
+
+        py::object py_default_usm_ndarray =
+            tensor_kl(py::tuple(), py::arg("dtype") = py::str("u1"),
+                      py::arg("buffer") = py_default_usm_memory);
+
+        default_usm_ndarray = std::shared_ptr<py::object>(
+            new py::object{py_default_usm_ndarray}, Deleter{});
+    }
+
+    dpctl_capi(dpctl_capi const &) = default;
+    dpctl_capi &operator=(dpctl_capi const &) = default;
+
+    static dpctl_capi lookup()
+    {
+        static dpctl_capi api;
+        return api;
+    }
+
+}; // struct dpctl_capi
+} // namespace detail
+} // namespace dpctl
+
 namespace pybind11
 {
 namespace detail
@@ -88,8 +365,9 @@ public:
     bool load(handle src, bool)
     {
         PyObject *source = src.ptr();
-        if (PyObject_TypeCheck(source, &PySyclQueueType)) {
-            DPCTLSyclQueueRef QRef = SyclQueue_GetQueueRef(
+        auto &api = ::dpctl::detail::dpctl_capi::get();
+        if (api.PySyclQueue_Check_(source)) {
+            DPCTLSyclQueueRef QRef = api.SyclQueue_GetQueueRef_(
                 reinterpret_cast<PySyclQueueObject *>(source));
             value = std::make_unique<sycl::queue>(
                 *(reinterpret_cast<sycl::queue *>(QRef)));
@@ -103,7 +381,9 @@ public:
 
     static handle cast(sycl::queue src, return_value_policy, handle)
     {
-        auto tmp = SyclQueue_Make(reinterpret_cast<DPCTLSyclQueueRef>(&src));
+        auto &api = ::dpctl::detail::dpctl_capi::get();
+        auto tmp =
+            api.SyclQueue_Make_(reinterpret_cast<DPCTLSyclQueueRef>(&src));
         return handle(reinterpret_cast<PyObject *>(tmp));
     }
 
@@ -120,8 +400,9 @@ public:
     bool load(handle src, bool)
     {
         PyObject *source = src.ptr();
-        if (PyObject_TypeCheck(source, &PySyclDeviceType)) {
-            DPCTLSyclDeviceRef DRef = SyclDevice_GetDeviceRef(
+        auto &api = ::dpctl::detail::dpctl_capi::get();
+        if (api.PySyclDevice_Check_(source)) {
+            DPCTLSyclDeviceRef DRef = api.SyclDevice_GetDeviceRef_(
                 reinterpret_cast<PySyclDeviceObject *>(source));
             value = std::make_unique<sycl::device>(
                 *(reinterpret_cast<sycl::device *>(DRef)));
@@ -135,7 +416,9 @@ public:
 
     static handle cast(sycl::device src, return_value_policy, handle)
     {
-        auto tmp = SyclDevice_Make(reinterpret_cast<DPCTLSyclDeviceRef>(&src));
+        auto &api = ::dpctl::detail::dpctl_capi::get();
+        auto tmp =
+            api.SyclDevice_Make_(reinterpret_cast<DPCTLSyclDeviceRef>(&src));
         return handle(reinterpret_cast<PyObject *>(tmp));
     }
 
@@ -152,8 +435,9 @@ public:
     bool load(handle src, bool)
     {
         PyObject *source = src.ptr();
-        if (PyObject_TypeCheck(source, &PySyclContextType)) {
-            DPCTLSyclContextRef CRef = SyclContext_GetContextRef(
+        auto &api = ::dpctl::detail::dpctl_capi::get();
+        if (api.PySyclContext_Check_(source)) {
+            DPCTLSyclContextRef CRef = api.SyclContext_GetContextRef_(
                 reinterpret_cast<PySyclContextObject *>(source));
             value = std::make_unique<sycl::context>(
                 *(reinterpret_cast<sycl::context *>(CRef)));
@@ -167,8 +451,9 @@ public:
 
     static handle cast(sycl::context src, return_value_policy, handle)
     {
+        auto &api = ::dpctl::detail::dpctl_capi::get();
         auto tmp =
-            SyclContext_Make(reinterpret_cast<DPCTLSyclContextRef>(&src));
+            api.SyclContext_Make_(reinterpret_cast<DPCTLSyclContextRef>(&src));
         return handle(reinterpret_cast<PyObject *>(tmp));
     }
 
@@ -185,8 +470,9 @@ public:
     bool load(handle src, bool)
     {
         PyObject *source = src.ptr();
-        if (PyObject_TypeCheck(source, &PySyclEventType)) {
-            DPCTLSyclEventRef ERef = SyclEvent_GetEventRef(
+        auto &api = ::dpctl::detail::dpctl_capi::get();
+        if (api.PySyclEvent_Check_(source)) {
+            DPCTLSyclEventRef ERef = api.SyclEvent_GetEventRef_(
                 reinterpret_cast<PySyclEventObject *>(source));
             value = std::make_unique<sycl::event>(
                 *(reinterpret_cast<sycl::event *>(ERef)));
@@ -200,7 +486,9 @@ public:
 
     static handle cast(sycl::event src, return_value_policy, handle)
     {
-        auto tmp = SyclEvent_Make(reinterpret_cast<DPCTLSyclEventRef>(&src));
+        auto &api = ::dpctl::detail::dpctl_capi::get();
+        auto tmp =
+            api.SyclEvent_Make_(reinterpret_cast<DPCTLSyclEventRef>(&src));
         return handle(reinterpret_cast<PyObject *>(tmp));
     }
 
@@ -211,93 +499,6 @@ public:
 
 namespace dpctl
 {
-
-namespace detail
-{
-
-struct dpctl_api
-{
-public:
-    static dpctl_api &get()
-    {
-        static dpctl_api api;
-        return api;
-    }
-
-    py::object sycl_queue_()
-    {
-        return *sycl_queue;
-    }
-    py::object default_usm_memory_()
-    {
-        return *default_usm_memory;
-    }
-    py::object default_usm_ndarray_()
-    {
-        return *default_usm_ndarray;
-    }
-    py::object as_usm_memory_()
-    {
-        return *as_usm_memory;
-    }
-
-private:
-    struct Deleter
-    {
-        void operator()(py::object *p) const
-        {
-            bool guard = (Py_IsInitialized() && !_Py_IsFinalizing());
-
-            if (guard) {
-                delete p;
-            }
-        }
-    };
-
-    std::shared_ptr<py::object> sycl_queue;
-    std::shared_ptr<py::object> default_usm_memory;
-    std::shared_ptr<py::object> default_usm_ndarray;
-    std::shared_ptr<py::object> as_usm_memory;
-
-    dpctl_api() : sycl_queue{}, default_usm_memory{}, default_usm_ndarray{}
-    {
-        import_dpctl();
-
-        sycl::queue q_;
-        py::object py_sycl_queue = py::cast(q_);
-        sycl_queue = std::shared_ptr<py::object>(new py::object{py_sycl_queue},
-                                                 Deleter{});
-
-        py::module_ mod_memory = py::module_::import("dpctl.memory");
-        py::object py_as_usm_memory = mod_memory.attr("as_usm_memory");
-        as_usm_memory = std::shared_ptr<py::object>(
-            new py::object{py_as_usm_memory}, Deleter{});
-
-        auto mem_kl = mod_memory.attr("MemoryUSMHost");
-        py::object py_default_usm_memory =
-            mem_kl(1, py::arg("queue") = py_sycl_queue);
-        default_usm_memory = std::shared_ptr<py::object>(
-            new py::object{py_default_usm_memory}, Deleter{});
-
-        py::module_ mod_usmarray =
-            py::module_::import("dpctl.tensor._usmarray");
-        auto tensor_kl = mod_usmarray.attr("usm_ndarray");
-
-        py::object py_default_usm_ndarray =
-            tensor_kl(py::tuple(), py::arg("dtype") = py::str("u1"),
-                      py::arg("buffer") = py_default_usm_memory);
-
-        default_usm_ndarray = std::shared_ptr<py::object>(
-            new py::object{py_default_usm_ndarray}, Deleter{});
-    }
-
-public:
-    dpctl_api(dpctl_api const &) = delete;
-    void operator=(dpctl_api const &) = delete;
-    ~dpctl_api(){};
-};
-
-} // namespace detail
 
 namespace memory
 {
@@ -313,13 +514,16 @@ public:
         usm_memory,
         py::object,
         [](PyObject *o) -> bool {
-            return PyObject_TypeCheck(o, &Py_MemoryType) != 0;
+            return PyObject_TypeCheck(
+                       o, ::dpctl::detail::dpctl_capi::get().Py_MemoryType_) !=
+                   0;
         },
         [](PyObject *o) -> PyObject * { return as_usm_memory(o); })
 
     usm_memory()
-        : py::object(::dpctl::detail::dpctl_api::get().default_usm_memory_(),
-                     borrowed_t{})
+        : py::object(
+              ::dpctl::detail::dpctl_capi::get().default_usm_memory_pyobj(),
+              borrowed_t{})
     {
         if (!m_ptr)
             throw py::error_already_set();
@@ -328,7 +532,8 @@ public:
     sycl::queue get_queue() const
     {
         Py_MemoryObject *mem_obj = reinterpret_cast<Py_MemoryObject *>(m_ptr);
-        DPCTLSyclQueueRef QRef = Memory_GetQueueRef(mem_obj);
+        auto &api = ::dpctl::detail::dpctl_capi::get();
+        DPCTLSyclQueueRef QRef = api.Memory_GetQueueRef_(mem_obj);
         sycl::queue *obj_q = reinterpret_cast<sycl::queue *>(QRef);
         return *obj_q;
     }
@@ -336,14 +541,16 @@ public:
     char *get_pointer() const
     {
         Py_MemoryObject *mem_obj = reinterpret_cast<Py_MemoryObject *>(m_ptr);
-        DPCTLSyclUSMRef MRef = Memory_GetUsmPointer(mem_obj);
+        auto &api = ::dpctl::detail::dpctl_capi::get();
+        DPCTLSyclUSMRef MRef = api.Memory_GetUsmPointer_(mem_obj);
         return reinterpret_cast<char *>(MRef);
     }
 
     size_t get_nbytes() const
     {
+        auto &api = ::dpctl::detail::dpctl_capi::get();
         Py_MemoryObject *mem_obj = reinterpret_cast<Py_MemoryObject *>(m_ptr);
-        return Memory_GetNumBytes(mem_obj);
+        return api.Memory_GetNumBytes_(mem_obj);
     }
 
 protected:
@@ -355,7 +562,8 @@ protected:
             return nullptr;
         }
 
-        auto convertor = ::dpctl::detail::dpctl_api::get().as_usm_memory_();
+        auto convertor =
+            ::dpctl::detail::dpctl_capi::get().as_usm_memory_pyobj();
 
         py::object res;
         try {
@@ -426,12 +634,14 @@ class usm_ndarray : public py::object
 {
 public:
     PYBIND11_OBJECT(usm_ndarray, py::object, [](PyObject *o) -> bool {
-        return PyObject_TypeCheck(o, &PyUSMArrayType) != 0;
+        return PyObject_TypeCheck(
+                   o, ::dpctl::detail::dpctl_capi::get().PyUSMArrayType_) != 0;
     })
 
     usm_ndarray()
-        : py::object(::dpctl::detail::dpctl_api::get().default_usm_ndarray_(),
-                     borrowed_t{})
+        : py::object(
+              ::dpctl::detail::dpctl_capi::get().default_usm_ndarray_pyobj(),
+              borrowed_t{})
     {
         if (!m_ptr)
             throw py::error_already_set();
@@ -441,7 +651,8 @@ public:
     {
         PyUSMArrayObject *raw_ar = this->usm_array_ptr();
 
-        return UsmNDArray_GetData(raw_ar);
+        auto &api = ::dpctl::detail::dpctl_capi::get();
+        return api.UsmNDArray_GetData_(raw_ar);
     }
 
     template <typename T> T *get_data() const
@@ -453,14 +664,16 @@ public:
     {
         PyUSMArrayObject *raw_ar = this->usm_array_ptr();
 
-        return UsmNDArray_GetNDim(raw_ar);
+        auto &api = ::dpctl::detail::dpctl_capi::get();
+        return api.UsmNDArray_GetNDim_(raw_ar);
     }
 
     const py::ssize_t *get_shape_raw() const
     {
         PyUSMArrayObject *raw_ar = this->usm_array_ptr();
 
-        return UsmNDArray_GetShape(raw_ar);
+        auto &api = ::dpctl::detail::dpctl_capi::get();
+        return api.UsmNDArray_GetShape_(raw_ar);
     }
 
     py::ssize_t get_shape(int i) const
@@ -473,15 +686,17 @@ public:
     {
         PyUSMArrayObject *raw_ar = this->usm_array_ptr();
 
-        return UsmNDArray_GetStrides(raw_ar);
+        auto &api = ::dpctl::detail::dpctl_capi::get();
+        return api.UsmNDArray_GetStrides_(raw_ar);
     }
 
     py::ssize_t get_size() const
     {
         PyUSMArrayObject *raw_ar = this->usm_array_ptr();
 
-        int ndim = UsmNDArray_GetNDim(raw_ar);
-        const py::ssize_t *shape = UsmNDArray_GetShape(raw_ar);
+        auto &api = ::dpctl::detail::dpctl_capi::get();
+        int ndim = api.UsmNDArray_GetNDim_(raw_ar);
+        const py::ssize_t *shape = api.UsmNDArray_GetShape_(raw_ar);
 
         py::ssize_t nelems = 1;
         for (int i = 0; i < ndim; ++i) {
@@ -496,9 +711,10 @@ public:
     {
         PyUSMArrayObject *raw_ar = this->usm_array_ptr();
 
-        int nd = UsmNDArray_GetNDim(raw_ar);
-        const py::ssize_t *shape = UsmNDArray_GetShape(raw_ar);
-        const py::ssize_t *strides = UsmNDArray_GetStrides(raw_ar);
+        auto &api = ::dpctl::detail::dpctl_capi::get();
+        int nd = api.UsmNDArray_GetNDim_(raw_ar);
+        const py::ssize_t *shape = api.UsmNDArray_GetShape_(raw_ar);
+        const py::ssize_t *strides = api.UsmNDArray_GetStrides_(raw_ar);
 
         py::ssize_t offset_min = 0;
         py::ssize_t offset_max = 0;
@@ -510,7 +726,7 @@ public:
             }
         }
         else {
-            offset_min = UsmNDArray_GetOffset(raw_ar);
+            offset_min = api.UsmNDArray_GetOffset_(raw_ar);
             offset_max = offset_min;
             for (int i = 0; i < nd; ++i) {
                 py::ssize_t delta = strides[i] * (shape[i] - 1);
@@ -529,7 +745,8 @@ public:
     {
         PyUSMArrayObject *raw_ar = this->usm_array_ptr();
 
-        DPCTLSyclQueueRef QRef = UsmNDArray_GetQueueRef(raw_ar);
+        auto &api = ::dpctl::detail::dpctl_capi::get();
+        DPCTLSyclQueueRef QRef = api.UsmNDArray_GetQueueRef_(raw_ar);
         return *(reinterpret_cast<sycl::queue *>(QRef));
     }
 
@@ -537,33 +754,45 @@ public:
     {
         PyUSMArrayObject *raw_ar = this->usm_array_ptr();
 
-        return UsmNDArray_GetTypenum(raw_ar);
+        auto &api = ::dpctl::detail::dpctl_capi::get();
+        return api.UsmNDArray_GetTypenum_(raw_ar);
     }
 
     int get_flags() const
     {
         PyUSMArrayObject *raw_ar = this->usm_array_ptr();
 
-        return UsmNDArray_GetFlags(raw_ar);
+        auto &api = ::dpctl::detail::dpctl_capi::get();
+        return api.UsmNDArray_GetFlags_(raw_ar);
     }
 
     int get_elemsize() const
     {
         PyUSMArrayObject *raw_ar = this->usm_array_ptr();
 
-        return UsmNDArray_GetElementSize(raw_ar);
+        auto &api = ::dpctl::detail::dpctl_capi::get();
+        return api.UsmNDArray_GetElementSize_(raw_ar);
     }
 
     bool is_c_contiguous() const
     {
         int flags = this->get_flags();
-        return static_cast<bool>(flags & USM_ARRAY_C_CONTIGUOUS);
+        auto &api = ::dpctl::detail::dpctl_capi::get();
+        return static_cast<bool>(flags & api.USM_ARRAY_C_CONTIGUOUS_);
     }
 
     bool is_f_contiguous() const
     {
         int flags = this->get_flags();
-        return static_cast<bool>(flags & USM_ARRAY_F_CONTIGUOUS);
+        auto &api = ::dpctl::detail::dpctl_capi::get();
+        return static_cast<bool>(flags & api.USM_ARRAY_F_CONTIGUOUS_);
+    }
+
+    bool is_writable() const
+    {
+        int flags = this->get_flags();
+        auto &api = ::dpctl::detail::dpctl_capi::get();
+        return static_cast<bool>(flags & api.USM_ARRAY_WRITABLE_);
     }
 
 private:

--- a/dpctl/tensor/libtensor/include/utils/type_dispatch.hpp
+++ b/dpctl/tensor/libtensor/include/utils/type_dispatch.hpp
@@ -159,83 +159,64 @@ public:
     }
 };
 
-// Lookup a type according to its size, and return a value corresponding to the
-// NumPy typenum.
-template <typename Concrete> constexpr int platform_typeid_lookup()
-{
-    return -1;
-}
-
-template <typename Concrete, typename T, typename... Ts, typename... Ints>
-constexpr int platform_typeid_lookup(int I, Ints... Is)
-{
-    return sizeof(Concrete) == sizeof(T)
-               ? I
-               : platform_typeid_lookup<Concrete, Ts...>(Is...);
-}
-
 struct usm_ndarray_types
 {
-    static usm_ndarray_types &get()
-    {
-        static usm_ndarray_types singleton = populate_fields();
-        return singleton;
-    }
 
     int typenum_to_lookup_id(int typenum)
     {
         using typenum_t = dpctl::tensor::detail::typenum_t;
+        auto &api = ::dpctl::detail::dpctl_capi::get();
 
-        if (typenum == UAR_DOUBLE_) {
+        if (typenum == api.UAR_DOUBLE_) {
             return static_cast<int>(typenum_t::DOUBLE);
         }
-        else if (typenum == UAR_INT64_) {
+        else if (typenum == api.UAR_INT64_) {
             return static_cast<int>(typenum_t::INT64);
         }
-        else if (typenum == UAR_INT32_) {
+        else if (typenum == api.UAR_INT32_) {
             return static_cast<int>(typenum_t::INT32);
         }
-        else if (typenum == UAR_BOOL_) {
+        else if (typenum == api.UAR_BOOL_) {
             return static_cast<int>(typenum_t::BOOL);
         }
-        else if (typenum == UAR_CDOUBLE_) {
+        else if (typenum == api.UAR_CDOUBLE_) {
             return static_cast<int>(typenum_t::CDOUBLE);
         }
-        else if (typenum == UAR_FLOAT_) {
+        else if (typenum == api.UAR_FLOAT_) {
             return static_cast<int>(typenum_t::FLOAT);
         }
-        else if (typenum == UAR_INT16_) {
+        else if (typenum == api.UAR_INT16_) {
             return static_cast<int>(typenum_t::INT16);
         }
-        else if (typenum == UAR_INT8_) {
+        else if (typenum == api.UAR_INT8_) {
             return static_cast<int>(typenum_t::INT8);
         }
-        else if (typenum == UAR_UINT64_) {
+        else if (typenum == api.UAR_UINT64_) {
             return static_cast<int>(typenum_t::UINT64);
         }
-        else if (typenum == UAR_UINT32_) {
+        else if (typenum == api.UAR_UINT32_) {
             return static_cast<int>(typenum_t::UINT32);
         }
-        else if (typenum == UAR_UINT16_) {
+        else if (typenum == api.UAR_UINT16_) {
             return static_cast<int>(typenum_t::UINT16);
         }
-        else if (typenum == UAR_UINT8_) {
+        else if (typenum == api.UAR_UINT8_) {
             return static_cast<int>(typenum_t::UINT8);
         }
-        else if (typenum == UAR_CFLOAT_) {
+        else if (typenum == api.UAR_CFLOAT_) {
             return static_cast<int>(typenum_t::CFLOAT);
         }
-        else if (typenum == UAR_HALF_) {
+        else if (typenum == api.UAR_HALF_) {
             return static_cast<int>(typenum_t::HALF);
         }
-        else if (typenum == UAR_INT || typenum == UAR_UINT) {
+        else if (typenum == api.UAR_INT_ || typenum == api.UAR_UINT_) {
             switch (sizeof(int)) {
             case sizeof(std::int32_t):
-                return ((typenum == UAR_INT)
+                return ((typenum == api.UAR_INT_)
                             ? static_cast<int>(typenum_t::INT32)
                             : static_cast<int>(typenum_t::UINT32));
             case sizeof(std::int64_t):
-                return ((typenum == UAR_INT)
+                return ((typenum == api.UAR_INT_)
                             ? static_cast<int>(typenum_t::INT64)
                             : static_cast<int>(typenum_t::UINT64));
             default:
@@ -251,58 +232,6 @@ struct usm_ndarray_types
     }
 
 private:
-    int UAR_BOOL_ = -1;
-    // Platform-dependent normalization
-    int UAR_INT8_ = -1;
-    int UAR_UINT8_ = -1;
-    int UAR_INT16_ = -1;
-    int UAR_UINT16_ = -1;
-    int UAR_INT32_ = -1;
-    int UAR_UINT32_ = -1;
-    int UAR_INT64_ = -1;
-    int UAR_UINT64_ = -1;
-    int UAR_HALF_ = -1;
-    int UAR_FLOAT_ = -1;
-    int UAR_DOUBLE_ = -1;
-    int UAR_CFLOAT_ = -1;
-    int UAR_CDOUBLE_ = -1;
-    int UAR_TYPE_SENTINEL_ = -1;
-
-    void init_constants()
-    {
-        UAR_BOOL_ = UAR_BOOL;
-        UAR_INT8_ = UAR_BYTE;
-        UAR_UINT8_ = UAR_UBYTE;
-        UAR_INT16_ = UAR_SHORT;
-        UAR_UINT16_ = UAR_USHORT;
-        UAR_INT32_ = platform_typeid_lookup<std::int32_t, long, int, short>(
-            UAR_LONG, UAR_INT, UAR_SHORT);
-        UAR_UINT32_ = platform_typeid_lookup<std::uint32_t, unsigned long,
-                                             unsigned int, unsigned short>(
-            UAR_ULONG, UAR_UINT, UAR_USHORT);
-        UAR_INT64_ = platform_typeid_lookup<std::int64_t, long, long long, int>(
-            UAR_LONG, UAR_LONGLONG, UAR_INT);
-        UAR_UINT64_ = platform_typeid_lookup<std::uint64_t, unsigned long,
-                                             unsigned long long, unsigned int>(
-            UAR_ULONG, UAR_ULONGLONG, UAR_UINT);
-        UAR_HALF_ = UAR_HALF;
-        UAR_FLOAT_ = UAR_FLOAT;
-        UAR_DOUBLE_ = UAR_DOUBLE;
-        UAR_CFLOAT_ = UAR_CFLOAT;
-        UAR_CDOUBLE_ = UAR_CDOUBLE;
-        UAR_TYPE_SENTINEL_ = UAR_TYPE_SENTINEL;
-    }
-
-    static usm_ndarray_types populate_fields()
-    {
-        import_dpctl();
-
-        usm_ndarray_types types;
-        types.init_constants();
-
-        return types;
-    }
-
     void throw_unrecognized_typenum_error(int typenum)
     {
         throw std::runtime_error("Unrecogized typenum " +

--- a/dpctl/tensor/libtensor/source/tensor_py.cpp
+++ b/dpctl/tensor/libtensor/source/tensor_py.cpp
@@ -299,7 +299,7 @@ copy_usm_ndarray_into_usm_ndarray(dpctl::tensor::usm_ndarray src,
     int src_typenum = src.get_typenum();
     int dst_typenum = dst.get_typenum();
 
-    auto array_types = dpctl::tensor::detail::usm_ndarray_types::get();
+    auto array_types = dpctl::tensor::detail::usm_ndarray_types();
     int src_type_id = array_types.typenum_to_lookup_id(src_typenum);
     int dst_type_id = array_types.typenum_to_lookup_id(dst_typenum);
 
@@ -544,7 +544,7 @@ copy_usm_ndarray_for_reshape(dpctl::tensor::usm_ndarray src,
     const py::ssize_t *src_shape = src.get_shape_raw();
     const py::ssize_t *dst_shape = dst.get_shape_raw();
 
-    auto array_types = dpctl::tensor::detail::usm_ndarray_types::get();
+    auto array_types = dpctl::tensor::detail::usm_ndarray_types();
     int type_id = array_types.typenum_to_lookup_id(src_typenum);
 
     auto fn = copy_for_reshape_generic_dispatch_vector[type_id];
@@ -729,7 +729,7 @@ void copy_numpy_ndarray_into_usm_ndarray(
         py::detail::array_descriptor_proxy(npy_src.dtype().ptr())->type_num;
     int dst_typenum = dst.get_typenum();
 
-    auto array_types = dpctl::tensor::detail::usm_ndarray_types::get();
+    auto array_types = dpctl::tensor::detail::usm_ndarray_types();
     int src_type_id = array_types.typenum_to_lookup_id(src_typenum);
     int dst_type_id = array_types.typenum_to_lookup_id(dst_typenum);
 
@@ -910,7 +910,7 @@ usm_ndarray_linear_sequence_step(py::object start,
             "Execution queue is not compatible with the allocation queue");
     }
 
-    auto array_types = dpctl::tensor::detail::usm_ndarray_types::get();
+    auto array_types = dpctl::tensor::detail::usm_ndarray_types();
     int dst_typenum = dst.get_typenum();
     int dst_typeid = array_types.typenum_to_lookup_id(dst_typenum);
 
@@ -959,7 +959,7 @@ usm_ndarray_linear_sequence_affine(py::object start,
             "Execution queue context is not the same as allocation context");
     }
 
-    auto array_types = dpctl::tensor::detail::usm_ndarray_types::get();
+    auto array_types = dpctl::tensor::detail::usm_ndarray_types();
     int dst_typenum = dst.get_typenum();
     int dst_typeid = array_types.typenum_to_lookup_id(dst_typenum);
 
@@ -1009,7 +1009,7 @@ usm_ndarray_full(py::object py_value,
             "Execution queue is not compatible with the allocation queue");
     }
 
-    auto array_types = dpctl::tensor::detail::usm_ndarray_types::get();
+    auto array_types = dpctl::tensor::detail::usm_ndarray_types();
     int dst_typenum = dst.get_typenum();
     int dst_typeid = array_types.typenum_to_lookup_id(dst_typenum);
 
@@ -1058,7 +1058,7 @@ eye(py::ssize_t k,
                               "allocation queue");
     }
 
-    auto array_types = dpctl::tensor::detail::usm_ndarray_types::get();
+    auto array_types = dpctl::tensor::detail::usm_ndarray_types();
     int dst_typenum = dst.get_typenum();
     int dst_typeid = array_types.typenum_to_lookup_id(dst_typenum);
 
@@ -1173,7 +1173,7 @@ tri(sycl::queue &exec_q,
         throw py::value_error("Arrays index overlapping segments of memory");
     }
 
-    auto array_types = dpctl::tensor::detail::usm_ndarray_types::get();
+    auto array_types = dpctl::tensor::detail::usm_ndarray_types();
 
     int src_typenum = src.get_typenum();
     int dst_typenum = dst.get_typenum();


### PR DESCRIPTION
This PR creates `dpctl::detail::dpctl_capi` singleton class that load Cython-generated CAPI functions implemented in Cython modules of dpctl, and re-exports them as class members. 

This PR removes another singleton `dpctl::tensor::detail::usm_ndarray_types` which is not a simple struct with trivial constructor.

This moves all initialization of static variables exported and implemented by Python into a single place, thus avoiding static order initialization fiasco.

- [X] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [X] Have you tested your changes locally for CPU and GPU devices?
- [X] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
