### PR TITLE
Fixes to dpctl-post-link prior changes gh-1081

### DIFF
--- a/conda-recipe/build.sh
+++ b/conda-recipe/build.sh
@@ -36,3 +36,4 @@ mkdir -p $PREFIX/etc/OpenCL/vendors
 echo "dpctl creates symbolic link to system installed /etc/OpenCL/vendors/intel.icd as a work-around." > $PREFIX/etc/OpenCL/vendors/.dpctl_readme
 
 cp $RECIPE_DIR/dpctl-post-link.sh $PREFIX/bin/.dpctl-post-link.sh
+cp $RECIPE_DIR/dpctl-pre-unlink.sh $PREFIX/bin/.dpctl-pre-unlink.sh

--- a/conda-recipe/build.sh
+++ b/conda-recipe/build.sh
@@ -33,5 +33,6 @@ fi
 
 # need to create this folder so ensure that .dpctl-post-link.sh can work correctly
 mkdir -p $PREFIX/etc/OpenCL/vendors
+echo "dpctl creates symbolic link to system installed /etc/OpenCL/vendors/intel.icd as a work-around." > $PREFIX/etc/OpenCL/vendors/.dpctl_readme
 
 cp $RECIPE_DIR/dpctl-post-link.sh $PREFIX/bin/.dpctl-post-link.sh

--- a/conda-recipe/dpctl-post-link.sh
+++ b/conda-recipe/dpctl-post-link.sh
@@ -2,7 +2,8 @@
 
 systemwide_icd=/etc/OpenCL/vendors/intel.icd
 local_vendors=$CONDA_PREFIX/etc/OpenCL/vendors/
+icd_fn=$local_vendors/intel-ocl-gpu.icd
 
-if [[ -f $systemwide_icd && -d $local_vendors && ! -f $local_vendors/intl-ocl-gpu.icd ]]; then
-    ln -s $systemwide_icd  $local_vendors/intel-ocl-gpu.icd
+if [[ -f $systemwide_icd && -d $local_vendors && ! -f $icd_fn ]]; then
+    ln -s $systemwide_icd $icd_fn
 fi

--- a/conda-recipe/dpctl-post-link.sh
+++ b/conda-recipe/dpctl-post-link.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/bash
 
 systemwide_icd=/etc/OpenCL/vendors/intel.icd
-local_vendors=$CONDA_PREFIX/etc/OpenCL/vendors/
+local_vendors=$PREFIX/etc/OpenCL/vendors/
 icd_fn=$local_vendors/intel-ocl-gpu.icd
 
 if [[ -f $systemwide_icd && -d $local_vendors && ! -f $icd_fn ]]; then

--- a/conda-recipe/dpctl-pre-unlink.sh
+++ b/conda-recipe/dpctl-pre-unlink.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/bash
+
+local_vendors=$PREFIX/etc/OpenCL/vendors/
+icd_fn=$local_vendors/intel-ocl-gpu.icd
+
+if [[ -L $icd_fn ]]; then
+    rm $icd_fn
+fi


### PR DESCRIPTION
This PR addresses some shortcomings introduced in gh-1081

conda prunes empty folders, so the dpctl tar-ball did not contain empty etc/OpenCL/vendors folder. Solved by create a dummy `.dpctl_readme` file in that folder.

The script dpctl-post-link.sh contained a type in the filename it was checking should not exist.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
