### PR TITLE
Reordered DPCTL_USM_HOST and DPCTL_USM_SHARED

### DIFF
--- a/dpctl/_backend.pxd
+++ b/dpctl/_backend.pxd
@@ -37,8 +37,8 @@ cdef extern from "syclinterface/dpctl_sycl_enum_types.h":
     ctypedef enum _usm_type 'DPCTLSyclUSMType':
         _USM_UNKNOWN     'DPCTL_USM_UNKNOWN'
         _USM_DEVICE      'DPCTL_USM_DEVICE'
-        _USM_HOST        'DPCTL_USM_HOST'
         _USM_SHARED      'DPCTL_USM_SHARED'
+        _USM_HOST        'DPCTL_USM_HOST'
 
     ctypedef enum _backend_type 'DPCTLSyclBackendType':
         _ALL_BACKENDS    'DPCTL_ALL_BACKENDS'

--- a/dpctl/enum_types.py
+++ b/dpctl/enum_types.py
@@ -113,14 +113,3 @@ class global_mem_cache_type(Enum):
     none = auto()
     read_only = auto()
     read_write = auto()
-
-
-class usm_type(Enum):
-    """
-    An enumeration of USM allocation types.
-    """
-
-    unknown = auto()
-    device = auto()
-    shared = auto()
-    host = auto()

--- a/dpctl/enum_types.py
+++ b/dpctl/enum_types.py
@@ -113,3 +113,14 @@ class global_mem_cache_type(Enum):
     none = auto()
     read_only = auto()
     read_write = auto()
+
+
+class usm_type(Enum):
+    """
+    An enumeration of USM allocation types.
+    """
+
+    unknown = auto()
+    device = auto()
+    shared = auto()
+    host = auto()

--- a/dpctl/memory/_memory.pxd
+++ b/dpctl/memory/_memory.pxd
@@ -22,7 +22,7 @@ in dpctl.memory._memory.pyx.
 
 """
 
-from .._backend cimport DPCTLSyclQueueRef, DPCTLSyclUSMRef
+from .._backend cimport DPCTLSyclQueueRef, DPCTLSyclUSMRef, _usm_type
 from .._sycl_context cimport SyclContext
 from .._sycl_device cimport SyclDevice
 from .._sycl_queue cimport SyclQueue
@@ -56,6 +56,8 @@ cdef public api class _Memory [object Py_MemoryObject, type Py_MemoryType]:
         DPCTLSyclUSMRef p, SyclContext ctx)
     @staticmethod
     cdef bytes get_pointer_type(DPCTLSyclUSMRef p, SyclContext ctx)
+    @staticmethod
+    cdef _usm_type get_pointer_type_enum(DPCTLSyclUSMRef p, SyclContext ctx)
     @staticmethod
     cdef object create_from_usm_pointer_size_qref(
         DPCTLSyclUSMRef USMRef,

--- a/dpctl/tests/test_sycl_usm.py
+++ b/dpctl/tests/test_sycl_usm.py
@@ -270,11 +270,13 @@ def test_create_with_size_and_alignment(memory_ctor):
     not has_sycl_platforms(),
     reason="No SYCL devices except the default host device.",
 )
-def test_create_with_only_size(memory_ctor):
-    m = memory_ctor(1024)
+def test_usm_type_execeptions():
+    m = MemoryUSMDevice(1024)
     assert m.nbytes == 1024
-    assert m.get_usm_type() == expected_usm_type_str(memory_ctor)
-    assert m.get_usm_type_enum() == expected_usm_type_enum(memory_ctor)
+    with pytest.raises(TypeError):
+        m.get_usm_type(syclobj=Ellipsis)
+    with pytest.raises(TypeError):
+        m.get_usm_type_enum(syclobj=list())
 
 
 @pytest.mark.skipif(

--- a/dpctl/tests/test_sycl_usm.py
+++ b/dpctl/tests/test_sycl_usm.py
@@ -271,8 +271,15 @@ def test_create_with_size_and_alignment(memory_ctor):
     reason="No SYCL devices except the default host device.",
 )
 def test_usm_type_execeptions():
-    m = MemoryUSMDevice(1024)
+    ctor = MemoryUSMDevice
+    m = ctor(1024)
     assert m.nbytes == 1024
+    q = m.sycl_queue
+    assert m.get_usm_type(syclobj=q) == expected_usm_type_str(ctor)
+    assert m.get_usm_type_enum(syclobj=q) == expected_usm_type_enum(ctor)
+    ctx = q.sycl_context
+    assert m.get_usm_type(syclobj=ctx) == expected_usm_type_str(ctor)
+    assert m.get_usm_type_enum(syclobj=ctx) == expected_usm_type_enum(ctor)
     with pytest.raises(TypeError):
         m.get_usm_type(syclobj=Ellipsis)
     with pytest.raises(TypeError):

--- a/dpctl/tests/test_sycl_usm.py
+++ b/dpctl/tests/test_sycl_usm.py
@@ -201,7 +201,7 @@ def test_pickling_reconstructor_invalid_type(memory_ctor):
 
     mobj = memory_ctor(1024, alignment=64)
     good_pickle_bytes = pickle.dumps(mobj)
-    usm_types = expected_usm_type(memory_ctor).encode("utf-8")
+    usm_types = expected_usm_type_str(memory_ctor).encode("utf-8")
     i = good_pickle_bytes.rfind(usm_types)
     bad_pickle_bytes = good_pickle_bytes[:i] + b"u" + good_pickle_bytes[i + 1 :]
     with pytest.raises(ValueError):
@@ -213,13 +213,22 @@ def memory_ctor(request):
     return request.param
 
 
-def expected_usm_type(ctor):
+def expected_usm_type_str(ctor):
     mapping = {
         MemoryUSMShared: "shared",
         MemoryUSMDevice: "device",
         MemoryUSMHost: "host",
     }
     return mapping.get(ctor, "unknown")
+
+
+def expected_usm_type_enum(ctor):
+    mapping = {
+        MemoryUSMShared: 2,
+        MemoryUSMDevice: 1,
+        MemoryUSMHost: 3,
+    }
+    return mapping.get(ctor, 0)
 
 
 @pytest.mark.skipif(
@@ -230,7 +239,8 @@ def test_create_with_size_and_alignment_and_queue(memory_ctor):
     q = dpctl.SyclQueue()
     m = memory_ctor(1024, alignment=64, queue=q)
     assert m.nbytes == 1024
-    assert m.get_usm_type() == expected_usm_type(memory_ctor)
+    assert m.get_usm_type() == expected_usm_type_str(memory_ctor)
+    assert m.get_usm_type_enum() == expected_usm_type_enum(memory_ctor)
 
 
 @pytest.mark.skipif(
@@ -241,7 +251,8 @@ def test_create_with_size_and_queue(memory_ctor):
     q = dpctl.SyclQueue()
     m = memory_ctor(1024, queue=q)
     assert m.nbytes == 1024
-    assert m.get_usm_type() == expected_usm_type(memory_ctor)
+    assert m.get_usm_type() == expected_usm_type_str(memory_ctor)
+    assert m.get_usm_type_enum() == expected_usm_type_enum(memory_ctor)
 
 
 @pytest.mark.skipif(
@@ -251,7 +262,8 @@ def test_create_with_size_and_queue(memory_ctor):
 def test_create_with_size_and_alignment(memory_ctor):
     m = memory_ctor(1024, alignment=64)
     assert m.nbytes == 1024
-    assert m.get_usm_type() == expected_usm_type(memory_ctor)
+    assert m.get_usm_type() == expected_usm_type_str(memory_ctor)
+    assert m.get_usm_type_enum() == expected_usm_type_enum(memory_ctor)
 
 
 @pytest.mark.skipif(
@@ -261,7 +273,8 @@ def test_create_with_size_and_alignment(memory_ctor):
 def test_create_with_only_size(memory_ctor):
     m = memory_ctor(1024)
     assert m.nbytes == 1024
-    assert m.get_usm_type() == expected_usm_type(memory_ctor)
+    assert m.get_usm_type() == expected_usm_type_str(memory_ctor)
+    assert m.get_usm_type_enum() == expected_usm_type_enum(memory_ctor)
 
 
 @pytest.mark.skipif(

--- a/libsyclinterface/include/dpctl_sycl_enum_types.h
+++ b/libsyclinterface/include/dpctl_sycl_enum_types.h
@@ -39,8 +39,8 @@ typedef enum
 {
     DPCTL_USM_UNKNOWN = 0,
     DPCTL_USM_DEVICE,
-    DPCTL_USM_HOST,
-    DPCTL_USM_SHARED
+    DPCTL_USM_SHARED,
+    DPCTL_USM_HOST
 } DPCTLSyclUSMType;
 
 /*!


### PR DESCRIPTION
In compute follows data we stipulate DEVICE<SHARED<HOST for the usm_type coercion logic.
It makes sense to keep integral values associated with the enum consistent with that mental model.

- [x] Have you provided a meaningful PR description?
- [x] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
