### PR TITLE
Simplify copy and cast kernels

### DIFF
--- a/dpctl/tensor/libtensor/include/kernels/copy_and_cast.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/copy_and_cast.hpp
@@ -197,7 +197,7 @@ template <typename fnT, typename D, typename S> struct CopyAndCastGenericFactory
     }
 };
 
-// Specialization of copy_and_cast for contiguous arrays of different data types
+// Specialization of copy_and_cast for contiguous arrays
 
 template <typename srcT,
           typename dstT,
@@ -339,21 +339,15 @@ sycl::event copy_and_cast_contig_impl(sycl::queue q,
 
 /*!
  * @brief Factory to get specialized function pointer for casting and copying
- * contiguous arrays of different types.
+ * contiguous arrays.
  * @ingroup CopyAndCastKernels
  */
 template <typename fnT, typename D, typename S> struct CopyAndCastContigFactory
 {
     fnT get()
     {
-        if constexpr (std::is_same_v<D, S>) {
-            fnT fn = nullptr;
-            return fn;
-        }
-        else {
-            fnT f = copy_and_cast_contig_impl<D, S>;
-            return f;
-        }
+        fnT f = copy_and_cast_contig_impl<D, S>;
+        return f;
     }
 };
 

--- a/dpctl/tensor/libtensor/source/copy_numpy_ndarray_into_usm_ndarray.cpp
+++ b/dpctl/tensor/libtensor/source/copy_numpy_ndarray_into_usm_ndarray.cpp
@@ -141,8 +141,6 @@ void copy_numpy_ndarray_into_usm_ndarray(
 
             return;
         }
-        // With contract_iter2 in place, there is no need to write
-        // dedicated kernels for casting between contiguous arrays
     }
 
     const py::ssize_t *src_strides =


### PR DESCRIPTION
This PR works copy-and-cast functionality by simplifying underlying functors, removing specialized implementation for 2d arrays based on `CIndexer_array` as it is only very marginally faster than general strided implementation based on `CIndexer_vector`. 

This PR also adds special implementation for copy-with-casting of contiguous arrays, making type casting of contiguous arrays several times faster.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [x] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
