### PR TITLE
Fixed unintended syntax in forming exception of SyclQueue constructor

### DIFF
--- a/dpctl/_sycl_queue.pyx
+++ b/dpctl/_sycl_queue.pyx
@@ -344,7 +344,7 @@ cdef class SyclQueue(_SyclQueue):
                 )
             elif status == -3 or status == -7:
                 raise SyclQueueCreationError(
-                    "SYCL Context could not be created "
+                    "SYCL Context could not be created " +
                     ("by default constructor" if len_args == 0 else
                      "from '{}'.".format(arg)
                     )


### PR DESCRIPTION
Fixed unintended syntax in forming exception in SyclQueue constructor code

Syntax parsed as a call operator on string type. Instead it was meant as concatenation operation.

This PR fixes that.

- [x] Have you provided a meaningful PR description?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
