### PR TITLE
Updated minimal required version of DPCPP >=2023.0.0

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -28,7 +28,7 @@ requirements:
         - python
         - {{ pin_compatible('numpy', min_pin='x.x', max_pin='x') }}
         - {{ pin_compatible('dpcpp-cpp-rt', min_pin='x.x', max_pin='x') }}  # [py<=39]
-        - dpcpp-cpp-rt  >=2022.2  # [py>39]
+        - dpcpp-cpp-rt  >=2023.0  # [py>39]
 
 test:
     requires:


### PR DESCRIPTION
Since `dpctl` is now built with oneAPI DPC++ 2023.0, the required RT version should change accordingly.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
