### PR TITLE
Fix for gh-1180: missing F-contiguous flags after calling squeeze

### DIFF
--- a/dpctl/tensor/_stride_utils.pxi
+++ b/dpctl/tensor/_stride_utils.pxi
@@ -62,8 +62,8 @@ cdef int _from_input_shape_strides(
     """
     cdef int i
     cdef int j
-    cdef int all_incr = 1
-    cdef int all_decr = 1
+    cdef bint all_incr = 1
+    cdef bint all_decr = 1
     cdef Py_ssize_t elem_count = 1
     cdef Py_ssize_t min_shift = 0
     cdef Py_ssize_t max_shift = 0
@@ -152,7 +152,7 @@ cdef int _from_input_shape_strides(
                 return 0
             if nd == 1:
                 if strides_arr[0] == 1:
-                    contig[0] = USM_ARRAY_C_CONTIGUOUS
+                    contig[0] = USM_ARRAY_C_CONTIGUOUS | USM_ARRAY_F_CONTIGUOUS
                 else:
                     contig[0] = 0
                 return 0

--- a/dpctl/tests/test_usm_ndarray_ctor.py
+++ b/dpctl/tests/test_usm_ndarray_ctor.py
@@ -71,6 +71,10 @@ def test_usm_ndarray_flags():
     assert f.forc
     assert f.fnc
 
+    f = dpt.usm_ndarray((5,), dtype="i4", strides=(1,)).flags
+    assert f.fc
+    assert f.forc
+
     f = dpt.usm_ndarray((5, 1, 2), dtype="i4", strides=(2, 0, 1)).flags
     assert f.c_contiguous
     assert f.forc


### PR DESCRIPTION
Closes gh-1180

Utility determining contiguity flags of the newly constructed array was not setting F-contiguous flags where it should have in a special case of 1D array.

```
In [1]: import dpctl.tensor as dpt, dpctl

In [2]: x = dpt.ones((1,3,1))

In [3]: y = dpt.squeeze(x)

In [4]: x.flags, y.flags
Out[4]:
(  C_CONTIGUOUS : True
   F_CONTIGUOUS : True
   WRITABLE : True,
   C_CONTIGUOUS : True
   F_CONTIGUOUS : True
   WRITABLE : True)
```

- [x] Have you provided a meaningful PR description?
- [x] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [x] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
