### PR TITLE
Work-around for not applying -fsycl-device-code-split=per_kernel on Windows

### DIFF
--- a/conda-recipe/bld.bat
+++ b/conda-recipe/bld.bat
@@ -6,7 +6,7 @@ set "INCLUDE=%BUILD_PREFIX%\include;%INCLUDE%"
 "%PYTHON%" setup.py clean --all
 set "SKBUILD_ARGS=-G Ninja -- -DCMAKE_C_COMPILER:PATH=icx -DCMAKE_CXX_COMPILER:PATH=icx"
 
-FOR %%V IN (14.0.0 15.0.0 16.0.0) DO @(
+FOR %%V IN (14.0.0 14 15.0.0 15 16.0.0 16) DO @(
   REM set DIR_HINT if directory exists
   IF EXIST "%BUILD_PREFIX%\Library\lib\clang\%%V\" (
      SET "SYCL_INCLUDE_DIR_HINT=%BUILD_PREFIX%\Library\lib\clang\%%V"

--- a/conda-recipe/bld.bat
+++ b/conda-recipe/bld.bat
@@ -18,11 +18,13 @@ set "FN=Windows-IntelLLVM.cmake"
 
 rem Save the original file, and copy patched file to
 rem fix the issue with IntelLLVM integration with cmake on Windows
-dir "%PLATFORM_DIR%\%FN%"
-copy /Y "%PLATFORM_DIR%\%FN%" .
-if errorlevel 1 exit 1
-copy /Y .github\workflows\Windows-IntelLLVM.cmake "%PLATFORM_DIR%"
-if errorlevel 1 exit 1
+if EXIST "%PLATFORM_DIR%" (
+  dir "%PLATFORM_DIR%\%FN%"
+  copy /Y "%PLATFORM_DIR%\%FN%" .
+  if errorlevel 1 exit 1
+  copy /Y .github\workflows\Windows-IntelLLVM.cmake "%PLATFORM_DIR%"
+  if errorlevel 1 exit 1
+)
 
 if NOT "%WHEELS_OUTPUT_FOLDER%"=="" (
     rem Install and assemble wheel package from the build bits

--- a/dpctl/CMakeLists.txt
+++ b/dpctl/CMakeLists.txt
@@ -23,7 +23,7 @@ if(WIN32)
     set(CMAKE_CXX_FLAGS_DEBUG
         "${CMAKE_CXX_FLAGS_DEBUG} ${WARNING_FLAGS} -O0 -g1 -DDEBUG"
     )
-    set(DPCTL_LDFLAGS "/link /NXCompat /DynamicBase")
+    set(DPCTL_LDFLAGS "/NXCompat;/DynamicBase")
 elseif(UNIX)
     string(CONCAT WARNING_FLAGS
         "-Wall "
@@ -140,7 +140,8 @@ function(build_dpctl_ext _trgt _src _dest)
         target_compile_options(${_trgt} PRIVATE -fno-sycl-use-footer)
     endif()
     target_link_libraries(${_trgt} DPCTLSyclInterface)
-    target_link_options(${_trgt} PRIVATE "LINKER:${DPCTL_LDFLAGS}")
+    set(_linker_options "LINKER:${DPCTL_LDFLAGS}")
+    target_link_options(${_trgt} PRIVATE ${_linker_options})
     python_extension_module(${_trgt})
     get_filename_component(_name_wle ${_generated_src} NAME_WLE)
     get_filename_component(_generated_src_dir ${_generated_src} DIRECTORY)

--- a/dpctl/tensor/CMakeLists.txt
+++ b/dpctl/tensor/CMakeLists.txt
@@ -15,6 +15,14 @@ add_custom_target(_dpctl4pybind11_deps
     _sycl_event_copy_capi_include
 )
 
+if(WIN32)
+    if (${CMAKE_VERSION} VERSION_LESS "3.23")
+        # this is a work-around for target_link_options inserting option after -link option, cause
+        # linker to ignore it.
+        set(CMAKE_CXX_LINK_FLAGS "${CMAKE_CXX_LINK_FLAGS} -fsycl-device-code-split=per_kernel")
+    endif()
+endif()
+
 set(python_module_name _tensor_impl)
 pybind11_add_module(${python_module_name} MODULE
     ${CMAKE_CURRENT_SOURCE_DIR}/libtensor/source/tensor_py.cpp
@@ -29,7 +37,10 @@ pybind11_add_module(${python_module_name} MODULE
     ${CMAKE_CURRENT_SOURCE_DIR}/libtensor/source/device_support_queries.cpp
 )
 target_link_options(${python_module_name} PRIVATE -fsycl-device-code-split=per_kernel)
-target_link_options(${python_module_name} PRIVATE -fsycl-link-huge-device-code)
+if(UNIX)
+    # this option is support on Linux only
+    target_link_options(${python_module_name} PRIVATE -fsycl-link-huge-device-code)
+endif()
 target_include_directories(${python_module_name}
     PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/../include


### PR DESCRIPTION
Tweaked `bld.bat` to account for possible folder names in `Library\lib\clang`.

Made the logic of patching `Windows-IntelLLVM.cmake` in conda package for cmake 3.22 dependent of existence of the folder.

Modified `CMakeLists.txt` to ensure that SDL flags `/NXCompat /DynamicBase` are correctly applied on Windows.

Worked around issue of oneAPI DPC++ integration with cmake 3.22 to ensure that `-fsycl-device-code-split=per_kernel` is correctly passed to the linker driver. 

Also ensure that `-fsycl-link-huge-device-code` is only added on Linux (option is [not supported](https://www.intel.com/content/www/us/en/develop/documentation/oneapi-dpcpp-cpp-compiler-dev-guide-and-reference/top/compiler-reference/compiler-options/offload-openmp-and-parallel-processing-options/fsycl-link-huge-device-code.html) on Windows).

The following line `python -c "import dpctl.tensor as dpt; print(dpt.arange(10))` can now execute on Windows machine with Iris Xe card.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
