### PR TITLE
Make usm_ndarray be writable by default

### DIFF
--- a/dpctl/tensor/_usmarray.pyx
+++ b/dpctl/tensor/_usmarray.pyx
@@ -257,7 +257,7 @@ cdef class usm_ndarray:
         self.shape_ = shape_ptr
         self.strides_ = strides_ptr
         self.typenum_ = typenum
-        self.flags_ = contig_flag
+        self.flags_ = (contig_flag | USM_ARRAY_WRITABLE)
         self.nd_ = nd
         self.array_namespace_ = array_namespace
 
@@ -952,6 +952,8 @@ cdef class usm_ndarray:
             _copy_from_numpy_into,
             _copy_from_usm_ndarray_to_usm_ndarray,
         )
+        if ((<usm_ndarray> Xv).flags_ & USM_ARRAY_WRITABLE) == 0:
+            raise ValueError("Can not modify read-only array.")
         if isinstance(val, usm_ndarray):
             _copy_from_usm_ndarray_to_usm_ndarray(Xv, val)
         else:

--- a/dpctl/tests/test_usm_ndarray_ctor.py
+++ b/dpctl/tests/test_usm_ndarray_ctor.py
@@ -999,11 +999,13 @@ def test_full_dtype_inference():
     assert np.issubdtype(dpt.full(10, 4).dtype, np.integer)
     assert dpt.full(10, True).dtype is dpt.dtype(np.bool_)
     assert np.issubdtype(dpt.full(10, 12.3).dtype, np.floating)
-    assert np.issubdtype(dpt.full(10, 0.3 - 2j).dtype, np.complexfloating)
+    cdt = dpt.full(10, 0.3 - 2j).dtype
+    assert np.issubdtype(cdt, np.complexfloating)
 
     assert np.issubdtype(dpt.full(10, 12.3, dtype=int).dtype, np.integer)
     assert np.issubdtype(dpt.full(10, 0.3 - 2j, dtype=int).dtype, np.integer)
-    assert np.issubdtype(dpt.full(10, 0.3 - 2j, dtype=float).dtype, np.floating)
+    rdt = np.finfo(cdt).dtype
+    assert np.issubdtype(dpt.full(10, 0.3 - 2j, dtype=rdt).dtype, np.floating)
 
 
 def test_full_fill_array():


### PR DESCRIPTION
`dpctl.tensor.usm_ndarray` constructor sets writable flag.

`__setitem__` raises on attempt to modify read-only array.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
