### PR TITLE
Require DPC++ >=2023.0.0, no need to require c-compiler

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -12,9 +12,8 @@ build:
 
 requirements:
     build:
-        - {{ compiler('c') }}
         - {{ compiler('cxx') }}
-        - {{ compiler('dpcpp') }}  >=2022.1  # [not osx]
+        - {{ compiler('dpcpp') }}  >=2023.0  # [not osx]
     host:
         - setuptools
         - cmake  >=3.21


### PR DESCRIPTION
Dropping `- {{ compiler('c') }}` and bumping up minimal version of DPC++.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
