### PR TITLE
Allow for mutation of usm_ndarray.flags.writable flag

### DIFF
--- a/dpctl/tensor/_flags.pyx
+++ b/dpctl/tensor/_flags.pyx
@@ -75,6 +75,12 @@ cdef class Flags:
         """
         return _check_bit(self.flags_, USM_ARRAY_WRITABLE)
 
+    @writable.setter
+    def writable(self, new_val):
+        if not isinstance(new_val, bool):
+            raise TypeError("Expecting a boolean value")
+        self.arr_._set_writable_flag(new_val)
+
     @property
     def fc(self):
         """
@@ -128,6 +134,14 @@ cdef class Flags:
             return self.fc
         elif name == "CONTIGUOUS":
             return self.forc
+
+    def __setitem__(self, name, val):
+        if name in ["WRITABLE", "W"]:
+            self.writable = val
+        else:
+            raise ValueError(
+                "Only writable ('W' or 'WRITABLE') flag can be set"
+            )
 
     def __repr__(self):
         out = []

--- a/dpctl/tensor/_usmarray.pxd
+++ b/dpctl/tensor/_usmarray.pxd
@@ -72,4 +72,6 @@ cdef api class usm_ndarray [object PyUSMArrayObject, type PyUSMArrayType]:
     cdef dpctl.DPCTLSyclQueueRef get_queue_ref(self) except *
     cdef dpctl.SyclQueue get_sycl_queue(self)
 
+    cdef _set_writable_flag(self, int)
+
     cdef __cythonbufferdefaults__ = {"mode": "strided"}

--- a/dpctl/tensor/_usmarray.pyx
+++ b/dpctl/tensor/_usmarray.pyx
@@ -532,6 +532,12 @@ cdef class usm_ndarray:
         """
         return _flags.Flags(self, self.flags_)
 
+    cdef _set_writable_flag(self, int flag):
+        cdef int arr_fl = self.flags_
+        arr_fl ^= (arr_fl & USM_ARRAY_WRITABLE)  # unset WRITABLE flag
+        arr_fl |= (USM_ARRAY_WRITABLE if flag else 0)
+        self.flags_ = arr_fl
+
     @property
     def usm_type(self):
         """
@@ -1390,12 +1396,10 @@ cdef api Py_ssize_t UsmNDArray_GetOffset(usm_ndarray arr):
     allocation"""
     return arr.get_offset()
 
+
 cdef api void UsmNDArray_SetWritableFlag(usm_ndarray arr, int flag):
     """Set/unset USM_ARRAY_WRITABLE in the given array `arr`."""
-    cdef int arr_fl = arr.flags_
-    arr_fl ^= (arr_fl & USM_ARRAY_WRITABLE)  # unset WRITABLE flag
-    arr_fl |= (USM_ARRAY_WRITABLE if flag else 0)
-    arr.flags_ = arr_fl
+    arr._set_writable_flag(flag)
 
 cdef api object UsmNDArray_MakeSimpleFromMemory(
     int nd, const Py_ssize_t *shape, int typenum,

--- a/dpctl/tests/test_usm_ndarray_ctor.py
+++ b/dpctl/tests/test_usm_ndarray_ctor.py
@@ -57,6 +57,7 @@ def test_allocate_usm_ndarray(shape, usm_type):
 
 
 def test_usm_ndarray_flags():
+    get_queue_or_skip()
     assert dpt.usm_ndarray((5,), dtype="i4").flags.fc
     assert dpt.usm_ndarray((5, 2), dtype="i4").flags.c_contiguous
     assert dpt.usm_ndarray((5, 2), dtype="i4", order="F").flags.f_contiguous
@@ -68,6 +69,17 @@ def test_usm_ndarray_flags():
         (5, 1, 2), dtype="i4", strides=(1, 0, 5)
     ).flags.f_contiguous
     assert dpt.usm_ndarray((5, 1, 1), dtype="i4", strides=(1, 0, 1)).flags.fc
+    x = dpt.empty(5, dtype="u2")
+    assert x.flags.writable is True
+    x.flags.writable = False
+    assert x.flags.writable is False
+    with pytest.raises(ValueError):
+        x[:] = 0
+    x.flags["W"] = True
+    assert x.flags.writable is True
+    x.flags["WRITABLE"] = True
+    assert x.flags.writable is True
+    x[:] = 0
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Closes gh-1138

Example:

```python
In [3]: x = dpt.ones((2,2))

In [4]: x.flags.writable
Out[4]: True

In [5]: x.flags.writable = False

In [6]: x.flags.writable
Out[6]: False

In [7]: x[:] = 0
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
Input In [7], in <cell line: 1>()
----> 1 x[:] = 0

File ~/repos/dpctl/dpctl/tensor/_usmarray.pyx:1002, in dpctl.tensor._usmarray.usm_ndarray.__setitem__()
   1000
   1001         if (self.flags_ & USM_ARRAY_WRITABLE) == 0:
-> 1002             raise ValueError("Can not modify read-only array.")
   1003
   1004         _meta = _basic_slice_meta(

ValueError: Can not modify read-only array.
```

- [x] Have you provided a meaningful PR description?
- [x] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
