### PR TITLE
Fix sycl queue argument validation

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ repos:
     -   id: black
         exclude: "versioneer.py|dpctl/_version.py"
 -   repo: https://github.com/pycqa/isort
-    rev: 5.10.1
+    rev: 5.12.0
     hooks:
     -   id: isort
         name: isort (python)

--- a/dpctl/_sycl_queue.pyx
+++ b/dpctl/_sycl_queue.pyx
@@ -290,6 +290,11 @@ cdef class SyclQueue(_SyclQueue):
         props = _parse_queue_properties(
             kwargs.pop('property', _queue_property_type._DEFAULT_PROPERTY)
         )
+        if (kwargs):
+            raise TypeError(
+                f"Unsupported keyword arguments {kwargs} to "
+                "SyclQueue constructor encountered."
+            )
         len_args = len(args)
         if len_args == 0:
             status = self._init_queue_default(props)

--- a/dpctl/tests/test_sycl_queue.py
+++ b/dpctl/tests/test_sycl_queue.py
@@ -84,6 +84,14 @@ def test_invalid_filter_selectors(invalid_filter):
         dpctl.SyclQueue(invalid_filter)
 
 
+def test_unexpected_keyword():
+    """
+    An unexpected keyword use raises TypeError.
+    """
+    with pytest.raises(TypeError):
+        dpctl.SyclQueue(device="cpu")
+
+
 def test_context_not_equals():
     try:
         gpuQ = dpctl.SyclQueue("gpu")


### PR DESCRIPTION
This fixes lack of validation in `dpctl.SyclQueue(device="gpu")` call to constructor.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
