### PR TITLE
Return events for comp. tasks, rather than temp-clean up host tasks

### DIFF
--- a/dpctl/tensor/libtensor/source/boolean_advanced_indexing.cpp
+++ b/dpctl/tensor/libtensor/source/boolean_advanced_indexing.cpp
@@ -988,8 +988,7 @@ std::pair<sycl::event, sycl::event> py_nonzero(
     sycl::event py_obj_management_host_task_ev = dpctl::utils::keep_args_alive(
         exec_q, {cumsum, indexes}, host_task_events);
 
-    return std::make_pair(py_obj_management_host_task_ev,
-                          temporaries_cleanup_ev);
+    return std::make_pair(py_obj_management_host_task_ev, non_zero_indexes_ev);
 }
 
 } // namespace py_internal

--- a/dpctl/tensor/libtensor/source/copy_and_cast_usm_to_usm.cpp
+++ b/dpctl/tensor/libtensor/source/copy_and_cast_usm_to_usm.cpp
@@ -272,7 +272,7 @@ copy_usm_ndarray_into_usm_ndarray(dpctl::tensor::usm_ndarray src,
     host_task_events.push_back(temporaries_cleanup_ev);
 
     return std::make_pair(keep_args_alive(exec_q, {src, dst}, host_task_events),
-                          temporaries_cleanup_ev);
+                          copy_and_cast_generic_ev);
 }
 
 void init_copy_and_cast_usm_to_usm_dispatch_tables(void)

--- a/dpctl/tensor/libtensor/source/copy_for_reshape.cpp
+++ b/dpctl/tensor/libtensor/source/copy_for_reshape.cpp
@@ -167,7 +167,7 @@ copy_usm_ndarray_for_reshape(dpctl::tensor::usm_ndarray src,
     host_task_events.push_back(temporaries_cleanup_ev);
 
     return std::make_pair(keep_args_alive(exec_q, {src, dst}, host_task_events),
-                          temporaries_cleanup_ev);
+                          copy_for_reshape_event);
 }
 
 void init_copy_for_reshape_dispatch_vectors(void)

--- a/dpctl/tensor/libtensor/source/integer_advanced_indexing.cpp
+++ b/dpctl/tensor/libtensor/source/integer_advanced_indexing.cpp
@@ -540,7 +540,7 @@ usm_ndarray_take(dpctl::tensor::usm_ndarray src,
     sycl::event arg_cleanup_ev =
         keep_args_alive(exec_q, {src, py_ind, dst}, host_task_events);
 
-    return std::make_pair(arg_cleanup_ev, temporaries_cleanup_ev);
+    return std::make_pair(arg_cleanup_ev, take_generic_ev);
 }
 
 std::pair<sycl::event, sycl::event>
@@ -854,7 +854,7 @@ usm_ndarray_put(dpctl::tensor::usm_ndarray dst,
     sycl::event arg_cleanup_ev =
         keep_args_alive(exec_q, {dst, py_ind, val}, host_task_events);
 
-    return std::make_pair(arg_cleanup_ev, temporaries_cleanup_ev);
+    return std::make_pair(arg_cleanup_ev, put_generic_ev);
 }
 
 void init_advanced_indexing_dispatch_tables(void)

--- a/dpctl/tensor/libtensor/source/triul_ctor.cpp
+++ b/dpctl/tensor/libtensor/source/triul_ctor.cpp
@@ -202,7 +202,7 @@ usm_ndarray_triul(sycl::queue exec_q,
     }
 
     auto temporaries_cleanup_ev = exec_q.submit([&](sycl::handler &cgh) {
-        cgh.depends_on({tri_ev});
+        cgh.depends_on(tri_ev);
         auto ctx = exec_q.get_context();
         cgh.host_task(
             [shp_host_shape_and_strides, dev_shape_and_strides, ctx]() {
@@ -213,8 +213,7 @@ usm_ndarray_triul(sycl::queue exec_q,
     });
 
     return std::make_pair(
-        keep_args_alive(exec_q, {src, dst}, {temporaries_cleanup_ev}),
-        temporaries_cleanup_ev);
+        keep_args_alive(exec_q, {src, dst}, {temporaries_cleanup_ev}), tri_ev);
 }
 
 void init_triul_ctor_dispatch_vectors(void)

--- a/dpctl/tensor/libtensor/source/where.cpp
+++ b/dpctl/tensor/libtensor/source/where.cpp
@@ -244,7 +244,7 @@ py_where(dpctl::tensor::usm_ndarray condition,
     sycl::event arg_cleanup_ev =
         keep_args_alive(exec_q, {x1, x2, condition, dst}, host_task_events);
 
-    return std::make_pair(arg_cleanup_ev, temporaries_cleanup_ev);
+    return std::make_pair(arg_cleanup_ev, where_ev);
 }
 
 void init_where_dispatch_tables(void)


### PR DESCRIPTION
Return events for computational tasks, rather than temp-clean up host tasks

This resolves a hang that Anton has uncovered. The gist of the bug is

```python
for i in range(op_count):
    v[i] = dpt.empty_like(a[i], order='F', dtype=v_type)

    ht_copy_ev[i], copy_ev = ti._copy_usm_ndarray_into_usm_ndarray(src=a[i], dst=v[i], sycl_queue=a_sycl_queue)

    di._wait(copy_ev)
```

Here is `di` is a Pybind11 extensions, whose function `_wait` was implemented as

```c++
   m.def("_wait", [](sycl::event e) -> void { e.wait(); }, "");
```

The script would hang on the second iteration of the loop if `di._wait` call. The hang disappears after the change in this commit. Out attempts to build a C++ reproducer have not been successful thus far.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [x] If this PR is a work in progress, are you opening the PR as a draft?
