### PR TITLE
Use pin-compatible dpcpp_cpp_rt instead of dpcpp-cpp-rt

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -27,8 +27,8 @@ requirements:
     run:
         - python
         - {{ pin_compatible('numpy', min_pin='x.x', max_pin='x') }}
-        - {{ pin_compatible('dpcpp-cpp-rt', min_pin='x.x', max_pin='x') }}  # [py<=39]
-        - dpcpp-cpp-rt  >=2022.2  # [py>39]
+        - {{ pin_compatible('dpcpp_cpp_rt', min_pin='x.x', max_pin='x') }}  # [py<=39]
+        - dpcpp_cpp_rt  >=2022.2  # [py>39]
 
 test:
     requires:


### PR DESCRIPTION
A `dpcpp_cpp_rt` is an interface to `dpcpp-cpp-rt` package. Thus a pin-compatible dependency needs to be defined on the interface package `dpcpp_cpp_rt`, rather than on a package from the middle of dependency ( i.e. where `dpcpp_cpp_rt` -> `dpcpp-cpp-rt` -> {`intel-cmplr-lib-rt`, ...}).

From another hand, currently dpctl can't be built with 2023 compiler in public CI. This is because dpctl build is pinned on `dpcpp-cpp-rt >=2022.2,<2023.0a0` from the package info, where 2022.2 is a version of `dpcpp-cpp-rt` installed into the host environment (since no explicit dependency on `dpcpp-cpp-rt` in host requirements, but in build ones).
While interface package `dpcpp_cpp_rt` installed to the host environment is 2023.0 as expected. So pining on it would be a right way forward.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
