### PR TITLE
Use pybind11 2.10.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,8 +33,8 @@ include(FetchContent)
 
 FetchContent_Declare(
     pybind11
-    URL https://github.com/pybind/pybind11/archive/refs/tags/v2.10.0.tar.gz
-    URL_HASH SHA256=eacf582fa8f696227988d08cfc46121770823839fe9e301a20fbce67e7cd70ec
+    URL https://github.com/pybind/pybind11/archive/refs/tags/v2.10.1.tar.gz
+    URL_HASH SHA256=111014b516b625083bef701df7880f78c2243835abdb263065b6b59b960b6bad
 )
 FetchContent_MakeAvailable(pybind11)
 

--- a/examples/pybind11/external_usm_allocation/CMakeLists.txt
+++ b/examples/pybind11/external_usm_allocation/CMakeLists.txt
@@ -13,8 +13,8 @@ set(CMAKE_CXX_STANDARD_REQUIRED True)
 include(FetchContent)
 FetchContent_Declare(
   pybind11
-  URL https://github.com/pybind/pybind11/archive/refs/tags/v2.10.0.tar.gz
-  URL_HASH SHA256=eacf582fa8f696227988d08cfc46121770823839fe9e301a20fbce67e7cd70ec
+  URL https://github.com/pybind/pybind11/archive/refs/tags/v2.10.1.tar.gz
+  URL_HASH SHA256=111014b516b625083bef701df7880f78c2243835abdb263065b6b59b960b6bad
 )
 FetchContent_MakeAvailable(pybind11)
 

--- a/examples/pybind11/onemkl_gemv/CMakeLists.txt
+++ b/examples/pybind11/onemkl_gemv/CMakeLists.txt
@@ -17,8 +17,8 @@ include(GNUInstallDirs)
 include(FetchContent)
 FetchContent_Declare(
   pybind11
-  URL https://github.com/pybind/pybind11/archive/refs/tags/v2.10.0.tar.gz
-  URL_HASH SHA256=eacf582fa8f696227988d08cfc46121770823839fe9e301a20fbce67e7cd70ec
+  URL https://github.com/pybind/pybind11/archive/refs/tags/v2.10.1.tar.gz
+  URL_HASH SHA256=111014b516b625083bef701df7880f78c2243835abdb263065b6b59b960b6bad
 )
 FetchContent_MakeAvailable(pybind11)
 

--- a/examples/pybind11/use_dpctl_syclqueue/CMakeLists.txt
+++ b/examples/pybind11/use_dpctl_syclqueue/CMakeLists.txt
@@ -13,8 +13,8 @@ set(CMAKE_CXX_STANDARD_REQUIRED True)
 include(FetchContent)
 FetchContent_Declare(
   pybind11
-  URL https://github.com/pybind/pybind11/archive/refs/tags/v2.10.0.tar.gz
-  URL_HASH SHA256=eacf582fa8f696227988d08cfc46121770823839fe9e301a20fbce67e7cd70ec
+  URL https://github.com/pybind/pybind11/archive/refs/tags/v2.10.1.tar.gz
+  URL_HASH SHA256=111014b516b625083bef701df7880f78c2243835abdb263065b6b59b960b6bad
 )
 FetchContent_MakeAvailable(pybind11)
 


### PR DESCRIPTION
Updated version of pybind11 fetched by cmake to 2.10.1

- [X] Have you provided a meaningful PR description?
- [X] Have you tested your changes locally for CPU and GPU devices?
- [X] Have you made sure that new changes do not introduce compiler warnings?
