### PR TITLE
Use latest CPU/fpga driver published on intel/llvm

### DIFF
--- a/.github/workflows/os-llvm-sycl-build.yml
+++ b/.github/workflows/os-llvm-sycl-build.yml
@@ -11,9 +11,9 @@ jobs:
 
     env:
       DOWNLOAD_URL_PREFIX: https://github.com/intel/llvm/releases/download
-      DRIVER_PATH: 2023-WW13
-      OCLCPUEXP_FN: oclcpuexp-2023.15.3.0.20_rel.tar.gz
-      FPGAEMU_FN: fpgaemu-2023.15.3.0.20_rel.tar.gz
+      DRIVER_PATH: 2023-WW27
+      OCLCPUEXP_FN: oclcpuexp-2023.16.6.0.28_rel.tar.gz
+      FPGAEMU_FN: fpgaemu-2023.16.6.0.28_rel.tar.gz
       TBB_URL: https://github.com/oneapi-src/oneTBB/releases/download/v2021.9.0/
       TBB_INSTALL_DIR: oneapi-tbb-2021.9.0
       TBB_FN: oneapi-tbb-2021.9.0-lin.tgz


### PR DESCRIPTION
Update workflow building `dpctl` with OS LLVM nightly builds to use latest CPU/FPGA_EMU drivers (https://github.com/intel/llvm/releases/tag/2023-WW27)

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
