### PR TITLE
Fix inconsistency system git and conda env

### DIFF
--- a/conda-recipe/build.sh
+++ b/conda-recipe/build.sh
@@ -5,7 +5,9 @@
 # activation scripts.
 export LDFLAGS="$LDFLAGS -Wl,-rpath,$PREFIX/lib"
 
-${PYTHON} setup.py clean --all
+if [ -e "_skbuild" ]; then
+    ${PYTHON} setup.py clean --all
+fi
 export CMAKE_GENERATOR="Ninja"
 SKBUILD_ARGS="-- -DCMAKE_C_COMPILER:PATH=icx -DCMAKE_CXX_COMPILER:PATH=icpx"
 echo "${PYTHON} setup.py install ${SKBUILD_ARGS}"

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -16,10 +16,11 @@ requirements:
         - {{ compiler('dpcpp') }}  >=2022.1  # [not osx]
     host:
         - setuptools
-        - cython
         - cmake  >=3.21
-        - python
         - ninja
+        - git
+        - cython
+        - python
         - scikit-build
         - numpy
         - wheel

--- a/libsyclinterface/cmake/modules/GetLevelZeroHeaders.cmake
+++ b/libsyclinterface/cmake/modules/GetLevelZeroHeaders.cmake
@@ -39,7 +39,7 @@ function(get_level_zero_headers)
 
         if(NOT result EQUAL 0)
             message(FATAL_ERROR
-                "Could not update Level Zero sources."
+                "Could not update Level Zero sources. Return code: ${result}"
             )
         endif()
     else()
@@ -54,7 +54,7 @@ function(get_level_zero_headers)
 
         if(NOT result EQUAL 0)
             message(FATAL_ERROR
-                "Could not clone Level Zero sources from github.com/oneapi-src/level-zero."
+                "Could not clone Level Zero sources from github.com/oneapi-src/level-zero. Return code: ${result}"
             )
         endif()
     endif()
@@ -72,7 +72,7 @@ function(get_level_zero_headers)
 
     if(NOT result EQUAL 0)
         message(FATAL_ERROR
-            "Could not get the name for the latest release."
+            "Could not get the name for the latest release. Return code: ${result}"
         )
     endif()
 
@@ -88,7 +88,7 @@ function(get_level_zero_headers)
 
     if(NOT result EQUAL 0)
         message(FATAL_ERROR
-            "Could not checkout the latest release."
+            "Could not checkout the latest release. Return code: ${result}"
         )
     endif()
 


### PR DESCRIPTION
Using system `git` in conda environment may be problematic due to inconsistency in dependent libraries. 

For example, #1000 and #999 were affected by this:

```
03:35:37.053600 git.c:460               trace: built-in: git clone https://github.com/oneapi-src/level-zero.git
Cloning into 'level-zero'...
03:35:37.060849 run-command.c:655       trace: run_command: git remote-https origin https://github.com/oneapi-src/level-zero.git
03:35:37.063415 git.c:750               trace: exec: git-remote-https origin https://github.com/oneapi-src/level-zero.git
03:35:37.063456 run-command.c:655       trace: run_command: git-remote-https origin https://github.com/oneapi-src/level-zero.git
/usr/lib/git-core/git-remote-https: symbol lookup error: /lib/x86_64-linux-gnu/libp11-kit.so.0: undefined symbol: ffi_type_pointer, version LIBFFI_BASE_7.0
```

This library version mismatch caused git to silently return with status code 128, and took using `GIT_TRACE=true` to pin-point the cause.

This PR:
   - add `git` to conda host environment 
   - Expands fatal error messages after `execute_process` to output process return code
   - avoid calling to `setup.py clean` in `build.sh` if `_skbuild/` folder does not exist

- [x] Have you provided a meaningful PR description?
- [x] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
