### PR TITLE
Condition test exercising fp16 support on availability of HW support

### DIFF
--- a/dpctl/tests/test_usm_ndarray_ctor.py
+++ b/dpctl/tests/test_usm_ndarray_ctor.py
@@ -825,8 +825,11 @@ def test_astype():
     X[:] = np.full((5, 5), 7, dtype="i4")
     Y = dpt.astype(X, "c8", order="C")
     assert np.allclose(dpt.to_numpy(Y), np.full((5, 5), 7, dtype="c8"))
-    Y = dpt.astype(X[::2, ::-1], "f2", order="K")
-    assert np.allclose(dpt.to_numpy(Y), np.full(Y.shape, 7, dtype="f2"))
+    if Y.sycl_device.has_aspect_fp16:
+        Y = dpt.astype(X[::2, ::-1], "f2", order="K")
+        assert np.allclose(dpt.to_numpy(Y), np.full(Y.shape, 7, dtype="f2"))
+    Y = dpt.astype(X[::2, ::-1], "f4", order="K")
+    assert np.allclose(dpt.to_numpy(Y), np.full(Y.shape, 7, dtype="f4"))
     Y = dpt.astype(X[::2, ::-1], "i4", order="K", copy=False)
     assert Y.usm_data is X.usm_data
 


### PR DESCRIPTION
This PR modifies the test which unconditionally exercises operations on arrays with float16 data-type.
The test fails on HW without float16 native support. 

This PR make test only do that if HW has aspect fp16. Test also adds step to unconditionally use float32
to maintain coverage level on all platforms.

- [x] Have you provided a meaningful PR description?
- [x] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
