### PR TITLE
Removed trailing slash in directory path

### DIFF
--- a/conda-recipe/dpctl-post-link.sh
+++ b/conda-recipe/dpctl-post-link.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/bash
 
 systemwide_icd=/etc/OpenCL/vendors/intel.icd
-local_vendors=$PREFIX/etc/OpenCL/vendors/
+local_vendors=$PREFIX/etc/OpenCL/vendors
 icd_fn=$local_vendors/intel-ocl-gpu.icd
 
 if [[ -f $systemwide_icd && -d $local_vendors && ! -f $icd_fn ]]; then

--- a/conda-recipe/dpctl-pre-unlink.sh
+++ b/conda-recipe/dpctl-pre-unlink.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/bash
 
-local_vendors=$PREFIX/etc/OpenCL/vendors/
+local_vendors=$PREFIX/etc/OpenCL/vendors
 icd_fn=$local_vendors/intel-ocl-gpu.icd
 
 if [[ -L $icd_fn ]]; then


### PR DESCRIPTION
Removed trailing slash in the directory name to avoid double slash in the absolute path of the ICD file.

Related: SAT-5617

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
