### PR TITLE
dpctl.tensor.take negative index wrapping fix

### DIFF
--- a/dpctl/tensor/libtensor/include/kernels/integer_advanced_indexing.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/integer_advanced_indexing.hpp
@@ -68,7 +68,8 @@ public:
     void operator()(py::ssize_t max_item, py::ssize_t &ind) const
     {
         max_item = std::max<py::ssize_t>(max_item, 1);
-        ind = (ind < 0) ? ind % max_item + max_item : ind % max_item;
+        ind = (ind < 0) ? (ind + max_item * ((-ind / max_item) + 1)) % max_item
+                        : ind % max_item;
         return;
     }
 };

--- a/dpctl/tests/test_usm_ndarray_indexing.py
+++ b/dpctl/tests/test_usm_ndarray_indexing.py
@@ -891,6 +891,28 @@ def test_put_strided_indices(ind_dt, order):
             assert_array_equal(x_np_copy, dpt.asnumpy(x_copy))
 
 
+def test_integer_indexing_modes():
+    q = get_queue_or_skip()
+
+    x = dpt.arange(5, sycl_queue=q)
+
+    # wrapping
+    ind = dpt.asarray([-6, -3, 0, 2, 6], dtype=np.intp, sycl_queue=q)
+    res = dpt.take(x, ind, mode="wrap")
+    expected_arr = np.take(dpt.asnumpy(x), dpt.asnumpy(ind), mode="wrap")
+
+    assert (dpt.asnumpy(res) == expected_arr).all()
+
+    # clipping to -n<=i<n,
+    # where n is the axis length
+    ind = dpt.asarray([-4, -3, 0, 2, 4], dtype=np.intp, sycl_queue=q)
+
+    res = dpt.take(x, ind, mode="clip")
+    expected_arr = np.take(dpt.asnumpy(x), dpt.asnumpy(ind), mode="raise")
+
+    assert (dpt.asnumpy(res) == expected_arr).all()
+
+
 def test_take_arg_validation():
     q = get_queue_or_skip()
 


### PR DESCRIPTION
Closes #1126 
This PR fixes incorrect logic in the WrapIndex class.
The previous logic was implemented to handle cases where modulus returns negative, but broke the implementation for indices lower than `-max_item`.
This re-implementation solves this.

- [X] Have you provided a meaningful PR description?
- [X] Have you added a test, reproducer or referred to an issue with a reproducer?
- [X] Have you tested your changes locally for CPU and GPU devices?
- [X] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
