### PR TITLE
Improved error handling for usm_ndarray.__setitem__

### DIFF
--- a/dpctl/tensor/_usmarray.pyx
+++ b/dpctl/tensor/_usmarray.pyx
@@ -1110,13 +1110,19 @@ cdef class usm_ndarray:
                             "converted to usm_ndarray"
                         )
                 else:
+                    rhs_np = np.asarray(rhs)
+                    if type_bytesize(rhs_np.dtype.num) < 0:
+                        raise ValueError(
+                            f"Input of type {type(rhs)} can not be "
+                            "assigned to usm_ndarray because of "
+                            f"unsupported data type '{rhs_np.dtype}'"
+                        )
                     try:
-                        rhs_np = np.asarray(rhs)
                         _copy_from_numpy_into(Xv, rhs_np)
                     except Exception:
                         raise ValueError(
                             f"Input of type {type(rhs)} could not be "
-                            "converted to usm_ndarray"
+                            "copied into dpctl.tensor.usm_ndarray"
                         )
             return
 


### PR DESCRIPTION
While reviewing #1139 the following suboptimal behavior was highlighted:

```python
import dpctl.tensor as dpt, numpy as np

u, n = dpt.empty(5), np.ones(5, dtype="O")
u[...] = n
```

This example used to raise a cascade of exceptions starting with cryptic  "RuntimeError: Unrecogized typenum 17 encountered.", where typenum 17 corresponds to type object. The latest exception raised was `ValueError`.

After this change, the error message is crisper:

```
ValueError: Input of type <class 'numpy.ndarray'> can not be \
    assigned to usm_ndarray because of unsupported data \
    type 'object'
```

Tests exist.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
