### PR TITLE
Refactoring/dpctl tensor type dispatch namespace

### DIFF
--- a/dpctl/tensor/libtensor/include/kernels/boolean_advanced_indexing.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/boolean_advanced_indexing.hpp
@@ -763,10 +763,6 @@ sycl::event masked_place_some_slices_strided_impl(
     return comp_ev;
 }
 
-static masked_place_all_slices_strided_impl_fn_ptr_t
-    masked_place_all_slices_strided_impl_dispatch_vector
-        [dpctl::tensor::detail::num_types];
-
 template <typename fnT, typename T> struct MaskPlaceAllSlicesStridedFactory
 {
     fnT get()
@@ -775,10 +771,6 @@ template <typename fnT, typename T> struct MaskPlaceAllSlicesStridedFactory
         return fn;
     }
 };
-
-static masked_place_some_slices_strided_impl_fn_ptr_t
-    masked_place_some_slices_strided_impl_dispatch_vector
-        [dpctl::tensor::detail::num_types];
 
 template <typename fnT, typename T> struct MaskPlaceSomeSlicesStridedFactory
 {

--- a/dpctl/tensor/libtensor/include/utils/type_dispatch.hpp
+++ b/dpctl/tensor/libtensor/include/utils/type_dispatch.hpp
@@ -33,7 +33,7 @@ namespace dpctl
 namespace tensor
 {
 
-namespace detail
+namespace type_dispatch
 {
 
 enum class typenum_t : int
@@ -164,7 +164,7 @@ struct usm_ndarray_types
 
     int typenum_to_lookup_id(int typenum) const
     {
-        using typenum_t = dpctl::tensor::detail::typenum_t;
+        using typenum_t = ::dpctl::tensor::type_dispatch::typenum_t;
         auto const &api = ::dpctl::detail::dpctl_capi::get();
 
         if (typenum == api.UAR_DOUBLE_) {
@@ -250,7 +250,7 @@ private:
     }
 };
 
-} // namespace detail
+} // namespace type_dispatch
 
 } // namespace tensor
 } // namespace dpctl

--- a/dpctl/tensor/libtensor/source/boolean_advanced_indexing.cpp
+++ b/dpctl/tensor/libtensor/source/boolean_advanced_indexing.cpp
@@ -93,27 +93,27 @@ void _split_iteration_space(const shT &shape_vec,
 
 // Computation of positions of masked elements
 
+namespace td_ns = dpctl::tensor::type_dispatch;
+
 using dpctl::tensor::kernels::indexing::mask_positions_contig_impl_fn_ptr_t;
 static mask_positions_contig_impl_fn_ptr_t
-    mask_positions_contig_dispatch_vector[dpctl::tensor::detail::num_types];
+    mask_positions_contig_dispatch_vector[td_ns::num_types];
 
 using dpctl::tensor::kernels::indexing::mask_positions_strided_impl_fn_ptr_t;
 static mask_positions_strided_impl_fn_ptr_t
-    mask_positions_strided_dispatch_vector[dpctl::tensor::detail::num_types];
+    mask_positions_strided_dispatch_vector[td_ns::num_types];
 
 void populate_mask_positions_dispatch_vectors(void)
 {
     using dpctl::tensor::kernels::indexing::MaskPositionsContigFactory;
-    dpctl::tensor::detail::DispatchVectorBuilder<
-        mask_positions_contig_impl_fn_ptr_t, MaskPositionsContigFactory,
-        dpctl::tensor::detail::num_types>
+    td_ns::DispatchVectorBuilder<mask_positions_contig_impl_fn_ptr_t,
+                                 MaskPositionsContigFactory, td_ns::num_types>
         dvb1;
     dvb1.populate_dispatch_vector(mask_positions_contig_dispatch_vector);
 
     using dpctl::tensor::kernels::indexing::MaskPositionsStridedFactory;
-    dpctl::tensor::detail::DispatchVectorBuilder<
-        mask_positions_strided_impl_fn_ptr_t, MaskPositionsStridedFactory,
-        dpctl::tensor::detail::num_types>
+    td_ns::DispatchVectorBuilder<mask_positions_strided_impl_fn_ptr_t,
+                                 MaskPositionsStridedFactory, td_ns::num_types>
         dvb2;
     dvb2.populate_dispatch_vector(mask_positions_strided_dispatch_vector);
 
@@ -158,14 +158,13 @@ size_t py_mask_positions(dpctl::tensor::usm_ndarray mask,
     const char *mask_data = mask.get_data();
     char *cumsum_data = cumsum.get_data();
 
-    auto const &array_types = dpctl::tensor::detail::usm_ndarray_types();
+    auto const &array_types = td_ns::usm_ndarray_types();
 
     int mask_typeid = array_types.typenum_to_lookup_id(mask_typenum);
     int cumsum_typeid = array_types.typenum_to_lookup_id(cumsum_typenum);
 
     // cumsum must be int64_t only
-    constexpr int int64_typeid =
-        static_cast<int>(dpctl::tensor::detail::typenum_t::INT64);
+    constexpr int int64_typeid = static_cast<int>(td_ns::typenum_t::INT64);
     if (cumsum_typeid != int64_typeid) {
         throw py::value_error(
             "Cumulative sum array must have int64 data-type.");
@@ -244,30 +243,28 @@ using dpctl::tensor::kernels::indexing::
     masked_extract_all_slices_strided_impl_fn_ptr_t;
 
 static masked_extract_all_slices_strided_impl_fn_ptr_t
-    masked_extract_all_slices_strided_impl_dispatch_vector
-        [dpctl::tensor::detail::num_types];
+    masked_extract_all_slices_strided_impl_dispatch_vector[td_ns::num_types];
 
 using dpctl::tensor::kernels::indexing::
     masked_extract_some_slices_strided_impl_fn_ptr_t;
 
 static masked_extract_some_slices_strided_impl_fn_ptr_t
-    masked_extract_some_slices_strided_impl_dispatch_vector
-        [dpctl::tensor::detail::num_types];
+    masked_extract_some_slices_strided_impl_dispatch_vector[td_ns::num_types];
 
 void populate_masked_extract_dispatch_vectors(void)
 {
     using dpctl::tensor::kernels::indexing::MaskExtractAllSlicesStridedFactory;
-    dpctl::tensor::detail::DispatchVectorBuilder<
+    td_ns::DispatchVectorBuilder<
         masked_extract_all_slices_strided_impl_fn_ptr_t,
-        MaskExtractAllSlicesStridedFactory, dpctl::tensor::detail::num_types>
+        MaskExtractAllSlicesStridedFactory, td_ns::num_types>
         dvb1;
     dvb1.populate_dispatch_vector(
         masked_extract_all_slices_strided_impl_dispatch_vector);
 
     using dpctl::tensor::kernels::indexing::MaskExtractSomeSlicesStridedFactory;
-    dpctl::tensor::detail::DispatchVectorBuilder<
+    td_ns::DispatchVectorBuilder<
         masked_extract_some_slices_strided_impl_fn_ptr_t,
-        MaskExtractSomeSlicesStridedFactory, dpctl::tensor::detail::num_types>
+        MaskExtractSomeSlicesStridedFactory, td_ns::num_types>
         dvb2;
     dvb2.populate_dispatch_vector(
         masked_extract_some_slices_strided_impl_dispatch_vector);
@@ -359,13 +356,12 @@ py_extract(dpctl::tensor::usm_ndarray src,
     int dst_typenum = dst.get_typenum();
     int cumsum_typenum = cumsum.get_typenum();
 
-    auto const &array_types = dpctl::tensor::detail::usm_ndarray_types();
+    auto const &array_types = td_ns::usm_ndarray_types();
     int src_typeid = array_types.typenum_to_lookup_id(src_typenum);
     int dst_typeid = array_types.typenum_to_lookup_id(dst_typenum);
     int cumsum_typeid = array_types.typenum_to_lookup_id(cumsum_typenum);
 
-    constexpr int int64_typeid =
-        static_cast<int>(dpctl::tensor::detail::typenum_t::INT64);
+    constexpr int int64_typeid = static_cast<int>(td_ns::typenum_t::INT64);
     if (cumsum_typeid != int64_typeid) {
         throw py::value_error(
             "Unexact data type of cumsum array, expecting 'int64'");
@@ -557,30 +553,28 @@ using dpctl::tensor::kernels::indexing::
     masked_place_all_slices_strided_impl_fn_ptr_t;
 
 static masked_place_all_slices_strided_impl_fn_ptr_t
-    masked_place_all_slices_strided_impl_dispatch_vector
-        [dpctl::tensor::detail::num_types];
+    masked_place_all_slices_strided_impl_dispatch_vector[td_ns::num_types];
 
 using dpctl::tensor::kernels::indexing::
     masked_place_some_slices_strided_impl_fn_ptr_t;
 
 static masked_place_some_slices_strided_impl_fn_ptr_t
-    masked_place_some_slices_strided_impl_dispatch_vector
-        [dpctl::tensor::detail::num_types];
+    masked_place_some_slices_strided_impl_dispatch_vector[td_ns::num_types];
 
 void populate_masked_place_dispatch_vectors(void)
 {
     using dpctl::tensor::kernels::indexing::MaskPlaceAllSlicesStridedFactory;
-    dpctl::tensor::detail::DispatchVectorBuilder<
-        masked_place_all_slices_strided_impl_fn_ptr_t,
-        MaskPlaceAllSlicesStridedFactory, dpctl::tensor::detail::num_types>
+    td_ns::DispatchVectorBuilder<masked_place_all_slices_strided_impl_fn_ptr_t,
+                                 MaskPlaceAllSlicesStridedFactory,
+                                 td_ns::num_types>
         dvb1;
     dvb1.populate_dispatch_vector(
         masked_place_all_slices_strided_impl_dispatch_vector);
 
     using dpctl::tensor::kernels::indexing::MaskPlaceSomeSlicesStridedFactory;
-    dpctl::tensor::detail::DispatchVectorBuilder<
-        masked_place_some_slices_strided_impl_fn_ptr_t,
-        MaskPlaceSomeSlicesStridedFactory, dpctl::tensor::detail::num_types>
+    td_ns::DispatchVectorBuilder<masked_place_some_slices_strided_impl_fn_ptr_t,
+                                 MaskPlaceSomeSlicesStridedFactory,
+                                 td_ns::num_types>
         dvb2;
     dvb2.populate_dispatch_vector(
         masked_place_some_slices_strided_impl_dispatch_vector);
@@ -673,13 +667,12 @@ py_place(dpctl::tensor::usm_ndarray dst,
     int rhs_typenum = rhs.get_typenum();
     int cumsum_typenum = cumsum.get_typenum();
 
-    auto const &array_types = dpctl::tensor::detail::usm_ndarray_types();
+    auto const &array_types = td_ns::usm_ndarray_types();
     int dst_typeid = array_types.typenum_to_lookup_id(dst_typenum);
     int rhs_typeid = array_types.typenum_to_lookup_id(rhs_typenum);
     int cumsum_typeid = array_types.typenum_to_lookup_id(cumsum_typenum);
 
-    constexpr int int64_typeid =
-        static_cast<int>(dpctl::tensor::detail::typenum_t::INT64);
+    constexpr int int64_typeid = static_cast<int>(td_ns::typenum_t::INT64);
     if (cumsum_typeid != int64_typeid) {
         throw py::value_error(
             "Unexact data type of cumsum array, expecting 'int64'");
@@ -913,15 +906,14 @@ std::pair<sycl::event, sycl::event> py_nonzero(
     py::ssize_t nz_elems = indexes_shape[1];
 
     int indexes_typenum = indexes.get_typenum();
-    auto const &array_types = dpctl::tensor::detail::usm_ndarray_types();
+    auto const &array_types = td_ns::usm_ndarray_types();
     int indexes_typeid = array_types.typenum_to_lookup_id(indexes_typenum);
 
     int cumsum_typenum = cumsum.get_typenum();
     int cumsum_typeid = array_types.typenum_to_lookup_id(cumsum_typenum);
 
     // cumsum must be int64_t only
-    constexpr int int64_typeid =
-        static_cast<int>(dpctl::tensor::detail::typenum_t::INT64);
+    constexpr int int64_typeid = static_cast<int>(td_ns::typenum_t::INT64);
     if (cumsum_typeid != int64_typeid || indexes_typeid != int64_typeid) {
         throw py::value_error(
             "Cumulative sum array and index array must have int64 data-type");

--- a/dpctl/tensor/libtensor/source/copy_and_cast_usm_to_usm.cpp
+++ b/dpctl/tensor/libtensor/source/copy_and_cast_usm_to_usm.cpp
@@ -49,18 +49,18 @@ namespace tensor
 namespace py_internal
 {
 
-namespace _ns = dpctl::tensor::detail;
+namespace td_ns = dpctl::tensor::type_dispatch;
 
 using dpctl::tensor::kernels::copy_and_cast::copy_and_cast_1d_fn_ptr_t;
 using dpctl::tensor::kernels::copy_and_cast::copy_and_cast_contig_fn_ptr_t;
 using dpctl::tensor::kernels::copy_and_cast::copy_and_cast_generic_fn_ptr_t;
 
 static copy_and_cast_generic_fn_ptr_t
-    copy_and_cast_generic_dispatch_table[_ns::num_types][_ns::num_types];
+    copy_and_cast_generic_dispatch_table[td_ns::num_types][td_ns::num_types];
 static copy_and_cast_1d_fn_ptr_t
-    copy_and_cast_1d_dispatch_table[_ns::num_types][_ns::num_types];
+    copy_and_cast_1d_dispatch_table[td_ns::num_types][td_ns::num_types];
 static copy_and_cast_contig_fn_ptr_t
-    copy_and_cast_contig_dispatch_table[_ns::num_types][_ns::num_types];
+    copy_and_cast_contig_dispatch_table[td_ns::num_types][td_ns::num_types];
 
 namespace py = pybind11;
 
@@ -121,7 +121,7 @@ copy_usm_ndarray_into_usm_ndarray(dpctl::tensor::usm_ndarray src,
     int src_typenum = src.get_typenum();
     int dst_typenum = dst.get_typenum();
 
-    auto array_types = dpctl::tensor::detail::usm_ndarray_types();
+    auto array_types = td_ns::usm_ndarray_types();
     int src_type_id = array_types.typenum_to_lookup_id(src_typenum);
     int dst_type_id = array_types.typenum_to_lookup_id(dst_typenum);
 
@@ -277,7 +277,7 @@ copy_usm_ndarray_into_usm_ndarray(dpctl::tensor::usm_ndarray src,
 
 void init_copy_and_cast_usm_to_usm_dispatch_tables(void)
 {
-    using namespace dpctl::tensor::detail;
+    using namespace td_ns;
 
     using dpctl::tensor::kernels::copy_and_cast::CopyAndCastContigFactory;
     DispatchTableBuilder<copy_and_cast_contig_fn_ptr_t,

--- a/dpctl/tensor/libtensor/source/copy_for_reshape.cpp
+++ b/dpctl/tensor/libtensor/source/copy_for_reshape.cpp
@@ -39,14 +39,14 @@ namespace tensor
 namespace py_internal
 {
 
-namespace _ns = dpctl::tensor::detail;
+namespace td_ns = dpctl::tensor::type_dispatch;
 
 using dpctl::tensor::kernels::copy_and_cast::copy_for_reshape_fn_ptr_t;
 using dpctl::utils::keep_args_alive;
 
 // define static vector
 static copy_for_reshape_fn_ptr_t
-    copy_for_reshape_generic_dispatch_vector[_ns::num_types];
+    copy_for_reshape_generic_dispatch_vector[td_ns::num_types];
 
 /*
  * Copies src into dst (same data type) of different shapes by using flat
@@ -121,7 +121,7 @@ copy_usm_ndarray_for_reshape(dpctl::tensor::usm_ndarray src,
     int src_nd = src.get_ndim();
     int dst_nd = dst.get_ndim();
 
-    auto array_types = dpctl::tensor::detail::usm_ndarray_types();
+    auto array_types = td_ns::usm_ndarray_types();
     int type_id = array_types.typenum_to_lookup_id(src_typenum);
 
     auto fn = copy_for_reshape_generic_dispatch_vector[type_id];
@@ -172,7 +172,7 @@ copy_usm_ndarray_for_reshape(dpctl::tensor::usm_ndarray src,
 
 void init_copy_for_reshape_dispatch_vectors(void)
 {
-    using namespace dpctl::tensor::detail;
+    using namespace td_ns;
     using dpctl::tensor::kernels::copy_and_cast::CopyForReshapeGenericFactory;
 
     DispatchVectorBuilder<copy_for_reshape_fn_ptr_t,

--- a/dpctl/tensor/libtensor/source/copy_numpy_ndarray_into_usm_ndarray.cpp
+++ b/dpctl/tensor/libtensor/source/copy_numpy_ndarray_into_usm_ndarray.cpp
@@ -36,7 +36,7 @@
 #include "simplify_iteration_space.hpp"
 
 namespace py = pybind11;
-namespace _ns = dpctl::tensor::detail;
+namespace td_ns = dpctl::tensor::type_dispatch;
 
 namespace dpctl
 {
@@ -49,8 +49,8 @@ using dpctl::tensor::kernels::copy_and_cast::
     copy_and_cast_from_host_blocking_fn_ptr_t;
 
 static copy_and_cast_from_host_blocking_fn_ptr_t
-    copy_and_cast_from_host_blocking_dispatch_table[_ns::num_types]
-                                                   [_ns::num_types];
+    copy_and_cast_from_host_blocking_dispatch_table[td_ns::num_types]
+                                                   [td_ns::num_types];
 
 void copy_numpy_ndarray_into_usm_ndarray(
     py::array npy_src,
@@ -111,7 +111,7 @@ void copy_numpy_ndarray_into_usm_ndarray(
         py::detail::array_descriptor_proxy(npy_src.dtype().ptr())->type_num;
     int dst_typenum = dst.get_typenum();
 
-    auto array_types = dpctl::tensor::detail::usm_ndarray_types();
+    auto array_types = td_ns::usm_ndarray_types();
     int src_type_id = array_types.typenum_to_lookup_id(src_typenum);
     int dst_type_id = array_types.typenum_to_lookup_id(dst_typenum);
 
@@ -239,11 +239,11 @@ void copy_numpy_ndarray_into_usm_ndarray(
 
 void init_copy_numpy_ndarray_into_usm_ndarray_dispatch_tables(void)
 {
-    using namespace dpctl::tensor::detail;
+    using namespace td_ns;
     using dpctl::tensor::kernels::copy_and_cast::CopyAndCastFromHostFactory;
 
     DispatchTableBuilder<copy_and_cast_from_host_blocking_fn_ptr_t,
-                         CopyAndCastFromHostFactory, _ns::num_types>
+                         CopyAndCastFromHostFactory, num_types>
         dtb_copy_from_numpy;
 
     dtb_copy_from_numpy.populate_dispatch_table(

--- a/dpctl/tensor/libtensor/source/eye_ctor.cpp
+++ b/dpctl/tensor/libtensor/source/eye_ctor.cpp
@@ -34,7 +34,7 @@
 #include "utils/type_dispatch.hpp"
 
 namespace py = pybind11;
-namespace _ns = dpctl::tensor::detail;
+namespace td_ns = dpctl::tensor::type_dispatch;
 
 namespace dpctl
 {
@@ -46,7 +46,7 @@ namespace py_internal
 using dpctl::utils::keep_args_alive;
 
 using dpctl::tensor::kernels::constructors::eye_fn_ptr_t;
-static eye_fn_ptr_t eye_dispatch_vector[_ns::num_types];
+static eye_fn_ptr_t eye_dispatch_vector[td_ns::num_types];
 
 std::pair<sycl::event, sycl::event>
 usm_ndarray_eye(py::ssize_t k,
@@ -66,7 +66,7 @@ usm_ndarray_eye(py::ssize_t k,
                               "allocation queue");
     }
 
-    auto array_types = dpctl::tensor::detail::usm_ndarray_types();
+    auto array_types = td_ns::usm_ndarray_types();
     int dst_typenum = dst.get_typenum();
     int dst_typeid = array_types.typenum_to_lookup_id(dst_typenum);
 
@@ -118,7 +118,7 @@ usm_ndarray_eye(py::ssize_t k,
 
 void init_eye_ctor_dispatch_vectors(void)
 {
-    using namespace dpctl::tensor::detail;
+    using namespace td_ns;
     using dpctl::tensor::kernels::constructors::EyeFactory;
 
     DispatchVectorBuilder<eye_fn_ptr_t, EyeFactory, num_types> dvb;

--- a/dpctl/tensor/libtensor/source/full_ctor.cpp
+++ b/dpctl/tensor/libtensor/source/full_ctor.cpp
@@ -37,7 +37,7 @@
 #include "full_ctor.hpp"
 
 namespace py = pybind11;
-namespace _ns = dpctl::tensor::detail;
+namespace td_ns = dpctl::tensor::type_dispatch;
 
 namespace dpctl
 {
@@ -51,7 +51,7 @@ using dpctl::utils::keep_args_alive;
 
 using dpctl::tensor::kernels::constructors::full_contig_fn_ptr_t;
 
-static full_contig_fn_ptr_t full_contig_dispatch_vector[_ns::num_types];
+static full_contig_fn_ptr_t full_contig_dispatch_vector[td_ns::num_types];
 
 std::pair<sycl::event, sycl::event>
 usm_ndarray_full(py::object py_value,
@@ -73,7 +73,7 @@ usm_ndarray_full(py::object py_value,
             "Execution queue is not compatible with the allocation queue");
     }
 
-    auto array_types = dpctl::tensor::detail::usm_ndarray_types();
+    auto array_types = td_ns::usm_ndarray_types();
     int dst_typenum = dst.get_typenum();
     int dst_typeid = array_types.typenum_to_lookup_id(dst_typenum);
 
@@ -99,7 +99,7 @@ usm_ndarray_full(py::object py_value,
 
 void init_full_ctor_dispatch_vectors(void)
 {
-    using namespace dpctl::tensor::detail;
+    using namespace td_ns;
     using dpctl::tensor::kernels::constructors::FullContigFactory;
 
     DispatchVectorBuilder<full_contig_fn_ptr_t, FullContigFactory, num_types>

--- a/dpctl/tensor/libtensor/source/integer_advanced_indexing.cpp
+++ b/dpctl/tensor/libtensor/source/integer_advanced_indexing.cpp
@@ -51,16 +51,16 @@ namespace tensor
 namespace py_internal
 {
 
-namespace _ns = dpctl::tensor::detail;
+namespace td_ns = dpctl::tensor::type_dispatch;
 
 using dpctl::tensor::kernels::indexing::put_fn_ptr_t;
 using dpctl::tensor::kernels::indexing::take_fn_ptr_t;
 
-static take_fn_ptr_t take_dispatch_table[INDEXING_MODES][_ns::num_types]
-                                        [_ns::num_types];
+static take_fn_ptr_t take_dispatch_table[INDEXING_MODES][td_ns::num_types]
+                                        [td_ns::num_types];
 
-static put_fn_ptr_t put_dispatch_table[INDEXING_MODES][_ns::num_types]
-                                      [_ns::num_types];
+static put_fn_ptr_t put_dispatch_table[INDEXING_MODES][td_ns::num_types]
+                                      [td_ns::num_types];
 
 namespace py = pybind11;
 
@@ -324,7 +324,7 @@ usm_ndarray_take(dpctl::tensor::usm_ndarray src,
     int src_typenum = src.get_typenum();
     int dst_typenum = dst.get_typenum();
 
-    auto array_types = dpctl::tensor::detail::usm_ndarray_types();
+    auto array_types = td_ns::usm_ndarray_types();
     int src_type_id = array_types.typenum_to_lookup_id(src_typenum);
     int dst_type_id = array_types.typenum_to_lookup_id(dst_typenum);
 
@@ -653,7 +653,7 @@ usm_ndarray_put(dpctl::tensor::usm_ndarray dst,
     int dst_typenum = dst.get_typenum();
     int val_typenum = val.get_typenum();
 
-    auto array_types = dpctl::tensor::detail::usm_ndarray_types();
+    auto array_types = td_ns::usm_ndarray_types();
     int dst_type_id = array_types.typenum_to_lookup_id(dst_typenum);
     int val_type_id = array_types.typenum_to_lookup_id(val_typenum);
 
@@ -859,7 +859,7 @@ usm_ndarray_put(dpctl::tensor::usm_ndarray dst,
 
 void init_advanced_indexing_dispatch_tables(void)
 {
-    using namespace dpctl::tensor::detail;
+    using namespace td_ns;
 
     using dpctl::tensor::kernels::indexing::TakeClipFactory;
     DispatchTableBuilder<take_fn_ptr_t, TakeClipFactory, num_types>

--- a/dpctl/tensor/libtensor/source/linear_sequences.cpp
+++ b/dpctl/tensor/libtensor/source/linear_sequences.cpp
@@ -37,7 +37,7 @@
 #include "linear_sequences.hpp"
 
 namespace py = pybind11;
-namespace _ns = dpctl::tensor::detail;
+namespace td_ns = dpctl::tensor::type_dispatch;
 
 namespace dpctl
 {
@@ -50,12 +50,12 @@ using dpctl::utils::keep_args_alive;
 
 using dpctl::tensor::kernels::constructors::lin_space_step_fn_ptr_t;
 
-static lin_space_step_fn_ptr_t lin_space_step_dispatch_vector[_ns::num_types];
+static lin_space_step_fn_ptr_t lin_space_step_dispatch_vector[td_ns::num_types];
 
 using dpctl::tensor::kernels::constructors::lin_space_affine_fn_ptr_t;
 
 static lin_space_affine_fn_ptr_t
-    lin_space_affine_dispatch_vector[_ns::num_types];
+    lin_space_affine_dispatch_vector[td_ns::num_types];
 
 std::pair<sycl::event, sycl::event>
 usm_ndarray_linear_sequence_step(py::object start,
@@ -82,7 +82,7 @@ usm_ndarray_linear_sequence_step(py::object start,
             "Execution queue is not compatible with the allocation queue");
     }
 
-    auto array_types = dpctl::tensor::detail::usm_ndarray_types();
+    auto array_types = td_ns::usm_ndarray_types();
     int dst_typenum = dst.get_typenum();
     int dst_typeid = array_types.typenum_to_lookup_id(dst_typenum);
 
@@ -130,7 +130,7 @@ usm_ndarray_linear_sequence_affine(py::object start,
             "Execution queue context is not the same as allocation context");
     }
 
-    auto array_types = dpctl::tensor::detail::usm_ndarray_types();
+    auto array_types = td_ns::usm_ndarray_types();
     int dst_typenum = dst.get_typenum();
     int dst_typeid = array_types.typenum_to_lookup_id(dst_typenum);
 
@@ -155,7 +155,7 @@ usm_ndarray_linear_sequence_affine(py::object start,
 
 void init_linear_sequences_dispatch_vectors(void)
 {
-    using namespace dpctl::tensor::detail;
+    using namespace td_ns;
     using dpctl::tensor::kernels::constructors::LinSpaceAffineFactory;
     using dpctl::tensor::kernels::constructors::LinSpaceStepFactory;
 

--- a/dpctl/tensor/libtensor/source/triul_ctor.cpp
+++ b/dpctl/tensor/libtensor/source/triul_ctor.cpp
@@ -35,7 +35,7 @@
 #include "utils/type_dispatch.hpp"
 
 namespace py = pybind11;
-namespace _ns = dpctl::tensor::detail;
+namespace td_ns = dpctl::tensor::type_dispatch;
 
 namespace dpctl
 {
@@ -48,8 +48,8 @@ using dpctl::utils::keep_args_alive;
 
 using dpctl::tensor::kernels::constructors::tri_fn_ptr_t;
 
-static tri_fn_ptr_t tril_generic_dispatch_vector[_ns::num_types];
-static tri_fn_ptr_t triu_generic_dispatch_vector[_ns::num_types];
+static tri_fn_ptr_t tril_generic_dispatch_vector[td_ns::num_types];
+static tri_fn_ptr_t triu_generic_dispatch_vector[td_ns::num_types];
 
 std::pair<sycl::event, sycl::event>
 usm_ndarray_triul(sycl::queue exec_q,
@@ -100,7 +100,7 @@ usm_ndarray_triul(sycl::queue exec_q,
         throw py::value_error("Arrays index overlapping segments of memory");
     }
 
-    auto array_types = dpctl::tensor::detail::usm_ndarray_types();
+    auto array_types = td_ns::usm_ndarray_types();
 
     int src_typenum = src.get_typenum();
     int dst_typenum = dst.get_typenum();
@@ -219,7 +219,7 @@ usm_ndarray_triul(sycl::queue exec_q,
 void init_triul_ctor_dispatch_vectors(void)
 {
 
-    using namespace dpctl::tensor::detail;
+    using namespace td_ns;
     using dpctl::tensor::kernels::constructors::TrilGenericFactory;
     using dpctl::tensor::kernels::constructors::TriuGenericFactory;
 

--- a/dpctl/tensor/libtensor/source/where.cpp
+++ b/dpctl/tensor/libtensor/source/where.cpp
@@ -46,15 +46,15 @@ namespace tensor
 namespace py_internal
 {
 
-namespace _ns = dpctl::tensor::detail;
+namespace td_ns = dpctl::tensor::type_dispatch;
 
 using dpctl::tensor::kernels::search::where_contig_impl_fn_ptr_t;
 using dpctl::tensor::kernels::search::where_strided_impl_fn_ptr_t;
 
-static where_contig_impl_fn_ptr_t where_contig_dispatch_table[_ns::num_types]
-                                                             [_ns::num_types];
-static where_strided_impl_fn_ptr_t where_strided_dispatch_table[_ns::num_types]
-                                                               [_ns::num_types];
+static where_contig_impl_fn_ptr_t where_contig_dispatch_table[td_ns::num_types]
+                                                             [td_ns::num_types];
+static where_strided_impl_fn_ptr_t
+    where_strided_dispatch_table[td_ns::num_types][td_ns::num_types];
 
 using dpctl::utils::keep_args_alive;
 
@@ -120,7 +120,7 @@ py_where(dpctl::tensor::usm_ndarray condition,
     int cond_typenum = condition.get_typenum();
     int dst_typenum = dst.get_typenum();
 
-    auto const &array_types = dpctl::tensor::detail::usm_ndarray_types();
+    auto const &array_types = td_ns::usm_ndarray_types();
     int cond_typeid = array_types.typenum_to_lookup_id(cond_typenum);
     int x1_typeid = array_types.typenum_to_lookup_id(x1_typenum);
     int x2_typeid = array_types.typenum_to_lookup_id(x2_typenum);
@@ -249,17 +249,16 @@ py_where(dpctl::tensor::usm_ndarray condition,
 
 void init_where_dispatch_tables(void)
 {
+    using namespace td_ns;
     using dpctl::tensor::kernels::search::WhereContigFactory;
-    dpctl::tensor::detail::DispatchTableBuilder<
-        where_contig_impl_fn_ptr_t, WhereContigFactory,
-        dpctl::tensor::detail::num_types>
+    DispatchTableBuilder<where_contig_impl_fn_ptr_t, WhereContigFactory,
+                         num_types>
         dtb1;
     dtb1.populate_dispatch_table(where_contig_dispatch_table);
 
     using dpctl::tensor::kernels::search::WhereStridedFactory;
-    dpctl::tensor::detail::DispatchTableBuilder<
-        where_strided_impl_fn_ptr_t, WhereStridedFactory,
-        dpctl::tensor::detail::num_types>
+    DispatchTableBuilder<where_strided_impl_fn_ptr_t, WhereStridedFactory,
+                         num_types>
         dtb2;
     dtb2.populate_dispatch_table(where_strided_dispatch_table);
 }


### PR DESCRIPTION
This PR moves type dispatching types from `dpctl::tensor::detail` to `dpctl::tensor::type_dispatch` namespace. 

Incidentally, it also removes static definition of function pointer arrays from `include/kernels/boolean_indexing.hpp`.
They are actually also defined `source/boolean_indexing.cpp`.

This change will likely require code changes in downstream projects using `"dpctl4pybind11.hpp"`.

This PR is the foundation for the further work on unary functions and reductions, so I'd appreciate a prompt review. 

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
