### PR TITLE
Corrected help string for cmake-opts option of build_locally

### DIFF
--- a/scripts/build_locally.py
+++ b/scripts/build_locally.py
@@ -126,7 +126,7 @@ if __name__ == "__main__":
     )
     driver.add_argument(
         "--cmake-opts",
-        help="DPCTLSyclInterface uses Google logger",
+        help="Options to pass through to cmake",
         dest="cmake_opts",
         default="",
         type=str,


### PR DESCRIPTION
This PR corrects help string associated with `cmake-opt` CLI option of `scripts/build_locally.py` script.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
