### PR TITLE
Require DPC++ 2023.1.0 and later, require min version of sysroot

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -13,7 +13,8 @@ build:
 requirements:
     build:
         - {{ compiler('cxx') }}
-        - {{ compiler('dpcpp') }}  >=2023.0  # [not osx]
+        - {{ compiler('dpcpp') }} >=2023.1  # [not osx]
+	- sysroot_linux-64 >=2.17  # [linux]
     host:
         - setuptools
         - cmake  >=3.21
@@ -28,7 +29,7 @@ requirements:
         - python
         - {{ pin_compatible('numpy', min_pin='x.x', max_pin='x') }}
         - {{ pin_compatible('dpcpp-cpp-rt', min_pin='x.x', max_pin='x') }}  # [py<=39]
-        - dpcpp-cpp-rt  >=2023.0  # [py>39]
+        - dpcpp-cpp-rt >=2023.1  # [py>39]
 
 test:
     requires:

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -14,7 +14,7 @@ requirements:
     build:
         - {{ compiler('cxx') }}
         - {{ compiler('dpcpp') }} >=2023.1  # [not osx]
-	- sysroot_linux-64 >=2.17  # [linux]
+        - sysroot_linux-64 >=2.17  # [linux]
     host:
         - setuptools
         - cmake  >=3.21


### PR DESCRIPTION
This PR bumps up required version of DPC++ compiler to 2023.1.0.

It also restricts the version of sysroot that may be installed into build environment from below.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
