### PR TITLE
Added step to display version of clang-format used in pre-commit workflow

### DIFF
--- a/.github/workflows/conda-package.yml
+++ b/.github/workflows/conda-package.yml
@@ -252,9 +252,10 @@ jobs:
           )
           SET "TEST_DEPENDENCIES=pytest pytest-cov cython"
           conda install ${{ env.PACKAGE_NAME }}=%PACKAGE_VERSION% %TEST_DEPENDENCIES% python=${{ matrix.python }} -c ${{ env.workdir }}/channel ${{ env.CHANNELS }}
-      - name: Report content of test environemtn
+      - name: Report content of test environment
         shell: cmd /C CALL {0}
         run: |
+          pip install --no-cache-dir brotli
           echo "Value of CONDA enviroment variable was: " %CONDA%
           conda list
       - name: Add library

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   pre-commit:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v3
     - uses: actions/setup-python@v4

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -13,4 +13,7 @@ jobs:
     - uses: actions/setup-python@v4
       with:
         python-version: '3.10'
+    - name: Version of clang-format
+      run: |
+        clang-format --version
     - uses: pre-commit/action@v3.0.0


### PR DESCRIPTION
Given unexpected pre-commit failure in #1008 due to `clang-format`, add a step to `pre-commit.yaml` workflow to output the version of `clang-format` used. 

This would allow to quickly tell if the pre-commit failure was caused by version update of `clang-format` in GitHub runner image.

- [x] Have you provided a meaningful PR description?
