### PR TITLE
Simplify iteration tweak

### DIFF
--- a/dpctl/tensor/libtensor/source/simplify_iteration_space.cpp
+++ b/dpctl/tensor/libtensor/source/simplify_iteration_space.cpp
@@ -120,11 +120,6 @@ void simplify_iteration_space(int &nd,
         simplified_dst_strides.resize(contracted_nd);
 
         nd = contracted_nd;
-        shape = const_cast<const py::ssize_t *>(simplified_shape.data());
-        src_strides =
-            const_cast<const py::ssize_t *>(simplified_src_strides.data());
-        dst_strides =
-            const_cast<const py::ssize_t *>(simplified_dst_strides.data());
     }
     else if (nd == 1) {
         // Populate vectors
@@ -171,6 +166,11 @@ void simplify_iteration_space(int &nd,
         assert(simplified_src_strides.size() == static_cast<size_t>(nd));
         assert(simplified_dst_strides.size() == static_cast<size_t>(nd));
     }
+    shape = const_cast<const py::ssize_t *>(simplified_shape.data());
+    src_strides =
+        const_cast<const py::ssize_t *>(simplified_src_strides.data());
+    dst_strides =
+        const_cast<const py::ssize_t *>(simplified_dst_strides.data());
 }
 
 } // namespace py_internal


### PR DESCRIPTION
This PR does not add new functionality, but cleans up C++ sources of copy-and-casting kernels.

1. A routine to simplify iteration space always sets `shape`, `src_strides` and `dst_strides` pointers.
2. Added `const` qualifiers for some arguments in implementation functions to simplify code and to better reflect the intent.
3. Upgraded `dpctl/tensor/libtensor/tests/test_copy.py` script to run on Iris Xe without support for double precision floating point numbers and to comply with compute follows data.

- [x] Have you provided a meaningful PR description?
