### PR TITLE
Use direct dpctl.tensor creation functions in tests instead of copying from host

### DIFF
--- a/dpctl/tests/test_usm_ndarray_operators.py
+++ b/dpctl/tests/test_usm_ndarray_operators.py
@@ -14,7 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import numpy as np
 import pytest
 
 import dpctl.tensor as dpt
@@ -109,7 +108,7 @@ def test_int_ops(namespace):
 
 @pytest.mark.parametrize("namespace", [None, Dummy()])
 def test_mat_ops(namespace):
-    M = dpt.from_numpy(np.eye(3, 3, dtype="d"))
+    M = dpt.eye(3, 3)
     M._set_namespace(namespace)
     assert M.__array_namespace__() is namespace
     M.__matmul__(M)


### PR DESCRIPTION
Replaced pattern `dpt.from_numpy(np.creation_op(...))` with `dpt.creation_op(...)` where applicable.

This change decreased test-suite runtime by 3 seconds. 

- [x] Have you provided a meaningful PR description?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you checked performance impact of proposed changes?
