### PR TITLE
update elementwise tests for exp, real, imag, and conj

### DIFF
--- a/dpctl/tensor/_elementwise_funcs.py
+++ b/dpctl/tensor/_elementwise_funcs.py
@@ -36,8 +36,11 @@ Args:
 Returns:
     usm_narray:
         An array containing the element-wise absolute values.
-        For complex input, the absolute value is its magnitude. The data type
-        of the returned array is determined by the Type Promotion Rules.
+        For complex input, the absolute value is its magnitude.
+        If `x` has a real-valued data type, the returned array has the
+        same data type as `x`. If `x` has a complex floating-point data type,
+        the returned array has a real-valued floating-point data type whose
+        precision matches the precision of `x`.
 """
 
 abs = UnaryElementwiseFunc("abs", ti._abs_result_type, ti._abs, _abs_docstring_)
@@ -133,8 +136,8 @@ Args:
         Default: "K".
 Returns:
     usm_narray:
-        An array containing the element-wise conjugate values. The data type
-        of the returned array is determined by the Type Promotion Rules.
+        An array containing the element-wise conjugate values.
+        The returned array has the same data type as `x`.
 """
 
 conj = UnaryElementwiseFunc(
@@ -216,8 +219,7 @@ Args:
 Returns:
     usm_narray:
         An array containing the result of element-wise equality comparison.
-        The data type of the returned array is determined by the
-        Type Promotion Rules.
+        The returned array has a data type of `bool`.
 """
 
 equal = BinaryElementwiseFunc(
@@ -264,6 +266,8 @@ Args:
 Return:
     usm_ndarray:
         An array containing the element-wise exp(x)-1 values.
+        The data type of the returned array is determined by the Type
+        Promotion Rules.
 """
 
 expm1 = UnaryElementwiseFunc(
@@ -288,7 +292,7 @@ Args:
         Second input array, also expected to have numeric data type.
 Returns:
     usm_narray:
-        an array containing the result of element-wise  floor division.
+        an array containing the result of element-wise floor division.
         The data type of the returned array is determined by the Type
         Promotion Rules.
 """
@@ -319,8 +323,7 @@ Args:
 Returns:
     usm_narray:
         An array containing the result of element-wise greater-than comparison.
-        The data type of the returned array is determined by the
-        Type Promotion Rules.
+        The returned array has a data type of `bool`.
 """
 
 greater = BinaryElementwiseFunc(
@@ -347,8 +350,7 @@ Returns:
     usm_narray:
         An array containing the result of element-wise greater-than or equal-to
         comparison.
-        The data type of the returned array is determined by the
-        Type Promotion Rules.
+        The returned array has a data type of `bool`.
 """
 
 greater_equal = BinaryElementwiseFunc(
@@ -376,8 +378,10 @@ Args:
 Returns:
     usm_narray:
         An array containing the element-wise imaginary component of input.
-        The data type of the returned array is determined
-        by the Type Promotion Rules.
+        If the input is a real-valued data type, the returned array has
+        the same datat type. If the input is a complex floating-point
+        data type, the returned array has a floating-point data type
+        with the same floating-point precision as complex input.
 """
 
 imag = UnaryElementwiseFunc(
@@ -403,7 +407,7 @@ Returns:
     usm_narray:
         An array which is True where `x` is not positive infinity,
         negative infinity, or NaN, False otherwise.
-        The data type of the returned array is boolean.
+        The data type of the returned array is `bool`.
 """
 
 isfinite = UnaryElementwiseFunc(
@@ -428,7 +432,7 @@ Args:
 Returns:
     usm_narray:
         An array which is True where `x` is positive or negative infinity,
-        False otherwise. The data type of the returned array is boolean.
+        False otherwise. The data type of the returned array is `bool`.
 """
 
 isinf = UnaryElementwiseFunc(
@@ -453,7 +457,7 @@ Args:
 Returns:
     usm_narray:
         An array which is True where x is NaN, False otherwise.
-        The data type of the returned array is boolean.
+        The data type of the returned array is `bool`.
 """
 
 isnan = UnaryElementwiseFunc(
@@ -481,8 +485,7 @@ Args:
 Returns:
     usm_narray:
         An array containing the result of element-wise less-than comparison.
-        The data type of the returned array is determined by the
-        Type Promotion Rules.
+        The returned array has a data type of `bool`.
 """
 
 less = BinaryElementwiseFunc(
@@ -508,9 +511,7 @@ Args:
 Returns:
     usm_narray:
         An array containing the result of element-wise less-than or equal-to
-        comparison.
-        The data type of the returned array is determined by the
-        Type Promotion Rules.
+        comparison. The returned array has a data type of `bool`.
 """
 
 less_equal = BinaryElementwiseFunc(
@@ -536,6 +537,8 @@ Args:
 Return:
     usm_ndarray:
         An array containing the element-wise natural logarithm values.
+        The data type of the returned array is determined by the Type
+        Promotion Rules.
 """
 
 log = UnaryElementwiseFunc("log", ti._log_result_type, ti._log, _log_docstring)
@@ -555,7 +558,8 @@ Args:
         Default: "K".
 Return:
     usm_ndarray:
-        An array containing the element-wise log(1+x) values.
+        An array containing the element-wise log(1+x) values. The data type
+        of the returned array is determined by the Type Promotion Rules.
 """
 
 log1p = UnaryElementwiseFunc(
@@ -804,8 +808,7 @@ Args:
 Returns:
     usm_narray:
         an array containing the result of element-wise inequality comparison.
-        The data type of the returned array is determined by the
-        Type Promotion Rules.
+        The returned array has a data type of `bool`.
 """
 
 not_equal = BinaryElementwiseFunc(
@@ -873,8 +876,8 @@ Args:
         Default: "K".
 Returns:
     usm_narray:
-        An array containing the element-wise projection. The data
-        type of the returned array is determined by the Type Promotion Rules.
+        An array containing the element-wise projection.
+        The returned array has the same data type as `x`.
 """
 
 proj = UnaryElementwiseFunc(
@@ -898,8 +901,11 @@ Args:
         Default: "K".
 Returns:
     usm_narray:
-        An array containing the element-wise real component of input. The data
-        type of the returned array is determined by the Type Promotion Rules.
+        An array containing the element-wise real component of input.
+        If the input is a real-valued data type, the returned array has
+        the same datat type. If the input is a complex floating-point
+        data type, the returned array has a floating-point data type
+        with the same floating-point precision as complex input.
 """
 
 real = UnaryElementwiseFunc(

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/exp.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/exp.hpp
@@ -89,7 +89,7 @@ template <typename argT, typename resT> struct ExpFunctor
                 }
             }
             else {
-                if (x > realT(0)) { /* x is +inf */
+                if (!std::signbit(x)) { /* x is +inf */
                     if (y == realT(0)) {
                         return resT{x, y};
                     }

--- a/dpctl/tests/elementwise/test_exp.py
+++ b/dpctl/tests/elementwise/test_exp.py
@@ -2,7 +2,7 @@ import itertools
 
 import numpy as np
 import pytest
-from numpy.testing import assert_allclose
+from numpy.testing import assert_allclose, assert_array_equal
 
 import dpctl.tensor as dpt
 from dpctl.tests.helper import get_queue_or_skip, skip_if_dtype_not_supported
@@ -21,36 +21,55 @@ def test_exp_out_type(dtype):
     assert dpt.exp(X).dtype == expected_dtype
 
 
-@pytest.mark.parametrize("dtype", ["f2", "f4", "f8", "c8", "c16"])
-def test_exp_output_contig(dtype):
+@pytest.mark.parametrize("dtype", ["f2", "f4", "f8"])
+def test_exp_real_contig(dtype):
     q = get_queue_or_skip()
     skip_if_dtype_not_supported(dtype, q)
 
-    n_seq = 1027
-
-    X = dpt.linspace(0, 11, num=n_seq, dtype=dtype, sycl_queue=q)
-    Xnp = dpt.asnumpy(X)
-
+    n_seq = 100
+    n_rep = 137
+    Xnp = np.linspace(0.01, 88.1, num=n_seq, dtype=dtype)
+    X = dpt.asarray(np.repeat(Xnp, n_rep), dtype=dtype, sycl_queue=q)
     Y = dpt.exp(X)
-    tol = 8 * dpt.finfo(Y.dtype).resolution
+    with np.errstate(all="ignore"):
+        Ynp = np.exp(Xnp)
 
-    assert_allclose(dpt.asnumpy(Y), np.exp(Xnp), atol=tol, rtol=tol)
+    tol = 8 * dpt.finfo(dtype).resolution
+    assert_allclose(dpt.asnumpy(Y), np.repeat(Ynp, n_rep), atol=tol, rtol=tol)
+
+    Z = dpt.empty_like(X, dtype=dtype)
+    dpt.exp(X, out=Z)
+
+    assert_allclose(dpt.asnumpy(Z), np.repeat(Ynp, n_rep), atol=tol, rtol=tol)
 
 
-@pytest.mark.parametrize("dtype", ["f2", "f4", "f8", "c8", "c16"])
-def test_exp_output_strided(dtype):
+@pytest.mark.parametrize("dtype", ["c8", "c16"])
+def test_exp_complex_contig(dtype):
     q = get_queue_or_skip()
     skip_if_dtype_not_supported(dtype, q)
 
-    n_seq = 2054
+    n_seq = 100
+    n_rep = 137
+    low = -88.0
+    high = 88.0
+    x1 = np.random.uniform(low=low, high=high, size=n_seq)
+    x2 = np.random.uniform(low=low, high=high, size=n_seq)
+    Xnp = np.array([complex(v1, v2) for v1, v2 in zip(x1, x2)], dtype=dtype)
 
-    X = dpt.linspace(0, 11, num=n_seq, dtype=dtype, sycl_queue=q)[::-2]
-    Xnp = dpt.asnumpy(X)
-
+    X = dpt.asarray(np.repeat(Xnp, n_rep), dtype=dtype, sycl_queue=q)
     Y = dpt.exp(X)
-    tol = 8 * dpt.finfo(Y.dtype).resolution
 
-    assert_allclose(dpt.asnumpy(Y), np.exp(Xnp), atol=tol, rtol=tol)
+    tol = 8 * dpt.finfo(dtype).resolution
+    assert_allclose(
+        dpt.asnumpy(Y), np.repeat(np.exp(Xnp), n_rep), atol=tol, rtol=tol
+    )
+
+    Z = dpt.empty_like(X, dtype=dtype)
+    dpt.exp(X, out=Z)
+
+    assert_allclose(
+        dpt.asnumpy(Z), np.repeat(np.exp(Xnp), n_rep), atol=tol, rtol=tol
+    )
 
 
 @pytest.mark.parametrize("usm_type", _usm_types)
@@ -87,11 +106,11 @@ def test_exp_order(dtype):
     X[..., 0::2] = 8.0
     X[..., 1::2] = 11.0
 
-    for ord in ["C", "F", "A", "K"]:
-        for perms in itertools.permutations(range(4)):
-            U = dpt.permute_dims(X[:, ::-1, ::-1, :], perms)
+    for perms in itertools.permutations(range(4)):
+        U = dpt.permute_dims(X[:, ::-1, ::-1, :], perms)
+        expected_Y = np.exp(dpt.asnumpy(U))
+        for ord in ["C", "F", "A", "K"]:
             Y = dpt.exp(U, order=ord)
-            expected_Y = np.exp(dpt.asnumpy(U))
             tol = 8 * max(
                 dpt.finfo(Y.dtype).resolution,
                 np.finfo(expected_Y.dtype).resolution,
@@ -99,8 +118,8 @@ def test_exp_order(dtype):
             assert_allclose(dpt.asnumpy(Y), expected_Y, atol=tol, rtol=tol)
 
 
-@pytest.mark.parametrize("dtype", ["f", "d"])
-def test_exp_values(dtype):
+@pytest.mark.parametrize("dtype", ["f2", "f4", "f8"])
+def test_exp_analytical_values(dtype):
     q = get_queue_or_skip()
     skip_if_dtype_not_supported(dtype, q)
 
@@ -112,39 +131,91 @@ def test_exp_values(dtype):
     assert_allclose(dpt.asnumpy(dpt.exp(X)), np.exp(Xnp), atol=tol, rtol=tol)
 
 
-@pytest.mark.parametrize("dtype", ["e", "f", "d"])
-def test_exp_special_cases(dtype):
+@pytest.mark.parametrize("dtype", ["f2", "f4", "f8"])
+def test_exp_real_special_cases(dtype):
     q = get_queue_or_skip()
     skip_if_dtype_not_supported(dtype, q)
 
     tol = 8 * dpt.finfo(dtype).resolution
-    x = [np.nan, -np.nan, np.inf, -np.inf, -1.0, 1.0, 0.0, -0.0]
+    x = [np.nan, np.inf, -np.inf, 0.0, -0.0]
     Xnp = np.array(x, dtype=dtype)
     X = dpt.asarray(x, dtype=dtype)
-    assert_allclose(dpt.asnumpy(dpt.exp(X)), np.exp(Xnp), atol=tol, rtol=tol)
+
+    Y = dpt.asnumpy(dpt.exp(X))
+    Ynp = np.exp(Xnp)
+    assert_allclose(Y, Ynp, atol=tol, rtol=tol)
+    assert_array_equal(np.signbit(Y), np.signbit(Ynp))
 
 
-@pytest.mark.parametrize("dtype", [np.float32, np.float64])
-def test_exp_strided(dtype):
+@pytest.mark.parametrize("dtype", ["f2", "f4", "f8"])
+def test_exp_real_strided(dtype):
     q = get_queue_or_skip()
     skip_if_dtype_not_supported(dtype, q)
 
     np.random.seed(42)
     strides = np.array([-4, -3, -2, -1, 1, 2, 3, 4])
-    sizes = np.arange(2, 100)
+    sizes = [2, 4, 6, 8, 9, 24, 72]
     tol = 8 * dpt.finfo(dtype).resolution
 
     for ii in sizes:
-        Xnp = dtype(np.random.uniform(low=0.01, high=88.1, size=ii))
+        Xnp = np.random.uniform(low=0.01, high=88.1, size=ii)
+        Xnp.astype(dtype)
         X = dpt.asarray(Xnp)
-        Y_expected = np.exp(Xnp)
+        Ynp = np.exp(Xnp)
         for jj in strides:
             assert_allclose(
                 dpt.asnumpy(dpt.exp(X[::jj])),
-                Y_expected[::jj],
+                Ynp[::jj],
                 atol=tol,
                 rtol=tol,
             )
+
+
+@pytest.mark.parametrize("dtype", ["c8", "c16"])
+def test_exp_complex_strided(dtype):
+    q = get_queue_or_skip()
+    skip_if_dtype_not_supported(dtype, q)
+
+    np.random.seed(42)
+    strides = np.array([-4, -3, -2, -1, 1, 2, 3, 4])
+    sizes = [2, 4, 6, 8, 9, 24, 72]
+    tol = 8 * dpt.finfo(dtype).resolution
+
+    low = -88.0
+    high = 88.0
+    for ii in sizes:
+        x1 = np.random.uniform(low=low, high=high, size=ii)
+        x2 = np.random.uniform(low=low, high=high, size=ii)
+        Xnp = np.array([complex(v1, v2) for v1, v2 in zip(x1, x2)], dtype=dtype)
+        X = dpt.asarray(Xnp)
+        Ynp = np.exp(Xnp)
+        for jj in strides:
+            assert_allclose(
+                dpt.asnumpy(dpt.exp(X[::jj])),
+                Ynp[::jj],
+                atol=tol,
+                rtol=tol,
+            )
+
+
+@pytest.mark.parametrize("dtype", ["c8", "c16"])
+def test_exp_complex_special_cases(dtype):
+    q = get_queue_or_skip()
+    skip_if_dtype_not_supported(dtype, q)
+
+    x = [np.nan, np.inf, -np.inf, +0.0, -0.0, +1.0, -1.0]
+    xc = [complex(*val) for val in itertools.product(x, repeat=2)]
+
+    Xc_np = np.array(xc, dtype=dtype)
+    Xc = dpt.asarray(Xc_np, dtype=dtype, sycl_queue=q)
+
+    with np.errstate(all="ignore"):
+        Ynp = np.exp(Xc_np)
+    Y = dpt.exp(Xc)
+
+    tol = 8 * dpt.finfo(dtype).resolution
+    assert_allclose(dpt.asnumpy(dpt.real(Y)), np.real(Ynp), atol=tol, rtol=tol)
+    assert_allclose(dpt.asnumpy(dpt.imag(Y)), np.imag(Ynp), atol=tol, rtol=tol)
 
 
 @pytest.mark.parametrize("dtype", ["f2", "f4", "f8", "c8", "c16"])


### PR DESCRIPTION
In this PR, tests for `dpctl.tensor.exp`, `dpctl.tensor.real`, `dpctl.tensor.imag`, and `dpctl.tensor.conj` are updated. Implementation of `dpt.exp` is also modified to handle special cases for floating-point complex numbers correctly. Moreover, doc-strings are modified.

- [x] Have you provided a meaningful PR description?
- [x] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [x] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
