### PR TITLE
Upload tar-balls to dev-channel for Windows and Python 3.10 too

### DIFF
--- a/.github/workflows/conda-package.yml
+++ b/.github/workflows/conda-package.yml
@@ -339,7 +339,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        python: ['3.8', '3.9']
+        python: ['3.8', '3.9', '3.10']
     steps:
       - name: Download artifact
         uses: actions/download-artifact@v3


### PR DESCRIPTION
As pointed out by @antonwolfy, conda tar-balls built for Py-3.10 on Windows were in fact not uploaded to the development channel.

This PR corrects that oversight.

- [x] Have you provided a meaningful PR description?
