### PR TITLE
dpt.asarray can now migrate arrays across devices

### DIFF
--- a/dpctl/tensor/_ctors.py
+++ b/dpctl/tensor/_ctors.py
@@ -186,10 +186,15 @@ def _asarray_from_usm_ndarray(
             order=order,
             buffer_ctor_kwargs={"queue": copy_q},
         )
-    hev, _ = ti._copy_usm_ndarray_into_usm_ndarray(
-        src=usm_ndary, dst=res, sycl_queue=copy_q
-    )
-    hev.wait()
+    eq = dpctl.utils.get_execution_queue([usm_ndary.sycl_queue, copy_q])
+    if eq is not None:
+        hev, _ = ti._copy_usm_ndarray_into_usm_ndarray(
+            src=usm_ndary, dst=res, sycl_queue=eq
+        )
+        hev.wait()
+    else:
+        tmp = dpt.asnumpy(usm_ndary)
+        res[...] = tmp
     return res
 
 


### PR DESCRIPTION
Within compute follows data programming model, we recommend explicit migration of inputs to the same allocation queue.

This is to be done using `usm_ndarray.to_device` method, or with `dpctl.tensor.asarray` operation. This operation until this commit was not able to migrate data across devices.

This commit adds such an ability by copying via host.

Test was added.

- [X] Have you provided a meaningful PR description?
- [X] Have you added a test, reproducer or referred to an issue with a reproducer?
- [X] Have you tested your changes locally for CPU and GPU devices?
- [X] Have you made sure that new changes do not introduce compiler warnings?
