### PR TITLE
Correct libtensor preambles

### DIFF
--- a/dpctl/tensor/libtensor/include/kernels/boolean_advanced_indexing.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/boolean_advanced_indexing.hpp
@@ -1,4 +1,4 @@
-//=== boolean_advance_indexing.hpp -                      ------*-C++-*--/===//
+//=== boolean_advanced_indexing.hpp -                      ------*-C++-*--/===//
 //
 //                      Data Parallel Control (dpctl)
 //

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/common_inplace.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/common_inplace.hpp
@@ -1,4 +1,5 @@
-//=== common.hpp -  Common code for elementwise operations ----- *-C++-*--/===//
+//=== common_inplace.hpp -  Common code for in-place elementwise operations
+//----- *-C++-*--/===//
 //
 //                      Data Parallel Control (dpctl)
 //
@@ -19,7 +20,7 @@
 //===---------------------------------------------------------------------===//
 ///
 /// \file
-/// This file defines common code for elementwise tensor operations.
+/// This file defines common code for in-place elementwise tensor operations.
 //===---------------------------------------------------------------------===//
 
 #pragma once

--- a/dpctl/tensor/libtensor/source/integer_advanced_indexing.cpp
+++ b/dpctl/tensor/libtensor/source/integer_advanced_indexing.cpp
@@ -1,4 +1,4 @@
-//===-- take_kernel_impl.cpp - Implementation of take  --*-C++-*-/===//
+//===-- integer_advanced_indexing.cpp -                         --*-C++-*-/===//
 //
 //                      Data Parallel Control (dpctl)
 //

--- a/dpctl/tensor/libtensor/source/integer_advanced_indexing.hpp
+++ b/dpctl/tensor/libtensor/source/integer_advanced_indexing.hpp
@@ -1,4 +1,4 @@
-//===----------- Implementation of _tensor_impl module  ---------*-C++-*-/===//
+//===-- integer_advanced_indexing.hpp -                         --*-C++-*-/===//
 //
 //                      Data Parallel Control (dpctl)
 //
@@ -19,7 +19,8 @@
 //===----------------------------------------------------------------------===//
 ///
 /// \file
-/// This file defines functions of dpctl.tensor._tensor_impl extensions
+/// This file declares Python API for implementation functions of
+/// dpctl.tensor.take and dpctl.tensor.put
 //===----------------------------------------------------------------------===//
 
 #pragma once


### PR DESCRIPTION
Changes preambles for ``common_inplace.hpp``, ``kernels/boolean_advanced_indexing.hpp``, ``source/integer_advanced_indexing.hpp``, and ``integer_advanced_indexing.cpp`` to the correct filename and description.

- [X] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
