### PR TITLE
Try using sysroot 2.28

### DIFF
--- a/.github/workflows/conda-package.yml
+++ b/.github/workflows/conda-package.yml
@@ -161,13 +161,20 @@ jobs:
         run: |
           . $CONDA/etc/profile.d/conda.sh
           conda activate test_dpctl
-          python -c "import dpctl; dpctl.lsplatform()"
+          python -c "import dpctl; dpctl.lsplatform(verbosity=2)"
+      - name: Install gdb
+        run: |
+          sudo apt-get install -y gdb
+      - name: Run test_elementwise under gdb
+        run: |
+          . $CONDA/etc/profile.d/conda.sh
+          conda activate test_dpctl
+          gdb --batch -ex r -ex 'info sharedlibrary' -ex 'set print elements 1000' -ex bt --args ${CONDA_PREFIX}/bin/python -m pytest -q -ra --disable-warnings --pyargs dpctl.tests.test_tensor_elementwise::test_cos_order -vv || true
       - name: Run tests
         run: |
           . $CONDA/etc/profile.d/conda.sh
           conda activate test_dpctl
-          # clinfo -l
-          python -m pytest --pyargs $MODULE_NAME
+          python -m pytest -v --pyargs $MODULE_NAME
 
   test_windows:
     needs: build_windows

--- a/.github/workflows/conda-package.yml
+++ b/.github/workflows/conda-package.yml
@@ -44,7 +44,7 @@ jobs:
         run: conda install conda-build
       - name: Build conda package
         run: |
-          CHANNELS="-c intel -c main --override-channels"
+          CHANNELS="-c dppy/label/tools -c intel -c main --override-channels"
           VERSIONS="--python ${{ matrix.python }}"
           TEST="--no-test"
           conda build \

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -14,7 +14,7 @@ requirements:
     build:
         - {{ compiler('cxx') }}
         - {{ compiler('dpcpp') }} >=2023.1  # [not osx]
-        - sysroot_linux-64 >=2.17  # [linux]
+        - sysroot_linux-64 >=2.28  # [linux]
     host:
         - setuptools
         - cmake  >=3.21

--- a/conda-recipe/run_test.sh
+++ b/conda-recipe/run_test.sh
@@ -3,5 +3,5 @@
 set -e
 
 ${PYTHON} -c "import dpctl; print(dpctl.__version__)"
-${PYTHON} -c "import dpctl; dpctl.lsplatform()"
+${PYTHON} -c "import dpctl; dpctl.lsplatform(verbosity=2)"
 ${PYTHON} -m pytest -q -ra --disable-warnings -p no:faulthandler --cov dpctl --cov-report term-missing --pyargs dpctl -vv


### PR DESCRIPTION
Update meta.yaml to require sysroot_linux-64 >=2.28, and use dppy/label/tools to get it until it comes online from conda-forge

The sysroot packages are from https://github.com/conda-forge/linux-sysroot-feedstock/pull/47, built locally and uploaded to dppy/label/tools for the purpose on unblocking the build.

**N.B.**: This PR is into feature/elementwise-functions which is presently broken due to default sysroot version, 2.17, is below the minimum version [required](https://www.intel.com/content/www/us/en/developer/articles/system-requirements/intel-oneapi-dpcpp-system-requirements.html) by DPC++. See gh-1203

- [x] Have you provided a meaningful PR description?
- [x] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [x] Have you checked performance impact of proposed changes?
- [x] If this PR is a work in progress, are you opening the PR as a draft?
