### PR TITLE
Clean-up PowerShell script to add registry expected by OpenCL loader

### DIFF
--- a/.github/workflows/conda-package.yml
+++ b/.github/workflows/conda-package.yml
@@ -269,28 +269,23 @@ jobs:
       - name: Configure Intel OpenCL CPU RT
         shell: pwsh
         run: |
-          $conda_env_library = "$env:CONDA_PREFIX\Library"
-          echo "OCL_ICD_FILENAMES=$conda_env_library\lib\intelocl64.dll" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
-          try {$list = Get-Item -Path HKLM:\SOFTWARE\Khronos\OpenCL\Vendors | Select-Object -ExpandProperty Property } catch {$list=@()}
-          if ($list.count -eq 0) {
-              if (-not (Test-Path -Path HKLM:\SOFTWARE\Khronos)) {
-                 New-Item -Path HKLM:\SOFTWARE\Khronos
-              }
-              if (-not (Test-Path -Path HKLM:\SOFTWARE\Khronos\OpenCL)) {
-                 New-Item -Path HKLM:\SOFTWARE\Khronos\OpenCL
-              }
-              if (-not (Test-Path -Path HKLM:\SOFTWARE\Khronos\OpenCL\Vendors)) {
-                 New-Item -Path HKLM:\SOFTWARE\Khronos\OpenCL\Vendors
-              }
-              New-ItemProperty -Path HKLM:\SOFTWARE\Khronos\OpenCL\Vendors -Name $conda_env_library\lib\intelocl64.dll -Value 0
-              try {$list = Get-Item -Path HKLM:\SOFTWARE\Khronos\OpenCL\Vendors | Select-Object -ExpandProperty Property } catch {$list=@()}
-              Write-Output $(Get-Item -Path HKLM:\SOFTWARE\Khronos\OpenCL\Vendors)
-              # Variable assisting OpenCL CPU driver to find TBB DLLs which are not located where it expects them by default
-              $cl_cfg="$conda_env_library\lib\cl.cfg"
-              Write-Output $cl_cfg
-              (Get-Content $cl_cfg) -replace '^CL_CONFIG_TBB_DLL_PATH =', "CL_CONFIG_TBB_DLL_PATH = $conda_env_library\bin" | Set-Content $cl_cfg
-              Get-Content -Tail 5 -Path $cl_cfg
+          if (-not (Test-Path -Path HKLM:\SOFTWARE\Khronos)) {
+              New-Item -Path HKLM:\SOFTWARE\Khronos
           }
+          if (-not (Test-Path -Path HKLM:\SOFTWARE\Khronos\OpenCL)) {
+              New-Item -Path HKLM:\SOFTWARE\Khronos\OpenCL
+          }
+          if (-not (Test-Path -Path HKLM:\SOFTWARE\Khronos\OpenCL\Vendors)) {
+              New-Item -Path HKLM:\SOFTWARE\Khronos\OpenCL\Vendors
+          }
+          $conda_env_library = "$env:CONDA_PREFIX\Library"
+          New-ItemProperty -Path HKLM:\SOFTWARE\Khronos\OpenCL\Vendors -Name $conda_env_library\lib\intelocl64.dll -Value 0
+          Write-Host $(Get-Item -Path HKLM:\SOFTWARE\Khronos\OpenCL\Vendors)
+          # Variable assisting OpenCL CPU driver to find TBB DLLs which are not located where it expects them by default
+          $cl_cfg="$conda_env_library\lib\cl.cfg"
+          Write-Output $cl_cfg
+          (Get-Content $cl_cfg) -replace '^CL_CONFIG_TBB_DLL_PATH =', "CL_CONFIG_TBB_DLL_PATH = $conda_env_library\bin" | Set-Content $cl_cfg
+          Get-Content -Tail 5 -Path $cl_cfg
       - name: Smoke test, step 1
         shell: cmd /C CALL {0}
         run: >-


### PR DESCRIPTION
The registry entry makes the OCL CPU library in the environment known to the loader, enabling the CPU SYCL device.

- [x] Have you provided a meaningful PR description?
