### PR TITLE
Incremented 2023-SWITCHOVER timestamp

### DIFF
--- a/libsyclinterface/include/Config/dpctl_config.h.in
+++ b/libsyclinterface/include/Config/dpctl_config.h.in
@@ -30,8 +30,9 @@
     @DPCTL_ENABLE_L0_PROGRAM_CREATION@
 
 /* Version of SYCL DPC++ 2023 compiler at which transition to SYCL 2020 occurs */
-/* Intel(R) oneAPI DPC++ 2022.2.1 compiler has version 20221020L */
-#define __SYCL_COMPILER_2023_SWITCHOVER 20221021L
+/* Intel(R) oneAPI DPC++ 2022.2.1 compiler has version 20221020L on Linux and
+   20221101L on Windows */
+#define __SYCL_COMPILER_2023_SWITCHOVER 20221102L
 
 /* Version of SYCL DPC++ compiler at which info::max_work_item_size was
    made templated */


### PR DESCRIPTION
Due to 2022.2.1 compiler release on Windows, we need to increment `__SYCL_COMPILER_2023_SWITCHOVER` timestamp to fence out code intended for 2023, since currently available compiler does not have those changes yet. 

- [x] Have you provided a meaningful PR description?
