### PR TITLE
Implement QOL properties of usm_ndarray

### DIFF
--- a/dpctl/tests/test_usm_ndarray_ctor.py
+++ b/dpctl/tests/test_usm_ndarray_ctor.py
@@ -2012,3 +2012,30 @@ def test_Device():
     assert dict[d2] == 1
     assert d1 == d2.sycl_queue
     assert not d1 == Ellipsis
+
+
+def test_element_offset():
+    n0, n1 = 3, 8
+    try:
+        x = dpt.empty((n0, n1), dtype="i4")
+    except dpctl.SyclDeviceCreationError:
+        pytest.skip("No SYCL devices available")
+    assert isinstance(x._element_offset, int)
+    assert x._element_offset == 0
+    y = x[::-1, ::2]
+    assert y._element_offset == (n0 - 1) * n1
+
+
+def test_byte_bounds():
+    n0, n1 = 3, 8
+    try:
+        x = dpt.empty((n0, n1), dtype="i4")
+    except dpctl.SyclDeviceCreationError:
+        pytest.skip("No SYCL devices available")
+    assert isinstance(x._byte_bounds, tuple)
+    assert len(x._byte_bounds) == 2
+    lo, hi = x._byte_bounds
+    assert hi - lo == n0 * n1 * x.itemsize
+    y = x[::-1, ::2]
+    lo, hi = y._byte_bounds
+    assert hi - lo == (n0 * n1 - 1) * x.itemsize


### PR DESCRIPTION
This PR implements request for quality-of-life properties of usm_ndarray requested in gh-1192. It adds ``usm_ndarray._element_offset`` and ``usm_ndarray._byte_bounds``.

The `_element_offset` gives the offset of the start of array from the beginning of the start of allocation in elements.

`_byte_bounds` gives the tuple with addresses of end-points of the array. Not every memory element in between the end-points may be addressed by indexing.

```

In [1]: import dpctl.tensor as dpt

In [2]: dpt.empty(10)[5:]._element_offset
Out[2]: 5

In [3]: dpt.empty(10)[5:]._byte_bounds
Out[3]: (18446664917462351892, 18446664917462351912)

In [4]: _[1] - _[0]
Out[4]: 20

In [5]: dpt.empty(10)[5:].itemsize
Out[5]: 4
```

Tests are added. This PR resolves gh-1192

- [x] Have you provided a meaningful PR description?
- [x] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [x] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
