### PR TITLE
Update empty vals check in dpt.place

### DIFF
--- a/dpctl/tensor/_indexing_functions.py
+++ b/dpctl/tensor/_indexing_functions.py
@@ -293,7 +293,7 @@ def place(arr, mask, vals):
         raise dpctl.utils.ExecutionPlacementError
     if arr.shape != mask.shape or vals.ndim != 1:
         raise ValueError("Array sizes are not as required")
-    if vals.size == 0:
+    if vals.size == 0 and dpt.nonzero(mask)[0].size:
         raise ValueError("Cannot insert from an empty array!")
     cumsum = dpt.empty(mask.size, dtype="i8", sycl_queue=exec_q)
     nz_count = ti.mask_positions(mask, cumsum, sycl_queue=exec_q)

--- a/dpctl/tensor/_indexing_functions.py
+++ b/dpctl/tensor/_indexing_functions.py
@@ -293,12 +293,12 @@ def place(arr, mask, vals):
         raise dpctl.utils.ExecutionPlacementError
     if arr.shape != mask.shape or vals.ndim != 1:
         raise ValueError("Array sizes are not as required")
-    if vals.size == 0 and dpt.nonzero(mask)[0].size:
-        raise ValueError("Cannot insert from an empty array!")
     cumsum = dpt.empty(mask.size, dtype="i8", sycl_queue=exec_q)
     nz_count = ti.mask_positions(mask, cumsum, sycl_queue=exec_q)
     if nz_count == 0:
         return
+    if vals.size == 0:
+        raise ValueError("Cannot insert from an empty array!")
     if vals.dtype == arr.dtype:
         rhs = vals
     else:

--- a/dpctl/tests/test_usm_ndarray_indexing.py
+++ b/dpctl/tests/test_usm_ndarray_indexing.py
@@ -1211,6 +1211,16 @@ def test_place_empty_vals_error():
         dpt.place(x, sel, y)
 
 
+def test_place_empty_vals_full_false_mask():
+    get_queue_or_skip()
+    x = dpt.ones(10, dtype="f4")
+    y = dpt.empty((0,), dtype=x.dtype)
+    sel = dpt.zeros(x.size, dtype="?")
+    expected = np.ones(10, dtype=x.dtype)
+    dpt.place(x, sel, y)
+    assert (dpt.asnumpy(x) == expected).all()
+
+
 def test_nonzero():
     get_queue_or_skip()
     x = dpt.concat((dpt.zeros(3), dpt.ones(4), dpt.zeros(3)))


### PR DESCRIPTION
This PR complements #1105 .
The original behavior of `numpy.place` throws an exception when it gets  an empty array of `vals` argument
BUT if the `mask` argument contains all `False`, `numpy.place` works without exceptions ([example](https://github.com/numpy/numpy/blob/main/numpy/lib/tests/test_function_base.py#L1335)).

- [X] Have you provided a meaningful PR description?
- [X] Have you added a test, reproducer or referred to an issue with a reproducer?
- [X] Have you tested your changes locally for CPU and GPU devices?
- [X] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
