### PR TITLE
Fixed usage of unwrap in comment to templated one

### DIFF
--- a/libsyclinterface/include/dpctl_sycl_queue_interface.h
+++ b/libsyclinterface/include/dpctl_sycl_queue_interface.h
@@ -178,7 +178,7 @@ DPCTLQueue_GetDevice(__dpctl_keep const DPCTLSyclQueueRef QRef);
  * A wrapper over ``sycl::queue.submit()``. The function takes an
  * interoperability kernel, the kernel arguments, and a ``sycl::queue`` as
  * input. The kernel is submitted as
- * ``parallel_for(range<NRange>, *unwrap(KRef))``.
+ * ``parallel_for(range<NRange>, *unwrap<kernel>(KRef))``.
  *
  * \todo ``sycl::buffer`` arguments are not supported yet.
  * \todo Add support for id<Dims> WorkItemOffset
@@ -222,7 +222,8 @@ DPCTLQueue_SubmitRange(__dpctl_keep const DPCTLSyclKernelRef KRef,
  *
  * A wrapper over ``sycl::queue.submit()``. The function takes an
  * interoperability kernel, the kernel arguments, and a Sycl queue as input.
- * The kernel is submitted as ``parallel_for(nd_range<NRange>, *unwrap(KRef))``.
+ * The kernel is submitted as
+ * ``parallel_for(nd_range<NRange>, *unwrap<kernel>(KRef))``.
  *
  * \todo sycl::buffer arguments are not supported yet.
  * \todo Add support for id<Dims> WorkItemOffset


### PR DESCRIPTION
Fixed usage of non-templated `unwrap(KRef)` to `unwrap<kernel>(KRef)` since implementation was changed in #960.

- [x] Have you provided a meaningful PR description?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
