### PR TITLE
Class Strided1DIndexer must used min(gid, size-1)

### DIFF
--- a/dpctl/tensor/libtensor/include/kernels/boolean_advanced_indexing.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/boolean_advanced_indexing.hpp
@@ -105,7 +105,9 @@ struct Strided1DIndexer
 
     size_t operator()(size_t gid) const
     {
-        return static_cast<size_t>(offset + std::min<size_t>(gid, size) * step);
+        // ensure 0 <= gid < size
+        return static_cast<size_t>(offset +
+                                   std::min<size_t>(gid, size - 1) * step);
     }
 
 private:


### PR DESCRIPTION
This is needed to ensure that `0<=gid < size`.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
