### PR TITLE
Make test_windows:smoke test 2 more verbose

### DIFF
--- a/.github/workflows/conda-package.yml
+++ b/.github/workflows/conda-package.yml
@@ -293,7 +293,7 @@ jobs:
       - name: Smoke test, step 2
         shell: cmd /C CALL {0}
         run: >-
-          conda activate dpctl_test && python -c "import dpctl; dpctl.lsplatform()"
+          conda activate dpctl_test && python -m dpctl -f
       - name: Run tests
         shell: cmd /C CALL {0}
         run: >-


### PR DESCRIPTION
This PR tweaks conda-package workflow to use `python -m dpctl -f` to display SYCL environment information instead of less verbose `python -c "import dpctl; dpctl.lsplatform()"`, which is equivalent to `python -m dpctl -l`.

 `python -m dpctl -f` will also display driver version of each available SYCL device. Hoping this to provide more insight into the cause for #1063 

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
