### PR TITLE
Adjusting test_windows step to work with intel-opencl-rt=2023.1.0

### DIFF
--- a/.github/workflows/conda-package.yml
+++ b/.github/workflows/conda-package.yml
@@ -269,22 +269,10 @@ jobs:
       - name: Configure Intel OpenCL CPU RT
         shell: pwsh
         run: |
-          if (-not (Test-Path -Path HKLM:\SOFTWARE\Khronos)) {
-              New-Item -Path HKLM:\SOFTWARE\Khronos
-          }
-          if (-not (Test-Path -Path HKLM:\SOFTWARE\Khronos\OpenCL)) {
-              New-Item -Path HKLM:\SOFTWARE\Khronos\OpenCL
-          }
-          if (-not (Test-Path -Path HKLM:\SOFTWARE\Khronos\OpenCL\Vendors)) {
-              New-Item -Path HKLM:\SOFTWARE\Khronos\OpenCL\Vendors
-          }
-          $conda_env_library = "$env:CONDA_PREFIX\Library"
-          New-ItemProperty -Path HKLM:\SOFTWARE\Khronos\OpenCL\Vendors -Name $conda_env_library\lib\intelocl64.dll -Value 0
-          Write-Host $(Get-Item -Path HKLM:\SOFTWARE\Khronos\OpenCL\Vendors)
-          # Variable assisting OpenCL CPU driver to find TBB DLLs which are not located where it expects them by default
-          $cl_cfg="$conda_env_library\lib\cl.cfg"
-          Write-Output $cl_cfg
-          (Get-Content $cl_cfg) -replace '^CL_CONFIG_TBB_DLL_PATH =', "CL_CONFIG_TBB_DLL_PATH = $conda_env_library\bin" | Set-Content $cl_cfg
+          $script_path="$env:CONDA_PREFIX\Scripts\set-intel-ocl-icd-registry.ps1"
+          &$script_path
+          # Check the variable assisting OpenCL CPU driver to find TBB DLLs which are not located where it expects them by default
+          $cl_cfg="$env:CONDA_PREFIX\Library\lib\cl.cfg"
           Get-Content -Tail 5 -Path $cl_cfg
       - name: Smoke test, step 1
         shell: cmd /C CALL {0}


### PR DESCRIPTION
In CI, shell scripts are executed with elevated privileges, hence OpenCL loader ignores variable `OCL_ICD_FILENAMES`. One must set a registry value. `intel-opencl-rt` comes with a script to do that.

It also comes with fixed `cl.cfg` file, so the step to modify `cl.cfg` in situ is no longer needed, and in fact corrupts the file.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
