### PR TITLE
In-place addition, multiplication, subtraction of usm_ndarrays

### DIFF
--- a/dpctl/tensor/_elementwise_common.py
+++ b/dpctl/tensor/_elementwise_common.py
@@ -31,6 +31,7 @@ from ._type_utils import (
     _empty_like_pair_orderK,
     _find_buf_dtype,
     _find_buf_dtype2,
+    _find_inplace_dtype,
     _to_device_supported_dtype,
 )
 
@@ -331,11 +332,19 @@ class BinaryElementwiseFunc:
     Class that implements binary element-wise functions.
     """
 
-    def __init__(self, name, result_type_resolver_fn, binary_dp_impl_fn, docs):
+    def __init__(
+        self,
+        name,
+        result_type_resolver_fn,
+        binary_dp_impl_fn,
+        docs,
+        binary_inplace_fn=None,
+    ):
         self.__name__ = "BinaryElementwiseFunc"
         self.name_ = name
         self.result_type_resolver_fn_ = result_type_resolver_fn
         self.binary_fn_ = binary_dp_impl_fn
+        self.binary_inplace_fn_ = binary_inplace_fn
         self.__doc__ = docs
 
     def __str__(self):
@@ -631,3 +640,113 @@ class BinaryElementwiseFunc:
         )
         dpctl.SyclEvent.wait_for([ht_copy1_ev, ht_copy2_ev, ht_])
         return out
+
+    def inplace(self, lhs, val):
+        if self.binary_inplace_fn_ is None:
+            raise ValueError(
+                f"In-place operation not supported for ufunc '{self.name_}'"
+            )
+        if not isinstance(lhs, dpt.usm_ndarray):
+            raise TypeError(
+                f"Expected dpctl.tensor.usm_ndarray, got {type(lhs)}"
+            )
+        q1, lhs_usm_type = _get_queue_usm_type(lhs)
+        q2, val_usm_type = _get_queue_usm_type(val)
+        if q2 is None:
+            exec_q = q1
+            usm_type = lhs_usm_type
+        else:
+            exec_q = dpctl.utils.get_execution_queue((q1, q2))
+            if exec_q is None:
+                raise ExecutionPlacementError(
+                    "Execution placement can not be unambiguously inferred "
+                    "from input arguments."
+                )
+            usm_type = dpctl.utils.get_coerced_usm_type(
+                (
+                    lhs_usm_type,
+                    val_usm_type,
+                )
+            )
+        dpctl.utils.validate_usm_type(usm_type, allow_none=False)
+        lhs_shape = _get_shape(lhs)
+        val_shape = _get_shape(val)
+        if not all(
+            isinstance(s, (tuple, list))
+            for s in (
+                lhs_shape,
+                val_shape,
+            )
+        ):
+            raise TypeError(
+                "Shape of arguments can not be inferred. "
+                "Arguments are expected to be "
+            )
+        try:
+            res_shape = _broadcast_shape_impl(
+                [
+                    lhs_shape,
+                    val_shape,
+                ]
+            )
+        except ValueError:
+            raise ValueError(
+                "operands could not be broadcast together with shapes "
+                f"{lhs_shape} and {val_shape}"
+            )
+        if res_shape != lhs_shape:
+            raise ValueError(
+                f"output shape {lhs_shape} does not match "
+                f"broadcast shape {res_shape}"
+            )
+        sycl_dev = exec_q.sycl_device
+        lhs_dtype = lhs.dtype
+        val_dtype = _get_dtype(val, sycl_dev)
+        if not _validate_dtype(val_dtype):
+            raise ValueError("Input operand of unsupported type")
+
+        lhs_dtype, val_dtype = _resolve_weak_types(
+            lhs_dtype, val_dtype, sycl_dev
+        )
+
+        buf_dt = _find_inplace_dtype(
+            lhs_dtype, val_dtype, self.result_type_resolver_fn_, sycl_dev
+        )
+
+        if buf_dt is None:
+            raise TypeError(
+                f"function '{self.name_}' does not support input types "
+                f"({lhs_dtype}, {val_dtype}), "
+                "and the inputs could not be safely coerced to any "
+                "supported types according to the casting rule ''safe''."
+            )
+
+        if isinstance(val, dpt.usm_ndarray):
+            rhs = val
+        else:
+            rhs = dpt.asarray(val, dtype=val_dtype, sycl_queue=exec_q)
+
+        if buf_dt == val_dtype:
+            rhs = dpt.broadcast_to(rhs, res_shape)
+            ht_, _ = self.binary_inplace_fn_(
+                lhs=lhs, rhs=rhs, sycl_queue=exec_q
+            )
+            ht_.wait()
+
+        else:
+            buf = dpt.empty_like(rhs, dtype=buf_dt)
+            ht_copy_ev, copy_ev = ti._copy_usm_ndarray_into_usm_ndarray(
+                src=rhs, dst=buf, sycl_queue=exec_q
+            )
+
+            buf = dpt.broadcast_to(buf, res_shape)
+            ht_, _ = self.binary_inplace_fn_(
+                lhs=lhs,
+                rhs=buf,
+                sycl_queue=exec_q,
+                depends=[copy_ev],
+            )
+            ht_copy_ev.wait()
+            ht_.wait()
+
+        return lhs

--- a/dpctl/tensor/_elementwise_common.py
+++ b/dpctl/tensor/_elementwise_common.py
@@ -650,6 +650,10 @@ class BinaryElementwiseFunc:
             raise TypeError(
                 f"Expected dpctl.tensor.usm_ndarray, got {type(lhs)}"
             )
+        if isinstance(val, dpt.usm_ndarray):
+            if ti._array_overlap(lhs, val):
+                # call standard operator in this case
+                return self(lhs, val)
         q1, lhs_usm_type = _get_queue_usm_type(lhs)
         q2, val_usm_type = _get_queue_usm_type(val)
         if q2 is None:

--- a/dpctl/tensor/_elementwise_funcs.py
+++ b/dpctl/tensor/_elementwise_funcs.py
@@ -73,7 +73,11 @@ Returns:
         returned array is determined by the Type Promotion Rules.
 """
 add = BinaryElementwiseFunc(
-    "add", ti._add_result_type, ti._add, _add_docstring_
+    "add",
+    ti._add_result_type,
+    ti._add,
+    _add_docstring_,
+    binary_inplace_fn=ti._add_inplace,
 )
 
 # U04: ===== ASIN  (x)

--- a/dpctl/tensor/_elementwise_funcs.py
+++ b/dpctl/tensor/_elementwise_funcs.py
@@ -607,7 +607,11 @@ Returns:
         the returned array is determined by the Type Promotion Rules.
 """
 multiply = BinaryElementwiseFunc(
-    "multiply", ti._multiply_result_type, ti._multiply, _multiply_docstring_
+    "multiply",
+    ti._multiply_result_type,
+    ti._multiply,
+    _multiply_docstring_,
+    ti._multiply_inplace,
 )
 
 # U25: ==== NEGATIVE    (x)
@@ -786,7 +790,11 @@ Returns:
         of the returned array is determined by the Type Promotion Rules.
 """
 subtract = BinaryElementwiseFunc(
-    "subtract", ti._subtract_result_type, ti._subtract, _subtract_docstring_
+    "subtract",
+    ti._subtract_result_type,
+    ti._subtract,
+    _subtract_docstring_,
+    ti._subtract_inplace,
 )
 
 

--- a/dpctl/tensor/_type_utils.py
+++ b/dpctl/tensor/_type_utils.py
@@ -294,9 +294,27 @@ def _find_buf_dtype2(arg1_dtype, arg2_dtype, query_fn, sycl_dev):
     return None, None, None
 
 
+def _find_inplace_dtype(lhs_dtype, rhs_dtype, query_fn, sycl_dev):
+    res_dt = query_fn(lhs_dtype, rhs_dtype)
+    if res_dt and res_dt == lhs_dtype:
+        return rhs_dtype
+
+    _fp16 = sycl_dev.has_aspect_fp16
+    _fp64 = sycl_dev.has_aspect_fp64
+    all_dts = _all_data_types(_fp16, _fp64)
+    for buf_dt in all_dts:
+        if _can_cast(rhs_dtype, buf_dt, _fp16, _fp64):
+            res_dt = query_fn(lhs_dtype, buf_dt)
+            if res_dt and res_dt == lhs_dtype:
+                return buf_dt
+
+    return None
+
+
 __all__ = [
     "_find_buf_dtype",
     "_find_buf_dtype2",
+    "_find_inplace_dtype",
     "_empty_like_orderK",
     "_empty_like_pair_orderK",
     "_to_device_supported_dtype",

--- a/dpctl/tensor/_usmarray.pyx
+++ b/dpctl/tensor/_usmarray.pyx
@@ -1245,11 +1245,8 @@ cdef class usm_ndarray:
         return _dispatch_binary_elementwise2(other, "logical_xor", self)
 
     def __iadd__(self, other):
-        res = self.__add__(other)
-        if res is NotImplemented:
-            return res
-        self.__setitem__(Ellipsis, res)
-        return self
+        from ._elementwise_funcs import add
+        return add.inplace(self, other)
 
     def __iand__(self, other):
         res = self.__and__(other)

--- a/dpctl/tensor/_usmarray.pyx
+++ b/dpctl/tensor/_usmarray.pyx
@@ -1284,11 +1284,8 @@ cdef class usm_ndarray:
         return self
 
     def __imul__(self, other):
-        res = self.__mul__(other)
-        if res is NotImplemented:
-            return res
-        self.__setitem__(Ellipsis, res)
-        return self
+        from ._elementwise_funcs import multiply
+        return multiply.inplace(self, other)
 
     def __ior__(self, other):
         res = self.__or__(other)
@@ -1312,11 +1309,8 @@ cdef class usm_ndarray:
         return self
 
     def __isub__(self, other):
-        res = self.__sub__(other)
-        if res is NotImplemented:
-            return res
-        self.__setitem__(Ellipsis, res)
-        return self
+        from ._elementwise_funcs import subtract
+        return subtract.inplace(self, other)
 
     def __itruediv__(self, other):
         res = self.__truediv__(other)

--- a/dpctl/tensor/_usmarray.pyx
+++ b/dpctl/tensor/_usmarray.pyx
@@ -1246,7 +1246,7 @@ cdef class usm_ndarray:
 
     def __iadd__(self, other):
         from ._elementwise_funcs import add
-        return add.inplace(self, other)
+        return add._inplace(self, other)
 
     def __iand__(self, other):
         res = self.__and__(other)
@@ -1285,7 +1285,7 @@ cdef class usm_ndarray:
 
     def __imul__(self, other):
         from ._elementwise_funcs import multiply
-        return multiply.inplace(self, other)
+        return multiply._inplace(self, other)
 
     def __ior__(self, other):
         res = self.__or__(other)
@@ -1310,7 +1310,7 @@ cdef class usm_ndarray:
 
     def __isub__(self, other):
         from ._elementwise_funcs import subtract
-        return subtract.inplace(self, other)
+        return subtract._inplace(self, other)
 
     def __itruediv__(self, other):
         res = self.__truediv__(other)

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/add.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/add.hpp
@@ -34,6 +34,7 @@
 #include "utils/type_utils.hpp"
 
 #include "kernels/elementwise_functions/common.hpp"
+#include "kernels/elementwise_functions/common_inplace.hpp"
 #include <pybind11/pybind11.h>
 
 namespace dpctl
@@ -212,7 +213,6 @@ template <typename fnT, typename T1, typename T2> struct AddTypeMapFactory
     std::enable_if_t<std::is_same<fnT, int>::value, int> get()
     {
         using rT = typename AddOutputType<T1, T2>::value_type;
-        ;
         return td_ns::GetTypeid<rT>{}.get();
     }
 };
@@ -360,6 +360,122 @@ struct AddContigRowContigMatrixBroadcastFactory
                     add_contig_row_contig_matrix_broadcast_impl<T1, T2, resT>;
                 return fn;
             }
+        }
+    }
+};
+
+template <typename argT, typename resT> struct AddInplaceFunctor
+{
+
+    using supports_sg_loadstore = std::negation<
+        std::disjunction<tu_ns::is_complex<argT>, tu_ns::is_complex<resT>>>;
+    using supports_vec = std::negation<
+        std::disjunction<tu_ns::is_complex<argT>, tu_ns::is_complex<resT>>>;
+
+    void operator()(resT &res, const argT &in)
+    {
+        res += in;
+    }
+
+    template <int vec_sz>
+    void operator()(sycl::vec<resT, vec_sz> &res,
+                    const sycl::vec<argT, vec_sz> &in)
+    {
+        res += in;
+    }
+};
+
+template <typename argT,
+          typename resT,
+          unsigned int vec_sz = 4,
+          unsigned int n_vecs = 2>
+using AddInplaceContigFunctor = elementwise_common::BinaryInplaceContigFunctor<
+    argT,
+    resT,
+    AddInplaceFunctor<argT, resT>,
+    vec_sz,
+    n_vecs>;
+
+template <typename argT, typename resT, typename IndexerT>
+using AddInplaceStridedFunctor =
+    elementwise_common::BinaryInplaceStridedFunctor<
+        argT,
+        resT,
+        IndexerT,
+        AddInplaceFunctor<argT, resT>>;
+
+template <typename argT,
+          typename resT,
+          unsigned int vec_sz,
+          unsigned int n_vecs>
+class add_inplace_contig_kernel;
+
+template <typename argTy, typename resTy>
+sycl::event
+add_inplace_contig_impl(sycl::queue exec_q,
+                        size_t nelems,
+                        const char *arg_p,
+                        py::ssize_t arg_offset,
+                        char *res_p,
+                        py::ssize_t res_offset,
+                        const std::vector<sycl::event> &depends = {})
+{
+    return elementwise_common::binary_inplace_contig_impl<
+        argTy, resTy, AddInplaceContigFunctor, add_inplace_contig_kernel>(
+        exec_q, nelems, arg_p, arg_offset, res_p, res_offset, depends);
+}
+
+template <typename fnT, typename T1, typename T2> struct AddInplaceContigFactory
+{
+    fnT get()
+    {
+        if constexpr (std::is_same_v<typename AddOutputType<T1, T2>::value_type,
+                                     void>) {
+            fnT fn = nullptr;
+            return fn;
+        }
+        else {
+            fnT fn = add_inplace_contig_impl<T1, T2>;
+            return fn;
+        }
+    }
+};
+
+template <typename resT, typename argT, typename IndexerT>
+class add_inplace_strided_kernel;
+
+template <typename argTy, typename resTy>
+sycl::event
+add_inplace_strided_impl(sycl::queue exec_q,
+                         size_t nelems,
+                         int nd,
+                         const py::ssize_t *shape_and_strides,
+                         const char *arg_p,
+                         py::ssize_t arg_offset,
+                         char *res_p,
+                         py::ssize_t res_offset,
+                         const std::vector<sycl::event> &depends,
+                         const std::vector<sycl::event> &additional_depends)
+{
+    return elementwise_common::binary_inplace_strided_impl<
+        argTy, resTy, AddInplaceStridedFunctor, add_inplace_strided_kernel>(
+        exec_q, nelems, nd, shape_and_strides, arg_p, arg_offset, res_p,
+        res_offset, depends, additional_depends);
+}
+
+template <typename fnT, typename T1, typename T2>
+struct AddInplaceStridedFactory
+{
+    fnT get()
+    {
+        if constexpr (std::is_same_v<typename AddOutputType<T1, T2>::value_type,
+                                     void>) {
+            fnT fn = nullptr;
+            return fn;
+        }
+        else {
+            fnT fn = add_inplace_strided_impl<T1, T2>;
+            return fn;
         }
     }
 };

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/common.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/common.hpp
@@ -618,7 +618,7 @@ public:
     }
 };
 
-// Typdefs for function pointers
+// Typedefs for function pointers
 
 typedef sycl::event (*unary_contig_impl_fn_ptr_t)(
     sycl::queue,

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/common_inplace.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/common_inplace.hpp
@@ -191,7 +191,7 @@ public:
     }
 };
 
-// Typdefs for function pointers
+// Typedefs for function pointers
 
 typedef sycl::event (*binary_inplace_contig_impl_fn_ptr_t)(
     sycl::queue,

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/common_inplace.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/common_inplace.hpp
@@ -1,0 +1,295 @@
+//=== common.hpp -  Common code for elementwise operations ----- *-C++-*--/===//
+//
+//                      Data Parallel Control (dpctl)
+//
+// Copyright 2020-2023 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+//===---------------------------------------------------------------------===//
+///
+/// \file
+/// This file defines common code for elementwise tensor operations.
+//===---------------------------------------------------------------------===//
+
+#pragma once
+#include <CL/sycl.hpp>
+#include <cstddef>
+#include <cstdint>
+#include <pybind11/pybind11.h>
+
+namespace dpctl
+{
+namespace tensor
+{
+namespace kernels
+{
+namespace elementwise_common
+{
+
+template <typename argT,
+          typename resT,
+          typename BinaryInplaceOperatorT,
+          unsigned int vec_sz = 4,
+          unsigned int n_vecs = 2>
+struct BinaryInplaceContigFunctor
+{
+private:
+    const argT *rhs = nullptr;
+    resT *lhs = nullptr;
+    const size_t nelems_;
+
+public:
+    BinaryInplaceContigFunctor(const argT *rhs_tp,
+                               resT *lhs_tp,
+                               const size_t n_elems)
+        : rhs(rhs_tp), lhs(lhs_tp), nelems_(n_elems)
+    {
+    }
+
+    void operator()(sycl::nd_item<1> ndit) const
+    {
+        BinaryInplaceOperatorT op{};
+        /* Each work-item processes vec_sz elements, contiguous in memory */
+
+        if constexpr (BinaryInplaceOperatorT::supports_sg_loadstore::value &&
+                      BinaryInplaceOperatorT::supports_vec::value)
+        {
+            auto sg = ndit.get_sub_group();
+            std::uint8_t sgSize = sg.get_local_range()[0];
+            std::uint8_t maxsgSize = sg.get_max_local_range()[0];
+
+            size_t base = n_vecs * vec_sz *
+                          (ndit.get_group(0) * ndit.get_local_range(0) +
+                           sg.get_group_id()[0] * sgSize);
+
+            if ((base + n_vecs * vec_sz * sgSize < nelems_) &&
+                (sgSize == maxsgSize)) {
+                using rhs_ptrT =
+                    sycl::multi_ptr<const argT,
+                                    sycl::access::address_space::global_space>;
+                using lhs_ptrT =
+                    sycl::multi_ptr<resT,
+                                    sycl::access::address_space::global_space>;
+                sycl::vec<argT, vec_sz> arg_vec;
+                sycl::vec<resT, vec_sz> res_vec;
+
+#pragma unroll
+                for (std::uint8_t it = 0; it < n_vecs * vec_sz; it += vec_sz) {
+                    arg_vec =
+                        sg.load<vec_sz>(rhs_ptrT(&rhs[base + it * sgSize]));
+                    res_vec =
+                        sg.load<vec_sz>(lhs_ptrT(&lhs[base + it * sgSize]));
+                    op(res_vec, arg_vec);
+                    sg.store<vec_sz>(lhs_ptrT(&lhs[base + it * sgSize]),
+                                     res_vec);
+                }
+            }
+            else {
+                for (size_t k = base + sg.get_local_id()[0]; k < nelems_;
+                     k += sgSize) {
+                    op(lhs[k], rhs[k]);
+                }
+            }
+        }
+        else if constexpr (BinaryInplaceOperatorT::supports_sg_loadstore::value)
+        {
+            auto sg = ndit.get_sub_group();
+            std::uint8_t sgSize = sg.get_local_range()[0];
+            std::uint8_t maxsgSize = sg.get_max_local_range()[0];
+
+            size_t base = n_vecs * vec_sz *
+                          (ndit.get_group(0) * ndit.get_local_range(0) +
+                           sg.get_group_id()[0] * sgSize);
+
+            if ((base + n_vecs * vec_sz * sgSize < nelems_) &&
+                (sgSize == maxsgSize)) {
+                using rhs_ptrT =
+                    sycl::multi_ptr<const argT,
+                                    sycl::access::address_space::global_space>;
+                using lhs_ptrT =
+                    sycl::multi_ptr<resT,
+                                    sycl::access::address_space::global_space>;
+                sycl::vec<argT, vec_sz> arg_vec;
+                sycl::vec<resT, vec_sz> res_vec;
+
+#pragma unroll
+                for (std::uint8_t it = 0; it < n_vecs * vec_sz; it += vec_sz) {
+                    arg_vec =
+                        sg.load<vec_sz>(rhs_ptrT(&rhs[base + it * sgSize]));
+                    res_vec =
+                        sg.load<vec_sz>(lhs_ptT(&lhs[base + it * sgSize]));
+#pragma unroll
+                    for (std::uint8_t vec_id = 0; vec_id < vec_sz; ++vec_id) {
+                        op(res_vec[vec_id], arg_vec[vec_id]);
+                    }
+                    sg.store<vec_sz>(lhs_ptrT(&lhs[base + it * sgSize]),
+                                     res_vec);
+                }
+            }
+            else {
+                for (size_t k = base + sg.get_local_id()[0]; k < nelems_;
+                     k += sgSize) {
+                    op(lhs[k], rhs[k]);
+                }
+            }
+        }
+        else {
+            std::uint8_t sgSize = ndit.get_sub_group().get_local_range()[0];
+            size_t base = ndit.get_global_linear_id();
+
+            base = (base / sgSize) * sgSize * n_vecs * vec_sz + (base % sgSize);
+            for (size_t offset = base;
+                 offset < std::min(nelems_, base + sgSize * (n_vecs * vec_sz));
+                 offset += sgSize)
+            {
+                op(lhs[offset], rhs[offset]);
+            }
+        }
+    }
+};
+
+template <typename argT,
+          typename resT,
+          typename TwoOffsets_IndexerT,
+          typename BinaryInplaceOperatorT>
+struct BinaryInplaceStridedFunctor
+{
+private:
+    const argT *rhs = nullptr;
+    resT *lhs = nullptr;
+    TwoOffsets_IndexerT two_offsets_indexer_;
+
+public:
+    BinaryInplaceStridedFunctor(const argT *rhs_tp,
+                                resT *lhs_tp,
+                                TwoOffsets_IndexerT inp_res_indexer)
+        : rhs(rhs_tp), lhs(lhs_tp), two_offsets_indexer_(inp_res_indexer)
+    {
+    }
+
+    void operator()(sycl::id<1> wid) const
+    {
+        const auto &two_offsets_ =
+            two_offsets_indexer_(static_cast<py::ssize_t>(wid.get(0)));
+
+        const auto &inp_offset = two_offsets_.get_first_offset();
+        const auto &lhs_offset = two_offsets_.get_second_offset();
+
+        BinaryInplaceOperatorT op{};
+        op(lhs[lhs_offset], rhs[inp_offset]);
+    }
+};
+
+// Typdefs for function pointers
+
+typedef sycl::event (*binary_inplace_contig_impl_fn_ptr_t)(
+    sycl::queue,
+    size_t,
+    const char *,
+    py::ssize_t,
+    char *,
+    py::ssize_t,
+    const std::vector<sycl::event> &);
+
+typedef sycl::event (*binary_inplace_strided_impl_fn_ptr_t)(
+    sycl::queue,
+    size_t,
+    int,
+    const py::ssize_t *,
+    const char *,
+    py::ssize_t,
+    char *,
+    py::ssize_t,
+    const std::vector<sycl::event> &,
+    const std::vector<sycl::event> &);
+
+template <typename argTy,
+          typename resTy,
+          template <typename T1, typename T2, unsigned int vs, unsigned int nv>
+          class BinaryInplaceContigFunctorT,
+          template <typename T1, typename T2, unsigned int vs, unsigned int nv>
+          class kernel_name,
+          unsigned int vec_sz = 4,
+          unsigned int n_vecs = 2>
+sycl::event
+binary_inplace_contig_impl(sycl::queue exec_q,
+                           size_t nelems,
+                           const char *rhs_p,
+                           py::ssize_t rhs_offset,
+                           char *lhs_p,
+                           py::ssize_t lhs_offset,
+                           const std::vector<sycl::event> &depends = {})
+{
+    sycl::event comp_ev = exec_q.submit([&](sycl::handler &cgh) {
+        cgh.depends_on(depends);
+
+        size_t lws = 64;
+        const size_t n_groups =
+            ((nelems + lws * n_vecs * vec_sz - 1) / (lws * n_vecs * vec_sz));
+        const auto gws_range = sycl::range<1>(n_groups * lws);
+        const auto lws_range = sycl::range<1>(lws);
+
+        const argTy *arg_tp =
+            reinterpret_cast<const argTy *>(rhs_p) + rhs_offset;
+        resTy *res_tp = reinterpret_cast<resTy *>(lhs_p) + lhs_offset;
+
+        cgh.parallel_for<kernel_name<argTy, resTy, vec_sz, n_vecs>>(
+            sycl::nd_range<1>(gws_range, lws_range),
+            BinaryInplaceContigFunctorT<argTy, resTy, vec_sz, n_vecs>(
+                arg_tp, res_tp, nelems));
+    });
+    return comp_ev;
+}
+
+template <typename argTy,
+          typename resTy,
+          template <typename T1, typename T2, typename IndT>
+          class BinaryInplaceStridedFunctorT,
+          template <typename T1, typename T2, typename IndT>
+          class kernel_name>
+sycl::event
+binary_inplace_strided_impl(sycl::queue exec_q,
+                            size_t nelems,
+                            int nd,
+                            const py::ssize_t *shape_and_strides,
+                            const char *rhs_p,
+                            py::ssize_t rhs_offset,
+                            char *lhs_p,
+                            py::ssize_t lhs_offset,
+                            const std::vector<sycl::event> &depends,
+                            const std::vector<sycl::event> &additional_depends)
+{
+    sycl::event comp_ev = exec_q.submit([&](sycl::handler &cgh) {
+        cgh.depends_on(depends);
+        cgh.depends_on(additional_depends);
+
+        using IndexerT =
+            typename dpctl::tensor::offset_utils::TwoOffsets_StridedIndexer;
+
+        IndexerT indexer{nd, rhs_offset, lhs_offset, shape_and_strides};
+
+        const argTy *arg_tp = reinterpret_cast<const argTy *>(rhs_p);
+        resTy *res_tp = reinterpret_cast<resTy *>(lhs_p);
+
+        cgh.parallel_for<kernel_name<argTy, resTy, IndexerT>>(
+            {nelems}, BinaryInplaceStridedFunctorT<argTy, resTy, IndexerT>(
+                          arg_tp, res_tp, indexer));
+    });
+    return comp_ev;
+}
+
+} // namespace elementwise_common
+} // namespace kernels
+} // namespace tensor
+} // namespace dpctl

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/subtract.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/subtract.hpp
@@ -385,6 +385,130 @@ struct SubtractContigRowContigMatrixBroadcastFactory
     }
 };
 
+template <typename argT, typename resT> struct SubtractInplaceFunctor
+{
+
+    using supports_sg_loadstore = std::negation<
+        std::disjunction<tu_ns::is_complex<argT>, tu_ns::is_complex<resT>>>;
+    using supports_vec = std::negation<
+        std::disjunction<tu_ns::is_complex<argT>, tu_ns::is_complex<resT>>>;
+
+    void operator()(resT &res, const argT &in)
+    {
+        res -= in;
+    }
+
+    template <int vec_sz>
+    void operator()(sycl::vec<resT, vec_sz> &res,
+                    const sycl::vec<argT, vec_sz> &in)
+    {
+        res -= in;
+    }
+};
+
+template <typename argT,
+          typename resT,
+          unsigned int vec_sz = 4,
+          unsigned int n_vecs = 2>
+using SubtractInplaceContigFunctor =
+    elementwise_common::BinaryInplaceContigFunctor<
+        argT,
+        resT,
+        SubtractInplaceFunctor<argT, resT>,
+        vec_sz,
+        n_vecs>;
+
+template <typename argT, typename resT, typename IndexerT>
+using SubtractInplaceStridedFunctor =
+    elementwise_common::BinaryInplaceStridedFunctor<
+        argT,
+        resT,
+        IndexerT,
+        SubtractInplaceFunctor<argT, resT>>;
+
+template <typename argT,
+          typename resT,
+          unsigned int vec_sz,
+          unsigned int n_vecs>
+class subtract_inplace_contig_kernel;
+
+template <typename argTy, typename resTy>
+sycl::event
+subtract_inplace_contig_impl(sycl::queue exec_q,
+                             size_t nelems,
+                             const char *arg_p,
+                             py::ssize_t arg_offset,
+                             char *res_p,
+                             py::ssize_t res_offset,
+                             const std::vector<sycl::event> &depends = {})
+{
+    return elementwise_common::binary_inplace_contig_impl<
+        argTy, resTy, SubtractInplaceContigFunctor,
+        subtract_inplace_contig_kernel>(exec_q, nelems, arg_p, arg_offset,
+                                        res_p, res_offset, depends);
+}
+
+template <typename fnT, typename T1, typename T2>
+struct SubtractInplaceContigFactory
+{
+    fnT get()
+    {
+        if constexpr (std::is_same_v<
+                          typename SubtractOutputType<T1, T2>::value_type,
+                          void>)
+        {
+            fnT fn = nullptr;
+            return fn;
+        }
+        else {
+            fnT fn = subtract_inplace_contig_impl<T1, T2>;
+            return fn;
+        }
+    }
+};
+
+template <typename resT, typename argT, typename IndexerT>
+class subtract_inplace_strided_kernel;
+
+template <typename argTy, typename resTy>
+sycl::event subtract_inplace_strided_impl(
+    sycl::queue exec_q,
+    size_t nelems,
+    int nd,
+    const py::ssize_t *shape_and_strides,
+    const char *arg_p,
+    py::ssize_t arg_offset,
+    char *res_p,
+    py::ssize_t res_offset,
+    const std::vector<sycl::event> &depends,
+    const std::vector<sycl::event> &additional_depends)
+{
+    return elementwise_common::binary_inplace_strided_impl<
+        argTy, resTy, SubtractInplaceStridedFunctor,
+        subtract_inplace_strided_kernel>(exec_q, nelems, nd, shape_and_strides,
+                                         arg_p, arg_offset, res_p, res_offset,
+                                         depends, additional_depends);
+}
+
+template <typename fnT, typename T1, typename T2>
+struct SubtractInplaceStridedFactory
+{
+    fnT get()
+    {
+        if constexpr (std::is_same_v<
+                          typename SubtractOutputType<T1, T2>::value_type,
+                          void>)
+        {
+            fnT fn = nullptr;
+            return fn;
+        }
+        else {
+            fnT fn = subtract_inplace_strided_impl<T1, T2>;
+            return fn;
+        }
+    }
+};
+
 } // namespace subtract
 } // namespace kernels
 } // namespace tensor

--- a/dpctl/tensor/libtensor/source/elementwise_functions.hpp
+++ b/dpctl/tensor/libtensor/source/elementwise_functions.hpp
@@ -63,6 +63,10 @@ py_unary_ufunc(dpctl::tensor::usm_ndarray src,
                const contig_dispatchT &contig_dispatch_vector,
                const strided_dispatchT &strided_dispatch_vector)
 {
+    if (!dst.is_writable()) {
+        throw py::value_error("Output array is read-only.");
+    }
+
     int src_typenum = src.get_typenum();
     int dst_typenum = dst.get_typenum();
 
@@ -306,6 +310,9 @@ std::pair<sycl::event, sycl::event> py_binary_ufunc(
     const contig_row_matrix_dispatchT
         &contig_row_matrix_broadcast_dispatch_table)
 {
+    if (!dst.is_writable()) {
+        throw py::value_error("Output array is read-only.");
+    }
     // check type_nums
     int src1_typenum = src1.get_typenum();
     int src2_typenum = src2.get_typenum();
@@ -602,6 +609,10 @@ py_binary_inplace_ufunc(dpctl::tensor::usm_ndarray lhs,
                         const contig_dispatchT &contig_dispatch_table,
                         const strided_dispatchT &strided_dispatch_table)
 {
+    if (!lhs.is_writable()) {
+        throw py::value_error("Output array is read-only.");
+    }
+
     // check type_nums
     int rhs_typenum = rhs.get_typenum();
     int lhs_typenum = lhs.get_typenum();

--- a/dpctl/tensor/libtensor/source/elementwise_functions.hpp
+++ b/dpctl/tensor/libtensor/source/elementwise_functions.hpp
@@ -587,6 +587,201 @@ py::object py_binary_ufunc_result_type(py::dtype input1_dtype,
     }
 }
 
+// ==================== Inplace binary functions =======================
+
+template <typename output_typesT,
+          typename contig_dispatchT,
+          typename strided_dispatchT>
+std::pair<sycl::event, sycl::event>
+py_binary_inplace_ufunc(dpctl::tensor::usm_ndarray lhs,
+                        dpctl::tensor::usm_ndarray rhs,
+                        sycl::queue exec_q,
+                        const std::vector<sycl::event> depends,
+                        //
+                        const output_typesT &output_type_table,
+                        const contig_dispatchT &contig_dispatch_table,
+                        const strided_dispatchT &strided_dispatch_table)
+{
+    // check type_nums
+    int rhs_typenum = rhs.get_typenum();
+    int lhs_typenum = lhs.get_typenum();
+
+    auto array_types = td_ns::usm_ndarray_types();
+    int rhs_typeid = array_types.typenum_to_lookup_id(rhs_typenum);
+    int lhs_typeid = array_types.typenum_to_lookup_id(lhs_typenum);
+
+    int output_typeid = output_type_table[rhs_typeid][lhs_typeid];
+
+    if (output_typeid != lhs_typeid) {
+        throw py::value_error(
+            "Destination array has unexpected elemental data type.");
+    }
+
+    // check that queues are compatible
+    if (!dpctl::utils::queues_are_compatible(exec_q, {rhs, lhs})) {
+        throw py::value_error(
+            "Execution queue is not compatible with allocation queues");
+    }
+
+    // check shapes, broadcasting is assumed done by caller
+    // check that dimensions are the same
+    int lhs_nd = lhs.get_ndim();
+    if (lhs_nd != rhs.get_ndim()) {
+        throw py::value_error("Array dimensions are not the same.");
+    }
+
+    // check that shapes are the same
+    const py::ssize_t *rhs_shape = rhs.get_shape_raw();
+    const py::ssize_t *lhs_shape = lhs.get_shape_raw();
+    bool shapes_equal(true);
+    size_t rhs_nelems(1);
+
+    for (int i = 0; i < lhs_nd; ++i) {
+        rhs_nelems *= static_cast<size_t>(rhs_shape[i]);
+        shapes_equal = shapes_equal && (rhs_shape[i] == lhs_shape[i]);
+    }
+    if (!shapes_equal) {
+        throw py::value_error("Array shapes are not the same.");
+    }
+
+    // if nelems is zero, return
+    if (rhs_nelems == 0) {
+        return std::make_pair(sycl::event(), sycl::event());
+    }
+
+    // ensure that output is ample enough to accomodate all elements
+    auto lhs_offsets = lhs.get_minmax_offsets();
+    // destination must be ample enough to accomodate all elements
+    {
+        size_t range =
+            static_cast<size_t>(lhs_offsets.second - lhs_offsets.first);
+        if (range + 1 < rhs_nelems) {
+            throw py::value_error(
+                "Destination array can not accomodate all the "
+                "elements of source array.");
+        }
+    }
+
+    // check memory overlap
+    auto const &overlap = dpctl::tensor::overlap::MemoryOverlap();
+    if (overlap(rhs, lhs)) {
+        throw py::value_error("Arrays index overlapping segments of memory");
+    }
+    // check memory overlap
+    const char *rhs_data = rhs.get_data();
+    char *lhs_data = lhs.get_data();
+
+    // handle contiguous inputs
+    bool is_rhs_c_contig = rhs.is_c_contiguous();
+    bool is_rhs_f_contig = rhs.is_f_contiguous();
+
+    bool is_lhs_c_contig = lhs.is_c_contiguous();
+    bool is_lhs_f_contig = lhs.is_f_contiguous();
+
+    bool both_c_contig = (is_rhs_c_contig && is_lhs_c_contig);
+    bool both_f_contig = (is_rhs_f_contig && is_lhs_f_contig);
+
+    // dispatch for contiguous inputs
+    if (both_c_contig || both_f_contig) {
+        auto contig_fn = contig_dispatch_table[lhs_typeid][rhs_typeid];
+
+        if (contig_fn != nullptr) {
+            auto comp_ev = contig_fn(exec_q, rhs_nelems, rhs_data, 0, lhs_data,
+                                     0, depends);
+            sycl::event ht_ev =
+                dpctl::utils::keep_args_alive(exec_q, {rhs, lhs}, {comp_ev});
+
+            return std::make_pair(ht_ev, comp_ev);
+        }
+    }
+
+    // simplify strides
+    auto const &rhs_strides = rhs.get_strides_vector();
+    auto const &lhs_strides = lhs.get_strides_vector();
+
+    using shT = std::vector<py::ssize_t>;
+    shT simplified_shape;
+    shT simplified_rhs_strides;
+    shT simplified_lhs_strides;
+    py::ssize_t rhs_offset(0);
+    py::ssize_t lhs_offset(0);
+
+    int nd = lhs_nd;
+    const py::ssize_t *shape = rhs_shape;
+
+    // all args except itemsizes and is_?_contig bools can be modified by
+    // reference
+    dpctl::tensor::py_internal::simplify_iteration_space(
+        nd, shape, rhs_strides, lhs_strides,
+        // outputs
+        simplified_shape, simplified_rhs_strides, simplified_lhs_strides,
+        rhs_offset, lhs_offset);
+
+    std::vector<sycl::event> host_tasks{};
+
+    if (nd < 2) {
+        static constexpr auto unit_stride =
+            std::initializer_list<py::ssize_t>{1};
+
+        if ((nd == 1) && isEqual(simplified_rhs_strides, unit_stride) &&
+            isEqual(simplified_lhs_strides, unit_stride))
+        {
+            auto contig_fn = contig_dispatch_table[lhs_typeid][rhs_typeid];
+
+            if (contig_fn != nullptr) {
+                auto comp_ev =
+                    contig_fn(exec_q, rhs_nelems, rhs_data, rhs_offset,
+                              lhs_data, lhs_offset, depends);
+                sycl::event ht_ev = dpctl::utils::keep_args_alive(
+                    exec_q, {rhs, lhs}, {comp_ev});
+
+                return std::make_pair(ht_ev, comp_ev);
+            }
+        }
+    }
+
+    // dispatch to strided code
+    auto strided_fn = strided_dispatch_table[lhs_typeid][rhs_typeid];
+
+    if (strided_fn == nullptr) {
+        throw std::runtime_error(
+            "Contiguous implementation is missing for rhs_typeid=" +
+            std::to_string(rhs_typeid) +
+            " and lhs_typeid=" + std::to_string(lhs_typeid));
+    }
+
+    using dpctl::tensor::offset_utils::device_allocate_and_pack;
+    const auto &ptr_sz_event_triple_ = device_allocate_and_pack<py::ssize_t>(
+        exec_q, host_tasks, simplified_shape, simplified_rhs_strides,
+        simplified_lhs_strides);
+
+    py::ssize_t *shape_strides = std::get<0>(ptr_sz_event_triple_);
+    sycl::event copy_shape_ev = std::get<2>(ptr_sz_event_triple_);
+
+    if (shape_strides == nullptr) {
+        throw std::runtime_error("Unabled to allocate device memory");
+    }
+
+    sycl::event strided_fn_ev =
+        strided_fn(exec_q, rhs_nelems, nd, shape_strides, rhs_data, rhs_offset,
+                   lhs_data, lhs_offset, depends, {copy_shape_ev});
+
+    // async free of shape_strides temporary
+    auto ctx = exec_q.get_context();
+
+    sycl::event tmp_cleanup_ev = exec_q.submit([&](sycl::handler &cgh) {
+        cgh.depends_on(strided_fn_ev);
+        cgh.host_task(
+            [ctx, shape_strides]() { sycl::free(shape_strides, ctx); });
+    });
+
+    host_tasks.push_back(tmp_cleanup_ev);
+
+    return std::make_pair(
+        dpctl::utils::keep_args_alive(exec_q, {rhs, lhs}, host_tasks),
+        strided_fn_ev);
+}
+
 extern void init_elementwise_functions(py::module_ m);
 
 } // namespace py_internal

--- a/dpctl/tests/elementwise/test_add.py
+++ b/dpctl/tests/elementwise/test_add.py
@@ -423,7 +423,7 @@ def test_add_inplace_errors():
     ar1 = np.ones(2, dtype="float32")
     ar2 = dpt.ones(2, dtype="float32")
     with pytest.raises(TypeError):
-        ar1 += ar2
+        dpt.add.inplace(ar1, ar2)
 
     ar1 = dpt.ones(2, dtype="float32")
     ar2 = dict()

--- a/dpctl/tests/elementwise/test_add.py
+++ b/dpctl/tests/elementwise/test_add.py
@@ -294,7 +294,8 @@ def test_add_errors():
 
     ar1 = dpt.ones(2, dtype="float32")
     ar2 = dpt.ones_like(ar1, dtype="int32")
-    y = ar1
+    # identical view but a different object
+    y = ar1[:]
     assert_raises_regex(
         TypeError,
         "Input and output arrays have memory overlap",
@@ -423,7 +424,7 @@ def test_add_inplace_errors():
     ar1 = np.ones(2, dtype="float32")
     ar2 = dpt.ones(2, dtype="float32")
     with pytest.raises(TypeError):
-        dpt.add.inplace(ar1, ar2)
+        ar1 += ar2
 
     ar1 = dpt.ones(2, dtype="float32")
     ar2 = dict()
@@ -434,3 +435,19 @@ def test_add_inplace_errors():
     ar2 = dpt.ones((1, 2), dtype="float32")
     with pytest.raises(ValueError):
         ar1 += ar2
+
+
+def test_add_inplace_overlap():
+    get_queue_or_skip()
+
+    ar1 = dpt.ones(10, dtype="i4")
+    ar1 += ar1
+    assert (dpt.asnumpy(ar1) == np.full(ar1.shape, 2, dtype="i4")).all()
+
+    ar1 = dpt.ones(10, dtype="i4")
+    ar2 = dpt.ones(10, dtype="i4")
+    dpt.add(ar1, ar2, out=ar1)
+    assert (dpt.asnumpy(ar1) == np.full(ar1.shape, 2, dtype="i4")).all()
+
+    dpt.add(ar2, ar1, out=ar2)
+    assert (dpt.asnumpy(ar2) == np.full(ar2.shape, 3, dtype="i4")).all()

--- a/dpctl/tests/elementwise/test_multiply.py
+++ b/dpctl/tests/elementwise/test_multiply.py
@@ -172,3 +172,59 @@ def test_multiply_python_scalar_gh1219(arr_dt, sc):
     R = dpt.multiply(sc, X)
     Rnp = np.multiply(sc, Xnp)
     assert _compare_dtypes(R.dtype, Rnp.dtype, sycl_queue=q)
+
+
+@pytest.mark.parametrize("dtype", _all_dtypes)
+def test_multiply_inplace_python_scalar(dtype):
+    q = get_queue_or_skip()
+    skip_if_dtype_not_supported(dtype, q)
+    X = dpt.ones((10, 10), dtype=dtype, sycl_queue=q)
+    dt_kind = X.dtype.kind
+    if dt_kind in "ui":
+        X *= int(1)
+    elif dt_kind == "f":
+        X *= float(1)
+    elif dt_kind == "c":
+        X *= complex(1)
+    elif dt_kind == "b":
+        X *= bool(1)
+
+
+@pytest.mark.parametrize("op1_dtype", _all_dtypes)
+@pytest.mark.parametrize("op2_dtype", _all_dtypes)
+def test_multiply_inplace_dtype_matrix(op1_dtype, op2_dtype):
+    q = get_queue_or_skip()
+    skip_if_dtype_not_supported(op1_dtype, q)
+    skip_if_dtype_not_supported(op2_dtype, q)
+
+    sz = 127
+    ar1 = dpt.ones(sz, dtype=op1_dtype)
+    ar2 = dpt.ones_like(ar1, dtype=op2_dtype)
+
+    if dpt.can_cast(op2_dtype, op1_dtype, casting="safe"):
+        ar1 *= ar2
+        assert (
+            dpt.asnumpy(ar1) == np.full(ar1.shape, 1, dtype=ar1.dtype)
+        ).all()
+
+        ar3 = dpt.ones(sz, dtype=op1_dtype)
+        ar4 = dpt.ones(2 * sz, dtype=op2_dtype)
+
+        ar3[::-1] *= ar4[::2]
+        assert (
+            dpt.asnumpy(ar3) == np.full(ar3.shape, 1, dtype=ar3.dtype)
+        ).all()
+
+    else:
+        with pytest.raises(TypeError):
+            ar1 *= ar2
+
+
+def test_multiply_inplace_broadcasting():
+    get_queue_or_skip()
+
+    m = dpt.ones((100, 5), dtype="i4")
+    v = dpt.arange(5, dtype="i4")
+
+    m *= v
+    assert (dpt.asnumpy(m) == np.arange(0, 5, dtype="i4")[np.newaxis, :]).all()


### PR DESCRIPTION
Closes #1229 
This pull request implements in-place addition, subtraction, and multiplication of ``usm_ndarray`` instances.

By avoiding the additional allocation of an output array, the performance advantage compared compared to applying the operator with a scalar, a la ``dpt.add(x, 2)``, is considerable.

For example:
```
In [8]: X = dpt.ones((16768, 16768), dtype="f4")

In [9]: %time X += 2
CPU times: user 58.5 ms, sys: 78.1 ms, total: 137 ms
Wall time: 133 ms

In [10]: %time dpt.add(X, 2)
CPU times: user 238 ms, sys: 147 ms, total: 385 ms
Wall time: 392 ms
```

- [X] Have you provided a meaningful PR description?
- [X] Have you added a test, reproducer or referred to an issue with a reproducer?
- [X] Have you tested your changes locally for CPU and GPU devices?
- [X] Have you made sure that new changes do not introduce compiler warnings?
- [X] Have you checked performance impact of proposed changes?
- [X] If this PR is a work in progress, are you opening the PR as a draft?
