### PR TITLE
Error building Cython test extension must fail the tests, not skip it

### DIFF
--- a/.github/workflows/conda-package.yml
+++ b/.github/workflows/conda-package.yml
@@ -150,9 +150,10 @@ jobs:
             ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}-
       - name: Install dpctl
         run: |
-          CHANNELS="-c $GITHUB_WORKSPACE/channel ${{ env.CHANNELS }}"
+          export CHANNELS="-c $GITHUB_WORKSPACE/channel ${{ env.CHANNELS }}"
+          export TEST_DEPENDENCIES="pytest pytest-cov cython"
           export PACKAGE_VERSION=$(python -c "${VER_SCRIPT1} ${VER_SCRIPT2}")
-          conda create -n test_dpctl $PACKAGE_NAME=${PACKAGE_VERSION} pytest python=${{ matrix.python }} $CHANNELS
+          conda create -n test_dpctl $PACKAGE_NAME=${PACKAGE_VERSION} ${TEST_DEPENDENCIES} python=${{ matrix.python }} ${CHANNELS}
           # Test installed packages
           conda list -n test_dpctl
       - name: Smoke test
@@ -249,7 +250,8 @@ jobs:
           FOR /F "tokens=* USEBACKQ" %%F IN (`python -c "%SCRIPT%"`) DO (
              SET PACKAGE_VERSION=%%F
           )
-          conda install ${{ env.PACKAGE_NAME }}=%PACKAGE_VERSION% pytest python=${{ matrix.python }} -c ${{ env.workdir }}/channel ${{ env.CHANNELS }}
+          SET "TEST_DEPENDENCIES=pytest pytest-cov cython"
+          conda install ${{ env.PACKAGE_NAME }}=%PACKAGE_VERSION% %TEST_DEPENDENCIES% python=${{ matrix.python }} -c ${{ env.workdir }}/channel ${{ env.CHANNELS }}
       - name: Report content of test environemtn
         shell: cmd /C CALL {0}
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [dev]
+
+### Added
+
+### Changed
+
+### Fixed
+
+
 ## [0.14.0] - 11/18/2022
 
 ### Added

--- a/dpctl/tests/setup_cython_api.py
+++ b/dpctl/tests/setup_cython_api.py
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import Cython.Build
 import setuptools
 
 import dpctl
@@ -25,4 +26,9 @@ ext = setuptools.Extension(
     language="c++",
 )
 
-setuptools.setup(name="_cython_api", version="0.0.0", ext_modules=[ext])
+setuptools.setup(
+    name="_cython_api",
+    version="0.0.0",
+    ext_modules=[ext],
+    cmdclass={"build_ext": Cython.Build.build_ext},
+)

--- a/dpctl/tests/test_sycl_queue.py
+++ b/dpctl/tests/test_sycl_queue.py
@@ -350,13 +350,13 @@ def dpctl_cython_extension(tmp_path_factory):
         sfx = sysconfig.get_config_vars()["EXT_SUFFIX"]
         pth = glob.glob(os.path.join(dr, "_cython_api*" + sfx))
         if not pth:
-            pytest.skip("Cython extension was not built")
+            pytest.fail("Cython extension was not built")
         spec = spec_from_file_location("_cython_api", pth[0])
         builder_module = module_from_spec(spec)
         spec.loader.exec_module(builder_module)
         return builder_module
     else:
-        pytest.skip("Cython extension could not be built")
+        pytest.fail("Cython extension could not be built")
 
 
 def test_cython_api(dpctl_cython_extension):

--- a/dpctl/tests/test_sycl_queue.py
+++ b/dpctl/tests/test_sycl_queue.py
@@ -325,6 +325,7 @@ def test_queue_memops():
 
 @pytest.fixture(scope="session")
 def dpctl_cython_extension(tmp_path_factory):
+    import os
     import os.path
     import shutil
     import subprocess
@@ -342,6 +343,7 @@ def dpctl_cython_extension(tmp_path_factory):
     res = subprocess.run(
         [sys.executable, "setup_cython_api.py", "build_ext", "--inplace"],
         cwd=dr,
+        env=os.environ,
     )
     if res.returncode == 0:
         import glob


### PR DESCRIPTION
Cython extension built during test run to exercise Cython only functions used to skip the test if extension building were to run into problem.

This PR makes it fail the test instead. Otherwise the problem may go undetected for a long time.

- [x] Have you provided a meaningful PR description?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
