### PR TITLE
Fix tests for py3.11

### DIFF
--- a/.github/workflows/generate-coverage.yaml
+++ b/.github/workflows/generate-coverage.yaml
@@ -11,7 +11,7 @@ jobs:
 
     env:
       ONEAPI_ROOT: /opt/intel/oneapi
-      GTEST_ROOT: /home/runner/work/googletest-release-1.11.0/install
+      GTEST_ROOT: /home/runner/work/googletest-1.13.0/install
 
     steps:
       - name: Cancel Previous Runs
@@ -39,7 +39,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.10'
+          python-version: '3.11'
           architecture: x64
 
       - name: Cache Gtest
@@ -47,8 +47,8 @@ jobs:
         uses: actions/cache@v3
         with:
           path: |
-            /home/runner/work/googletest-release-1.11.0/install
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('/home/runner/work/googletest-release-1.11.0/install/include/gtest/*') }}
+            /home/runner/work/googletest-1.13.0/install
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('/home/runner/work/googletest-1.13.0/install/include/gtest/*') }}
           restore-keys: |
             ${{ runner.os }}-build-${{ env.cache-name }}-
             ${{ runner.os }}-build-
@@ -59,12 +59,12 @@ jobs:
         shell: bash -l {0}
         run: |
           cd /home/runner/work
-          wget https://github.com/google/googletest/archive/refs/tags/release-1.11.0.tar.gz
-          tar xf release-1.11.0.tar.gz
-          cd googletest-release-1.11.0
+          wget https://github.com/google/googletest/archive/refs/tags/v1.13.0.tar.gz
+          tar xf v1.13.0.tar.gz
+          cd googletest-1.13.0
           mkdir build
           cd build
-          cmake .. -DCMAKE_INSTALL_PREFIX=/home/runner/work/googletest-release-1.11.0/install
+          cmake .. -DCMAKE_INSTALL_PREFIX=/home/runner/work/googletest-1.13.0/install
           make && make install
 
       - name: Checkout repo

--- a/dpctl/tensor/_ctors.py
+++ b/dpctl/tensor/_ctors.py
@@ -785,6 +785,12 @@ def _get_arange_length(start, stop, step):
     return _round_for_arange(tmp)
 
 
+def _to_scalar(obj, sc_ty):
+    "A way to convert object to NumPy scalar type"
+    zd_arr = np.asarray(obj).astype(sc_ty, casting="unsafe")
+    return zd_arr[tuple()]
+
+
 def arange(
     start,
     /,
@@ -861,9 +867,9 @@ def arange(
         buffer_ctor_kwargs={"queue": sycl_queue},
     )
     sc_ty = dt.type
-    _first = sc_ty(start)
+    _first = _to_scalar(start, sc_ty)
     if sh > 1:
-        _second = sc_ty(start + step)
+        _second = _to_scalar(start + step, sc_ty)
         if dt in [dpt.uint8, dpt.uint16, dpt.uint32, dpt.uint64]:
             int64_ty = dpt.int64.type
             _step = int64_ty(_second) - int64_ty(_first)

--- a/dpctl/tests/test_sycl_queue_manager.py
+++ b/dpctl/tests/test_sycl_queue_manager.py
@@ -18,6 +18,7 @@
 """
 
 import contextlib
+import sys
 
 import pytest
 from helper import has_cpu, has_gpu, has_sycl_platforms
@@ -216,7 +217,13 @@ def test_device_context_activates_nested_context():
     "factory, exception, match",
     [
         (True, TypeError, "object is not callable"),
-        (lambda x: None, AttributeError, "no attribute '__exit__'"),
+        (lambda x: None, AttributeError, "no attribute '__exit__'")
+        if sys.version_info < (3, 11)
+        else (
+            lambda x: None,
+            TypeError,
+            r".* object does not support the context manager protocol",
+        ),
     ],
 )
 def test_nested_context_factory_exception_if_wrong_factory(


### PR DESCRIPTION
This PR addresses deprecation warning reported when `dpt.arange(512*1024, 0, step=-1, dtype="i2")` is evaluated issued by NumPy 1.24.

This PR also fixes `test_sycl_queue_manager.py:: test_device_context_activates_nested_context` which fails with Python 3.11 due
to the change the exception type raised when attempting to nest contexts using object which does not implement context protocol.


- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
