### PR TITLE
Mark static function usm_ndarray_types::typenum_to_lookup_id const

### DIFF
--- a/dpctl/tensor/libtensor/include/utils/type_dispatch.hpp
+++ b/dpctl/tensor/libtensor/include/utils/type_dispatch.hpp
@@ -162,7 +162,7 @@ public:
 struct usm_ndarray_types
 {
 
-    int typenum_to_lookup_id(int typenum)
+    int typenum_to_lookup_id(int typenum) const
     {
         using typenum_t = dpctl::tensor::detail::typenum_t;
         auto const &api = ::dpctl::detail::dpctl_capi::get();
@@ -232,7 +232,7 @@ struct usm_ndarray_types
     }
 
 private:
-    void throw_unrecognized_typenum_error(int typenum)
+    void throw_unrecognized_typenum_error(int typenum) const
     {
         throw std::runtime_error("Unrecogized typenum " +
                                  std::to_string(typenum) + " encountered.");


### PR DESCRIPTION
Mark static function ``usm_ndarray_types::typenum_to_lookup_id`` as `const`.

This allows to call it for `const struct` references.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
