### PR TITLE
Use black 22.12.0

### DIFF
--- a/.github/workflows/python_style_checks.yml
+++ b/.github/workflows/python_style_checks.yml
@@ -41,6 +41,7 @@ jobs:
         with:
           src: "."
           options: "--check"
+	  verson: "22.12.0"
 
   flake8:
     runs-on: ubuntu-latest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,7 @@ repos:
     -   id: end-of-file-fixer
     -   id: trailing-whitespace
 -   repo: https://github.com/psf/black
-    rev: 22.10.0
+    rev: 22.12.0
     hooks:
     -   id: black
         exclude: "versioneer.py|dpctl/_version.py"


### PR DESCRIPTION
This change fixes version of black specified in pre-commit config and in python_style_check workflow to 22.12.0

Latest release 23.1.0 suggests further changes to previously passing code.

- [x] Have you provided a meaningful PR description?
