### PR TITLE
Use no associative math

### DIFF
--- a/dpctl/tests/test_usm_ndarray_ctor.py
+++ b/dpctl/tests/test_usm_ndarray_ctor.py
@@ -1168,6 +1168,21 @@ def test_linspace_fp():
     assert X.strides == (1,)
 
 
+@pytest.mark.parametrize("dtype", ["f2", "f4", "f8"])
+def test_linspace_fp_max(dtype):
+    q = get_queue_or_skip()
+    skip_if_dtype_not_supported(dtype, q)
+    n = 16
+    dt = dpt.dtype(dtype)
+    max_ = dpt.finfo(dt).max
+    X = dpt.linspace(max_, max_, endpoint=True, num=n, dtype=dt, sycl_queue=q)
+    assert X.shape == (n,)
+    assert X.strides == (1,)
+    assert np.allclose(
+        dpt.asnumpy(X), np.linspace(max_, max_, endpoint=True, num=n, dtype=dt)
+    )
+
+
 @pytest.mark.parametrize(
     "dt",
     _all_dtypes,


### PR DESCRIPTION
This PR changes to `_tensor_impl` with `-fno-associate-math` compiler flag. See https://clang.llvm.org/docs/UsersManual.html#controlling-floating-point-behavior for how to control FP-behavior in clang.

This fixes output of `dpt.linspace(dpt.finfo('f4').max, dpt.finfo('f4').max, num=16, dtype='f4')` which unexpectedly contained `nan` values as discovered by @npolina4 

- [x] Have you provided a meaningful PR description?
- [x] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?

