### PR TITLE
Cached queue use filter string support

### DIFF
--- a/dpctl/_sycl_queue_manager.pyx
+++ b/dpctl/_sycl_queue_manager.pyx
@@ -310,6 +310,9 @@ cdef class _DeviceDefaultQueueCache:
         elif isinstance(key, SyclDevice):
             q = SyclQueue(key)
             ctx_dev = q.sycl_context, key
+        elif isinstance(key, str):
+            q = SyclQueue(key)
+            ctx_dev = q.sycl_context, q.sycl_device
         else:
             raise TypeError
         if ctx_dev in self.__device_queue_map__:

--- a/dpctl/_sycl_queue_manager.pyx
+++ b/dpctl/_sycl_queue_manager.pyx
@@ -303,8 +303,14 @@ cdef class _DeviceDefaultQueueCache:
         self.__device_queue_map__ = dict()
 
     def get_or_create(self, key):
-        """Return instance of SyclQueue and indicator if cache has been modified"""
-        if isinstance(key, tuple) and len(key) == 2 and isinstance(key[0], SyclContext) and isinstance(key[1], SyclDevice):
+        """Return instance of SyclQueue and indicator if cache
+        has been modified"""
+        if (
+            isinstance(key, tuple)
+            and len(key) == 2
+            and isinstance(key[0], SyclContext)
+            and isinstance(key[1], SyclDevice)
+        ):
             ctx_dev = key
             q = None
         elif isinstance(key, SyclDevice):
@@ -325,12 +331,16 @@ cdef class _DeviceDefaultQueueCache:
         self.__device_queue_map__.update(dev_queue_map)
 
     def __copy__(self):
-        cdef _DeviceDefaultQueueCache _copy = _DeviceDefaultQueueCache.__new__(_DeviceDefaultQueueCache)
+        cdef _DeviceDefaultQueueCache _copy = _DeviceDefaultQueueCache.__new__(
+	     _DeviceDefaultQueueCache)
         _copy._update_map(self.__device_queue_map__)
         return _copy
 
 
-_global_device_queue_cache = ContextVar('global_device_queue_cache', default=_DeviceDefaultQueueCache())
+_global_device_queue_cache = ContextVar(
+    'global_device_queue_cache',
+    default=_DeviceDefaultQueueCache()
+)
 
 
 cpdef object get_device_cached_queue(object key):

--- a/dpctl/tests/test_sycl_queue_manager.py
+++ b/dpctl/tests/test_sycl_queue_manager.py
@@ -245,3 +245,5 @@ def test__DeviceDefaultQueueCache():
 
     assert not changed
     assert q1 == q2
+    q3 = get_device_cached_queue(d.filter_string)
+    assert q3 == q1


### PR DESCRIPTION


Per discussion in gh-1076, this adds support for filter-string input in `get_device_cached_queue` utility function:

```
In [1]: import dpctl

In [2]: import dpctl._sycl_queue_manager as qm

In [3]: qm.__pyx_capi__
Out[3]:
{'get_current_queue': <capsule object "struct PySyclQueueObject *(int __pyx_skip_dispatch)" at 0x7fe2260bcc30>,
 'get_current_device_type': <capsule object "PyObject *(int __pyx_skip_dispatch)" at 0x7fe2260bcc60>,
 'get_current_backend': <capsule object "PyObject *(int __pyx_skip_dispatch)" at 0x7fe2260bcc90>,
 'get_device_cached_queue': <capsule object "PyObject *(PyObject *, int __pyx_skip_dispatch)" at 0x7fe2260bccc0>}

In [4]: qm.get_device_cached_queue("cpu")
Out[4]: <dpctl.SyclQueue at 0x7fe226945b80>

In [5]: qm.get_device_cached_queue("gpu")
Out[5]: <dpctl.SyclQueue at 0x7fe21c032ec0>

In [6]: quit
```

- [x] Have you provided a meaningful PR description?
- [x] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
