### PR TITLE
Include sycl/ext/oneapi/backend/level_zero.hpp instead of deprecated path

### DIFF
--- a/libsyclinterface/source/dpctl_sycl_kernel_bundle_interface.cpp
+++ b/libsyclinterface/source/dpctl_sycl_kernel_bundle_interface.cpp
@@ -44,8 +44,8 @@
 // not reorder the includes.
 // clang-format off
 #include "ze_api.h" /* Level Zero headers */
-#if __has_include(<sycl/backend/level_zero.hpp>)
-#include <sycl/backend/level_zero.hpp>
+#if __has_include(<sycl/ext/oneapi/backend/level_zero.hpp>)
+#include <sycl/ext/oneapi/backend/level_zero.hpp>
 #else
 #include <CL/sycl/backend/level_zero.hpp>
 #endif


### PR DESCRIPTION
Use "sycl/ext/oneapi/backend/level_zero.hpp" instead of deprecated path "sycl/backend/level_zero.hpp" but that header path is now deprecated.

- [X] Have you provided a meaningful PR description?
- [X] Have you tested your changes locally for CPU and GPU devices?
- [X] Have you made sure that new changes do not introduce compiler warnings?
