### PR TITLE
This PR modifies conda-recipe to add post-link to dpctl

### DIFF
--- a/conda-recipe/build.sh
+++ b/conda-recipe/build.sh
@@ -30,3 +30,8 @@ else
     # Perform regular install
     ${PYTHON} setup.py install ${SKBUILD_ARGS}
 fi
+
+# need to create this folder so ensure that .dpctl-post-link.sh can work correctly
+mkdir -p $PREFIX/etc/OpenCL/vendors
+
+cp $RECIPE_DIR/dpctl-post-link.sh $PREFIX/bin/.dpctl-post-link.sh

--- a/conda-recipe/dpctl-post-link.sh
+++ b/conda-recipe/dpctl-post-link.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/bash
+
+systemwide_icd=/etc/OpenCL/vendors/intel.icd
+local_vendors=$CONDA_PREFIX/etc/OpenCL/vendors/
+
+if [[ -f $systemwide_icd && -d $local_vendors && ! -f $local_vendors/intl-ocl-gpu.icd ]]; then
+    ln -s $systemwide_icd  $local_vendors/intel-ocl-gpu.icd
+fi


### PR DESCRIPTION
The post-link creates a symbolic link from `$PREFIX/etc/OpenCL/vendors/intel-gpu.icd` to `/etc/OpenCL/vendors/intel.icd` if one exists.

This is a work-around to ensure that OpenCL GPU device from system installation can be found by OpenCL loader in ``intel-opencl-rt`` forthcoming package.

- [x] Have you provided a meaningful PR description?
