### PR TITLE
Used functools.cache to cache filter_string property

### DIFF
--- a/dpctl/_sycl_device.pyx
+++ b/dpctl/_sycl_device.pyx
@@ -199,7 +199,7 @@ cdef void _init_helper(_SyclDevice device, DPCTLSyclDeviceRef DRef):
     device._max_work_item_sizes = DPCTLDevice_GetMaxWorkItemSizes3d(DRef)
 
 
-@functools.cache
+@functools.lru_cache(maxsize=None)
 def _cached_filter_string(d : SyclDevice):
     """
     Internal utility to compute filter_string of input SyclDevice


### PR DESCRIPTION
Partially addresses gh-1098, improving timing of `dpctl.SyclDevice.filter_string` property on repeated invocations.

Fixed docstring of `filter_string` property.

Introduced internal `dpctl._sycl_device._cached_filter_string` stand-alone function that is decorated with ``functools.cache``.

Used that internal function in implementation of
`dpctl.SyclDevice.filter_string`.

Caching improved timing of `filter_string` property:

```
In [1]: import dpctl

In [2]: d = dpctl.SyclDevice()

In [3]: %timeit d.filter_string
2.31 µs ± 42.7 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)
```

Previously, the timing was around `200 ms`.

Tests already exist.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
