### PR TITLE
Hotfix/incorrect mask positions

### DIFF
--- a/dpctl/tests/test_usm_ndarray_indexing.py
+++ b/dpctl/tests/test_usm_ndarray_indexing.py
@@ -1218,3 +1218,12 @@ def test_assign_scalar():
     x[dpt.nonzero(cond)] = -1
     expected = np.array([-1, -1, -1, -1, -1, 0, 1, 2, 3, 4], dtype=x.dtype)
     assert (dpt.asnumpy(x) == expected).all()
+
+
+def test_nonzero_large():
+    get_queue_or_skip()
+    m = dpt.full((60, 80), True)
+    assert m[m].size == m.size
+
+    m = dpt.full((30, 60, 80), True)
+    assert m[m].size == m.size


### PR DESCRIPTION
This PR fixes an issue found by @antonwolfy where the following test would not clear the assertion:

```python
import dpctl.tensor as dpt
m = dpt.full((60, 80,), True)
assert m[m].size == m.size
```

This was caused by `inclusive_scan_rec` implementation unconditionally applying non-zero indicator transformation on the input data, even for the recursive call where it was unintended. 

The fix is to add the `transformer` argument to the function, and set to it to no-op for the recursive call.

A test is added.

- [x] Have you provided a meaningful PR description?
- [x] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
