### PR TITLE
Add USMAllocationError exception, use it for USM allocation failures

### DIFF
--- a/dpctl/memory/__init__.py
+++ b/dpctl/memory/__init__.py
@@ -32,6 +32,7 @@ from ._memory import (
     MemoryUSMDevice,
     MemoryUSMHost,
     MemoryUSMShared,
+    USMAllocationError,
     as_usm_memory,
 )
 
@@ -39,5 +40,6 @@ __all__ = [
     "MemoryUSMDevice",
     "MemoryUSMHost",
     "MemoryUSMShared",
+    "USMAllocationError",
     "as_usm_memory",
 ]


### PR DESCRIPTION
This PR addresses concern about use of non-descriptive RuntimeError exception in earlier versions raised in issue gh-1158

```
In [1]: import dpctl

In [2]: import dpctl.memory as dpm

In [3]: dpm.MemoryUSMDevice( 1024 * 1024 * 1024 * 8)
---------------------------------------------------------------------------
USMAllocationError                        Traceback (most recent call last)
Input In [3], in <cell line: 1>()
----> 1 dpm.MemoryUSMDevice( 1024 * 1024 * 1024 * 8)

File ~/repos/dpctl/dpctl/memory/_memory.pyx:783, in dpctl.memory._memory.MemoryUSMDevice.__cinit__()
    781           SyclQueue queue=None, int copy=False):
    782 if (isinstance(other, numbers.Integral)):
--> 783     self._cinit_alloc(alignment, <Py_ssize_t>other, b"device", queue)
    784 else:
    785     self._cinit_other(other)

File ~/repos/dpctl/dpctl/memory/_memory.pyx:201, in dpctl.memory._memory._Memory._cinit_alloc()
    199     self.queue = queue
    200 else:
--> 201     raise USMAllocationError(
    202         "USM allocation failed"
    203     )

USMAllocationError: USM allocation failed

In [4]: quit
```

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [x] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
