### PR TITLE
MAINT Include tuple in 'utils/strided_iters.hpp'

### DIFF
--- a/dpctl/tensor/libtensor/include/utils/strided_iters.hpp
+++ b/dpctl/tensor/libtensor/include/utils/strided_iters.hpp
@@ -29,8 +29,8 @@
 #include <algorithm> // sort
 #include <array>
 #include <numeric> // std::iota
-#include <vector>
 #include <tuple>
+#include <vector>
 
 /* An N-dimensional array can be stored in a single
  * contiguous chunk of memory by contiguously laying

--- a/dpctl/tensor/libtensor/include/utils/strided_iters.hpp
+++ b/dpctl/tensor/libtensor/include/utils/strided_iters.hpp
@@ -30,6 +30,7 @@
 #include <array>
 #include <numeric> // std::iota
 #include <vector>
+#include <tuple>
 
 /* An N-dimensional array can be stored in a single
  * contiguous chunk of memory by contiguously laying


### PR DESCRIPTION
Fixes https://github.com/IntelPython/dpctl/issues/1007.

This include directive seems to have been forgotten and it is impossible for me to compile dpctl without it.

---

- [x] Have you provided a meaningful PR description?
- [x] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [x] If this PR is a work in progress, are you filing the PR as a draft?
