### PR TITLE
Updated versions of checks in pre-commit, use github for flake8

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,18 +2,18 @@
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
 -   repo: https://github.com/PyCQA/bandit
-    rev: '1.7.0'
+    rev: '1.7.4'
     hooks:
     -   id: bandit
         pass_filenames: false
         args: ["-r", "dpctl", "-lll"]
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.0.1
+    rev: v4.3.0
     hooks:
     -   id: end-of-file-fixer
     -   id: trailing-whitespace
 -   repo: https://github.com/psf/black
-    rev: 22.3.0
+    rev: 22.10.0
     hooks:
     -   id: black
         exclude: "versioneer.py|dpctl/_version.py"
@@ -28,12 +28,12 @@ repos:
     -   id: isort
         name: isort (pyi)
         types: [pyi]
--   repo: https://gitlab.com/pycqa/flake8
-    rev: 4.0.1
+-   repo: https://github.com/pycqa/flake8
+    rev: 5.0.4
     hooks:
     -   id: flake8
 -   repo: https://github.com/pocc/pre-commit-hooks
-    rev: v1.1.1
+    rev: v1.3.5
     hooks:
     -   id: clang-format
         args: ["-i"]


### PR DESCRIPTION
Checking out `pycqa/flake8` from gitlab has stopped working (see https://github.com/IntelPython/dpctl/actions/runs/3473890443/jobs/5808023582). 

This PR updates to use github.com/pycqa/flake8` instead. It also updates tags
of individual components to the latest at the time of commit. 

- [x] Have you provided a meaningful PR description?
- [x] Have you added a test, reproducer or referred to an issue with a reproducer?
