### PR TITLE
Removed use of unnecessary compiler option --dpcpp in vendored compiler config cmake script

### DIFF
--- a/cmake/IntelDPCPPConfig.cmake
+++ b/cmake/IntelDPCPPConfig.cmake
@@ -240,12 +240,6 @@ if( "x${CMAKE_CXX_COMPILER_ID}" STREQUAL "xClang" OR
   set(SYCL_LINK_FLAGS "-fsycl ")
 endif()
 
-# Based on Compiler ID, add support for DPCPP
-if( "x${CMAKE_CXX_COMPILER_ID}" STREQUAL "xIntelLLVM")
-  set(SYCL_FLAGS "--dpcpp ${SYCL_FLAGS}")
-  set(SYCL_LINK_FLAGS "--dpcpp ${SYCL_LINK_FLAGS}")
-endif()
-
 # TODO verify if this is needed
 # Windows: Add Exception handling
 if(WIN32)


### PR DESCRIPTION
Compiler oneAPI DPC++ 2022.2.0 no longer requires use of `--dpcpp` option.

The work-in-progress compiler generates warnings when `--dpcpp` is used. Removing this flag now to be future-proof.

- [x] Have you provided a meaningful PR description?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
