### PR TITLE
Changed generating integer output for linspace() function.

### DIFF
--- a/dpctl/tests/test_usm_ndarray_ctor.py
+++ b/dpctl/tests/test_usm_ndarray_ctor.py
@@ -1192,6 +1192,13 @@ def test_linspace_fp_max(dtype):
     )
 
 
+def test_linspace_int():
+    q = get_queue_or_skip()
+    X = dpt.linspace(0.1, 9.1, 11, endpoint=True, dtype=int, sycl_queue=q)
+    Xnp = np.linspace(0.1, 9.1, 11, endpoint=True, dtype=int)
+    assert np.array_equal(dpt.asnumpy(X), Xnp)
+
+
 @pytest.mark.parametrize(
     "dt",
     _all_dtypes,


### PR DESCRIPTION
Changed generating integer output for dpctl.tensor.linspace() function like in numpy.linspace().

``` python
xp.linspace(0.1, 9.1, 11, endpoint=True, dtype=int)
# old out:
array([0, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
# new out:
array([0, 1, 1, 2, 3, 4, 5, 6, 7, 8, 9])
# numpy out:
array([0, 1, 1, 2, 3, 4, 5, 6, 7, 8, 9])
```

- [x] Have you provided a meaningful PR description?
- [x] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
