### PR TITLE
Fixes incorrect result when multiplying real array and complex scalar

### DIFF
--- a/dpctl/tensor/_elementwise_common.py
+++ b/dpctl/tensor/_elementwise_common.py
@@ -255,7 +255,7 @@ def _resolve_weak_types(o1_dtype, o2_dtype, dev):
             raise ValueError
         o1_kind_num = _weak_type_num_kind(o1_dtype)
         o2_kind_num = _strong_dtype_num_kind(o2_dtype)
-        if o1_kind_num > o2_kind_num:
+        if o1_kind_num > o2_kind_num or o1_kind_num == 2:
             if isinstance(o1_dtype, WeakBooleanType):
                 return dpt.bool, o2_dtype
             if isinstance(o1_dtype, WeakIntegralType):
@@ -273,7 +273,7 @@ def _resolve_weak_types(o1_dtype, o2_dtype, dev):
     ):
         o1_kind_num = _strong_dtype_num_kind(o1_dtype)
         o2_kind_num = _weak_type_num_kind(o2_dtype)
-        if o2_kind_num > o1_kind_num:
+        if o2_kind_num > o1_kind_num or o2_kind_num == 2:
             if isinstance(o2_dtype, WeakBooleanType):
                 return o1_dtype, dpt.bool
             if isinstance(o2_dtype, WeakIntegralType):

--- a/dpctl/tests/elementwise/test_multiply.py
+++ b/dpctl/tests/elementwise/test_multiply.py
@@ -152,3 +152,18 @@ def test_multiply_python_scalar(arr_dt):
         assert isinstance(R, dpt.usm_ndarray)
         R = dpt.multiply(sc, X)
         assert isinstance(R, dpt.usm_ndarray)
+
+
+def test_multiply_python_scalar_gh1219():
+    q = get_queue_or_skip()
+
+    X = dpt.ones(4, dtype="f4", sycl_queue=q)
+
+    r = dpt.multiply(X, 2j)
+    expected = dpt.multiply(X, dpt.asarray(2j, sycl_queue=q))
+    assert _compare_dtypes(r.dtype, expected.dtype, sycl_queue=q)
+
+    # symmetric case
+    r = dpt.multiply(2j, X)
+    expected = dpt.multiply(dpt.asarray(2j, sycl_queue=q), X)
+    assert _compare_dtypes(r.dtype, expected.dtype, sycl_queue=q)


### PR DESCRIPTION
Resolves #1219 

Changes ``_resolve_weak_types`` to handle complex scalars properly and adds a test for the issue/fix.

- [X] Have you provided a meaningful PR description?
- [X] Have you added a test, reproducer or referred to an issue with a reproducer?
- [X] Have you tested your changes locally for CPU and GPU devices?
- [X] Have you made sure that new changes do not introduce compiler warnings?
- [X] Have you checked performance impact of proposed changes?
- [X] If this PR is a work in progress, are you opening the PR as a draft?
