### PR TITLE
Fixed a typo in _map_to_device_dtype pointed out by @antonwolf

### DIFF
--- a/dpctl/tensor/_ctors.py
+++ b/dpctl/tensor/_ctors.py
@@ -196,16 +196,16 @@ def _asarray_from_usm_ndarray(
 
 
 def _map_to_device_dtype(dt, q):
-    if dt.char == "?" or np.issubdtype(dt, np.integer):
+    dtc = dt.char
+    if dtc == "?" or np.issubdtype(dt, np.integer):
         return dt
     d = q.sycl_device
-    dtc = dt.char
     if np.issubdtype(dt, np.floating):
         if dtc == "f":
             return dt
         if dtc == "d" and d.has_aspect_fp64:
             return dt
-        if dtc == "h" and d.has_aspect_fp16:
+        if dtc == "e" and d.has_aspect_fp16:
             return dt
         return dpt.dtype("f4")
     if np.issubdtype(dt, np.complexfloating):


### PR DESCRIPTION
Fixed a typo in `_map_to_device_dtype` function pointed out by @antonwolf

Also additional small change of creating `dtc` atop the function definition and using it throughout.

- [x] Have you provided a meaningful PR description?
- [x] Have you made sure that new changes do not introduce compiler warnings?
