### PR TITLE
Adjust examples for changes in dpctl4pybind11

### DIFF
--- a/examples/pybind11/external_usm_allocation/README.md
+++ b/examples/pybind11/external_usm_allocation/README.md
@@ -7,9 +7,9 @@ to dpctl.memory entities using `__sycl_usm_array_interface__`.
 
 # Building extension
 
-```
+```bash
 source /opt/intel/oneapi/compiler/latest/env/vars.sh
-CXX=dpcpp CC=dpcpp python setup.py build_ext --inplace
+CXX=icpx CC=icx python setup.py build_ext --inplace
 python -m pytest tests
 python example.py
 ```

--- a/examples/pybind11/external_usm_allocation/external_usm_allocation/_usm_alloc_example.cpp
+++ b/examples/pybind11/external_usm_allocation/external_usm_allocation/_usm_alloc_example.cpp
@@ -134,9 +134,6 @@ py::list tolist(DMatrix &m)
 
 PYBIND11_MODULE(_external_usm_alloc, m)
 {
-    // Import the dpctl extensions
-    import_dpctl();
-
     py::class_<DMatrix> dm(m, "DMatrix");
     dm.def(py::init(&create_matrix),
            "DMatrix(dpctl.SyclQueue, n_rows, n_cols)");

--- a/examples/pybind11/onemkl_gemv/CMakeLists.txt
+++ b/examples/pybind11/onemkl_gemv/CMakeLists.txt
@@ -53,6 +53,7 @@ set_source_files_properties(${_sycl_gemm_sources}
   PROPERTIES
   COMPILE_OPTIONS "-O3"
 )
+target_link_options(${py_module_name} PRIVATE -fsycl-device-code-split=per_kernel)
 
 add_executable(standalone_cpp
   EXCLUDE_FROM_ALL

--- a/examples/pybind11/onemkl_gemv/sycl_gemm/_onemkl.cpp
+++ b/examples/pybind11/onemkl_gemv/sycl_gemm/_onemkl.cpp
@@ -62,13 +62,11 @@ py_gemv(sycl::queue q,
         throw std::runtime_error("Inconsistent shapes.");
     }
 
-    auto q_ctx = q.get_context();
-    if (q_ctx != matrix.get_queue().get_context() ||
-        q_ctx != vector.get_queue().get_context() ||
-        q_ctx != result.get_queue().get_context())
+    if (!dpctl::utils::queues_are_compatible(
+            q, {matrix.get_queue(), vector.get_queue(), result.get_queue()}))
     {
         throw std::runtime_error(
-            "USM allocation is not bound to the context in execution queue.");
+            "USM allocations are not compatible with the execution queue.");
     }
 
     auto &api = dpctl::detail::dpctl_capi::get();

--- a/examples/pybind11/onemkl_gemv/tests/test_gemm.py
+++ b/examples/pybind11/onemkl_gemv/tests/test_gemm.py
@@ -18,9 +18,9 @@ def test_gemv():
     except dpctl.SyclQueueCreationError:
         pytest.skip("Queue could not be created")
     Mnp, vnp = np.random.randn(5, 3), np.random.randn(3)
-    r = dpt.empty((5,), dtype="d", sycl_queue=q)
     M = dpt.asarray(Mnp, sycl_queue=q)
     v = dpt.asarray(vnp, sycl_queue=q)
+    r = dpt.empty((5,), dtype=v.dtype, sycl_queue=q)
     hev, ev = gemv(q, M, v, r, [])
     hev.wait()
     rnp = dpt.asnumpy(r)
@@ -33,9 +33,9 @@ def test_sub():
     except dpctl.SyclQueueCreationError:
         pytest.skip("Queue could not be created")
     anp, bnp = np.random.randn(5), np.random.randn(5)
-    r = dpt.empty((5,), dtype="d", sycl_queue=q)
     a = dpt.asarray(anp, sycl_queue=q)
     b = dpt.asarray(bnp, sycl_queue=q)
+    r = dpt.empty((5,), dtype=b.dtype, sycl_queue=q)
     hev, ev = sub(q, a, b, r, [])
     hev.wait()
     rnp = dpt.asnumpy(r)

--- a/examples/pybind11/use_dpctl_syclqueue/use_queue_device/_example.cpp
+++ b/examples/pybind11/use_dpctl_syclqueue/use_queue_device/_example.cpp
@@ -45,7 +45,7 @@ uint64_t get_device_local_mem_size(sycl::device &d)
 }
 
 py::array_t<int64_t>
-offloaded_array_mod(sycl::queue &q,
+offloaded_array_mod(sycl::queue q,
                     py::array_t<int64_t, py::array::c_style> array,
                     int64_t mod)
 {
@@ -86,13 +86,11 @@ offloaded_array_mod(sycl::queue &q,
 
 PYBIND11_MODULE(_use_queue_device, m)
 {
-    // Import the dpctl extensions
-    import_dpctl();
     m.def(
         "get_max_compute_units",
-        [=](sycl::queue &q) -> size_t {
-            return q.get_device()
-                .get_info<sycl::info::device::max_compute_units>();
+        [=](sycl::queue q) -> size_t {
+            sycl::device d = q.get_device();
+            return d.get_info<sycl::info::device::max_compute_units>();
         },
         "Computes max_compute_units property of the device underlying given "
         "dpctl.SyclQueue");


### PR DESCRIPTION
This PR modifies examples `examples/pybind11` to account for changes in dpctl4pybind11. 

Specifically, one no longer needs to do `import_dpctl()` at the start of the initialization, since type casters do that through use of `dpctl_capi` singleton.

- [X] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [X] Have you tested your changes locally for CPU and GPU devices?
- [X] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
