### PR TITLE
Add sdl flags

### DIFF
--- a/conda-recipe/bld.bat
+++ b/conda-recipe/bld.bat
@@ -4,7 +4,7 @@ set "LIB=%BUILD_PREFIX%\Library\lib;%BUILD_PREFIX%\compiler\lib;%LIB%"
 set "INCLUDE=%BUILD_PREFIX%\include;%INCLUDE%"
 
 "%PYTHON%" setup.py clean --all
-set "SKBUILD_ARGS=-G Ninja -- -DCMAKE_C_COMPILER:PATH=icx -DCMAKE_CXX_COMPILER:PATH=icx"
+set "SKBUILD_ARGS=-G Ninja -- -DCMAKE_C_COMPILER:PATH=icx -DCMAKE_CXX_COMPILER:PATH=icx -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON"
 
 FOR %%V IN (14.0.0 14 15.0.0 15 16.0.0 16) DO @(
   REM set DIR_HINT if directory exists

--- a/conda-recipe/build.sh
+++ b/conda-recipe/build.sh
@@ -14,7 +14,7 @@ if [ -e "_skbuild" ]; then
     ${PYTHON} setup.py clean --all
 fi
 export CMAKE_GENERATOR="Ninja"
-SKBUILD_ARGS="-- -DCMAKE_C_COMPILER:PATH=icx -DCMAKE_CXX_COMPILER:PATH=icpx"
+SKBUILD_ARGS="-- -DCMAKE_C_COMPILER:PATH=icx -DCMAKE_CXX_COMPILER:PATH=icpx -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON"
 echo "${PYTHON} setup.py install ${SKBUILD_ARGS}"
 
 if [ -n "${WHEELS_OUTPUT_FOLDER}" ]; then

--- a/dpctl/CMakeLists.txt
+++ b/dpctl/CMakeLists.txt
@@ -15,13 +15,17 @@ if(WIN32)
         "-Wmissing-declarations "
         "-Wno-unused-parameter "
     )
-    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /Ox ${WARNING_FLAGS}")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /Ox ${WARNING_FLAGS}")
+    string(CONCAT SDL_FLAGS
+        "/GS "
+        "/DynamicBase "
+    )
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /Ox ${WARNING_FLAGS} ${SDL_FLAGS}")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /Ox ${WARNING_FLAGS} ${SDL_FLAGS}")
     set(CMAKE_C_FLAGS_DEBUG
-        "${CMAKE_C_FLAGS_DEBUG} ${WARNING_FLAGS} -O0 -g1 -DDEBUG"
+        "${CMAKE_C_FLAGS_DEBUG} ${WARNING_FLAGS} ${SDL_FLAGS} -O0 -g1 -DDEBUG"
     )
     set(CMAKE_CXX_FLAGS_DEBUG
-        "${CMAKE_CXX_FLAGS_DEBUG} ${WARNING_FLAGS} -O0 -g1 -DDEBUG"
+        "${CMAKE_CXX_FLAGS_DEBUG} ${WARNING_FLAGS} ${SDL_FLAGS} -O0 -g1 -DDEBUG"
     )
     set(DPCTL_LDFLAGS "/NXCompat;/DynamicBase")
 elseif(UNIX)
@@ -44,6 +48,7 @@ elseif(UNIX)
         "-Wformat-security "
         "-fno-strict-overflow "
         "-fno-delete-null-pointer-checks "
+        "-fwrapv "
     )
     string(CONCAT CFLAGS
         "${WARNING_FLAGS}"

--- a/dpctl/tensor/CMakeLists.txt
+++ b/dpctl/tensor/CMakeLists.txt
@@ -49,5 +49,7 @@ target_include_directories(${python_module_name}
     ${CMAKE_CURRENT_SOURCE_DIR}/libtensor/include
     ${CMAKE_CURRENT_SOURCE_DIR}/libtensor/source/
 )
+set(_linker_options "LINKER:${DPCTL_LDFLAGS}")
+target_link_options(${python_module_name} PRIVATE ${_linker_options})
 add_dependencies(${python_module_name} _dpctl4pybind11_deps)
 install(TARGETS ${python_module_name} DESTINATION "dpctl/tensor")

--- a/libsyclinterface/CMakeLists.txt
+++ b/libsyclinterface/CMakeLists.txt
@@ -111,8 +111,12 @@ if(WIN32)
         "-Wuninitialized "
         "-Wmissing-declarations "
     )
-    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${WARNING_FLAGS}")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${WARNING_FLAGS}")
+    string(CONCAT SDL_FLAGS
+        "/GS "
+	"/DynamicBase "
+    )
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${WARNING_FLAGS} ${SDL_FLAGS}")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${WARNING_FLAGS} ${SDL_FLAGS}")
     set(CMAKE_C_FLAGS_DEBUG
         "${CMAKE_C_FLAGS_DEBUG} ${WARNING_FLAGS} -O0 -ggdb3 -DDEBUG"
     )
@@ -139,6 +143,7 @@ elseif(UNIX)
         "-Wformat-security "
         "-fno-strict-overflow "
         "-fno-delete-null-pointer-checks "
+        "-fwrapv "
     )
     string(CONCAT CFLAGS
         "${WARNING_FLAGS}"

--- a/scripts/build_locally.py
+++ b/scripts/build_locally.py
@@ -28,6 +28,7 @@ def run(
     compiler_root=None,
     cmake_executable=None,
     use_glog=False,
+    verbose=False,
     cmake_opts="",
 ):
     build_system = None
@@ -58,6 +59,10 @@ def run(
         "-DDPCTL_ENABLE_L0_PROGRAM_CREATION=" + ("ON" if level_zero else "OFF"),
         "-DDPCTL_ENABLE_GLOG:BOOL=" + ("ON" if use_glog else "OFF"),
     ]
+    if verbose:
+        cmake_args += [
+            "-DCMAKE_VERBOSE_MAKEFILE:BOOL=ON",
+        ]
     if cmake_opts:
         cmake_args += cmake_opts.split()
     subprocess.check_call(
@@ -111,6 +116,12 @@ if __name__ == "__main__":
         "--glog",
         help="DPCTLSyclInterface uses Google logger",
         dest="glog",
+        action="store_true",
+    )
+    driver.add_argument(
+        "--verbose",
+        help="Build using vebose makefile mode",
+        dest="verbose",
         action="store_true",
     )
     driver.add_argument(
@@ -173,5 +184,6 @@ if __name__ == "__main__":
         compiler_root=args.compiler_root,
         cmake_executable=args.cmake_executable,
         use_glog=args.glog,
+        verbose=args.verbose,
         cmake_opts=args.cmake_opts,
     )


### PR DESCRIPTION
Make sure that `-fwrapv` is used on Linux, and `/GS /DynamicBase` is used on Windows. 

`script/build_locally.py` now has `--verbose` mode to invoke `cmake` with `-DCMAKE_MAKEFILE_VERBOSE:BOOL=ON`.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
