### PR TITLE
Fix boolean mask asignment scalar

### DIFF
--- a/dpctl/tensor/_copy_utils.py
+++ b/dpctl/tensor/_copy_utils.py
@@ -514,13 +514,17 @@ def _place_impl(ary, ary_mask, vals, axis=0):
         raise TypeError(
             f"Expecting type dpctl.tensor.usm_ndarray, got {type(ary_mask)}"
         )
-    if not isinstance(vals, dpt.usm_ndarray):
-        raise TypeError(
-            f"Expecting type dpctl.tensor.usm_ndarray, got {type(ary_mask)}"
-        )
     exec_q = dpctl.utils.get_execution_queue(
-        (ary.sycl_queue, ary_mask.sycl_queue, vals.sycl_queue)
+        (
+            ary.sycl_queue,
+            ary_mask.sycl_queue,
+        )
     )
+    if exec_q is not None:
+        if not isinstance(vals, dpt.usm_ndarray):
+            vals = dpt.asarray(vals, dtype=ary.dtype, sycl_queue=exec_q)
+        else:
+            exec_q = dpctl.utils.get_execution_queue((exec_q, vals.sycl_queue))
     if exec_q is None:
         raise dpctl.utils.ExecutionPlacementError(
             "arrays have different associated queues. "

--- a/dpctl/tests/test_usm_ndarray_indexing.py
+++ b/dpctl/tests/test_usm_ndarray_indexing.py
@@ -1206,3 +1206,15 @@ def test_nonzero():
     x = dpt.concat((dpt.zeros(3), dpt.ones(4), dpt.zeros(3)))
     (i,) = dpt.nonzero(x)
     assert (dpt.asnumpy(i) == np.array([3, 4, 5, 6])).all()
+
+
+def test_assign_scalar():
+    get_queue_or_skip()
+    x = dpt.arange(-5, 5, dtype="i8")
+    cond = dpt.asarray(
+        [True, True, True, True, True, False, False, False, False, False]
+    )
+    x[cond] = 0  # no error expected
+    x[dpt.nonzero(cond)] = -1
+    expected = np.array([-1, -1, -1, -1, -1, 0, 1, 2, 3, 4], dtype=x.dtype)
+    assert (dpt.asnumpy(x) == expected).all()


### PR DESCRIPTION
Fix for 

```python
import dpnp
x = dpnp.random.randn(200)
x[x<0] = 0   # used to raise TypeError, expecting r.h.s. to be a 0-d usm_ndarray 
```

- [x] Have you provided a meaningful PR description?
- [x] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
