### PR TITLE
Fixed typo resulting in backwards FNC flag

### DIFF
--- a/dpctl/tensor/_flags.pyx
+++ b/dpctl/tensor/_flags.pyx
@@ -110,8 +110,8 @@ cdef class Flags:
         instance is F-contiguous and not C-contiguous.
         """
         return (
-           _check_bit(self.flags_, USM_ARRAY_C_CONTIGUOUS)
-           and not _check_bit(self.flags_, USM_ARRAY_F_CONTIGUOUS)
+           _check_bit(self.flags_, USM_ARRAY_F_CONTIGUOUS)
+           and not _check_bit(self.flags_, USM_ARRAY_C_CONTIGUOUS)
         )
 
     @property
@@ -132,7 +132,9 @@ cdef class Flags:
             return self.writable
         elif name == "FC":
             return self.fc
-        elif name == "CONTIGUOUS":
+        elif name == "FNC":
+            return self.fnc
+        elif name in ["FORC", "CONTIGUOUS"]:
             return self.forc
 
     def __setitem__(self, name, val):

--- a/dpctl/tests/test_usm_ndarray_ctor.py
+++ b/dpctl/tests/test_usm_ndarray_ctor.py
@@ -60,14 +60,20 @@ def test_usm_ndarray_flags():
     get_queue_or_skip()
     assert dpt.usm_ndarray((5,), dtype="i4").flags.fc
     assert dpt.usm_ndarray((5, 2), dtype="i4").flags.c_contiguous
+    assert not dpt.usm_ndarray((5, 2), dtype="i4").flags.fnc
     assert dpt.usm_ndarray((5, 2), dtype="i4", order="F").flags.f_contiguous
     assert dpt.usm_ndarray((5, 1, 2), dtype="i4", order="F").flags.f_contiguous
+    assert dpt.usm_ndarray((5, 1, 2), dtype="i4", order="F").flags.fnc
     assert dpt.usm_ndarray(
         (5, 1, 2), dtype="i4", strides=(2, 0, 1)
     ).flags.c_contiguous
+    assert not dpt.usm_ndarray(
+        (5, 1, 2), dtype="i4", strides=(2, 0, 1)
+    ).flags.fnc
     assert dpt.usm_ndarray(
         (5, 1, 2), dtype="i4", strides=(1, 0, 5)
     ).flags.f_contiguous
+    assert dpt.usm_ndarray((5, 1, 2), dtype="i4", strides=(1, 0, 5)).flags.fnc
     assert dpt.usm_ndarray((5, 1, 1), dtype="i4", strides=(1, 0, 1)).flags.fc
     x = dpt.empty(5, dtype="u2")
     assert x.flags.writable is True


### PR DESCRIPTION
- FNC (F-not-C-contiguous) flag was returning CNF instead
- Added tests for correct behavior

- [X] Have you provided a meaningful PR description?
- [X] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [X] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
