### PR TITLE
No need to call _copy_overlapping if src and dst address same memory

### DIFF
--- a/dpctl/tensor/_copy_utils.py
+++ b/dpctl/tensor/_copy_utils.py
@@ -213,6 +213,11 @@ def _copy_same_shape(dst, src):
     """Assumes src and dst have the same shape."""
     # check that memory regions do not overlap
     if ti._array_overlap(dst, src):
+        if src._pointer == dst._pointer and (
+            src is dst
+            or (src.strides == dst.strides and src.dtype == dst.dtype)
+        ):
+            return
         _copy_overlapping(src=src, dst=dst)
         return
 


### PR DESCRIPTION
```
In [1]: import dpctl.tensor as dpt, dpctl, dpctl.utils

In [2]: n, m = 8 * 540, 8 * 960

In [3]: a = dpt.ones((m, n))

In [4]: b = dpt.zeros((m, n))

In [5]: b_s = dpt.zeros((m, n+2))

In [6]: with dpctl.utils.onetrace_enabled():
   ...:     b_s[:,:-2] += a
      ...:
      Device Timeline (queue: 0x556080b9cea0): zeCommandListAppendMemoryCopy(H2D)[48 bytes]<4.1> [ns] = 16946404661 (append) 16952292497 (submit) 16952613747 (start) 16952623538 (end)
      Device Timeline (queue: 0x556080b9cea0): dpctl::tensor::kernels::add::add_inplace_strided_kernel<float, float, dpctl::tensor::offset_utils::TwoOffsets_StridedIndexer>[SIMD32 {64800; 1; 1} {512; 1; 1}]<5.1> [ns] = 17017855801 (append) 17018342202 (submit) 17019138920 (start) 17030770482 (end)
```

Earlier, two more copy operations were being performed as well.

Previously:

```
In [7]: %time b_s[:,:-2] += a
CPU times: user 13.2 ms, sys: 24.7 ms, total: 37.9 ms
Wall time: 53 ms
```

Now:

```
In [7]: %time b_s[:,:-2] += a
CPU times: user 5.08 ms, sys: 9.58 ms, total: 14.7 ms
Wall time: 16.7 ms
```

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [x] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
