### PR TITLE
Added dtype compatibility check for device for result_type() and can_cast() functions.

### DIFF
--- a/dpctl/tensor/__init__.py
+++ b/dpctl/tensor/__init__.py
@@ -48,6 +48,7 @@ from dpctl.tensor._manipulation_functions import (
     broadcast_to,
     can_cast,
     concat,
+    device_result_type,
     expand_dims,
     finfo,
     flip,
@@ -137,4 +138,5 @@ __all__ = [
     "get_print_options",
     "set_print_options",
     "print_options",
+    "device_result_type",
 ]


### PR DESCRIPTION
Added dtype compatibility check for device for dpctl.tensor.result_type() and dpctl.tensor.can_cast() functions.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
