### PR TITLE
Change default_device_int_type to return 'l' for long.

### DIFF
--- a/dpctl/tensor/libtensor/source/device_support_queries.cpp
+++ b/dpctl/tensor/libtensor/source/device_support_queries.cpp
@@ -51,7 +51,9 @@ std::string _default_device_fp_type(sycl::device d)
 
 std::string _default_device_int_type(sycl::device)
 {
-    return "i8";
+    return "l"; // code for numpy.dtype('long') to be consisent
+                // with NumPy's default integer type across
+                // platforms.
 }
 
 std::string _default_device_complex_type(sycl::device d)


### PR DESCRIPTION
Change `default_device_int_type` to return 'l' (code for for long type).

This should make `dpt.arange(10)` be int32 on Windows.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
