### PR TITLE
Fix fallout of recent changes

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,5 @@
 recursive-include dpctl/include *.h
+recursive-include dpctl/include *.hpp
 include dpctl/include/dpctl4pybind11.hpp
 recursive-include dpctl *.pxd
 recursive-include dpctl *.cmake

--- a/libsyclinterface/CMakeLists.txt
+++ b/libsyclinterface/CMakeLists.txt
@@ -251,6 +251,7 @@ endif()
 # Install all headers
 
 file(GLOB MAIN_HEADERS "${CMAKE_CURRENT_SOURCE_DIR}/include/*.h")
+file(GLOB MAIN_HEADERS "${CMAKE_CURRENT_SOURCE_DIR}/include/*.hpp")
 file(GLOB SUPPORT_HEADERS "${CMAKE_CURRENT_SOURCE_DIR}/include/Support/*.h")
 file(GLOB CONFIG_HEADERS "${CMAKE_CURRENT_SOURCE_DIR}/include/Config/*.h")
 

--- a/libsyclinterface/include/Config/dpctl_config.h.in
+++ b/libsyclinterface/include/Config/dpctl_config.h.in
@@ -30,11 +30,12 @@
     @DPCTL_ENABLE_L0_PROGRAM_CREATION@
 
 /* Version of SYCL DPC++ 2023 compiler at which transition to SYCL 2020 occurs */
-#define __SYCL_COMPILER_2023_SWITCHOVER 20221020L
+/* Intel(R) oneAPI DPC++ 2022.2.1 compiler has version 20221020L */
+#define __SYCL_COMPILER_2023_SWITCHOVER 20221021L
 
 /* Version of SYCL DPC++ compiler at which info::max_work_item_size was
    made templated */
-#define __SYCL_COMPILER_MAX_WORK_ITEM_SIZE_THRESHOLD 20220805L
+#define __SYCL_COMPILER_MAX_WORK_ITEM_SIZE_THRESHOLD __SYCL_COMPILER_2023_SWITCHOVER
 
 /* The DPCPP version used to build dpctl */
 #define DPCTL_DPCPP_VERSION "@IntelSycl_VERSION@"


### PR DESCRIPTION
Incremented `__SYCL_COMPILER_2023_SWITCHOVER` by a day to fix compilation issue with Intel(R) oneAPI DPC++ 2022.2.1 compiler. 

Adjusted `libsyclinterface/CMakeLists.txt` to copy `*.hpp` files into `dpctl/include`. 

Adjusted `MANIFEST.in` to copy `dpctl/include/*.hpp` files into the installation folder.

- [x] Have you provided a meaningful PR description?
- [x] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
