### PR TITLE
[CI] Do not use SYCL_ENABLE_HOST_DEVICE in GitHub actions

### DIFF
--- a/.github/workflows/conda-package.yml
+++ b/.github/workflows/conda-package.yml
@@ -160,7 +160,6 @@ jobs:
           . $CONDA/etc/profile.d/conda.sh
           conda activate test_dpctl
           export OCL_ICD_FILENAMES=libintelocl.so
-          export SYCL_ENABLE_HOST_DEVICE=1
           python -c "import dpctl; dpctl.lsplatform()"
       - name: Run tests
         run: |
@@ -168,7 +167,6 @@ jobs:
           conda activate test_dpctl
           # echo "libintelocl.so" | tee /etc/OpenCL/vendors/intel-cpu.icd
           export OCL_ICD_FILENAMES=libintelocl.so
-          export SYCL_ENABLE_HOST_DEVICE=1
           # clinfo -l
           python -m pytest -p no:faulthandler --pyargs $MODULE_NAME
 
@@ -297,14 +295,12 @@ jobs:
         shell: cmd /C CALL {0}
         run: |
           python -c "import sys; print(sys.executable)"
-          set SYCL_ENABLE_HOST_DEVICE=1
           python -c "import dpctl; dpctl.lsplatform()"
           python -c "import dpctl; print(dpctl.get_devices(backend='opencl', device_type='gpu'))"
           python -c "import dpctl; print(dpctl.get_num_devices(backend='opencl', device_type='gpu'))"
       - name: Run tests
         shell: cmd /C CALL {0}
         run: |
-          set SYCL_ENABLE_HOST_DEVICE=1
           python -c "import sys; print(sys.executable)"
           python -m pytest -p no:faulthandler --pyargs ${{ env.MODULE_NAME }}
 
@@ -435,7 +431,6 @@ jobs:
         run: |
           source $CONDA/etc/profile.d/conda.sh
           export OCL_ICD_FILENAMES=libintelocl.so
-          export SYCL_ENABLE_HOST_DEVICE=1
           conda activate examples
           conda list
           cd examples/pybind11
@@ -497,7 +492,6 @@ jobs:
           cd examples/python
           source $CONDA/etc/profile.d/conda.sh
           export OCL_ICD_FILENAMES=libintelocl.so
-          export SYCL_ENABLE_HOST_DEVICE=1
           conda activate examples
           for script in $(find . \( -not -name "_*" -and -name "*.py" \))
           do
@@ -603,7 +597,6 @@ jobs:
           conda activate test_dpctl
           # echo "libintelocl.so" | tee /etc/OpenCL/vendors/intel-cpu.icd
           export OCL_ICD_FILENAMES=libintelocl.so
-          export SYCL_ENABLE_HOST_DEVICE=1
           python -c "import dpctl; dpctl.lsplatform()"
           export ARRAY_API_TESTS_MODULE=dpctl.tensor
           cd /home/runner/work/array-api-tests

--- a/.github/workflows/generate-coverage.yaml
+++ b/.github/workflows/generate-coverage.yaml
@@ -85,7 +85,7 @@ jobs:
         shell: bash -l {0}
         run: |
           source /opt/intel/oneapi/setvars.sh
-          SYCL_ENABLE_HOST_DEVICE=1 python scripts/gen_coverage.py
+          python scripts/gen_coverage.py
 
       - name: Install coverall dependencies
         shell: bash -l {0}

--- a/.github/workflows/os-llvm-sycl-build.yml
+++ b/.github/workflows/os-llvm-sycl-build.yml
@@ -119,4 +119,4 @@ jobs:
           sycl-ls
           CC=clang CXX=clang++ python setup.py develop -G Ninja
           python -c "import dpctl; dpctl.lsplatform()" || exit 1
-          SYCL_ENABLE_HOST_DEVICE=1 python -m pytest -v dpctl/tests
+          python -m pytest -v dpctl/tests


### PR DESCRIPTION
Do not use `SYCL_ENABLE_HOST_DEVICE=1` in GitHub actions.

Host device is deprecated in 2023 compiler.

- [x] Have you provided a meaningful PR description?
