### PR TITLE
Validation of integer indexing modes fixed

### DIFF
--- a/dpctl/tensor/libtensor/source/integer_advanced_indexing.cpp
+++ b/dpctl/tensor/libtensor/source/integer_advanced_indexing.cpp
@@ -253,8 +253,8 @@ usm_ndarray_take(dpctl::tensor::usm_ndarray src,
         throw py::value_error("Axis cannot be negative.");
     }
 
-    if (mode != 0 && mode != 1 && mode != 2) {
-        throw py::value_error("Mode must be 0, 1, or 2.");
+    if (mode != 0 && mode != 1) {
+        throw py::value_error("Mode must be 0 or 1.");
     }
 
     const dpctl::tensor::usm_ndarray ind_rep = ind[0];
@@ -564,8 +564,8 @@ usm_ndarray_put(dpctl::tensor::usm_ndarray dst,
         throw py::value_error("Axis cannot be negative.");
     }
 
-    if (mode != 0 && mode != 1 && mode != 2) {
-        throw py::value_error("Mode must be 0, 1, or 2.");
+    if (mode != 0 && mode != 1) {
+        throw py::value_error("Mode must be 0 or 1.");
     }
 
     if (!dst.is_writable()) {


### PR DESCRIPTION
- No longer permits passing 2 as a flag (leftover from changes to clip and wrap modes)

- [X] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [X] Have you tested your changes locally for CPU and GPU devices?
- [X] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
