### PR TITLE
Utility validate_type_for_device must flag complex128 as it flags double

### DIFF
--- a/dpctl/tensor/libtensor/include/utils/type_utils.hpp
+++ b/dpctl/tensor/libtensor/include/utils/type_utils.hpp
@@ -76,14 +76,21 @@ template <typename T> void validate_type_for_device(const sycl::device &d)
         if (!d.has(sycl::aspect::fp64)) {
             throw std::runtime_error("Device " +
                                      d.get_info<sycl::info::device::name>() +
-                                     " does not support type 'double'");
+                                     " does not support type 'float64'");
+        }
+    }
+    else if constexpr (std::is_same_v<T, std::complex<double>>) {
+        if (!d.has(sycl::aspect::fp64)) {
+            throw std::runtime_error("Device " +
+                                     d.get_info<sycl::info::device::name>() +
+                                     " does not support type 'complex128'");
         }
     }
     else if constexpr (std::is_same_v<T, sycl::half>) {
         if (!d.has(sycl::aspect::fp16)) {
             throw std::runtime_error("Device " +
                                      d.get_info<sycl::info::device::name>() +
-                                     " does not support type 'half'");
+                                     " does not support type 'float16'");
         }
     }
 }


### PR DESCRIPTION
Utility `validate_type_for_device<T>(sycl::device &)` modified to flag `std::complex<double>` for devices with no `aspect::fp64`.

- [x] Have you provided a meaningful PR description?
- [x] Have you tested your changes locally for CPU and GPU devices?

To test, I used:

```
In [1]: import dpctl.tensor as dpt, dpctl.tensor._tensor_impl as ti

In [2]: dpt.ones(10, dtype='c16')
---------------------------------------------------------------------------
RuntimeError                              Traceback (most recent call last)
Input In [2], in <cell line: 1>()
----> 1 dpt.ones(10, dtype='c16')

File ~/repos/dpctl/dpctl/tensor/_ctors.py:708, in ones(sh, dtype, order, device, usm_type, sycl_queue)
    700 dtype = _get_dtype(dtype, sycl_queue)
    701 res = dpt.usm_ndarray(
    702     sh,
    703     dtype=dtype,
   (...)
    706     buffer_ctor_kwargs={"queue": sycl_queue},
    707 )
--> 708 hev, _ = ti._full_usm_ndarray(1, res, sycl_queue)
    709 hev.wait()
    710 return res

RuntimeError: Device Intel(R) Graphics [0x9a49] does not support type 'complex128'

In [3]: quit
```