### PR TITLE
skip numpy_usm_shared tests

### DIFF
--- a/dpctl/tests/test_dparray.py
+++ b/dpctl/tests/test_dparray.py
@@ -18,8 +18,13 @@
 """
 
 import numpy
+import pytest
 
 from dpctl.tensor import numpy_usm_shared as dparray
+
+pytestmark = pytest.mark.skip(
+    "skipping numpy_usm_shared unit tests pending submodule removal"
+)
 
 
 def get_arg():


### PR DESCRIPTION
With this PR, all tests for the numpy_usm_shared module are now skipped pending eventual removal.

This also fixes the coverage CI, which currently fails due to changes in Numpy 1.25.0 that break tests for the numpy_usm_shared module.

- [X] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [X] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
