### PR TITLE
dpctl_sycl_interface.h now includes kernel and kernel_bundle ifaces

### DIFF
--- a/dpctl/apis/include/dpctl_sycl_interface.h
+++ b/dpctl/apis/include/dpctl_sycl_interface.h
@@ -40,4 +40,6 @@
 #include "syclinterface/dpctl_sycl_device_manager.h"
 #include "syclinterface/dpctl_sycl_platform_manager.h"
 #include "syclinterface/dpctl_sycl_queue_manager.h"
+#include "syclinterface/dpctl_sycl_kernel_bundle_interface.h"
+#include "syclinterface/dpctl_sycl_kernel_interface.h"
 // clang-format on


### PR DESCRIPTION
dpctl_sycl_interface.h now includes kernel and kernel_bundle iface headers.

- [x] Have you provided a meaningful PR description?

