### PR TITLE
Add an empty value check for dpt.place

### DIFF
--- a/dpctl/tensor/_indexing_functions.py
+++ b/dpctl/tensor/_indexing_functions.py
@@ -293,6 +293,8 @@ def place(arr, mask, vals):
         raise dpctl.utils.ExecutionPlacementError
     if arr.shape != mask.shape or vals.ndim != 1:
         raise ValueError("Array sizes are not as required")
+    if vals.size == 0:
+        raise ValueError("Cannot insert from an empty array!")
     cumsum = dpt.empty(mask.size, dtype="i8", sycl_queue=exec_q)
     nz_count = ti.mask_positions(mask, cumsum, sycl_queue=exec_q)
     if nz_count == 0:

--- a/dpctl/tests/test_usm_ndarray_indexing.py
+++ b/dpctl/tests/test_usm_ndarray_indexing.py
@@ -1201,6 +1201,16 @@ def test_place_subset():
     assert (dpt.asnumpy(x) == expected).all()
 
 
+def test_place_empty_vals_error():
+    get_queue_or_skip()
+    x = dpt.zeros(10, dtype="f4")
+    y = dpt.empty((0,), dtype=x.dtype)
+    sel = dpt.ones(x.size, dtype="?")
+    sel[::2] = False
+    with pytest.raises(ValueError):
+        dpt.place(x, sel, y)
+
+
 def test_nonzero():
     get_queue_or_skip()
     x = dpt.concat((dpt.zeros(3), dpt.ones(4), dpt.zeros(3)))


### PR DESCRIPTION
This PR adds a check for an empty array for `vals` argument and throws a `ValueError` exception in case of truth as numpy and covers this case with test.

The PR solves #1104.
- [X] Have you provided a meaningful PR description?
- [X] Have you added a test, reproducer or referred to an issue with a reproducer?
- [X] Have you tested your changes locally for CPU and GPU devices?
- [X] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
