### PR TITLE
Slicing bug gh 1135

### DIFF
--- a/dpctl/tests/test_usm_ndarray_indexing.py
+++ b/dpctl/tests/test_usm_ndarray_indexing.py
@@ -455,6 +455,32 @@ def test_integer_strided_indexing():
     assert (dpt.asnumpy(y) == dpt.asnumpy(yc)).all()
 
 
+def test_TrueFalse_indexing():
+    get_queue_or_skip()
+    n0, n1 = 2, 3
+    x = dpt.ones((n0, n1))
+    for ind in [True, dpt.asarray(True)]:
+        y1 = x[ind]
+        assert y1.shape == (1, n0, n1)
+        assert y1._pointer == x._pointer
+        y2 = x[:, ind]
+        assert y2.shape == (n0, 1, n1)
+        assert y2._pointer == x._pointer
+        y3 = x[..., ind]
+        assert y3.shape == (n0, n1, 1)
+        assert y3._pointer == x._pointer
+    for ind in [False, dpt.asarray(False)]:
+        y1 = x[ind]
+        assert y1.shape == (0, n0, n1)
+        assert y1._pointer == x._pointer
+        y2 = x[:, ind]
+        assert y2.shape == (n0, 0, n1)
+        assert y2._pointer == x._pointer
+        y3 = x[..., ind]
+        assert y3.shape == (n0, n1, 0)
+        assert y3._pointer == x._pointer
+
+
 @pytest.mark.parametrize(
     "data_dt",
     _all_dtypes,


### PR DESCRIPTION
Closes gh-1135.

Handle `x[True]` and `x[False]` as NumPy does, even though the behavior
may be undocumented. NumPy treats `True` as `None` (insert axis with size 1),
and treats `False` as `None` followed by empty slicing (insert axis with size 0).

Changed the logic of `_basic_slice_meta` utility function to correctly handle
boolean scalars (surprisingly, `insinstance(True, int)` evaluates to `True`).
0d arrays are handled on the same footing as the Python scalars.

Introduced `_is_integral` and `_is_boolean` utilty functions and used them in
`_basic_slice_meta` utility.

- [x] Have you provided a meaningful PR description?
- [x] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
