### PR TITLE
Added support for python -m dpctl -l to list platforms

### DIFF
--- a/dpctl/tests/test_service.py
+++ b/dpctl/tests/test_service.py
@@ -182,3 +182,49 @@ def test_cmakedir():
     assert res.stdout
     cmake_dir = res.stdout.decode("utf-8").strip()
     assert os.path.exists(os.path.join(cmake_dir, "FindDpctl.cmake"))
+
+
+def test_main_full_list():
+    res = subprocess.run(
+        [sys.executable, "-m", "dpctl", "-f"], capture_output=True
+    )
+    assert res.returncode == 0
+    assert res.stdout
+    assert res.stdout.decode("utf-8")
+
+
+def test_main_long_list():
+    res = subprocess.run(
+        [sys.executable, "-m", "dpctl", "-l"], capture_output=True
+    )
+    assert res.returncode == 0
+    assert res.stdout
+    assert res.stdout.decode("utf-8")
+
+
+def test_main_summary():
+    res = subprocess.run(
+        [sys.executable, "-m", "dpctl", "-s"], capture_output=True
+    )
+    assert res.returncode == 0
+    assert res.stdout
+    assert res.stdout.decode("utf-8")
+
+
+def test_main_warnings():
+    res = subprocess.run(
+        [sys.executable, "-m", "dpctl", "-s", "--includes"], capture_output=True
+    )
+    assert res.returncode == 0
+    assert res.stdout
+    assert "UserWarning" in res.stderr.decode("utf-8")
+    assert "is being ignored." in res.stderr.decode("utf-8")
+
+    res = subprocess.run(
+        [sys.executable, "-m", "dpctl", "-s", "--includes", "--cmakedir"],
+        capture_output=True,
+    )
+    assert res.returncode == 0
+    assert res.stdout
+    assert "UserWarning" in res.stderr.decode("utf-8")
+    assert "are being ignored." in res.stderr.decode("utf-8")


### PR DESCRIPTION
It is pretty cumbersome to use DPCTL to enumerate devices typing `python -c "import dpctl; dpctl.lsplatform(verbosity=2)"`. 

This change adds support for enumerating devices in all visible platforms to `__main__`, replacing the above with much easier to type `python -m dpctl -f`.

```
(dev_dpctl) opavlyk@opavlyk-mobl:~/repos/dpctl$ python -m dpctl --help
usage: __main__.py [-h] [--includes] [--cmakedir] [--library] [-l] [-e] [-s]

optional arguments:
  -h, --help       show this help message and exit
  --includes       Include flags dpctl headers.
  --cmakedir       CMake module directory, ideal for setting -DDPCTL_ROOT in CMake.
  --library        Linker flags for SyclInterface library.
  -f, --full-list  Enumerate system platforms, using dpctl.lsplatform(verbosity=2)
  -l, --long-list  Enumerate system platforms, using dpctl.lsplatform(verbosity=1)
  -s, --summary    Enumerate system platforms, using dpctl.lsplatform()
```

- [x] Have you provided a meaningful PR description?
- [x] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
