### PR TITLE
Fixed gh-998: exception raised while forming an expected TypeError exception message  

### DIFF
--- a/dpctl/tensor/_types.pxi
+++ b/dpctl/tensor/_types.pxi
@@ -134,7 +134,7 @@ cdef int descr_to_typenum(object dtype):
     return typenum_from_format(obj)
 
 
-cdef int dtype_to_typenum(dtype) except *:
+cdef int dtype_to_typenum(dtype):
     if isinstance(dtype, str):
         return typenum_from_format(dtype)
     elif isinstance(dtype, bytes):

--- a/dpctl/tensor/_usmarray.pyx
+++ b/dpctl/tensor/_usmarray.pyx
@@ -188,9 +188,15 @@ cdef class usm_ndarray:
                 raise TypeError("Argument shape must be a list or a tuple.")
         nd = len(shape)
         typenum = dtype_to_typenum(dtype)
+        if (typenum < 0):
+            if typenum == -2:
+                raise ValueError("Data type '" + str(dtype) + "' can only have native byteorder.")
+            elif typenum == -1:
+                raise ValueError("Data type '" + str(dtype) + "' is not understood.")
+            raise TypeError(f"Expected string or a dtype object, got {type(dtype)}")
         itemsize = type_bytesize(typenum)
         if (itemsize < 1):
-            raise TypeError("dtype=" + dtype + " is not supported.")
+            raise TypeError("dtype=" + np.dtype(dtype).name + " is not supported.")
         # allocate host C-arrays for shape, strides
         err = _from_input_shape_strides(
             nd, shape, strides, itemsize, <char> ord(order),

--- a/dpctl/tests/test_usm_ndarray_ctor.py
+++ b/dpctl/tests/test_usm_ndarray_ctor.py
@@ -95,13 +95,23 @@ def test_dtypes(dtype):
     assert expected_fmt == actual_fmt
 
 
-@pytest.mark.parametrize("dtype", ["", ">f4", "invalid", 123])
+@pytest.mark.parametrize(
+    "dtype",
+    [
+        "",
+        ">f4",
+        "invalid",
+        123,
+        np.dtype(">f4"),
+        np.dtype([("a", ">f4"), ("b", "i4")]),
+    ],
+)
 def test_dtypes_invalid(dtype):
     with pytest.raises((TypeError, ValueError)):
         dpt.usm_ndarray((1,), dtype=dtype)
 
 
-@pytest.mark.parametrize("dt", ["d", "c16"])
+@pytest.mark.parametrize("dt", ["f", "c8"])
 def test_properties(dt):
     """
     Test that properties execute
@@ -1179,6 +1189,11 @@ def test_empty_like(dt, usm_kind):
     assert X.dtype == Y.dtype
     assert X.usm_type == Y.usm_type
     assert X.sycl_queue == Y.sycl_queue
+
+
+def test_empty_unexpected_data_type():
+    with pytest.raises(TypeError):
+        dpt.empty(1, dtype=np.object_)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This change fixes formation of `TypeError` message string.

Closes #998. 

It also reworks `dtype` argument validation, fixing unreferenced issue with `dpt.usm_ndarray(1, dtype=np.dtype(">f4"))`.

- [x] Have you provided a meaningful PR description?
- [x] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
