### PR TITLE
Implemented and deployed validate_type_for_device<T>(q)

### DIFF
--- a/dpctl/tensor/libtensor/include/kernels/constructors.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/constructors.hpp
@@ -129,6 +129,7 @@ sycl::event lin_space_step_impl(sycl::queue exec_q,
                                 char *array_data,
                                 const std::vector<sycl::event> &depends)
 {
+    dpctl::tensor::type_utils::validate_type_for_device<Ty>(exec_q);
     sycl::event lin_space_step_event = exec_q.submit([&](sycl::handler &cgh) {
         cgh.depends_on(depends);
         cgh.parallel_for<linear_sequence_step_kernel<Ty>>(
@@ -270,6 +271,8 @@ sycl::event lin_space_affine_impl(sycl::queue exec_q,
                                   char *array_data,
                                   const std::vector<sycl::event> &depends)
 {
+    dpctl::tensor::type_utils::validate_type_for_device<Ty>(exec_q);
+
     bool device_supports_doubles = exec_q.get_device().has(sycl::aspect::fp64);
     sycl::event lin_space_affine_event = exec_q.submit([&](sycl::handler &cgh) {
         cgh.depends_on(depends);
@@ -378,6 +381,7 @@ sycl::event full_contig_impl(sycl::queue q,
                              char *dst_p,
                              const std::vector<sycl::event> &depends)
 {
+    dpctl::tensor::type_utils::validate_type_for_device<dstTy>(q);
     sycl::event fill_ev = q.submit([&](sycl::handler &cgh) {
         cgh.depends_on(depends);
         dstTy *p = reinterpret_cast<dstTy *>(dst_p);
@@ -496,6 +500,7 @@ sycl::event eye_impl(sycl::queue exec_q,
                      char *array_data,
                      const std::vector<sycl::event> &depends)
 {
+    dpctl::tensor::type_utils::validate_type_for_device<Ty>(exec_q);
     sycl::event eye_event = exec_q.submit([&](sycl::handler &cgh) {
         cgh.depends_on(depends);
         cgh.parallel_for<eye_kernel<Ty>>(
@@ -575,6 +580,8 @@ sycl::event tri_impl(sycl::queue exec_q,
     py::ssize_t nd_2 = nd - 2;
     Ty *src = reinterpret_cast<Ty *>(src_p);
     Ty *dst = reinterpret_cast<Ty *>(dst_p);
+
+    dpctl::tensor::type_utils::validate_type_for_device<Ty>(exec_q);
 
     sycl::event tri_ev = exec_q.submit([&](sycl::handler &cgh) {
         cgh.depends_on(depends);

--- a/dpctl/tensor/libtensor/include/kernels/copy_and_cast.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/copy_and_cast.hpp
@@ -215,6 +215,9 @@ copy_and_cast_generic_impl(sycl::queue q,
                            const std::vector<sycl::event> &depends,
                            const std::vector<sycl::event> &additional_depends)
 {
+    dpctl::tensor::type_utils::validate_type_for_device<dstTy>(q);
+    dpctl::tensor::type_utils::validate_type_for_device<srcTy>(q);
+
     sycl::event copy_and_cast_ev = q.submit([&](sycl::handler &cgh) {
         cgh.depends_on(depends);
         cgh.depends_on(additional_depends);
@@ -317,6 +320,9 @@ copy_and_cast_nd_specialized_impl(sycl::queue q,
                                   py::ssize_t dst_offset,
                                   const std::vector<sycl::event> &depends)
 {
+    dpctl::tensor::type_utils::validate_type_for_device<dstTy>(q);
+    dpctl::tensor::type_utils::validate_type_for_device<srcTy>(q);
+
     sycl::event copy_and_cast_ev = q.submit([&](sycl::handler &cgh) {
         cgh.depends_on(depends);
         cgh.parallel_for<copy_cast_spec_kernel<srcTy, dstTy, nd>>(
@@ -486,6 +492,10 @@ void copy_and_cast_from_host_impl(
     const std::vector<sycl::event> &additional_depends)
 {
     py::ssize_t nelems_range = src_max_nelem_offset - src_min_nelem_offset + 1;
+
+    dpctl::tensor::type_utils::validate_type_for_device<dstTy>(q);
+    dpctl::tensor::type_utils::validate_type_for_device<srcTy>(q);
+
     sycl::buffer<srcTy, 1> npy_buf(
         reinterpret_cast<const srcTy *>(host_src_p) + src_min_nelem_offset,
         sycl::range<1>(nelems_range), {sycl::property::buffer::use_host_ptr{}});
@@ -637,6 +647,8 @@ copy_for_reshape_generic_impl(sycl::queue q,
                               char *dst_p,
                               const std::vector<sycl::event> &depends)
 {
+    dpctl::tensor::type_utils::validate_type_for_device<Ty>(q);
+
     sycl::event copy_for_reshape_ev = q.submit([&](sycl::handler &cgh) {
         cgh.depends_on(depends);
         cgh.parallel_for<copy_for_reshape_generic_kernel<Ty>>(


### PR DESCRIPTION
Implemented and deployed `validate_type_for_device<T>(q)` utility function.

This check would produce more succinct error message:

```
In [1]: import dpctl.tensor as dpt

In [2]: dpt.arange(0, 10, dtype='f8')
---------------------------------------------------------------------------
RuntimeError                              Traceback (most recent call last)
Input In [2], in <cell line: 1>()
----> 1 dpt.arange(0, 10, dtype='f8')

File ~/repos/dpctl/dpctl/tensor/_ctors.py:603, in arange(start, stop, step, dtype, device, usm_type, sycl_queue)
    601     _step = sc_ty(1)
    602 _start = _first
--> 603 hev, _ = ti._linspace_step(_start, _step, res, sycl_queue)
    604 hev.wait()
    605 if is_bool:

RuntimeError: Device Intel(R) Graphics [0x9a49] does not support type 'double'
```

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
