### PR TITLE
Conda packages must be built with Ubuntu 20.04

### DIFF
--- a/.github/workflows/conda-package.yml
+++ b/.github/workflows/conda-package.yml
@@ -14,7 +14,7 @@ env:
 
 jobs:
   build_linux:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     strategy:
       matrix:
@@ -104,7 +104,7 @@ jobs:
       matrix:
         python: ['3.8', '3.9', '3.10']
         experimental: [false]
-        runner: [ubuntu-latest]
+        runner: [ubuntu-20.04]
     continue-on-error: ${{ matrix.experimental }}
     env:
       CHANNELS: -c intel -c main --override-channels
@@ -310,7 +310,7 @@ jobs:
   upload_linux:
     needs: test_linux
     if: ${{github.ref == 'refs/heads/master' || (startsWith(github.ref, 'refs/heads/release') == true) || github.event_name == 'push' && contains(github.ref, 'refs/tags/')}}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         python: ['3.8', '3.9', '3.10']
@@ -365,7 +365,7 @@ jobs:
       matrix:
         python: ['3.9']
         experimental: [false]
-        runner: [ubuntu-latest]
+        runner: [ubuntu-20.04]
     continue-on-error: ${{ matrix.experimental }}
     env:
       CHANNELS: -c intel -c main --override-channels
@@ -510,7 +510,7 @@ jobs:
       matrix:
         python: ['3.10']
         experimental: [false]
-        runner: [ubuntu-latest]
+        runner: [ubuntu-20.04]
     continue-on-error: ${{ matrix.experimental }}
     env:
       CHANNELS: -c intel -c main --override-channels


### PR DESCRIPTION
`ubuntu-latest` image now refers to Ubuntu-22.04. Conda packages built there can be installed on Ubunutu 20.04 due to 

```
ImportError: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.32' not found
```

This changes uses ubuntu-20.04 image for "build_linux" and "test_linux" steps.

- [x] Have you provided a meaningful PR description?
