### PR TITLE
Fixed regression in iteration space simplifier, fixed arguments of numpy to usm_ndarray copying function 

### DIFF
--- a/dpctl/tensor/libtensor/source/copy_numpy_ndarray_into_usm_ndarray.cpp
+++ b/dpctl/tensor/libtensor/source/copy_numpy_ndarray_into_usm_ndarray.cpp
@@ -211,8 +211,8 @@ void copy_numpy_ndarray_into_usm_ndarray(
     }
 
     // Minumum and maximum element offsets for source np.ndarray
-    py::ssize_t npy_src_min_nelem_offset(0);
-    py::ssize_t npy_src_max_nelem_offset(0);
+    py::ssize_t npy_src_min_nelem_offset(src_offset);
+    py::ssize_t npy_src_max_nelem_offset(src_offset);
     for (int i = 0; i < nd; ++i) {
         if (simplified_src_strides[i] < 0) {
             npy_src_min_nelem_offset +=

--- a/dpctl/tensor/libtensor/source/simplify_iteration_space.cpp
+++ b/dpctl/tensor/libtensor/source/simplify_iteration_space.cpp
@@ -141,19 +141,22 @@ void simplify_iteration_space(int &nd,
         assert(simplified_shape.size() == static_cast<size_t>(nd));
 
         simplified_src_strides.reserve(nd);
-        simplified_src_strides.push_back(
-            (src_strides[0] >= 0) ? src_strides[0] : -src_strides[0]);
-        if ((src_strides[0] < 0) && (shape[0] > 1)) {
-            src_offset += (shape[0] - 1) * src_strides[0];
-        }
-        assert(simplified_src_strides.size() == static_cast<size_t>(nd));
-
         simplified_dst_strides.reserve(nd);
-        simplified_dst_strides.push_back(
-            (dst_strides[0] >= 0) ? dst_strides[0] : -dst_strides[0]);
-        if ((dst_strides[0] < 0) && (shape[0] > 1)) {
-            dst_offset += (shape[0] - 1) * dst_strides[0];
+
+        if (src_strides[0] < 0 && dst_strides[0] < 0) {
+            simplified_src_strides.push_back(-src_strides[0]);
+            simplified_dst_strides.push_back(-dst_strides[0]);
+            if (shape[0] > 1) {
+                src_offset += (shape[0] - 1) * src_strides[0];
+                dst_offset += (shape[0] - 1) * dst_strides[0];
+            }
         }
+        else {
+            simplified_src_strides.push_back(src_strides[0]);
+            simplified_dst_strides.push_back(dst_strides[0]);
+        }
+
+        assert(simplified_src_strides.size() == static_cast<size_t>(nd));
         assert(simplified_dst_strides.size() == static_cast<size_t>(nd));
     }
 }
@@ -226,27 +229,28 @@ void simplify_iteration_space_3(
         assert(simplified_shape.size() == static_cast<size_t>(nd));
 
         simplified_src1_strides.reserve(nd);
-        simplified_src1_strides.push_back(
-            (src1_strides[0] >= 0) ? src1_strides[0] : -src1_strides[0]);
-        if ((src1_strides[0] < 0) && (shape[0] > 1)) {
-            src1_offset += src1_strides[0] * (shape[0] - 1);
-        }
-        assert(simplified_src1_strides.size() == static_cast<size_t>(nd));
-
         simplified_src2_strides.reserve(nd);
-        simplified_src2_strides.push_back(
-            (src2_strides[0] >= 0) ? src2_strides[0] : -src2_strides[0]);
-        if ((src2_strides[0] < 0) && (shape[0] > 1)) {
-            src2_offset += src2_strides[0] * (shape[0] - 1);
-        }
-        assert(simplified_src2_strides.size() == static_cast<size_t>(nd));
-
         simplified_dst_strides.reserve(nd);
-        simplified_dst_strides.push_back(
-            (dst_strides[0] >= 0) ? dst_strides[0] : -dst_strides[0]);
-        if ((dst_strides[0] < 0) && (shape[0] > 1)) {
-            dst_offset += dst_strides[0] * (shape[0] - 1);
+
+        if ((src1_strides[0] < 0) && (src2_strides[0] < 0) &&
+            (dst_strides[0] < 0)) {
+            simplified_src1_strides.push_back(-src1_strides[0]);
+            simplified_src2_strides.push_back(-src2_strides[0]);
+            simplified_dst_strides.push_back(-dst_strides[0]);
+            if (shape[0] > 1) {
+                src1_offset += src1_strides[0] * (shape[0] - 1);
+                src2_offset += src2_strides[0] * (shape[0] - 1);
+                dst_offset += dst_strides[0] * (shape[0] - 1);
+            }
         }
+        else {
+            simplified_src1_strides.push_back(src1_strides[0]);
+            simplified_src2_strides.push_back(src2_strides[0]);
+            simplified_dst_strides.push_back(dst_strides[0]);
+        }
+
+        assert(simplified_src1_strides.size() == static_cast<size_t>(nd));
+        assert(simplified_src2_strides.size() == static_cast<size_t>(nd));
         assert(simplified_dst_strides.size() == static_cast<size_t>(nd));
     }
 }
@@ -333,35 +337,34 @@ void simplify_iteration_space_4(
         assert(simplified_shape.size() == static_cast<size_t>(nd));
 
         simplified_src1_strides.reserve(nd);
-        simplified_src1_strides.push_back(
-            (src1_strides[0] >= 0) ? src1_strides[0] : -src1_strides[0]);
-        if ((src1_strides[0] < 0) && (shape[0] > 1)) {
-            src1_offset += src1_strides[0] * (shape[0] - 1);
-        }
-        assert(simplified_src1_strides.size() == static_cast<size_t>(nd));
-
         simplified_src2_strides.reserve(nd);
-        simplified_src2_strides.push_back(
-            (src2_strides[0] >= 0) ? src2_strides[0] : -src2_strides[0]);
-        if ((src2_strides[0] < 0) && (shape[0] > 1)) {
-            src2_offset += src2_strides[0] * (shape[0] - 1);
-        }
-        assert(simplified_src2_strides.size() == static_cast<size_t>(nd));
-
         simplified_src3_strides.reserve(nd);
-        simplified_src3_strides.push_back(
-            (src3_strides[0] >= 0) ? src3_strides[0] : -src3_strides[0]);
-        if ((src3_strides[0] < 0) && (shape[0] > 1)) {
-            src3_offset += src3_strides[0] * (shape[0] - 1);
-        }
-        assert(simplified_src3_strides.size() == static_cast<size_t>(nd));
-
         simplified_dst_strides.reserve(nd);
-        simplified_dst_strides.push_back(
-            (dst_strides[0] >= 0) ? dst_strides[0] : -dst_strides[0]);
-        if ((dst_strides[0] < 0) && (shape[0] > 1)) {
-            dst_offset += dst_strides[0] * (shape[0] - 1);
+
+        if ((src1_strides[0] < 0) && (src2_strides[0] < 0) &&
+            (src3_strides[0] < 0) && (dst_strides[0] < 0))
+        {
+            simplified_src1_strides.push_back(-src1_strides[0]);
+            simplified_src2_strides.push_back(-src2_strides[0]);
+            simplified_src3_strides.push_back(-src3_strides[0]);
+            simplified_dst_strides.push_back(-dst_strides[0]);
+            if (shape[0] > 1) {
+                src1_offset += src1_strides[0] * (shape[0] - 1);
+                src2_offset += src2_strides[0] * (shape[0] - 1);
+                src3_offset += src3_strides[0] * (shape[0] - 1);
+                dst_offset += dst_strides[0] * (shape[0] - 1);
+            }
         }
+        else {
+            simplified_src1_strides.push_back(src1_strides[0]);
+            simplified_src2_strides.push_back(src2_strides[0]);
+            simplified_src3_strides.push_back(src3_strides[0]);
+            simplified_dst_strides.push_back(dst_strides[0]);
+        }
+
+        assert(simplified_src1_strides.size() == static_cast<size_t>(nd));
+        assert(simplified_src2_strides.size() == static_cast<size_t>(nd));
+        assert(simplified_src3_strides.size() == static_cast<size_t>(nd));
         assert(simplified_dst_strides.size() == static_cast<size_t>(nd));
     }
 }

--- a/dpctl/tests/test_usm_ndarray_ctor.py
+++ b/dpctl/tests/test_usm_ndarray_ctor.py
@@ -2059,3 +2059,16 @@ def test_byte_bounds():
     y = x[::-1, ::2]
     lo, hi = y._byte_bounds
     assert hi - lo == (n0 * n1 - 1) * x.itemsize
+
+
+def test_gh_1201():
+    n = 100
+    a = np.flipud(np.arange(n, dtype="i4"))
+    try:
+        b = dpt.asarray(a)
+    except dpctl.SyclDeviceCreationError:
+        pytest.skip("No SYCL devices available")
+    assert (dpt.asnumpy(b) == a).all()
+    c = dpt.flip(dpt.empty(a.shape, dtype=a.dtype))
+    c[:] = a
+    assert (dpt.asnumpy(c) == a).all()


### PR DESCRIPTION
This PR fixes issues in `simplify_iteration_space*` functions introduced in gh-1198.

It also corrects calculation of numpy array byte-boundaries to form `sycl::buffer` accessing
content of NumPy's array from a SYCL kernel.

Closes gh-1201

- [x] Have you provided a meaningful PR description?
- [x] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [x] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
