### PR TITLE
Fix redundant steps in workflows

### DIFF
--- a/.github/workflows/conda-package.yml
+++ b/.github/workflows/conda-package.yml
@@ -323,7 +323,6 @@ jobs:
         env:
           ANACONDA_TOKEN: ${{ secrets.ANACONDA_TOKEN }}
         run: |
-          conda install anaconda-client
           anaconda --token $ANACONDA_TOKEN upload --user dppy --label dev ${PACKAGE_NAME}-*.tar.bz2
 
   upload_windows:
@@ -349,7 +348,6 @@ jobs:
         env:
           ANACONDA_TOKEN: ${{ secrets.ANACONDA_TOKEN }}
         run: |
-          conda install anaconda-client
           anaconda --token ${{ env.ANACONDA_TOKEN }} upload --user dppy --label dev ${{ env.PACKAGE_NAME }}-*.tar.bz2
 
   test_examples_linux:

--- a/.github/workflows/os-llvm-sycl-build.yml
+++ b/.github/workflows/os-llvm-sycl-build.yml
@@ -150,7 +150,6 @@ jobs:
           export LD_LIBRARY_PATH=${SYCL_BUNDLE_FOLDER}/${TBB_INSTALL_DIR}/lib/intel64/gcc4.8:${LD_LIBRARY_PATH}
           export OCL_ICD_FILENAMES=libintelocl.so:libintelocl_emu.so
           python -m dpctl -f || exit 1
-          python -m pytest -v dpctl/tests
 
       - name: Run dpctl/tests
         shell: bash -l {0}


### PR DESCRIPTION
Workflow to build `dpctl` with open source LLVM SYCL bundle was exercising test suite twice. Excising one of these runs. 

Workflow to build conda packages was attempting to install `anaconda-client` twice in upload step. Removed one install. 

Thank you @samaid for catching these inefficiencies.

- [x] Have you provided a meaningful PR description?
