### PR TITLE
Fixed missing copy for dpctl.tensor.full() function if fill_value is array

### DIFF
--- a/dpctl/tensor/_ctors.py
+++ b/dpctl/tensor/_ctors.py
@@ -770,7 +770,7 @@ def full(
             usm_type=usm_type,
             sycl_queue=sycl_queue,
         )
-        return dpt.copy(dpt.broadcast_to(X, sh))
+        return dpt.copy(dpt.broadcast_to(X, sh), order=order)
 
     sycl_queue = normalize_queue_device(sycl_queue=sycl_queue, device=device)
     usm_type = usm_type if usm_type is not None else "device"

--- a/dpctl/tensor/_ctors.py
+++ b/dpctl/tensor/_ctors.py
@@ -766,10 +766,11 @@ def full(
         X = dpt.asarray(
             fill_value,
             dtype=dtype,
+            order=order,
             usm_type=usm_type,
             sycl_queue=sycl_queue,
         )
-        return dpt.broadcast_to(X, sh)
+        return dpt.copy(dpt.broadcast_to(X, sh))
 
     sycl_queue = normalize_queue_device(sycl_queue=sycl_queue, device=device)
     usm_type = usm_type if usm_type is not None else "device"

--- a/dpctl/tests/test_usm_ndarray_ctor.py
+++ b/dpctl/tests/test_usm_ndarray_ctor.py
@@ -1027,6 +1027,31 @@ def test_full_compute_follows_data():
     assert np.array_equal(dpt.asnumpy(Y), np.full(10, 3, dtype="f4"))
 
 
+@pytest.mark.parametrize("order1", ["F", "C"])
+@pytest.mark.parametrize("order2", ["F", "C"])
+def test_full_order(order1, order2):
+    q = get_queue_or_skip()
+    Xnp = np.array([1,2,3], order=order1)
+    Ynp = np.full((3), Xnp, order=order2)
+    Y = dpt.full((3), Xnp, order=order2, sycl_queue=q)
+    assert Y.flags.f_contiguous == Ynp.flags.f_contiguous
+    assert Y.flags.c_contiguous == Ynp.flags.c_contiguous
+    assert np.array_equal(dpt.asnumpy(Y), Ynp)
+
+
+def test_full_strides():
+    q = get_queue_or_skip()
+    X = dpt.full((3,3), dpt.arange(3, dtype='i4'), sycl_queue=q)
+    Xnp = np.full((3,3), np.arange(3, dtype='i4'))
+    assert X.strides == tuple( el // Xnp.itemsize for el in Xnp.strides)
+    assert np.array_equal(dpt.asnumpy(X), Xnp)
+
+    X = dpt.full((3,3), dpt.arange(6, dtype='i4')[::2], sycl_queue=q)
+    Xnp = np.full((3,3), np.arange(6, dtype='i4')[::2])
+    assert X.strides == tuple( el // Xnp.itemsize for el in Xnp.strides)
+    assert np.array_equal(dpt.asnumpy(X), Xnp)
+
+
 @pytest.mark.parametrize(
     "dt",
     _all_dtypes[1:],

--- a/dpctl/tests/test_usm_ndarray_ctor.py
+++ b/dpctl/tests/test_usm_ndarray_ctor.py
@@ -1031,24 +1031,24 @@ def test_full_compute_follows_data():
 @pytest.mark.parametrize("order2", ["F", "C"])
 def test_full_order(order1, order2):
     q = get_queue_or_skip()
-    Xnp = np.array([1,2,3], order=order1)
-    Ynp = np.full((3), Xnp, order=order2)
-    Y = dpt.full((3), Xnp, order=order2, sycl_queue=q)
-    assert Y.flags.f_contiguous == Ynp.flags.f_contiguous
+    Xnp = np.array([1, 2, 3], order=order1)
+    Ynp = np.full((3, 3), Xnp, order=order2)
+    Y = dpt.full((3, 3), Xnp, order=order2, sycl_queue=q)
     assert Y.flags.c_contiguous == Ynp.flags.c_contiguous
+    assert Y.flags.f_contiguous == Ynp.flags.f_contiguous
     assert np.array_equal(dpt.asnumpy(Y), Ynp)
 
 
 def test_full_strides():
     q = get_queue_or_skip()
-    X = dpt.full((3,3), dpt.arange(3, dtype='i4'), sycl_queue=q)
-    Xnp = np.full((3,3), np.arange(3, dtype='i4'))
-    assert X.strides == tuple( el // Xnp.itemsize for el in Xnp.strides)
+    X = dpt.full((3, 3), dpt.arange(3, dtype="i4"), sycl_queue=q)
+    Xnp = np.full((3, 3), np.arange(3, dtype="i4"))
+    assert X.strides == tuple(el // Xnp.itemsize for el in Xnp.strides)
     assert np.array_equal(dpt.asnumpy(X), Xnp)
 
-    X = dpt.full((3,3), dpt.arange(6, dtype='i4')[::2], sycl_queue=q)
-    Xnp = np.full((3,3), np.arange(6, dtype='i4')[::2])
-    assert X.strides == tuple( el // Xnp.itemsize for el in Xnp.strides)
+    X = dpt.full((3, 3), dpt.arange(6, dtype="i4")[::2], sycl_queue=q)
+    Xnp = np.full((3, 3), np.arange(6, dtype="i4")[::2])
+    assert X.strides == tuple(el // Xnp.itemsize for el in Xnp.strides)
     assert np.array_equal(dpt.asnumpy(X), Xnp)
 
 


### PR DESCRIPTION
Fixed missing copy for full() function if fill_value is array.
Added tests that check order and strides for dpctl.tensor.full() function.

- [x] Have you provided a meaningful PR description?
- [x] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
