### PR TITLE
Added _contract_iter3 utility to simplify iteration space over 3 arrays

### DIFF
--- a/dpctl/tensor/libtensor/source/tensor_py.cpp
+++ b/dpctl/tensor/libtensor/source/tensor_py.cpp
@@ -133,6 +133,16 @@ PYBIND11_MODULE(_tensor_impl, m)
         "as the original "
         "iterator, possibly in a different order.");
 
+    m.def(
+        "_contract_iter3", &contract_iter3<py::ssize_t, py::value_error>,
+        "Simplifies iteration over elements of 3-tuple of arrays of given "
+        "shape "
+        "with strides stride1, stride2, and stride3. Returns "
+        "a 7-tuple: shape, stride and offset for the new iterator of possible "
+        "smaller dimension for each array, which traverses the same elements "
+        "as the original "
+        "iterator, possibly in a different order.");
+
     m.def("_copy_usm_ndarray_for_reshape", &copy_usm_ndarray_for_reshape,
           "Copies from usm_ndarray `src` into usm_ndarray `dst` with the same "
           "number of elements using underlying 'C'-contiguous order for flat "


### PR DESCRIPTION
Added `dpctl.tensor._tensor_impl._contract_iter3` utility to simplify iteration space over indices of 3 arrays with the same shape, but possibly different strides.

```
In [1]: import dpctl.tensor as dpt, dpctl.tensor._tensor_impl as ti, dpctl

In [4]: import itertools

In [5]: ti._contract_iter2((2, 5, 3), (15, -3, 1), (0,0,1))
Out[5]: ([10, 3], [3, 1], -12, [0, 1], 0)

In [6]: or_s = set( (15*i0 - 3*i1 + i2, i2, 15*i0 - 3*i1 + i2) for i0,i1,i2 in itertools.product(range(2), range(5), range(3)) )

In [7]: alt_s = set( (3*i0 + i1 - 12, i1, 3*i0 + i1 - 12) for i0,i1 in itertools.product(range(10), range(3)) )

In [8]: or_s == alt_s
Out[8]: True
```

This utility is going to be useful in implementation of binary functions, `_binary_func( in1, in2, out)`, example of which is `out = in1 + in2`.


- [x] Have you provided a meaningful PR description?
