### PR TITLE
Fix out of bounds integer behavior in dpctl.tensor.full

### DIFF
--- a/dpctl/tensor/_ctors.py
+++ b/dpctl/tensor/_ctors.py
@@ -1101,6 +1101,8 @@ def full(
         fill_value = int(fill_value.real)
     elif fill_value_type is complex and np.issubdtype(dtype, np.floating):
         fill_value = fill_value.real
+    elif fill_value_type is int and np.issubdtype(dtype, np.integer):
+        fill_value = _to_scalar(fill_value, dtype)
 
     hev, _ = ti._full_usm_ndarray(fill_value, res, sycl_queue)
     hev.wait()

--- a/dpctl/tests/test_usm_ndarray_ctor.py
+++ b/dpctl/tests/test_usm_ndarray_ctor.py
@@ -1477,6 +1477,19 @@ def test_full_strides():
     assert np.array_equal(dpt.asnumpy(X), Xnp)
 
 
+def test_full_gh_1230():
+    q = get_queue_or_skip()
+    dtype = "i4"
+    dt_maxint = dpt.iinfo(dtype).max
+    X = dpt.full(1, dt_maxint + 1, dtype=dtype, sycl_queue=q)
+    X_np = dpt.asnumpy(X)
+    assert X.dtype == dpt.dtype(dtype)
+    assert np.array_equal(X_np, np.full_like(X_np, dt_maxint + 1))
+
+    with pytest.raises(OverflowError):
+        dpt.full(1, dpt.iinfo(dpt.uint64).max + 1, sycl_queue=q)
+
+
 @pytest.mark.parametrize(
     "dt",
     _all_dtypes[1:],


### PR DESCRIPTION
Resolves #1230 

This PR adjusts how integer overflow and underflow is handled by ``dpctl.tensor.full``.

Previously, when an integer that would overflow the type of array in the result of ``full`` was passed in as ``fill_value``, an exception would be thrown by pybind11.

Now, ``_to_scalar`` is used to get fill value back after it has been converted to a Numpy scalar, which brings the value into the range of the type and allows pybind11 to unpack the scalar.

- [X] Have you provided a meaningful PR description?
- [X] Have you added a test, reproducer or referred to an issue with a reproducer?
- [X] Have you tested your changes locally for CPU and GPU devices?
- [X] Have you made sure that new changes do not introduce compiler warnings?
- [X] Have you checked performance impact of proposed changes?
- [X] If this PR is a work in progress, are you opening the PR as a draft?
