### PR TITLE
Use _depenv_s in libsyclinterface on Windows

### DIFF
--- a/libsyclinterface/helper/source/dpctl_error_handlers.cpp
+++ b/libsyclinterface/helper/source/dpctl_error_handlers.cpp
@@ -27,6 +27,9 @@
 #include "dpctl_service.h"
 #include <cstring>
 #include <sstream>
+#ifdef _WIN32
+#include <cstdlib>
+#endif
 #ifdef ENABLE_GLOG
 #include <glog/logging.h>
 #endif
@@ -48,9 +51,16 @@ namespace
 {
 int requested_verbosity_level(void)
 {
-    int requested_level = 0;
+    char *verbose = nullptr;
+    size_t len = 0;
 
-    const char *verbose = std::getenv("DPCTL_VERBOSITY");
+#ifdef _WIN32
+    _dupenv_s(&verbose, &len, "DPCTL_VERBOSITY");
+#else
+    verbose = std::getenv("DPCTL_VERBOSITY");
+#endif
+
+    int requested_level = 0;
 
     if (verbose) {
         if (!std::strncmp(verbose, "none", 4))
@@ -60,6 +70,11 @@ int requested_verbosity_level(void)
         else if (!std::strncmp(verbose, "warning", 7))
             requested_level = error_level::warning;
     }
+
+#ifdef _WIN32
+    if (verbose)
+        free(verbose);
+#endif
 
     return requested_level;
 }

--- a/libsyclinterface/helper/source/dpctl_error_handlers.cpp
+++ b/libsyclinterface/helper/source/dpctl_error_handlers.cpp
@@ -52,9 +52,9 @@ namespace
 int requested_verbosity_level(void)
 {
     char *verbose = nullptr;
-    size_t len = 0;
 
 #ifdef _WIN32
+    size_t len = 0;
     _dupenv_s(&verbose, &len, "DPCTL_VERBOSITY");
 #else
     verbose = std::getenv("DPCTL_VERBOSITY");


### PR DESCRIPTION
This RP refactors `requested_verbosity_level` function to solve #1246 and suggest the usage of  `_dupenv_s` for Windows by conditional compilation.
 

- [X] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [X] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
