### PR TITLE
Fix loss of L0-program creation from gh-1039

### DIFF
--- a/libsyclinterface/include/Config/dpctl_config.h.in
+++ b/libsyclinterface/include/Config/dpctl_config.h.in
@@ -26,7 +26,7 @@
 #pragma once
 
 /* Defined when dpctl was built with level zero program creation enabled. */
-#cmakedefine DPCTL_ENABLE_L0_PROGRAM @DPCTL_ENABLE_L0_PROGRAM_CREATION@
+#cmakedefine DPCTL_ENABLE_L0_PROGRAM_CREATION 1
 
 #define __SYCL_COMPILER_VERSION_REQUIRED 20221201L
 

--- a/libsyclinterface/source/dpctl_sycl_kernel_bundle_interface.cpp
+++ b/libsyclinterface/source/dpctl_sycl_kernel_bundle_interface.cpp
@@ -39,7 +39,7 @@
 #endif
 #include <sstream>
 
-#ifdef DPCTL_ENABLE_L0_PROGRAM
+#ifdef DPCTL_ENABLE_L0_PROGRAM_CREATION
 // Note: include ze_api.h before level_zero.hpp. Make sure clang-format does
 // not reorder the includes.
 // clang-format off
@@ -332,7 +332,7 @@ _GetKernel_ocl_impl(const kernel_bundle<bundle_state::executable> &kb,
     }
 }
 
-#ifdef DPCTL_ENABLE_L0_PROGRAM
+#ifdef DPCTL_ENABLE_L0_PROGRAM_CREATION
 
 #ifdef __linux__
 static const char *zeLoaderName = DPCTL_LIBZE_LOADER_FILENAME;
@@ -579,7 +579,7 @@ bool _HasKernel_ze_impl(const kernel_bundle<bundle_state::executable> &kb,
     return false;
 }
 
-#endif /* #ifdef DPCTL_ENABLE_L0_PROGRAM */
+#endif /* #ifdef DPCTL_ENABLE_L0_PROGRAM_CREATION */
 
 } /* end of anonymous namespace */
 
@@ -619,7 +619,7 @@ DPCTLKernelBundle_CreateFromSpirv(__dpctl_keep const DPCTLSyclContextRef CtxRef,
                                                    length, CompileOpts);
         break;
     case backend::ext_oneapi_level_zero:
-#ifdef DPCTL_ENABLE_L0_PROGRAM
+#ifdef DPCTL_ENABLE_L0_PROGRAM_CREATION
         KBRef = _CreateKernelBundleWithIL_ze_impl(*SyclCtx, *SyclDev, IL,
                                                   length, CompileOpts);
         break;
@@ -701,7 +701,7 @@ DPCTLKernelBundle_GetKernel(__dpctl_keep DPCTLSyclKernelBundleRef KBRef,
     case sycl::backend::opencl:
         return _GetKernel_ocl_impl(*SyclKB, KernelName);
     case sycl::backend::ext_oneapi_level_zero:
-#ifdef DPCTL_ENABLE_L0_PROGRAM
+#ifdef DPCTL_ENABLE_L0_PROGRAM_CREATION
         return _GetKernel_ze_impl(*SyclKB, KernelName);
 #endif
     default:
@@ -731,7 +731,7 @@ bool DPCTLKernelBundle_HasKernel(__dpctl_keep DPCTLSyclKernelBundleRef KBRef,
     case sycl::backend::opencl:
         return _HasKernel_ocl_impl(*SyclKB, KernelName);
     case sycl::backend::ext_oneapi_level_zero:
-#ifdef DPCTL_ENABLE_L0_PROGRAM
+#ifdef DPCTL_ENABLE_L0_PROGRAM_CREATION
         return _HasKernel_ze_impl(*SyclKB, KernelName);
 #endif
     default:


### PR DESCRIPTION
Changes from gh-1039 inadvertently broke L0 program creation support, resulting in failure of test

test_sycl_program.py::test_create_program_from_spirv_l0

This PR fixes it, while still resolving issues raised in gh-1039.

- [x] Have you provided a meaningful PR description?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
