### PR TITLE
get_minmax_offsets should always return data relative to data ptr

### DIFF
--- a/dpctl/apis/include/dpctl4pybind11.hpp
+++ b/dpctl/apis/include/dpctl4pybind11.hpp
@@ -943,8 +943,6 @@ public:
             }
         }
         else {
-            offset_min = api.UsmNDArray_GetOffset_(raw_ar);
-            offset_max = offset_min;
             for (int i = 0; i < nd; ++i) {
                 py::ssize_t delta = strides[i] * (shape[i] - 1);
                 if (strides[i] > 0) {


### PR DESCRIPTION
This means that it should not be making call to `UsmNDArray_GetOffset`. This restores correctness to checks for array region overlapping.

- [x] Have you provided a meaningful PR description?
- [x] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
