### PR TITLE
Set DOWNLOAD_EXTRACT_TIMESTAMP FALSE per cmake policy CMP0135

### DIFF
--- a/.github/workflows/conda-package.yml
+++ b/.github/workflows/conda-package.yml
@@ -175,7 +175,9 @@ jobs:
   test_windows:
     needs: build_windows
     runs-on:  ${{ matrix.runner }}
-
+    defaults:
+          run:
+            shell: cmd /C CALL {0}
     strategy:
       matrix:
         python: ['3.8', '3.9', '3.10']
@@ -197,8 +199,7 @@ jobs:
           auto-update-conda: true
           conda-build-version: '*'
           miniconda-version: 'latest'
-          auto-activate-base: true
-          activate-environment: "dpctl_test"
+          activate-environment: dpctl_test
           python-version: ${{ matrix.python }}
       - name: Create conda channel with the artifact bit
         shell: cmd /C CALL {0}
@@ -216,6 +217,7 @@ jobs:
         run: |
           conda search ${{ env.PACKAGE_NAME }} -c ${{ env.workdir }}/channel --override-channels --info --json > ${{ env.workdir }}\ver.json
       - name: Output content of produced ver.json
+        shell: pwsh
         run: Get-Content -Path ${{ env.workdir }}\ver.json
       - name: Collect dependencies
         shell: cmd /C CALL {0}
@@ -229,6 +231,7 @@ jobs:
           )
           conda install ${{ env.PACKAGE_NAME }}=%PACKAGE_VERSION% python=${{ matrix.python }} -c ${{ env.workdir }}/channel ${{ env.CHANNELS }} --only-deps --dry-run > lockfile
       - name: Display lockfile content
+        shell: pwsh
         run: Get-Content -Path .\lockfile
       - name: Cache conda packages
         uses: actions/cache@v3

--- a/.github/workflows/conda-package.yml
+++ b/.github/workflows/conda-package.yml
@@ -176,8 +176,8 @@ jobs:
     needs: build_windows
     runs-on:  ${{ matrix.runner }}
     defaults:
-          run:
-            shell: cmd /C CALL {0}
+      run:
+        shell: cmd /C CALL {0}
     strategy:
       matrix:
         python: ['3.8', '3.9', '3.10']
@@ -229,7 +229,7 @@ jobs:
           FOR /F "tokens=* USEBACKQ" %%F IN (`python -c "%SCRIPT%"`) DO (
              SET PACKAGE_VERSION=%%F
           )
-          conda install ${{ env.PACKAGE_NAME }}=%PACKAGE_VERSION% python=${{ matrix.python }} -c ${{ env.workdir }}/channel ${{ env.CHANNELS }} --only-deps --dry-run > lockfile
+          conda install -n dpctl_test ${{ env.PACKAGE_NAME }}=%PACKAGE_VERSION% python=${{ matrix.python }} -c ${{ env.workdir }}/channel ${{ env.CHANNELS }} --only-deps --dry-run > lockfile
       - name: Display lockfile content
         shell: pwsh
         run: Get-Content -Path .\lockfile
@@ -246,7 +246,7 @@ jobs:
             ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}-
       - name: Install opencl_rt
         shell: cmd /C CALL {0}
-        run: conda install opencl_rt -c intel --override-channels
+        run: conda install -n dpctl_test opencl_rt -c intel --override-channels
       - name: Install dpctl
         shell: cmd /C CALL {0}
         run: |
@@ -259,13 +259,13 @@ jobs:
              SET PACKAGE_VERSION=%%F
           )
           SET "TEST_DEPENDENCIES=pytest pytest-cov cython"
-          conda install ${{ env.PACKAGE_NAME }}=%PACKAGE_VERSION% %TEST_DEPENDENCIES% python=${{ matrix.python }} -c ${{ env.workdir }}/channel ${{ env.CHANNELS }}
+          conda install -n dpctl_test ${{ env.PACKAGE_NAME }}=%PACKAGE_VERSION% %TEST_DEPENDENCIES% python=${{ matrix.python }} -c ${{ env.workdir }}/channel ${{ env.CHANNELS }}
       - name: Report content of test environment
         shell: cmd /C CALL {0}
         run: |
           echo "Value of CONDA enviroment variable was: " %CONDA%
           echo "Value of CONDA_PREFIX enviroment variable was: " %CONDA_PREFIX%
-          conda list
+          conda info && conda list -n dpctl_test
       - name: Configure Intel OpenCL CPU RT
         shell: pwsh
         run: |
@@ -291,18 +291,18 @@ jobs:
               (Get-Content $cl_cfg) -replace '^CL_CONFIG_TBB_DLL_PATH =', "CL_CONFIG_TBB_DLL_PATH = $conda_env_library\bin" | Set-Content $cl_cfg
               Get-Content -Tail 5 -Path $cl_cfg
           }
-      - name: Smoke test
+      - name: Smoke test, step 1
         shell: cmd /C CALL {0}
-        run: |
-          python -c "import sys; print(sys.executable)"
-          python -c "import dpctl; dpctl.lsplatform()"
-          python -c "import dpctl; print(dpctl.get_devices(backend='opencl', device_type='gpu'))"
-          python -c "import dpctl; print(dpctl.get_num_devices(backend='opencl', device_type='gpu'))"
+        run: >-
+          conda activate dpctl_test && python -c "import sys; print(sys.executable)"
+      - name: Smoke test, step 2
+        shell: cmd /C CALL {0}
+        run: >-
+          conda activate dpctl_test && python -c "import dpctl; dpctl.lsplatform()"
       - name: Run tests
         shell: cmd /C CALL {0}
-        run: |
-          python -c "import sys; print(sys.executable)"
-          python -m pytest -p no:faulthandler --pyargs ${{ env.MODULE_NAME }}
+        run: >-
+          conda activate dpctl_test && python -m pytest -p no:faulthandler --pyargs ${{ env.MODULE_NAME }}
 
   upload_linux:
     needs: test_linux

--- a/.github/workflows/conda-package.yml
+++ b/.github/workflows/conda-package.yml
@@ -197,6 +197,7 @@ jobs:
           auto-update-conda: true
           conda-build-version: '*'
           miniconda-version: 'latest'
+          auto-activate-base: true
           activate-environment: "dpctl_test"
           python-version: ${{ matrix.python }}
       - name: Create conda channel with the artifact bit
@@ -259,8 +260,8 @@ jobs:
       - name: Report content of test environment
         shell: cmd /C CALL {0}
         run: |
-          REM pip install --no-cache-dir brotli
           echo "Value of CONDA enviroment variable was: " %CONDA%
+          echo "Value of CONDA_PREFIX enviroment variable was: " %CONDA_PREFIX%
           conda list
       - name: Configure Intel OpenCL CPU RT
         shell: pwsh

--- a/.github/workflows/conda-package.yml
+++ b/.github/workflows/conda-package.yml
@@ -72,9 +72,11 @@ jobs:
           fetch-depth: 0
       - uses: conda-incubator/setup-miniconda@v2
         with:
+          use-only-tar-bz2: true
           auto-activate-base: true
           conda-build-version: "*"
-          activate-environment: ""
+          activate-environment: true
+          python-version: ${{ matrix.python }}
 
       - name: Cache conda packages
         uses: actions/cache@v3
@@ -196,6 +198,7 @@ jobs:
           conda-build-version: '*'
           miniconda-version: 'latest'
           activate-environment: "dpctl_test"
+          python-version: ${{ matrix.python }}
       - name: Create conda channel with the artifact bit
         shell: cmd /C CALL {0}
         run: |

--- a/.github/workflows/conda-package.yml
+++ b/.github/workflows/conda-package.yml
@@ -259,7 +259,7 @@ jobs:
       - name: Report content of test environment
         shell: cmd /C CALL {0}
         run: |
-          pip install --no-cache-dir brotli
+          REM pip install --no-cache-dir brotli
           echo "Value of CONDA enviroment variable was: " %CONDA%
           conda list
       - name: Add library

--- a/.github/workflows/conda-package.yml
+++ b/.github/workflows/conda-package.yml
@@ -262,7 +262,7 @@ jobs:
           REM pip install --no-cache-dir brotli
           echo "Value of CONDA enviroment variable was: " %CONDA%
           conda list
-      - name: Add library
+      - name: Configure Intel OpenCL CPU RT
         shell: pwsh
         run: |
           $conda_env_library = "$env:CONDA_PREFIX\Library"
@@ -281,17 +281,6 @@ jobs:
               New-ItemProperty -Path HKLM:\SOFTWARE\Khronos\OpenCL\Vendors -Name $conda_env_library\lib\intelocl64.dll -Value 0
               try {$list = Get-Item -Path HKLM:\SOFTWARE\Khronos\OpenCL\Vendors | Select-Object -ExpandProperty Property } catch {$list=@()}
               Write-Output $(Get-Item -Path HKLM:\SOFTWARE\Khronos\OpenCL\Vendors)
-              # Now copy OpenCL.dll into system folder
-              $system_ocl_icd_loader="C:\Windows\System32\OpenCL.dll"
-              $python_ocl_icd_loader="$conda_env_library\bin\OpenCL.dll"
-              Copy-Item -Path $python_ocl_icd_loader -Destination $system_ocl_icd_loader
-              if (Test-Path -Path $system_ocl_icd_loader) {
-                 Write-Output "$system_ocl_icd_loader has been copied"
-                 $acl = Get-Acl $system_ocl_icd_loader
-                 Write-Output $acl
-              } else {
-                 Write-Output "OCL-ICD-Loader was not copied"
-              }
               # Variable assisting OpenCL CPU driver to find TBB DLLs which are not located where it expects them by default
               $cl_cfg="$conda_env_library\lib\cl.cfg"
               Write-Output $cl_cfg

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,9 @@
 cmake_minimum_required(VERSION 3.21...3.22 FATAL_ERROR)
 
+if (${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.24")
+  cmake_policy(SET CMP0135 NEW)
+endif()
+
 project(dpctl
     LANGUAGES CXX
     DESCRIPTION "Python interface for XPU programming"


### PR DESCRIPTION
Set `DOWNLOAD_EXTRACT_TIMESTAMP FALSE` in `FetchContet_Declare` cmake functions per CML0135-related warning.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
