### PR TITLE
Fixed failure of test_floor_ceil_trunc_errors, sped up usm_type test

### DIFF
--- a/dpctl/tests/elementwise/test_floor_ceil_trunc.py
+++ b/dpctl/tests/elementwise/test_floor_ceil_trunc.py
@@ -57,7 +57,7 @@ def test_floor_ceil_trunc_usm_type(np_call, dpt_call, usm_type):
     q = get_queue_or_skip()
 
     arg_dt = np.dtype("f4")
-    input_shape = (2, 2, 2, 10)
+    input_shape = (10, 10, 10, 10)
     X = dpt.empty(input_shape, dtype=arg_dt, usm_type=usm_type, sycl_queue=q)
     X[..., 0::2] = -0.4
     X[..., 1::2] = 0.7
@@ -67,8 +67,7 @@ def test_floor_ceil_trunc_usm_type(np_call, dpt_call, usm_type):
     assert Y.sycl_queue == X.sycl_queue
     assert Y.flags.c_contiguous
 
-    expected_Y = np.empty(input_shape, dtype=arg_dt)
-    expected_Y = np_call(np.float32(X))
+    expected_Y = np_call(dpt.asnumpy(X))
     tol = 8 * dpt.finfo(Y.dtype).resolution
     assert_allclose(dpt.asnumpy(Y), expected_Y, atol=tol, rtol=tol)
 
@@ -123,12 +122,6 @@ def test_floor_ceil_trunc_errors(dpt_call):
         dpt_call,
         x,
         y,
-    )
-
-    x = dpt.zeros(2)
-    y = x
-    assert_raises_regex(
-        TypeError, "Input and output arrays have memory overlap", dpt_call, x, y
     )
 
     x = dpt.zeros(2, dtype="float32")


### PR DESCRIPTION
Since support for overlapping out and argument arrays has been added the expected TypeError is no longer raised.

Do not use `np.float32(usm_ndarray)` use-pattern, use `dpt.asnumpy(usm_ndarray)` instead. The former generates usm_ndarray.size single-element device-to-host transfers, while the latter does it in a single kernel invocation.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
