### PR TITLE
Fix failure of proj to JIT-compile associated kernel on HW without fp64-support 

### DIFF
--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/proj.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/proj.hpp
@@ -72,7 +72,7 @@ template <typename argT, typename resT> struct ProjFunctor
         const realT y = std::imag(in);
 
         if (std::isinf(x) || std::isinf(y)) {
-            const realT res_im = std::copysign(0.0, y);
+            const realT res_im = std::copysign(realT(0), y);
             return resT{std::numeric_limits<realT>::infinity(), res_im};
         }
         return in;

--- a/dpctl/tests/elementwise/test_complex.py
+++ b/dpctl/tests/elementwise/test_complex.py
@@ -59,14 +59,14 @@ def test_complex_output(np_call, dpt_call, dtype):
     x1 = np.linspace(0, 10, num=n_seq, dtype=dtype)
     x2 = np.linspace(0, 20, num=n_seq, dtype=dtype)
     Xnp = x1 + 1j * x2
-    X = dpt.asarray(Xnp, dtype=Xnp.dtype, sycl_queue=q)
+    X = dpt.asarray(Xnp, sycl_queue=q)
 
     Y = dpt_call(X)
     tol = 8 * dpt.finfo(Y.dtype).resolution
 
     assert_allclose(dpt.asnumpy(Y), np_call(Xnp), atol=tol, rtol=tol)
 
-    Z = dpt.empty_like(X, dtype=np_call(Xnp).dtype)
+    Z = dpt.empty_like(X, dtype=Y.dtype)
     dpt_call(X, out=Z)
 
     assert_allclose(dpt.asnumpy(Z), np_call(Xnp), atol=tol, rtol=tol)


### PR DESCRIPTION
Closes gh-1275

This PR modifies the kernel associated with `dpctl.tensor.proj` to avoid using literal constants of type `double` to allow compilation for hardware without fp64 support.

Modified test `test_complex.py::test_complex_output` to pass on such HW as well.

- [x] Have you provided a meaningful PR description?
- [x] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
