### PR TITLE
Changes to integer indexing modes

### DIFF
--- a/dpctl/tensor/libtensor/source/integer_advanced_indexing.cpp
+++ b/dpctl/tensor/libtensor/source/integer_advanced_indexing.cpp
@@ -39,9 +39,10 @@
 
 #include "integer_advanced_indexing.hpp"
 
-#define INDEXING_MODES 2
-#define CLIP_MODE 0
-#define WRAP_MODE 1
+#define INDEXING_MODES 3
+#define FANCY_MODE 0
+#define CLIP_MODE 1
+#define WRAP_MODE 2
 
 namespace dpctl
 {
@@ -252,8 +253,8 @@ usm_ndarray_take(dpctl::tensor::usm_ndarray src,
         throw py::value_error("Axis cannot be negative.");
     }
 
-    if (mode != 0 && mode != 1) {
-        throw py::value_error("Mode must be 0 or 1.");
+    if (mode != 0 && mode != 1 && mode != 2) {
+        throw py::value_error("Mode must be 0, 1, or 2.");
     }
 
     const dpctl::tensor::usm_ndarray ind_rep = ind[0];
@@ -575,8 +576,8 @@ usm_ndarray_put(dpctl::tensor::usm_ndarray dst,
         throw py::value_error("Axis cannot be negative.");
     }
 
-    if (mode != 0 && mode != 1) {
-        throw py::value_error("Mode must be 0 or 1.");
+    if (mode != 0 && mode != 1 && mode != 2) {
+        throw py::value_error("Mode must be 0, 1, or 2.");
     }
 
     if (!dst.is_writable()) {
@@ -883,6 +884,11 @@ void init_advanced_indexing_dispatch_tables(void)
 {
     using namespace dpctl::tensor::detail;
 
+    using dpctl::tensor::kernels::indexing::TakeFancyFactory;
+    DispatchTableBuilder<take_fn_ptr_t, TakeFancyFactory, num_types>
+        dtb_takefancy;
+    dtb_takefancy.populate_dispatch_table(take_dispatch_table[FANCY_MODE]);
+
     using dpctl::tensor::kernels::indexing::TakeClipFactory;
     DispatchTableBuilder<take_fn_ptr_t, TakeClipFactory, num_types>
         dtb_takeclip;
@@ -892,6 +898,10 @@ void init_advanced_indexing_dispatch_tables(void)
     DispatchTableBuilder<take_fn_ptr_t, TakeWrapFactory, num_types>
         dtb_takewrap;
     dtb_takewrap.populate_dispatch_table(take_dispatch_table[WRAP_MODE]);
+
+    using dpctl::tensor::kernels::indexing::PutFancyFactory;
+    DispatchTableBuilder<put_fn_ptr_t, PutFancyFactory, num_types> dtb_putfancy;
+    dtb_putfancy.populate_dispatch_table(put_dispatch_table[FANCY_MODE]);
 
     using dpctl::tensor::kernels::indexing::PutClipFactory;
     DispatchTableBuilder<put_fn_ptr_t, PutClipFactory, num_types> dtb_putclip;

--- a/dpctl/tests/test_usm_ndarray_indexing.py
+++ b/dpctl/tests/test_usm_ndarray_indexing.py
@@ -895,11 +895,20 @@ def test_integer_indexing_modes():
     q = get_queue_or_skip()
 
     x = dpt.arange(5, sycl_queue=q)
+    x_np = dpt.asnumpy(x)
+
+    ind = dpt.asarray([-6, -3, 0, 2, 6], dtype=np.intp, sycl_queue=q)
+    ind_np = dpt.asnumpy(ind)
 
     # wrapping
-    ind = dpt.asarray([-6, -3, 0, 2, 6], dtype=np.intp, sycl_queue=q)
     res = dpt.take(x, ind, mode="wrap")
-    expected_arr = np.take(dpt.asnumpy(x), dpt.asnumpy(ind), mode="wrap")
+    expected_arr = np.take(x_np, ind_np, mode="wrap")
+
+    assert (dpt.asnumpy(res) == expected_arr).all()
+
+    # clipping to 0 (disabling negative indices)
+    res = dpt.take(x, ind, mode="clip")
+    expected_arr = np.take(x_np, ind_np, mode="clip")
 
     assert (dpt.asnumpy(res) == expected_arr).all()
 
@@ -907,7 +916,7 @@ def test_integer_indexing_modes():
     # where n is the axis length
     ind = dpt.asarray([-4, -3, 0, 2, 4], dtype=np.intp, sycl_queue=q)
 
-    res = dpt.take(x, ind, mode="clip")
+    res = dpt.take(x, ind, mode="fancy")
     expected_arr = np.take(dpt.asnumpy(x), dpt.asnumpy(ind), mode="raise")
 
     assert (dpt.asnumpy(res) == expected_arr).all()


### PR DESCRIPTION
Resolves #1129 
- Re-implements ClipIndex to clip indices from 0 <= i < n
- Adds FancyIndex class, which clips indices to -n <= i < n then wraps negative indices (old ClipIndex)
- Integer indexing functions have "fancy" mode (old "clip") and "clip" mode (uses new behavior)
- dpctl.tensor.take and dpctl.tensor.put now default to "fancy" mode rather than "clip" mode
- Indexing mode tests now test for new clip behavior

- [X] Have you provided a meaningful PR description?
- [X] Have you added a test, reproducer or referred to an issue with a reproducer?
- [X] Have you tested your changes locally for CPU and GPU devices?
- [X] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
