### PR TITLE
Try out a hunch that crashes are caused by dangling host_task-s.

### DIFF
--- a/dpctl/apis/include/dpctl4pybind11.hpp
+++ b/dpctl/apis/include/dpctl4pybind11.hpp
@@ -1000,14 +1000,10 @@ sycl::event keep_args_alive(sycl::queue q,
             shp_arr[i]->inc_ref();
         }
         cgh.host_task([=]() {
-            bool guard = (Py_IsInitialized() && !_Py_IsFinalizing());
-            if (guard) {
-                PyGILState_STATE gstate;
-                gstate = PyGILState_Ensure();
-                for (std::size_t i = 0; i < num; ++i) {
-                    shp_arr[i]->dec_ref();
-                }
-                PyGILState_Release(gstate);
+            py::gil_scoped_acquire acquire;
+
+            for (std::size_t i = 0; i < num; ++i) {
+                shp_arr[i]->dec_ref();
             }
         });
     });

--- a/dpctl/tensor/libtensor/source/integer_advanced_indexing.cpp
+++ b/dpctl/tensor/libtensor/source/integer_advanced_indexing.cpp
@@ -599,21 +599,22 @@ usm_ndarray_take(dpctl::tensor::usm_ndarray src,
     std::shared_ptr<shT> host_ind_offsets_shp =
         std::make_shared<shT>(k, ind_allocator);
 
+    std::copy(ind_sh_sts.begin(), ind_sh_sts.end(),
+              host_ind_shapes_strides_shp->begin());
+    std::copy(ind_ptrs.begin(), ind_ptrs.end(), host_ind_ptrs_shp->begin());
+    std::copy(ind_offsets.begin(), ind_offsets.end(),
+              host_ind_offsets_shp->begin());
+
     std::vector<sycl::event> host_task_events;
     host_task_events.reserve(5);
 
-    std::copy(ind_sh_sts.begin(), ind_sh_sts.end(),
-              host_ind_shapes_strides_shp->begin());
     sycl::event packed_ind_ptrs_copy_ev = exec_q.copy<char *>(
         host_ind_ptrs_shp->data(), packed_ind_ptrs, host_ind_ptrs_shp->size());
 
-    std::copy(ind_ptrs.begin(), ind_ptrs.end(), host_ind_ptrs_shp->begin());
     sycl::event packed_ind_shapes_strides_copy_ev = exec_q.copy<py::ssize_t>(
         host_ind_shapes_strides_shp->data(), packed_ind_shapes_strides,
         host_ind_shapes_strides_shp->size());
 
-    std::copy(ind_offsets.begin(), ind_offsets.end(),
-              host_ind_offsets_shp->begin());
     sycl::event packed_ind_offsets_copy_ev = exec_q.copy<py::ssize_t>(
         host_ind_offsets_shp->data(), packed_ind_offsets,
         host_ind_offsets_shp->size());
@@ -1010,38 +1011,39 @@ usm_ndarray_put(dpctl::tensor::usm_ndarray dst,
     std::shared_ptr<shT> host_ind_offsets_shp =
         std::make_shared<shT>(k, ind_allocator);
 
+    std::copy(ind_sh_sts.begin(), ind_sh_sts.end(),
+              host_ind_shapes_strides_shp->begin());
+    std::copy(ind_ptrs.begin(), ind_ptrs.end(), host_ind_ptrs_shp->begin());
+    std::copy(ind_offsets.begin(), ind_offsets.end(),
+              host_ind_offsets_shp->begin());
+
     std::vector<sycl::event> host_task_events;
     host_task_events.reserve(5);
 
-    std::copy(ind_ptrs.begin(), ind_ptrs.end(), host_ind_ptrs_shp->begin());
-    sycl::event device_ind_ptrs_copy_ev = exec_q.copy<char *>(
+    sycl::event packed_ind_ptrs_copy_ev = exec_q.copy<char *>(
         host_ind_ptrs_shp->data(), packed_ind_ptrs, host_ind_ptrs_shp->size());
 
-    std::copy(ind_sh_sts.begin(), ind_sh_sts.end(),
-              host_ind_shapes_strides_shp->begin());
-    sycl::event device_ind_shapes_strides_copy_ev = exec_q.copy<py::ssize_t>(
+    sycl::event packed_ind_shapes_strides_copy_ev = exec_q.copy<py::ssize_t>(
         host_ind_shapes_strides_shp->data(), packed_ind_shapes_strides,
         host_ind_shapes_strides_shp->size());
 
-    std::copy(ind_offsets.begin(), ind_offsets.end(),
-              host_ind_offsets_shp->begin());
-    sycl::event device_ind_offsets_copy_ev = exec_q.copy<py::ssize_t>(
+    sycl::event packed_ind_offsets_copy_ev = exec_q.copy<py::ssize_t>(
         host_ind_offsets_shp->data(), packed_ind_offsets,
         host_ind_offsets_shp->size());
 
     sycl::event shared_ptr_cleanup_host_task =
         exec_q.submit([&](sycl::handler &cgh) {
-            cgh.depends_on(device_ind_ptrs_copy_ev);
-            cgh.depends_on(device_ind_shapes_strides_copy_ev);
-            cgh.depends_on(device_ind_offsets_copy_ev);
-            cgh.host_task([host_ind_ptrs_shp, host_ind_shapes_strides_shp,
-                           host_ind_offsets_shp]() {});
+            cgh.depends_on({packed_ind_offsets_copy_ev,
+                            packed_ind_shapes_strides_copy_ev,
+                            packed_ind_ptrs_copy_ev});
+            cgh.host_task([host_ind_offsets_shp, host_ind_shapes_strides_shp,
+                           host_ind_ptrs_shp]() {});
         });
     host_task_events.push_back(shared_ptr_cleanup_host_task);
 
-    std::vector<sycl::event> ind_pack_depends{device_ind_ptrs_copy_ev,
-                                              device_ind_shapes_strides_copy_ev,
-                                              device_ind_offsets_copy_ev};
+    std::vector<sycl::event> ind_pack_depends{packed_ind_ptrs_copy_ev,
+                                              packed_ind_shapes_strides_copy_ev,
+                                              packed_ind_offsets_copy_ev};
 
     bool is_dst_c_contig = dst.is_c_contiguous();
     bool is_dst_f_contig = dst.is_f_contiguous();

--- a/dpctl/tensor/libtensor/source/integer_advanced_indexing.cpp
+++ b/dpctl/tensor/libtensor/source/integer_advanced_indexing.cpp
@@ -723,8 +723,8 @@ usm_ndarray_take(dpctl::tensor::usm_ndarray src,
         });
     });
 
-    sycl::event::wait(host_task_events);
     sycl::event::wait({take_generic_ev, temporaries_cleanup_ev});
+    sycl::event::wait(host_task_events);
 
     /*
     sycl::event host_task_ev = keep_args_alive(exec_q, {src, py_ind, dst},
@@ -1137,8 +1137,8 @@ usm_ndarray_put(dpctl::tensor::usm_ndarray dst,
         });
     });
 
-    sycl::event::wait(host_task_events);
     sycl::event::wait({put_generic_ev, temporaries_cleanup_ev});
+    sycl::event::wait(host_task_events);
 
     /*
     sycl::event py_obj_cleanup_ev =

--- a/dpctl/tensor/libtensor/source/integer_advanced_indexing.cpp
+++ b/dpctl/tensor/libtensor/source/integer_advanced_indexing.cpp
@@ -229,6 +229,7 @@ std::vector<sycl::event> _populate_packed_shapes_strides_for_indexing(
                 cgh.host_task([packed_host_axes_shapes_strides_shp,
                                packed_host_shapes_strides_shp]() {});
             });
+        clean_up_host_task_ev.wait();
         host_task_events.push_back(clean_up_host_task_ev);
 
         std::vector<sycl::event> v = {device_orthog_shapes_strides_copy_ev,
@@ -282,6 +283,7 @@ std::vector<sycl::event> _populate_packed_shapes_strides_for_indexing(
                 cgh.depends_on(device_axes_shapes_strides_copy_ev);
                 cgh.host_task([packed_host_axes_shapes_strides_shp]() {});
             });
+        clean_up_host_task_ev.wait();
         host_task_events.push_back(clean_up_host_task_ev);
 
         std::vector<sycl::event> v = {device_orthog_shapes_strides_fill_ev,
@@ -627,6 +629,7 @@ usm_ndarray_take(dpctl::tensor::usm_ndarray src,
             cgh.host_task([host_ind_offsets_shp, host_ind_shapes_strides_shp,
                            host_ind_ptrs_shp]() {});
         });
+    shared_ptr_cleanup_host_task.wait();
     host_task_events.push_back(shared_ptr_cleanup_host_task);
 
     std::vector<sycl::event> ind_pack_depends{packed_ind_ptrs_copy_ev,
@@ -1039,6 +1042,7 @@ usm_ndarray_put(dpctl::tensor::usm_ndarray dst,
             cgh.host_task([host_ind_offsets_shp, host_ind_shapes_strides_shp,
                            host_ind_ptrs_shp]() {});
         });
+    shared_ptr_cleanup_host_task.wait();
     host_task_events.push_back(shared_ptr_cleanup_host_task);
 
     std::vector<sycl::event> ind_pack_depends{packed_ind_ptrs_copy_ev,


### PR DESCRIPTION
Added synchronization for every `host_task` that is supposed to manage life-time of temporary vector with usm_host allocator.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [x] If this PR is a work in progress, are you filing the PR as a draft?
