### PR TITLE
Make dependency of _usmarray.pyx on *.pxi files explicit in cmake

### DIFF
--- a/dpctl/tensor/CMakeLists.txt
+++ b/dpctl/tensor/CMakeLists.txt
@@ -5,6 +5,13 @@ foreach(_cy_file ${_cython_sources})
     target_include_directories(${_trgt} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include)
 endforeach()
 
+add_custom_target(_usmarray_deps SOURCES
+    ${CMAKE_CURRENT_SOURCE_DIR}/_slicing.pxi
+    ${CMAKE_CURRENT_SOURCE_DIR}/_types.pxi
+    ${CMAKE_CURRENT_SOURCE_DIR}/_stride_utils.pxi
+)
+add_dependencies(_usmarray _usmarray_deps)
+
 add_custom_target(_dpctl4pybind11_deps
     DEPENDS
     _usmarray_copy_capi_include


### PR DESCRIPTION
`"dpctl/tensor/_usmarray.pyx"` includes several `*.pxi` files, but this dependency was not reflect in cmake script. 

This PR addresses that oversight.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
