### PR TITLE
duplicate: Fix implementation of dpctl.tensor.moveaxis() 

### DIFF
--- a/dpctl/tensor/_manipulation_functions.py
+++ b/dpctl/tensor/_manipulation_functions.py
@@ -814,6 +814,7 @@ def moveaxis(X, src, dst):
 
     Raises:
         AxisError: if `axis` value is invalid.
+        ValueError: if `src` and `dst` have not equal number of elements.
     """
     if not isinstance(X, dpt.usm_ndarray):
         raise TypeError(f"Expected usm_ndarray type, got {type(X)}.")
@@ -824,12 +825,18 @@ def moveaxis(X, src, dst):
     if not isinstance(dst, (tuple, list)):
         dst = (dst,)
 
+    if len(src) != len(dst):
+        raise ValueError(
+            "`srs` and `dst` arguments must have the same number "
+            f"of elements, got `src`: {len(src)}, `dst`: {len(dst)}"
+        )
+
     src = normalize_axis_tuple(src, X.ndim, "src")
     dst = normalize_axis_tuple(dst, X.ndim, "dst")
-    ind = list(range(0, X.ndim))
-    for i in range(len(src)):
-        ind.remove(src[i])  # using the value here which is the same as index
-        ind.insert(dst[i], src[i])
+
+    ind = [i for i in range(X.ndim) if i not in src]
+    for d, s in sorted(zip(dst, src)):
+        ind.insert(d, s)
 
     return dpt.permute_dims(X, tuple(ind))
 

--- a/dpctl/tests/test_usm_ndarray_manipulation.py
+++ b/dpctl/tests/test_usm_ndarray_manipulation.py
@@ -1078,12 +1078,17 @@ def test_moveaxis_1axis():
     assert_array_equal(exp, dpt.asnumpy(res))
 
 
-def test_moveaxis_2axes():
+@pytest.mark.parametrize(
+    "axes",
+    [[[0, 1], [-1, -2]], [[0, 1], [1, 2]]],
+    ids=["[[0, 1], [-1, -2]", "[[0, 1], [1, 2]]"],
+)
+def test_moveaxis_2axes(axes):
     x = np.arange(60).reshape((3, 4, 5))
-    exp = np.moveaxis(x, [0, 1], [-1, -2])
+    exp = np.moveaxis(x, *axes)
 
     y = dpt.reshape(dpt.arange(60), (3, 4, 5))
-    res = dpt.moveaxis(y, [0, 1], [-1, -2])
+    res = dpt.moveaxis(y, *axes)
 
     assert_array_equal(exp, dpt.asnumpy(res))
 
@@ -1096,6 +1101,19 @@ def test_moveaxis_3axes():
     res = dpt.moveaxis(y, [0, 1, 2], [-1, -2, -3])
 
     assert_array_equal(exp, dpt.asnumpy(res))
+
+
+def test_moveaxis_invalid():
+    x = np.zeros((3, 4, 5))
+    with pytest.raises(TypeError):
+        dpt.moveaxis(x, 0, 1)
+
+    y = dpt.asarray(x)
+    with pytest.raises(np.AxisError):
+        dpt.moveaxis(y, 0, 3)
+
+    with pytest.raises(ValueError):
+        dpt.moveaxis(y, [0, 1], [1, 2, 3])
 
 
 def test_unstack_axis0():


### PR DESCRIPTION
This PR 

- modifies getting the resulting array of index permutations(`ind`) 
- adds check of number of elements in `src` and `dst` parameters
- adds new ValueError raise 
- add new tests 

The previous implementation did not work correctly due to removing and inserting an element into the same array at each iteration.
Also it didn't check the same number of elements for `src` and `dst` parameters and raised an `IndexError`

```
a = dpt.zeros((2, 3, 4))
res = dpt.moveaxis(a, [0,1], [1,2])
# expected res.shape = (4, 2, 3)
res.shape = (2, 4, 3)

# expected ind = [2, 0, 1]
ind = [0 , 2, 1]


# Numpy vs dpt
np_arr = np.zeros((2,3,4))
res = np.moveaxis(np_arr, [0,1], [1,2])
res.shape
>> (4, 2, 3)

dpt_arr = dpt.asarray(np_arr)
res = dpt.moveaxis(dpt_arr, [0,1], [1,2])
res.shape
>> (2, 4, 3)

# Error
np.moveaxis(np_arr, [0,1], [1,2, 3])
>> numpy.AxisError: destination: axis 3 is out of bounds for array of dimension 3

dpt.moveaxis(dpt_arr, [0,1], [1,2])
>> ind.insert(dst[i], src[i])
>> IndexError: tuple index out of range
```


- [X] Have you provided a meaningful PR description?
- [X] Have you added a test, reproducer or referred to an issue with a reproducer?
- [X] Have you tested your changes locally for CPU and GPU devices?
- [X] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
