### PR TITLE
Add double type support check condition for test_print_repr

### DIFF
--- a/dpctl/tests/test_usm_ndarray_print.py
+++ b/dpctl/tests/test_usm_ndarray_print.py
@@ -256,7 +256,10 @@ class TestPrintFns(TestPrint):
         assert repr(x) == "usm_ndarray(0)"
 
         x = dpt.asarray([np.nan, np.inf], sycl_queue=q)
-        assert repr(x) == "usm_ndarray([nan, inf])"
+        if x.sycl_device.has_aspect_fp64:
+            assert repr(x) == "usm_ndarray([nan, inf])"
+        else:
+            assert repr(x) == "usm_ndarray([nan, inf], dtype=float32)"
 
         x = dpt.arange(9, sycl_queue=q, dtype="int64")
         assert repr(x) == "usm_ndarray([0, 1, 2, 3, 4, 5, 6, 7, 8])"


### PR DESCRIPTION
- [X] Have you provided a meaningful PR description?
- [X] Have you added a test, reproducer or referred to an issue with a reproducer?
- [X] Have you tested your changes locally for CPU and GPU devices?
- [X] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?

This PR solves the issue #1069.
The PR adds the `has_aspect_fp64` condition in the `test_usm_ndarray_print.py::TestPrintFns::test_print_rep` to check for double type support on devices and allows that this test passes on Iris Xe.  
