### PR TITLE
Fix for gh 1167

### DIFF
--- a/dpctl/tensor/libtensor/include/utils/type_dispatch.hpp
+++ b/dpctl/tensor/libtensor/include/utils/type_dispatch.hpp
@@ -223,6 +223,17 @@ struct usm_ndarray_types
                 throw_unrecognized_typenum_error(typenum);
             }
         }
+        else if (typenum == api.UAR_LONGLONG_ || typenum == api.UAR_ULONGLONG_)
+        {
+            switch (sizeof(long long)) {
+            case sizeof(std::int64_t):
+                return ((typenum == api.UAR_LONGLONG_)
+                            ? static_cast<int>(typenum_t::INT64)
+                            : static_cast<int>(typenum_t::UINT64));
+            default:
+                throw_unrecognized_typenum_error(typenum);
+            }
+        }
         else {
             throw_unrecognized_typenum_error(typenum);
         }
@@ -234,7 +245,7 @@ struct usm_ndarray_types
 private:
     void throw_unrecognized_typenum_error(int typenum) const
     {
-        throw std::runtime_error("Unrecogized typenum " +
+        throw std::runtime_error("Unrecognized typenum " +
                                  std::to_string(typenum) + " encountered.");
     }
 };

--- a/dpctl/tests/test_tensor_asarray.py
+++ b/dpctl/tests/test_tensor_asarray.py
@@ -355,3 +355,11 @@ def test_asarray_seq_of_arrays_on_different_queues():
 
     with pytest.raises(dpctl.utils.ExecutionPlacementError):
         dpt.asarray([m, [w, py_seq]])
+
+
+def test_ulonglong_gh_1167():
+    get_queue_or_skip()
+    x = dpt.asarray(9223372036854775807, dtype="u8")
+    assert x.dtype == dpt.uint64
+    x = dpt.asarray(9223372036854775808, dtype="u8")
+    assert x.dtype == dpt.uint64


### PR DESCRIPTION
Closes gh-1167.

Adds mapping of typenums corresponding to 'long long' and 'unsigned long long' to mapper typenum-to-look-up-id.

Test is added.

Generally, `long` and `ulong` are 64-bit on Linux, but NumPy must have a special-casing intended to covert Windows platform too:

```
Python 3.9.12 (main, Jun  1 2022, 11:38:51)
Type 'copyright', 'credits' or 'license' for more information
IPython 8.4.0 -- An enhanced Interactive Python. Type '?' for help.

In [1]: import numpy as np

In [2]: np.asarray(9223372036854775807).dtype.char
Out[2]: 'l'

In [3]: np.asarray(9223372036854775808).dtype.char
Out[3]: 'Q'

In [4]: np.dtype('ulonglong').char
Out[4]: 'Q'
```

- [x] Have you provided a meaningful PR description?
- [x] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [x] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
