### PR TITLE
Got rid of setting OCL_ICD_FILENAMES now that intel-opencl-rt is fixed

### DIFF
--- a/.github/workflows/conda-package.yml
+++ b/.github/workflows/conda-package.yml
@@ -161,14 +161,11 @@ jobs:
         run: |
           . $CONDA/etc/profile.d/conda.sh
           conda activate test_dpctl
-          export OCL_ICD_FILENAMES=libintelocl.so
           python -c "import dpctl; dpctl.lsplatform()"
       - name: Run tests
         run: |
           . $CONDA/etc/profile.d/conda.sh
           conda activate test_dpctl
-          # echo "libintelocl.so" | tee /etc/OpenCL/vendors/intel-cpu.icd
-          export OCL_ICD_FILENAMES=libintelocl.so
           # clinfo -l
           python -m pytest --pyargs $MODULE_NAME
 
@@ -413,7 +410,6 @@ jobs:
         shell: bash -l {0}
         run: |
           source $CONDA/etc/profile.d/conda.sh
-          export OCL_ICD_FILENAMES=libintelocl.so
           conda activate examples
           conda list
           cd examples/pybind11
@@ -441,7 +437,6 @@ jobs:
         shell: bash -l {0}
         run: |
           source $CONDA/etc/profile.d/conda.sh
-          export OCL_ICD_FILENAMES=libintelocl.so
           conda activate examples
           conda list
           cd examples/cython
@@ -458,7 +453,6 @@ jobs:
         shell: bash -l {0}
         run: |
           source $CONDA/etc/profile.d/conda.sh
-          export OCL_ICD_FILENAMES=libintelocl.so
           conda activate examples
           conda list
           cd examples/c
@@ -476,7 +470,6 @@ jobs:
         run: |
           cd examples/python
           source $CONDA/etc/profile.d/conda.sh
-          export OCL_ICD_FILENAMES=libintelocl.so
           conda activate examples
           for script in $(find . \( -not -name "_*" -and -name "*.py" \))
           do
@@ -581,7 +574,6 @@ jobs:
           . $CONDA/etc/profile.d/conda.sh
           conda activate test_dpctl
           # echo "libintelocl.so" | tee /etc/OpenCL/vendors/intel-cpu.icd
-          export OCL_ICD_FILENAMES=libintelocl.so
           python -c "import dpctl; dpctl.lsplatform()"
           export ARRAY_API_TESTS_MODULE=dpctl.tensor
           cd /home/runner/work/array-api-tests


### PR DESCRIPTION
Since intel-opencl-rt=2023.1.0 has corrected logic to activate OpenCL CPU RT, the kludge can be removed.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
