### PR TITLE
Better handle no devices systems

### DIFF
--- a/.github/workflows/os-llvm-sycl-build.yml
+++ b/.github/workflows/os-llvm-sycl-build.yml
@@ -14,9 +14,9 @@ jobs:
       DRIVER_PATH: 2023-WW13
       OCLCPUEXP_FN: oclcpuexp-2023.15.3.0.20_rel.tar.gz
       FPGAEMU_FN: fpgaemu-2023.15.3.0.20_rel.tar.gz
-      TBB_URL: https://github.com/oneapi-src/oneTBB/releases/download/v2021.8.0/
-      TBB_INSTALL_DIR: oneapi-tbb-2021.8.0
-      TBB_FN: oneapi-tbb-2021.8.0-lin.tgz
+      TBB_URL: https://github.com/oneapi-src/oneTBB/releases/download/v2021.9.0/
+      TBB_INSTALL_DIR: oneapi-tbb-2021.9.0
+      TBB_FN: oneapi-tbb-2021.9.0-lin.tgz
 
     steps:
       - name: Cancel Previous Runs

--- a/.github/workflows/os-llvm-sycl-build.yml
+++ b/.github/workflows/os-llvm-sycl-build.yml
@@ -107,57 +107,49 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Report compiler version
+      - name: Create set_allvars.sh
         shell: bash -l {0}
         run: |
+          cat << 'EOF' > set_allvars.sh
+          #!/usr/bin/bash
           export SYCL_BUNDLE_FOLDER=/home/runner/work/sycl_bundle
           source ${SYCL_BUNDLE_FOLDER}/dpcpp_compiler/startup.sh
           export LD_LIBRARY_PATH=${SYCL_BUNDLE_FOLDER}/oclcpuexp/x64:${LD_LIBRARY_PATH}
           export LD_LIBRARY_PATH=${SYCL_BUNDLE_FOLDER}/fpgaemu/x64:${LD_LIBRARY_PATH}
           export LD_LIBRARY_PATH=${SYCL_BUNDLE_FOLDER}/${TBB_INSTALL_DIR}/lib/intel64/gcc4.8:${LD_LIBRARY_PATH}
+          export OCL_ICD_VENDORS=
           export OCL_ICD_FILENAMES=libintelocl.so:libintelocl_emu.so
+          EOF
+          chmod +x set_allvars.sh
+          cat set_allvars.sh
+
+      - name: Report compiler version
+        shell: bash -l {0}
+        run: |
+          source set_allvars.sh
           clang++ --version
 
       - name: Run sycl-ls
         shell: bash -l {0}
         run: |
-          export SYCL_BUNDLE_FOLDER=/home/runner/work/sycl_bundle
-          source ${SYCL_BUNDLE_FOLDER}/dpcpp_compiler/startup.sh
-          export LD_LIBRARY_PATH=${SYCL_BUNDLE_FOLDER}/oclcpuexp/x64:${LD_LIBRARY_PATH}
-          export LD_LIBRARY_PATH=${SYCL_BUNDLE_FOLDER}/fpgaemu/x64:${LD_LIBRARY_PATH}
-          export LD_LIBRARY_PATH=${SYCL_BUNDLE_FOLDER}/${TBB_INSTALL_DIR}/lib/intel64/gcc4.8:${LD_LIBRARY_PATH}
-          export OCL_ICD_FILENAMES=libintelocl.so:libintelocl_emu.so
+          source set_allvars.sh
           sycl-ls
 
       - name: build dpctl
         shell: bash -l {0}
         run: |
-          export SYCL_BUNDLE_FOLDER=/home/runner/work/sycl_bundle
-          source ${SYCL_BUNDLE_FOLDER}/dpcpp_compiler/startup.sh
-          export LD_LIBRARY_PATH=${SYCL_BUNDLE_FOLDER}/oclcpuexp/x64:${LD_LIBRARY_PATH}
-          export LD_LIBRARY_PATH=${SYCL_BUNDLE_FOLDER}/fpgaemu/x64:${LD_LIBRARY_PATH}
-          export LD_LIBRARY_PATH=${SYCL_BUNDLE_FOLDER}/${TBB_INSTALL_DIR}/lib/intel64/gcc4.8:${LD_LIBRARY_PATH}
-          export OCL_ICD_FILENAMES=libintelocl.so:libintelocl_emu.so
+          source set_allvars.sh
           CC=clang CXX=clang++ python setup.py develop -G Ninja
 
       - name: Run lsplatforms
         shell: bash -l {0}
         run: |
-          export SYCL_BUNDLE_FOLDER=/home/runner/work/sycl_bundle
-          source ${SYCL_BUNDLE_FOLDER}/dpcpp_compiler/startup.sh
-          export LD_LIBRARY_PATH=${SYCL_BUNDLE_FOLDER}/oclcpuexp/x64:${LD_LIBRARY_PATH}
-          export LD_LIBRARY_PATH=${SYCL_BUNDLE_FOLDER}/fpgaemu/x64:${LD_LIBRARY_PATH}
-          export LD_LIBRARY_PATH=${SYCL_BUNDLE_FOLDER}/${TBB_INSTALL_DIR}/lib/intel64/gcc4.8:${LD_LIBRARY_PATH}
-          export OCL_ICD_FILENAMES=libintelocl.so:libintelocl_emu.so
+          source set_allvars.sh
           python -m dpctl -f || exit 1
 
       - name: Run dpctl/tests
         shell: bash -l {0}
         run: |
-          export SYCL_BUNDLE_FOLDER=/home/runner/work/sycl_bundle
-          source ${SYCL_BUNDLE_FOLDER}/dpcpp_compiler/startup.sh
-          export LD_LIBRARY_PATH=${SYCL_BUNDLE_FOLDER}/oclcpuexp/x64:${LD_LIBRARY_PATH}
-          export LD_LIBRARY_PATH=${SYCL_BUNDLE_FOLDER}/fpgaemu/x64:${LD_LIBRARY_PATH}
-          export LD_LIBRARY_PATH=${SYCL_BUNDLE_FOLDER}/${TBB_INSTALL_DIR}/lib/intel64/gcc4.8:${LD_LIBRARY_PATH}
-          export OCL_ICD_FILENAMES=libintelocl.so:libintelocl_emu.so
-          python -m pytest -v dpctl/tests
+          source set_allvars.sh
+          # skip test due to https://github.com/intel/llvm/issues/9264
+          python -m pytest -v dpctl/tests -k "not test_event_backend"

--- a/.github/workflows/os-llvm-sycl-build.yml
+++ b/.github/workflows/os-llvm-sycl-build.yml
@@ -11,12 +11,12 @@ jobs:
 
     env:
       DOWNLOAD_URL_PREFIX: https://github.com/intel/llvm/releases/download
-      DRIVER_PATH: 2022-WW50
-      OCLCPUEXP_FN: oclcpuexp-2022.15.12.0.01_rel.tar.gz
-      FPGAEMU_FN: fpgaemu-2022.15.12.0.01_rel.tar.gz
-      TBB_URL: https://github.com/oneapi-src/oneTBB/releases/download/v2021.7.0/
-      TBB_INSTALL_DIR: oneapi-tbb-2021.7.0
-      TBB_FN: oneapi-tbb-2021.7.0-lin.tgz
+      DRIVER_PATH: 2023-WW13
+      OCLCPUEXP_FN: oclcpuexp-2023.15.3.0.20_rel.tar.gz
+      FPGAEMU_FN: fpgaemu-2023.15.3.0.20_rel.tar.gz
+      TBB_URL: https://github.com/oneapi-src/oneTBB/releases/download/v2021.8.0/
+      TBB_INSTALL_DIR: oneapi-tbb-2021.8.0
+      TBB_FN: oneapi-tbb-2021.8.0-lin.tgz
 
     steps:
       - name: Cancel Previous Runs

--- a/dpctl/tests/test_sycl_context.py
+++ b/dpctl/tests/test_sycl_context.py
@@ -58,7 +58,10 @@ def test_address_of():
     """
     Test if the address_of method returns an int value.
     """
-    ctx = dpctl.SyclContext()
+    try:
+        ctx = dpctl.SyclContext()
+    except dpctl.SyclContextCreationError:
+        pytest.skip("Failed to create context using default constructor")
     assert ctx.addressof_ref() is not None
     assert isinstance(ctx.addressof_ref(), int)
 
@@ -85,7 +88,10 @@ def test_context_not_equals2():
     Test if comparing a SyclContext object to some random Python object is
     correctly handled and returns False.
     """
-    ctx = dpctl.SyclContext()
+    try:
+        ctx = dpctl.SyclContext()
+    except dpctl.SyclContextCreationError:
+        pytest.skip("Failed to create context using default constructor")
     assert ctx != "some context"
 
 
@@ -103,7 +109,10 @@ def test_name():
     """
     Test if a __name__ method is defined for SyclContext.
     """
-    ctx = dpctl.SyclContext()
+    try:
+        ctx = dpctl.SyclContext()
+    except dpctl.SyclContextCreationError:
+        pytest.skip("Failed to create context using default constructor")
     assert ctx.__name__ == "SyclContext"
 
 
@@ -111,7 +120,10 @@ def test_repr():
     """
     Test if a __repr__ method is defined for SyclContext.
     """
-    ctx = dpctl.SyclContext()
+    try:
+        ctx = dpctl.SyclContext()
+    except dpctl.SyclContextCreationError:
+        pytest.skip("Failed to create context using default constructor")
     assert ctx.__repr__ is not None
 
 
@@ -181,12 +193,19 @@ def test_hashing_of_context():
     as a dictionary key.
 
     """
-    ctx_dict = {dpctl.SyclContext(): "default_context"}
+    try:
+        ctx = dpctl.SyclContext()
+    except dpctl.SyclContextCreationError:
+        pytest.skip("Failed to create context using default constructor")
+    ctx_dict = {ctx: "default_context"}
     assert ctx_dict
 
 
 def test_context_repr():
-    ctx = dpctl.SyclContext()
+    try:
+        ctx = dpctl.SyclContext()
+    except dpctl.SyclContextCreationError:
+        pytest.skip("Failed to create context using default constructor")
     assert type(ctx.__repr__()) is str
 
 
@@ -194,7 +213,10 @@ def test_cpython_api_SyclContext_GetContextRef():
     import ctypes
     import sys
 
-    ctx = dpctl.SyclContext()
+    try:
+        ctx = dpctl.SyclContext()
+    except dpctl.SyclContextCreationError:
+        pytest.skip("Failed to create context using default constructor")
     mod = sys.modules[ctx.__class__.__module__]
     # get capsule storign SyclContext_GetContextRef function ptr
     ctx_ref_fn_cap = mod.__pyx_capi__["SyclContext_GetContextRef"]
@@ -217,7 +239,10 @@ def test_cpython_api_SyclContext_Make():
     import ctypes
     import sys
 
-    ctx = dpctl.SyclContext()
+    try:
+        ctx = dpctl.SyclContext()
+    except dpctl.SyclContextCreationError:
+        pytest.skip("Failed to create context using default constructor")
     mod = sys.modules[ctx.__class__.__module__]
     # get capsule storign SyclContext_Make function ptr
     make_ctx_fn_cap = mod.__pyx_capi__["SyclContext_Make"]
@@ -243,6 +268,8 @@ def test_invalid_capsule():
 
 def test_multi_device_different_platforms():
     devs = dpctl.get_devices()  # all devices
-    if len(devs) > 1:
+    if len(devs) > 1 and len(set(d.sycl_platform for d in devs)) > 1:
         with pytest.raises(dpctl.SyclContextCreationError):
             dpctl.SyclContext(devs)
+    else:
+        pytest.skip("Insufficient amount of available devices for this test")

--- a/dpctl/tests/test_sycl_event.py
+++ b/dpctl/tests/test_sycl_event.py
@@ -121,7 +121,7 @@ def test_execution_status_nondefault_event():
     assert type(wl) is list
 
 
-def test_backend():
+def test_event_backend():
     if dpctl.get_num_devices() == 0:
         pytest.skip("No backends are available")
     try:

--- a/dpctl/tests/test_sycl_event.py
+++ b/dpctl/tests/test_sycl_event.py
@@ -122,6 +122,8 @@ def test_execution_status_nondefault_event():
 
 
 def test_backend():
+    if dpctl.get_num_devices() == 0:
+        pytest.skip("No backends are available")
     try:
         dpctl.SyclEvent().backend
     except ValueError:

--- a/dpctl/tests/test_sycl_queue_memcpy.py
+++ b/dpctl/tests/test_sycl_queue_memcpy.py
@@ -18,7 +18,6 @@
 """
 
 import pytest
-from helper import has_sycl_platforms
 
 import dpctl
 import dpctl.memory
@@ -30,12 +29,11 @@ def _create_memory(q):
     return mobj
 
 
-@pytest.mark.skipif(
-    not has_sycl_platforms(),
-    reason="No SYCL devices except the default host device.",
-)
 def test_memcpy_copy_usm_to_usm():
-    q = dpctl.SyclQueue()
+    try:
+        q = dpctl.SyclQueue()
+    except dpctl.SyclQueueCreationError:
+        pytest.skip("Default constructor for SyclQueue failed")
     mobj1 = _create_memory(q)
     mobj2 = _create_memory(q)
 
@@ -49,12 +47,11 @@ def test_memcpy_copy_usm_to_usm():
     assert mv2[:3], b"123"
 
 
-# @pytest.mark.skipif(
-#    not has_sycl_platforms(),
-#    reason="No SYCL devices except the default host device."
-# )
 def test_memcpy_type_error():
-    q = dpctl.SyclQueue()
+    try:
+        q = dpctl.SyclQueue()
+    except dpctl.SyclQueueCreationError:
+        pytest.skip("Default constructor for SyclQueue failed")
     mobj = _create_memory(q)
 
     with pytest.raises(TypeError) as cm:

--- a/dpctl/tests/test_usm_ndarray_ctor.py
+++ b/dpctl/tests/test_usm_ndarray_ctor.py
@@ -161,7 +161,10 @@ def test_properties(dt):
     """
     Test that properties execute
     """
-    X = dpt.usm_ndarray((3, 4, 5), dtype=dt)
+    try:
+        X = dpt.usm_ndarray((3, 4, 5), dtype=dt)
+    except dpctl.SyclDeviceCreationError:
+        pytest.skip("No SYCL devices available")
     assert isinstance(X.sycl_queue, dpctl.SyclQueue)
     assert isinstance(X.sycl_device, dpctl.SyclDevice)
     assert isinstance(X.sycl_context, dpctl.SyclContext)
@@ -193,7 +196,10 @@ def test_properties(dt):
 @pytest.mark.parametrize("shape", [tuple(), (1,), (1, 1), (1, 1, 1)])
 @pytest.mark.parametrize("dtype", ["|b1", "|u2", "|f4", "|i8"])
 def test_copy_scalar_with_func(func, shape, dtype):
-    X = dpt.usm_ndarray(shape, dtype=dtype)
+    try:
+        X = dpt.usm_ndarray(shape, dtype=dtype)
+    except dpctl.SyclDeviceCreationError:
+        pytest.skip("No SYCL devices available")
     Y = np.arange(1, X.size + 1, dtype=dtype).reshape(shape)
     X.usm_data.copy_from_host(Y.reshape(-1).view("|u1"))
     assert func(X) == func(Y)
@@ -205,7 +211,10 @@ def test_copy_scalar_with_func(func, shape, dtype):
 @pytest.mark.parametrize("shape", [tuple(), (1,), (1, 1), (1, 1, 1)])
 @pytest.mark.parametrize("dtype", ["|b1", "|u2", "|f4", "|i8"])
 def test_copy_scalar_with_method(method, shape, dtype):
-    X = dpt.usm_ndarray(shape, dtype=dtype)
+    try:
+        X = dpt.usm_ndarray(shape, dtype=dtype)
+    except dpctl.SyclDeviceCreationError:
+        pytest.skip("No SYCL devices available")
     Y = np.arange(1, X.size + 1, dtype=dtype).reshape(shape)
     X.usm_data.copy_from_host(Y.reshape(-1).view("|u1"))
     assert getattr(X, method)() == getattr(Y, method)()
@@ -214,7 +223,10 @@ def test_copy_scalar_with_method(method, shape, dtype):
 @pytest.mark.parametrize("func", [bool, float, int, complex])
 @pytest.mark.parametrize("shape", [(2,), (1, 2), (3, 4, 5), (0,)])
 def test_copy_scalar_invalid_shape(func, shape):
-    X = dpt.usm_ndarray(shape, dtype="i8")
+    try:
+        X = dpt.usm_ndarray(shape, dtype="i8")
+    except dpctl.SyclDeviceCreationError:
+        pytest.skip("No SYCL devices available")
     with pytest.raises(ValueError):
         func(X)
 
@@ -222,7 +234,10 @@ def test_copy_scalar_invalid_shape(func, shape):
 def test_index_noninteger():
     import operator
 
-    X = dpt.usm_ndarray(1, "f4")
+    try:
+        X = dpt.usm_ndarray(1, "f4")
+    except dpctl.SyclDeviceCreationError:
+        pytest.skip("No SYCL devices available")
     with pytest.raises(IndexError):
         operator.index(X)
 
@@ -251,7 +266,10 @@ def test_index_noninteger():
     ],
 )
 def test_basic_slice(ind):
-    X = dpt.usm_ndarray((2 * 3, 2 * 4, 3 * 5, 2 * 7), dtype="u1")
+    try:
+        X = dpt.usm_ndarray((2 * 3, 2 * 4, 3 * 5, 2 * 7), dtype="u1")
+    except dpctl.SyclDeviceCreationError:
+        pytest.skip("No SYCL devices available")
     Xnp = np.empty(X.shape, dtype=X.dtype)
     S = X[ind]
     Snp = Xnp[ind]
@@ -262,7 +280,10 @@ def test_basic_slice(ind):
 
 def test_empty_slice():
     # see gh801
-    X = dpt.empty((1, 0, 1), dtype="u1")
+    try:
+        X = dpt.empty((1, 0, 1), dtype="u1")
+    except dpctl.SyclDeviceCreationError:
+        pytest.skip("No SYCL devices available")
     Y = X[:, ::-1, :]
     assert Y.shape == X.shape
     Z = X[:, ::2, :]
@@ -279,7 +300,10 @@ def test_empty_slice():
 
 def test_slice_constructor_1d():
     Xh = np.arange(37, dtype="i4")
-    Xusm = dpt.arange(Xh.size, dtype="i4")
+    try:
+        Xusm = dpt.arange(Xh.size, dtype="i4")
+    except dpctl.SyclDeviceCreationError:
+        pytest.skip("No SYCL devices available")
     for ind in [
         slice(1, None, 2),
         slice(0, None, 3),
@@ -297,7 +321,10 @@ def test_slice_constructor_1d():
 
 def test_slice_constructor_3d():
     Xh = np.ones((37, 24, 35), dtype="i4")
-    Xusm = dpt.ones(Xh.shape, dtype=Xh.dtype)
+    try:
+        Xusm = dpt.ones(Xh.shape, dtype=Xh.dtype)
+    except dpctl.SyclDeviceCreationError:
+        pytest.skip("No SYCL devices available")
     for ind in [
         slice(1, None, 2),
         slice(0, None, 3),
@@ -317,7 +344,10 @@ def test_slice_constructor_3d():
 @pytest.mark.parametrize("usm_type", ["device", "shared", "host"])
 def test_slice_suai(usm_type):
     Xh = np.arange(0, 10, dtype="u1")
-    Xusm = dpt.arange(0, 10, dtype="u1", usm_type=usm_type)
+    try:
+        Xusm = dpt.arange(0, 10, dtype="u1", usm_type=usm_type)
+    except dpctl.SyclDeviceCreationError:
+        pytest.skip("No SYCL devices available")
     for ind in [slice(2, 3, None), slice(5, 7, None), slice(3, 9, None)]:
         assert np.array_equal(
             dpm.as_usm_memory(Xusm[ind]).copy_to_host(), Xh[ind]
@@ -325,7 +355,10 @@ def test_slice_suai(usm_type):
 
 
 def test_slicing_basic():
-    Xusm = dpt.usm_ndarray((10, 5), dtype="c8")
+    try:
+        Xusm = dpt.usm_ndarray((10, 5), dtype="c8")
+    except dpctl.SyclDeviceCreationError:
+        pytest.skip("No SYCL devices available")
     Xusm[None]
     Xusm[...]
     Xusm[8]
@@ -360,7 +393,10 @@ def test_ctor_invalid_order():
 
 
 def test_ctor_buffer_kwarg():
-    dpt.usm_ndarray(10, dtype="i8", buffer=b"device")
+    try:
+        dpt.usm_ndarray(10, dtype="i8", buffer=b"device")
+    except dpctl.SyclDeviceCreationError:
+        pytest.skip("No SYCL devices available")
     with pytest.raises(ValueError):
         dpt.usm_ndarray(10, buffer="invalid_param")
     Xusm = dpt.usm_ndarray((10, 5), dtype="c8")
@@ -373,7 +409,10 @@ def test_ctor_buffer_kwarg():
 
 
 def test_usm_ndarray_props():
-    Xusm = dpt.usm_ndarray((10, 5), dtype="c8", order="F")
+    try:
+        Xusm = dpt.usm_ndarray((10, 5), dtype="c8", order="F")
+    except dpctl.SyclDeviceCreationError:
+        pytest.skip("No SYCL devices available")
     Xusm.ndim
     repr(Xusm)
     Xusm.flags
@@ -390,7 +429,10 @@ def test_usm_ndarray_props():
 
 
 def test_datapi_device():
-    X = dpt.usm_ndarray(1, dtype="i4")
+    try:
+        X = dpt.usm_ndarray(1, dtype="i4")
+    except dpctl.SyclDeviceCreationError:
+        pytest.skip("No SYCL devices available")
     dev_t = type(X.device)
     with pytest.raises(TypeError):
         dev_t()
@@ -433,7 +475,10 @@ def _pyx_capi_fnptr_to_callable(
 
 
 def test_pyx_capi_get_data():
-    X = dpt.usm_ndarray(17, dtype="i8")[1::2]
+    try:
+        X = dpt.usm_ndarray(17, dtype="i8")[1::2]
+    except dpctl.SyclDeviceCreationError:
+        pytest.skip("No SYCL devices available")
     get_data_fn = _pyx_capi_fnptr_to_callable(
         X,
         "UsmNDArray_GetData",
@@ -447,7 +492,10 @@ def test_pyx_capi_get_data():
 
 
 def test_pyx_capi_get_shape():
-    X = dpt.usm_ndarray(17, dtype="u4")[1::2]
+    try:
+        X = dpt.usm_ndarray(17, dtype="u4")[1::2]
+    except dpctl.SyclDeviceCreationError:
+        pytest.skip("No SYCL devices available")
     get_shape_fn = _pyx_capi_fnptr_to_callable(
         X,
         "UsmNDArray_GetShape",
@@ -461,7 +509,10 @@ def test_pyx_capi_get_shape():
 
 
 def test_pyx_capi_get_strides():
-    X = dpt.usm_ndarray(17, dtype="f4")[1::2]
+    try:
+        X = dpt.usm_ndarray(17, dtype="f4")[1::2]
+    except dpctl.SyclDeviceCreationError:
+        pytest.skip("No SYCL devices available")
     get_strides_fn = _pyx_capi_fnptr_to_callable(
         X,
         "UsmNDArray_GetStrides",
@@ -478,7 +529,10 @@ def test_pyx_capi_get_strides():
 
 
 def test_pyx_capi_get_ndim():
-    X = dpt.usm_ndarray(17, dtype="?")[1::2]
+    try:
+        X = dpt.usm_ndarray(17, dtype="?")[1::2]
+    except dpctl.SyclDeviceCreationError:
+        pytest.skip("No SYCL devices available")
     get_ndim_fn = _pyx_capi_fnptr_to_callable(
         X,
         "UsmNDArray_GetNDim",
@@ -490,7 +544,10 @@ def test_pyx_capi_get_ndim():
 
 
 def test_pyx_capi_get_typenum():
-    X = dpt.usm_ndarray(17, dtype="c8")[1::2]
+    try:
+        X = dpt.usm_ndarray(17, dtype="c8")[1::2]
+    except dpctl.SyclDeviceCreationError:
+        pytest.skip("No SYCL devices available")
     get_typenum_fn = _pyx_capi_fnptr_to_callable(
         X,
         "UsmNDArray_GetTypenum",
@@ -504,7 +561,10 @@ def test_pyx_capi_get_typenum():
 
 
 def test_pyx_capi_get_elemsize():
-    X = dpt.usm_ndarray(17, dtype="u8")[1::2]
+    try:
+        X = dpt.usm_ndarray(17, dtype="u8")[1::2]
+    except dpctl.SyclDeviceCreationError:
+        pytest.skip("No SYCL devices available")
     get_elemsize_fn = _pyx_capi_fnptr_to_callable(
         X,
         "UsmNDArray_GetElementSize",
@@ -518,7 +578,10 @@ def test_pyx_capi_get_elemsize():
 
 
 def test_pyx_capi_get_flags():
-    X = dpt.usm_ndarray(17, dtype="i8")[1::2]
+    try:
+        X = dpt.usm_ndarray(17, dtype="i8")[1::2]
+    except dpctl.SyclDeviceCreationError:
+        pytest.skip("No SYCL devices available")
     get_flags_fn = _pyx_capi_fnptr_to_callable(
         X,
         "UsmNDArray_GetFlags",
@@ -531,7 +594,10 @@ def test_pyx_capi_get_flags():
 
 
 def test_pyx_capi_get_offset():
-    X = dpt.usm_ndarray(17, dtype="u2")[1::2]
+    try:
+        X = dpt.usm_ndarray(17, dtype="u2")[1::2]
+    except dpctl.SyclDeviceCreationError:
+        pytest.skip("No SYCL devices available")
     get_offset_fn = _pyx_capi_fnptr_to_callable(
         X,
         "UsmNDArray_GetOffset",
@@ -545,7 +611,10 @@ def test_pyx_capi_get_offset():
 
 
 def test_pyx_capi_get_queue_ref():
-    X = dpt.usm_ndarray(17, dtype="i2")[1::2]
+    try:
+        X = dpt.usm_ndarray(17, dtype="i2")[1::2]
+    except dpctl.SyclDeviceCreationError:
+        pytest.skip("No SYCL devices available")
     get_queue_ref_fn = _pyx_capi_fnptr_to_callable(
         X,
         "UsmNDArray_GetQueueRef",
@@ -789,7 +858,10 @@ def _pyx_capi_int(X, pyx_capi_name, caps_name=b"int", val_restype=ctypes.c_int):
 
 
 def test_pyx_capi_check_constants():
-    X = dpt.usm_ndarray(17, dtype="i1")[1::2]
+    try:
+        X = dpt.usm_ndarray(17, dtype="i1")[1::2]
+    except dpctl.SyclDeviceCreationError:
+        pytest.skip("No SYCL devices available")
     cc_flag = _pyx_capi_int(X, "USM_ARRAY_C_CONTIGUOUS")
     assert cc_flag > 0 and 0 == (cc_flag & (cc_flag - 1))
     fc_flag = _pyx_capi_int(X, "USM_ARRAY_F_CONTIGUOUS")
@@ -996,7 +1068,10 @@ def test_shape_setter():
         4,
         5,
     )
-    X = dpt.usm_ndarray(sh_s, dtype="i8")
+    try:
+        X = dpt.usm_ndarray(sh_s, dtype="i8")
+    except dpctl.SyclDeviceCreationError:
+        pytest.skip("No SYCL devices available")
     X.shape = sh_f
     assert X.shape == sh_f
     assert relaxed_strides_equal(X.strides, cc_strides(sh_f), sh_f)
@@ -1054,7 +1129,10 @@ def test_shape_setter():
 
 
 def test_len():
-    X = dpt.usm_ndarray(1, "i4")
+    try:
+        X = dpt.usm_ndarray(1, "i4")
+    except dpctl.SyclDeviceCreationError:
+        pytest.skip("No SYCL devices available")
     assert len(X) == 1
     X = dpt.usm_ndarray((2, 1), "i4")
     assert len(X) == 2
@@ -1064,20 +1142,29 @@ def test_len():
 
 
 def test_array_namespace():
-    X = dpt.usm_ndarray(1, "i4")
+    try:
+        X = dpt.usm_ndarray(1, "i4")
+    except dpctl.SyclDeviceCreationError:
+        pytest.skip("No SYCL devices available")
     X.__array_namespace__()
     X._set_namespace(dpt)
     assert X.__array_namespace__() is dpt
 
 
 def test_dlpack():
-    X = dpt.usm_ndarray(1, "i4")
+    try:
+        X = dpt.usm_ndarray(1, "i4")
+    except dpctl.SyclDeviceCreationError:
+        pytest.skip("No SYCL devices available")
     X.__dlpack_device__()
     X.__dlpack__(stream=None)
 
 
 def test_to_device():
-    X = dpt.usm_ndarray(1, "f4")
+    try:
+        X = dpt.usm_ndarray(1, "f4")
+    except dpctl.SyclDeviceCreationError:
+        pytest.skip("No SYCL devices available")
     for dev in dpctl.get_devices():
         if dev.default_selector_score > 0:
             Y = X.to_device(dev)
@@ -1095,7 +1182,10 @@ def test_to_device_migration():
 
 
 def test_astype():
-    X = dpt.empty((5, 5), dtype="i4")
+    try:
+        X = dpt.empty((5, 5), dtype="i4")
+    except dpctl.SyclDeviceCreationError:
+        pytest.skip("No SYCL devices available")
     X[:] = np.full((5, 5), 7, dtype="i4")
     Y = dpt.astype(X, "c8", order="C")
     assert np.allclose(dpt.to_numpy(Y), np.full((5, 5), 7, dtype="c8"))
@@ -1109,13 +1199,19 @@ def test_astype():
 
 
 def test_astype_invalid_order():
-    X = dpt.usm_ndarray(5, "i4")
+    try:
+        X = dpt.usm_ndarray(5, "i4")
+    except dpctl.SyclDeviceCreationError:
+        pytest.skip("No SYCL devices available")
     with pytest.raises(ValueError):
         dpt.astype(X, "i4", order="WRONG")
 
 
 def test_copy():
-    X = dpt.usm_ndarray((5, 5), "i4")[2:4, 1:4]
+    try:
+        X = dpt.usm_ndarray((5, 5), "i4")[2:4, 1:4]
+    except dpctl.SyclDeviceCreationError:
+        pytest.skip("No SYCL devices available")
     X[:] = 42
     Yc = dpt.copy(X, order="C")
     Yf = dpt.copy(X, order="F")
@@ -1137,7 +1233,10 @@ def test_copy():
 
 
 def test_ctor_invalid():
-    m = dpm.MemoryUSMShared(12)
+    try:
+        m = dpm.MemoryUSMShared(12)
+    except dpctl.SyclDeviceCreationError:
+        pytest.skip("No SYCL devices available")
     with pytest.raises(ValueError):
         dpt.usm_ndarray((4,), dtype="i4", buffer=m)
     m = dpm.MemoryUSMShared(64)
@@ -1146,7 +1245,10 @@ def test_ctor_invalid():
 
 
 def test_reshape():
-    X = dpt.usm_ndarray((5, 5), "i4")
+    try:
+        X = dpt.usm_ndarray((5, 5), "i4")
+    except dpctl.SyclDeviceCreationError:
+        pytest.skip("No SYCL devices available")
     # can be done as views
     Y = dpt.reshape(X, (25,))
     assert Y.shape == (25,)
@@ -1192,7 +1294,10 @@ def test_reshape():
 
 
 def test_reshape_copy_kwrd():
-    X = dpt.usm_ndarray((2, 3), "i4")
+    try:
+        X = dpt.usm_ndarray((2, 3), "i4")
+    except dpctl.SyclDeviceCreationError:
+        pytest.skip("No SYCL devices available")
     new_shape = (6,)
     Z = dpt.reshape(X, new_shape, copy=True)
     assert Z.shape == new_shape
@@ -1208,7 +1313,10 @@ def test_reshape_copy_kwrd():
 
 def test_transpose():
     n, m = 2, 3
-    X = dpt.usm_ndarray((n, m), "f4")
+    try:
+        X = dpt.usm_ndarray((n, m), "f4")
+    except dpctl.SyclDeviceCreationError:
+        pytest.skip("No SYCL devices available")
     Xnp = np.arange(n * m, dtype="f4").reshape((n, m))
     X[:] = Xnp
     assert np.array_equal(dpt.to_numpy(X.T), Xnp.T)
@@ -1217,7 +1325,10 @@ def test_transpose():
 
 def test_real_imag_views():
     n, m = 2, 3
-    X = dpt.usm_ndarray((n, m), "c8")
+    try:
+        X = dpt.usm_ndarray((n, m), "c8")
+    except dpctl.SyclDeviceCreationError:
+        pytest.skip("No SYCL devices available")
     Xnp_r = np.arange(n * m, dtype="f4").reshape((n, m))
     Xnp_i = np.arange(n * m, 2 * n * m, dtype="f4").reshape((n, m))
     Xnp = Xnp_r + 1j * Xnp_i
@@ -1262,10 +1373,22 @@ def test_full(dtype):
 
 
 def test_full_dtype_inference():
-    assert np.issubdtype(dpt.full(10, 4).dtype, np.integer)
-    assert dpt.full(10, True).dtype is dpt.dtype(np.bool_)
+    try:
+        X = dpt.full(10, 4)
+    except dpctl.SyclDeviceCreationError:
+        pytest.skip("No SYCL devices available")
+    assert np.issubdtype(X.dtype, np.integer)
+    try:
+        X = dpt.full(10, True)
+    except dpctl.SyclDeviceCreationError:
+        pytest.skip("No SYCL devices available")
+    assert X.dtype is dpt.dtype(np.bool_)
     assert np.issubdtype(dpt.full(10, 12.3).dtype, np.floating)
-    cdt = dpt.full(10, 0.3 - 2j).dtype
+    try:
+        X = dpt.full(10, 0.3 - 2j)
+    except dpctl.SyclDeviceCreationError:
+        pytest.skip("No SYCL devices available")
+    cdt = X.dtype
     assert np.issubdtype(cdt, np.complexfloating)
 
     assert np.issubdtype(dpt.full(10, 12.3, dtype=int).dtype, np.integer)
@@ -1488,7 +1611,10 @@ def test_empty_like(dt, usm_kind):
 
 def test_empty_unexpected_data_type():
     with pytest.raises(TypeError):
-        dpt.empty(1, dtype=np.object_)
+        try:
+            dpt.empty(1, dtype=np.object_)
+        except dpctl.SyclDeviceCreationError:
+            pytest.skip("No SYCL devices available")
 
 
 @pytest.mark.parametrize(
@@ -1815,7 +1941,10 @@ def test_common_arg_validation():
         dpt.full(10, 1, order=order)
     with pytest.raises(ValueError):
         dpt.eye(10, order=order)
-    X = dpt.empty(10)
+    try:
+        X = dpt.empty(10)
+    except dpctl.SyclDeviceCreationError:
+        pytest.skip("No SYCL devices available")
     with pytest.raises(ValueError):
         dpt.empty_like(X, order=order)
     with pytest.raises(ValueError):
@@ -1843,7 +1972,10 @@ def test_common_arg_validation():
 
 
 def test_flags():
-    x = dpt.empty(tuple(), "i4")
+    try:
+        x = dpt.empty(tuple(), "i4")
+    except dpctl.SyclDeviceCreationError:
+        pytest.skip("No SYCL devices available")
     f = x.flags
     f.__repr__()
     assert f.c_contiguous == f["C"]
@@ -1859,7 +1991,10 @@ def test_flags():
 
 def test_asarray_uint64():
     Xnp = np.ndarray(1, dtype=np.uint64)
-    X = dpt.asarray(Xnp)
+    try:
+        X = dpt.asarray(Xnp)
+    except dpctl.SyclDeviceCreationError:
+        pytest.skip("No SYCL devices available")
     assert X.dtype == Xnp.dtype
 
 

--- a/dpctl/tests/test_usm_ndarray_dlpack.py
+++ b/dpctl/tests/test_usm_ndarray_dlpack.py
@@ -85,7 +85,10 @@ def test_dlpack_exporter_empty(typestr, usm_type):
     caps_fn = ctypes.pythonapi.PyCapsule_IsValid
     caps_fn.restype = bool
     caps_fn.argtypes = [ctypes.py_object, ctypes.c_char_p]
-    sycl_dev = dpctl.select_default_device()
+    try:
+        sycl_dev = dpctl.select_default_device()
+    except dpctl.SyclDeviceCreationError:
+        pytest.skip("No SYCL devices available")
     skip_if_dtype_not_supported(typestr, sycl_dev)
     X = dpt.empty((0,), dtype=typestr, usm_type=usm_type, device=sycl_dev)
     caps = X.__dlpack__()

--- a/dpctl/tests/test_usm_ndarray_manipulation.py
+++ b/dpctl/tests/test_usm_ndarray_manipulation.py
@@ -20,6 +20,7 @@ import pytest
 from helper import get_queue_or_skip
 from numpy.testing import assert_, assert_array_equal, assert_raises_regex
 
+import dpctl
 import dpctl.tensor as dpt
 
 
@@ -139,7 +140,10 @@ def test_expand_dims_tuple(axes):
 
 
 def test_expand_dims_incorrect_tuple():
-    X = dpt.empty((3, 3, 3), dtype="i4")
+    try:
+        X = dpt.empty((3, 3, 3), dtype="i4")
+    except dpctl.SyclDeviceCreationError:
+        pytest.skip("No SYCL devices available")
     with pytest.raises(np.AxisError):
         dpt.expand_dims(X, (0, -6))
     with pytest.raises(np.AxisError):
@@ -1014,7 +1018,11 @@ def test_moveaxis_move_multiples(shape, source, destination, expected):
 
 
 def test_moveaxis_errors():
-    x = dpt.reshape(dpt.arange(6), (1, 2, 3))
+    try:
+        x_flat = dpt.arange(6)
+    except dpctl.SyclDeviceCreationError:
+        pytest.skip("No SYCL devices available")
+    x = dpt.reshape(x_flat, (1, 2, 3))
     assert_raises_regex(
         np.AxisError, "source.*out of bounds", dpt.moveaxis, x, 3, 0
     )
@@ -1044,7 +1052,11 @@ def test_moveaxis_errors():
 
 
 def test_unstack_axis0():
-    y = dpt.reshape(dpt.arange(6), (2, 3))
+    try:
+        x_flat = dpt.arange(6)
+    except dpctl.SyclDeviceCreationError:
+        pytest.skip("No SYCL devices available")
+    y = dpt.reshape(x_flat, (2, 3))
     res = dpt.unstack(y)
 
     assert_array_equal(dpt.asnumpy(y[0, ...]), dpt.asnumpy(res[0]))
@@ -1052,7 +1064,11 @@ def test_unstack_axis0():
 
 
 def test_unstack_axis1():
-    y = dpt.reshape(dpt.arange(6), (2, 3))
+    try:
+        x_flat = dpt.arange(6)
+    except dpctl.SyclDeviceCreationError:
+        pytest.skip("No SYCL devices available")
+    y = dpt.reshape(x_flat, (2, 3))
     res = dpt.unstack(y, 1)
 
     assert_array_equal(dpt.asnumpy(y[:, 0, ...]), dpt.asnumpy(res[0]))
@@ -1061,7 +1077,11 @@ def test_unstack_axis1():
 
 
 def test_unstack_axis2():
-    y = dpt.reshape(dpt.arange(60), (4, 5, 3))
+    try:
+        x_flat = dpt.arange(60)
+    except dpctl.SyclDeviceCreationError:
+        pytest.skip("No SYCL devices available")
+    y = dpt.reshape(x_flat, (4, 5, 3))
     res = dpt.unstack(y, 2)
 
     assert_array_equal(dpt.asnumpy(y[:, :, 0, ...]), dpt.asnumpy(res[0]))

--- a/dpctl/tests/test_usm_ndarray_operators.py
+++ b/dpctl/tests/test_usm_ndarray_operators.py
@@ -16,6 +16,7 @@
 
 import pytest
 
+import dpctl
 import dpctl.tensor as dpt
 
 
@@ -48,7 +49,10 @@ class Dummy:
 
 @pytest.mark.parametrize("namespace", [None, Dummy()])
 def test_fp_ops(namespace):
-    X = dpt.ones(1)
+    try:
+        X = dpt.ones(1)
+    except dpctl.SyclDeviceCreationError:
+        pytest.skip("No SYCL devices available")
     X._set_namespace(namespace)
     assert X.__array_namespace__() is namespace
     X[0] = -2.5
@@ -79,7 +83,10 @@ def test_fp_ops(namespace):
 
 @pytest.mark.parametrize("namespace", [None, Dummy()])
 def test_int_ops(namespace):
-    X = dpt.usm_ndarray(1, "i4")
+    try:
+        X = dpt.usm_ndarray(1, "i4")
+    except dpctl.SyclDeviceCreationError:
+        pytest.skip("No SYCL devices available")
     X._set_namespace(namespace)
     assert X.__array_namespace__() is namespace
     X.__lshift__(2)
@@ -108,7 +115,10 @@ def test_int_ops(namespace):
 
 @pytest.mark.parametrize("namespace", [None, Dummy()])
 def test_mat_ops(namespace):
-    M = dpt.eye(3, 3)
+    try:
+        M = dpt.eye(3, 3)
+    except dpctl.SyclDeviceCreationError:
+        pytest.skip("No SYCL devices available")
     M._set_namespace(namespace)
     assert M.__array_namespace__() is namespace
     M.__matmul__(M)

--- a/dpctl/tests/test_usm_ndarray_print.py
+++ b/dpctl/tests/test_usm_ndarray_print.py
@@ -18,6 +18,7 @@ import numpy as np
 import pytest
 from helper import get_queue_or_skip, skip_if_dtype_not_supported
 
+import dpctl
 import dpctl.tensor as dpt
 
 
@@ -53,7 +54,10 @@ class TestArgValidation(TestPrint):
         with pytest.raises(TypeError):
             dpt.usm_ndarray_repr(X)
 
-        X = dpt.arange(4)
+        try:
+            X = dpt.arange(4)
+        except dpctl.SyclDeviceCreationError:
+            pytest.skip("No SYCL devices available")
         with pytest.raises(TypeError):
             dpt.usm_ndarray_repr(X, line_width="I")
 
@@ -68,7 +72,11 @@ class TestArgValidation(TestPrint):
         with pytest.raises(TypeError):
             dpt.usm_ndarray_str(X)
 
-        X = dpt.arange(4)
+        try:
+            X = dpt.arange(4)
+        except dpctl.SyclDeviceCreationError:
+            pytest.skip("No SYCL devices available")
+
         with pytest.raises(TypeError):
             dpt.usm_ndarray_str(X, line_width="I")
 
@@ -363,8 +371,12 @@ class TestPrintFns(TestPrint):
 class TestContextManager:
     def test_context_manager_basic(self):
         options = dpt.get_print_options()
+        try:
+            X = dpt.asarray(1.234567)
+        except dpctl.SyclDeviceCreationError:
+            pytest.skip("No SYCL devices available")
         with dpt.print_options(precision=4):
-            s = str(dpt.asarray(1.234567))
+            s = str(X)
         assert s == "1.2346"
         assert options == dpt.get_print_options()
 

--- a/libsyclinterface/source/dpctl_sycl_device_manager.cpp
+++ b/libsyclinterface/source/dpctl_sycl_device_manager.cpp
@@ -113,7 +113,7 @@ struct DeviceCacheBuilder
      * post-creation we do not need any further protection to ensure
      * thread-safety.
      */
-    static const DeviceCache &getDeviceCache() noexcept
+    static const DeviceCache &getDeviceCache()
     {
         static DeviceCache *cache = new DeviceCache([] {
             DeviceCache cache_l{};

--- a/libsyclinterface/source/dpctl_sycl_device_manager.cpp
+++ b/libsyclinterface/source/dpctl_sycl_device_manager.cpp
@@ -208,7 +208,14 @@ DPCTLDeviceMgr_GetDevices(int device_identifier)
     if (!device_identifier)
         return wrap<vecTy>(Devices);
 
-    const auto &root_devices = device::get_devices();
+    std::vector<device> root_devices;
+    try {
+        root_devices = device::get_devices();
+    } catch (std::exception const &e) {
+        delete Devices;
+        error_handler(e, __FILE__, __func__, __LINE__);
+        return nullptr;
+    }
     dpctl_default_selector mRanker;
 
     for (const auto &root_device : root_devices) {

--- a/libsyclinterface/source/dpctl_sycl_device_manager.cpp
+++ b/libsyclinterface/source/dpctl_sycl_device_manager.cpp
@@ -113,12 +113,18 @@ struct DeviceCacheBuilder
      * post-creation we do not need any further protection to ensure
      * thread-safety.
      */
-    static const DeviceCache &getDeviceCache()
+    static const DeviceCache &getDeviceCache() noexcept
     {
         static DeviceCache *cache = new DeviceCache([] {
-            DeviceCache cache_l;
+            DeviceCache cache_l{};
             dpctl_default_selector mRanker;
-            auto Platforms = platform::get_platforms();
+            std::vector<platform> Platforms{};
+            try {
+                Platforms = platform::get_platforms();
+            } catch (std::exception const &e) {
+                error_handler(e, __FILE__, __func__, __LINE__);
+                return cache_l;
+            }
             for (const auto &P : Platforms) {
                 auto Devices = P.get_devices();
                 for (const auto &D : Devices) {
@@ -169,7 +175,15 @@ DPCTLDeviceMgr_GetCachedContext(__dpctl_keep const DPCTLSyclDeviceRef DRef)
                       __FILE__, __func__, __LINE__);
         return CRef;
     }
-    auto &cache = DeviceCacheBuilder::getDeviceCache();
+
+    using CacheT = typename DeviceCacheBuilder::DeviceCache;
+    CacheT const &cache = DeviceCacheBuilder::getDeviceCache();
+
+    if (cache.empty()) {
+        // an exception was caught and logged by getDeviceCache
+        return nullptr;
+    }
+
     auto entry = cache.find(*Device);
     if (entry != cache.end()) {
         context *ContextPtr = nullptr;
@@ -289,7 +303,13 @@ int DPCTLDeviceMgr_GetPositionInDevices(__dpctl_keep DPCTLSyclDeviceRef DRef,
 size_t DPCTLDeviceMgr_GetNumDevices(int device_identifier)
 {
     size_t nDevices = 0;
-    auto &cache = DeviceCacheBuilder::getDeviceCache();
+    using CacheT = typename DeviceCacheBuilder::DeviceCache;
+    CacheT const &cache = DeviceCacheBuilder::getDeviceCache();
+
+    if (cache.empty()) {
+        // an exception was caught and logged by getDeviceCache
+        return 0;
+    }
 
     device_identifier = to_canonical_device_id(device_identifier);
     if (!device_identifier)

--- a/libsyclinterface/source/dpctl_sycl_platform_interface.cpp
+++ b/libsyclinterface/source/dpctl_sycl_platform_interface.cpp
@@ -194,7 +194,13 @@ __dpctl_give DPCTLPlatformVectorRef DPCTLPlatform_GetPlatforms()
     using vecTy = std::vector<DPCTLSyclPlatformRef>;
     vecTy *Platforms = nullptr;
 
-    auto platforms = platform::get_platforms();
+    std::vector<platform> platforms;
+    try {
+        platforms = platform::get_platforms();
+    } catch (std::exception const &e) {
+        error_handler(e, __FILE__, __func__, __LINE__);
+        return nullptr;
+    }
 
     try {
         Platforms = new vecTy();

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,12 +22,14 @@ source = [
 omit = [
     "dpctl/tests/*",
     "dpctl/_version.py",
+    "*/_cython_api*/stringsource",
 ]
 
 [tool.coverage.report]
 omit = [
     "dpctl/tests/*",
     "dpctl/_version.py",
+    "*/_cython_api*/stringsource",
 ]
 
 [tool.pytest.ini.options]


### PR DESCRIPTION
Wrapped certain DPC++ RT function calls, such as `sycl::device::get_devices` and `sycl::platform::get_platforms` in try/except.

Added validation of object returned by cache builders.

Fixed typo in exception name in a Python test suite file, then run each test file individually with invalid setting of `ONEAPI_DEVICE_SELECTOR=cpu` to make sure the all execute fine. 

All but `test_sycl_queue_manager.py` pass. This one hangs due to filed problem in DPC++ Runtime.

Test suite continues to run clean with unset `ONEAPI_DEVICE_SELECTOR` environment variable, or it being set to a valid value, i.e. `ONEAPI_DEVICE_SELECTOR=*:cpu`.

- [x] Have you provided a meaningful PR description?
- [x] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [x] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
