### PR TITLE
Fix gh 1038 empty zero check device aspects

### DIFF
--- a/dpctl/tensor/_ctors.py
+++ b/dpctl/tensor/_ctors.py
@@ -153,6 +153,7 @@ def _asarray_from_usm_ndarray(
     if order == "K" and fc_contig:
         order = "C" if c_contig else "F"
     if order == "K":
+        _ensure_native_dtype_device_support(dtype, copy_q.sycl_device)
         # new USM allocation
         res = dpt.usm_ndarray(
             usm_ndary.shape,
@@ -176,6 +177,7 @@ def _asarray_from_usm_ndarray(
             strides=new_strides,
         )
     else:
+        _ensure_native_dtype_device_support(dtype, copy_q.sycl_device)
         res = dpt.usm_ndarray(
             usm_ndary.shape,
             dtype=dtype,
@@ -242,6 +244,7 @@ def _asarray_from_numpy_ndarray(
         order = "C" if c_contig else "F"
     if order == "K":
         # new USM allocation
+        _ensure_native_dtype_device_support(dtype, copy_q.sycl_device)
         res = dpt.usm_ndarray(
             ary.shape,
             dtype=dtype,
@@ -261,6 +264,7 @@ def _asarray_from_numpy_ndarray(
             res.shape, dtype=res.dtype, buffer=res.usm_data, strides=new_strides
         )
     else:
+        _ensure_native_dtype_device_support(dtype, copy_q.sycl_device)
         res = dpt.usm_ndarray(
             ary.shape,
             dtype=dtype,
@@ -870,6 +874,7 @@ def empty_like(
     sycl_queue = normalize_queue_device(sycl_queue=sycl_queue, device=device)
     sh = x.shape
     dtype = dpt.dtype(dtype)
+    _ensure_native_dtype_device_support(dtype, sycl_queue.sycl_device)
     res = dpt.usm_ndarray(
         sh,
         dtype=dtype,
@@ -1202,6 +1207,7 @@ def eye(
     dpctl.utils.validate_usm_type(usm_type, allow_none=False)
     sycl_queue = normalize_queue_device(sycl_queue=sycl_queue, device=device)
     dtype = _get_dtype(dtype, sycl_queue)
+    _ensure_native_dtype_device_support(dtype, sycl_queue.sycl_device)
     res = dpt.usm_ndarray(
         (n_rows, n_cols),
         dtype=dtype,

--- a/dpctl/tests/test_usm_ndarray_dlpack.py
+++ b/dpctl/tests/test_usm_ndarray_dlpack.py
@@ -17,6 +17,7 @@
 import ctypes
 
 import pytest
+from helper import skip_if_dtype_not_supported
 
 import dpctl
 import dpctl.tensor as dpt
@@ -71,6 +72,7 @@ def test_dlpack_exporter(typestr, usm_type):
     caps_fn.argtypes = [ctypes.py_object, ctypes.c_char_p]
     all_root_devices = dpctl.get_devices()
     for sycl_dev in all_root_devices:
+        skip_if_dtype_not_supported(typestr, sycl_dev)
         X = dpt.empty((64,), dtype=typestr, usm_type=usm_type, device=sycl_dev)
         caps = X.__dlpack__()
         assert caps_fn(caps, b"dltensor")
@@ -95,6 +97,7 @@ def test_dlpack_exporter_stream():
 def test_from_dlpack(shape, typestr, usm_type):
     all_root_devices = dpctl.get_devices()
     for sycl_dev in all_root_devices:
+        skip_if_dtype_not_supported(typestr, sycl_dev)
         X = dpt.empty(shape, dtype=typestr, usm_type=usm_type, device=sycl_dev)
         Y = dpt.from_dlpack(X)
         assert X.shape == Y.shape


### PR DESCRIPTION
Closes gh-1038.

Added checks to `dpctl.tensor.empty` and `dpctl.tensor.zeros` to disallow creation of arrays with data-types not natively supported by the requested device. 

Also added check to `dpctl.tensor.usm_ndarray` constructor to raise the error if an attempt to create an instance requests data type not natively supported by the device.

- [x] Have you provided a meaningful PR description?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?

