### PR TITLE
test_async_submit is to try few times before failing

### DIFF
--- a/dpctl/tests/test_sycl_kernel_submit.py
+++ b/dpctl/tests/test_sycl_kernel_submit.py
@@ -167,61 +167,68 @@ def test_async_submit():
     assert isinstance(kern2Kernel, dpctl_prog.SyclKernel)
 
     status_complete = dpctl.event_status_type.complete
-    n = 1024 * 1024 * 4
+    n = 256 * 1024
     X = dpt.empty((3, n), dtype="u4", usm_type="device", sycl_queue=q)
     first_row = dpctl_mem.as_usm_memory(X[0])
     second_row = dpctl_mem.as_usm_memory(X[1])
     third_row = dpctl_mem.as_usm_memory(X[2])
 
-    e1 = q.submit(
-        kern1Kernel,
-        [
-            first_row,
-            ctypes.c_uint(17),
-        ],
-        [
-            n,
-        ],
-    )
-    e2 = q.submit(
-        kern2Kernel,
-        [
-            second_row,
-            ctypes.c_uint(27),
-        ],
-        [
-            n,
-        ],
-    )
-    e3 = q.submit(
-        kern3Kernel,
-        [third_row, first_row, second_row],
-        [
-            n,
-        ],
-        None,
-        [e1, e2],
-    )
-    e3_st = e3.execution_status
-    e2_st = e2.execution_status
-    e1_st = e1.execution_status
-    assert not all(
-        [
-            e == status_complete
-            for e in (
-                e1_st,
-                e2_st,
-                e3_st,
-            )
-        ]
-    )
+    p1, p2 = 17, 27
 
-    e3.wait()
+    async_detected = False
+    for _ in range(5):
+        e1 = q.submit(
+            kern1Kernel,
+            [
+                first_row,
+                ctypes.c_uint(p1),
+            ],
+            [
+                n,
+            ],
+        )
+        e2 = q.submit(
+            kern2Kernel,
+            [
+                second_row,
+                ctypes.c_uint(p2),
+            ],
+            [
+                n,
+            ],
+        )
+        e3 = q.submit(
+            kern3Kernel,
+            [third_row, first_row, second_row],
+            [
+                n,
+            ],
+            None,
+            [e1, e2],
+        )
+        e3_st = e3.execution_status
+        e2_st = e2.execution_status
+        e1_st = e1.execution_status
+        if not all(
+            [
+                e == status_complete
+                for e in (
+                    e1_st,
+                    e2_st,
+                    e3_st,
+                )
+            ]
+        ):
+            async_detected = True
+            e3.wait()
+            break
+
+    assert async_detected, "No evidence of async submission detected, unlucky?"
     Xnp = dpt.asnumpy(X)
     Xref = np.empty((3, n), dtype="u4")
     for i in range(n):
-        Xref[0, i] = (i * i) % 17
-        Xref[1, i] = (i * i * i) % 27
+        Xref[0, i] = (i * i) % p1
+        Xref[1, i] = (i * i * i) % p2
         Xref[2, i] = min(Xref[0, i], Xref[1, i])
 
     assert np.array_equal(Xnp, Xref)


### PR DESCRIPTION
test_sycl_kernel_submit::test_async_submit sporadically fails on Windows where in kernels finish execution before test checks are done. Typical remedy is to restart Windows tests and after few iterations they pass.

This PR changes the tests to attempt launching kernels few times and rechecking tests condition before asserting test failure.

- [x] Have you provided a meaningful PR description?
- [x] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
