### PR TITLE
As type supports sequence of arrays from multiple devices

### DIFF
--- a/dpctl/tests/test_tensor_asarray.py
+++ b/dpctl/tests/test_tensor_asarray.py
@@ -337,5 +337,13 @@ def test_asarray_seq_of_arrays_on_different_queues():
     assert res.sycl_queue == q3
     assert dpt.isdtype(res.dtype, "integral")
 
+    res = dpt.asarray([m, [w, w]], sycl_queue=q)
+    assert res.sycl_queue == q
+    assert dpt.isdtype(res.dtype, "integral")
+
+    res = dpt.asarray([m, [w, dpt.asnumpy(w)]], sycl_queue=q2)
+    assert res.sycl_queue == q2
+    assert dpt.isdtype(res.dtype, "integral")
+
     with pytest.raises(dpctl.utils.ExecutionPlacementError):
         dpt.asarray([m, [w, py_seq]])

--- a/dpctl/tests/test_tensor_asarray.py
+++ b/dpctl/tests/test_tensor_asarray.py
@@ -321,3 +321,21 @@ def test_asarray_seq_of_suai_different_queue():
     x = dpt.asarray([d, d], sycl_queue=q)
     assert x.sycl_queue == q
     assert x.shape == (2,) + d.shape
+
+
+def test_asarray_seq_of_arrays_on_different_queues():
+    q = get_queue_or_skip()
+
+    m = dpt.empty((2, 4), dtype="i2", sycl_queue=q)
+    q2 = dpctl.SyclQueue()
+    w = dpt.empty(4, dtype="i1", sycl_queue=q2)
+    q3 = dpctl.SyclQueue()
+    py_seq = [
+        0,
+    ] * w.shape[0]
+    res = dpt.asarray([m, [w, py_seq]], sycl_queue=q3)
+    assert res.sycl_queue == q3
+    assert dpt.isdtype(res.dtype, "integral")
+
+    with pytest.raises(dpctl.utils.ExecutionPlacementError):
+        dpt.asarray([m, [w, py_seq]])

--- a/dpctl/tests/test_tensor_asarray.py
+++ b/dpctl/tests/test_tensor_asarray.py
@@ -337,12 +337,20 @@ def test_asarray_seq_of_arrays_on_different_queues():
     assert res.sycl_queue == q3
     assert dpt.isdtype(res.dtype, "integral")
 
+    res = dpt.asarray([m, [w, range(w.shape[0])]], sycl_queue=q3)
+    assert res.sycl_queue == q3
+    assert dpt.isdtype(res.dtype, "integral")
+
     res = dpt.asarray([m, [w, w]], sycl_queue=q)
     assert res.sycl_queue == q
     assert dpt.isdtype(res.dtype, "integral")
 
     res = dpt.asarray([m, [w, dpt.asnumpy(w)]], sycl_queue=q2)
     assert res.sycl_queue == q2
+    assert dpt.isdtype(res.dtype, "integral")
+
+    res = dpt.asarray([w, dpt.asnumpy(w)])
+    assert res.sycl_queue == w.sycl_queue
     assert dpt.isdtype(res.dtype, "integral")
 
     with pytest.raises(dpctl.utils.ExecutionPlacementError):


### PR DESCRIPTION
Added support for `asarray` to create arrays from sequences of usm_ndarray objects allocated on different devices, and other Python sequences or numpy arrays.

```
In [1]: import dpctl, dpctl.tensor as dpt

In [2]: m = dpt.zeros((2, 4), dtype="i2", device="cpu")

In [3]: w = dpt.full(4, -1, device="opencl:gpu")

In [4]: res = dpt.asarray([m, [w, [0,] * 4 ]], dtype="f4", device="cpu")

In [5]: res
Out[5]:
usm_ndarray([[[ 0.,  0.,  0.,  0.],
              [ 0.,  0.,  0.,  0.]],

             [[-1., -1., -1., -1.],
              [ 0.,  0.,  0.,  0.]]], dtype=float32)

In [6]: res.device
Out[6]: Device(opencl:cpu:0)
```

- [x] Have you provided a meaningful PR description?
- [x] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
