### PR TITLE
Test async changes

### DIFF
--- a/dpctl/tests/test_sycl_kernel_submit.py
+++ b/dpctl/tests/test_sycl_kernel_submit.py
@@ -167,7 +167,9 @@ def test_async_submit():
     assert isinstance(kern2Kernel, dpctl_prog.SyclKernel)
 
     status_complete = dpctl.event_status_type.complete
-    n = 256 * 1024
+    # choose input size based on capability of the device
+    f = q.sycl_device.max_work_group_size
+    n = f * 1024
     X = dpt.empty((3, n), dtype="u4", usm_type="device", sycl_queue=q)
     first_row = dpctl_mem.as_usm_memory(X[0])
     second_row = dpctl_mem.as_usm_memory(X[1])

--- a/dpctl/tests/test_sycl_kernel_submit.py
+++ b/dpctl/tests/test_sycl_kernel_submit.py
@@ -167,10 +167,13 @@ def test_async_submit():
     assert isinstance(kern2Kernel, dpctl_prog.SyclKernel)
 
     status_complete = dpctl.event_status_type.complete
+
     # choose input size based on capability of the device
     f = q.sycl_device.max_work_group_size
     n = f * 1024
-    X = dpt.empty((3, n), dtype="u4", usm_type="device", sycl_queue=q)
+    n_alloc = 4 * n
+
+    X = dpt.empty((3, n_alloc), dtype="u4", usm_type="device", sycl_queue=q)
     first_row = dpctl_mem.as_usm_memory(X[0])
     second_row = dpctl_mem.as_usm_memory(X[1])
     third_row = dpctl_mem.as_usm_memory(X[2])
@@ -178,7 +181,7 @@ def test_async_submit():
     p1, p2 = 17, 27
 
     async_detected = False
-    for _ in range(5):
+    for attempt in range(5):
         e1 = q.submit(
             kern1Kernel,
             [
@@ -211,19 +214,22 @@ def test_async_submit():
         e3_st = e3.execution_status
         e2_st = e2.execution_status
         e1_st = e1.execution_status
-        if not all(
-            [
-                e == status_complete
-                for e in (
-                    e1_st,
-                    e2_st,
-                    e3_st,
-                )
-            ]
-        ):
+        are_complete = [
+            e == status_complete
+            for e in (
+                e1_st,
+                e2_st,
+                e3_st,
+            )
+        ]
+        e3.wait()
+        if not all(are_complete):
             async_detected = True
-            e3.wait()
             break
+        else:
+            n = n * (1 if attempt % 2 == 0 else 2)
+            if n > n_alloc:
+                break
 
     assert async_detected, "No evidence of async submission detected, unlucky?"
     Xnp = dpt.asnumpy(X)
@@ -233,4 +239,4 @@ def test_async_submit():
         Xref[1, i] = (i * i * i) % p2
         Xref[2, i] = min(Xref[0, i], Xref[1, i])
 
-    assert np.array_equal(Xnp, Xref)
+    assert np.array_equal(Xnp[:, :n], Xref[:, :n])


### PR DESCRIPTION
`test_sycl_kernel_submit.py::test_async_submit` has been sporadically failing as it attempts to confirm that concurrency was indeed detected. The chance of such detection decreases on beefier machines. 

This PR selects global-work-size for the submitted kernels based on device's max_work_group_size property, and increases it few times before failing the test. 

This change should reduce the need to restart failing jobs just to get this test to pass.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
