### PR TITLE
Running tests needs setuptools for test_cython_capi test

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -33,6 +33,7 @@ requirements:
 test:
     requires:
         - cython
+        - setuptools
         - pytest
         - pytest-cov
 


### PR DESCRIPTION
The test `test_cython_capi` requires setuptools, so it should be recorded in test requirements.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
