### PR TITLE
Boolean indexing performance

### DIFF
--- a/dpctl/tensor/libtensor/source/boolean_advanced_indexing.hpp
+++ b/dpctl/tensor/libtensor/source/boolean_advanced_indexing.hpp
@@ -68,8 +68,8 @@ py_place(dpctl::tensor::usm_ndarray dst,
 extern void populate_masked_place_dispatch_vectors(void);
 
 extern std::pair<sycl::event, sycl::event> py_nonzero(
-    dpctl::tensor::usm_ndarray cumsum,  // int64 input array, 1D, C-contiguous
-    dpctl::tensor::usm_ndarray indexes, // int64 2D output array, C-contiguous
+    dpctl::tensor::usm_ndarray cumsum,  // int32 input array, 1D, C-contiguous
+    dpctl::tensor::usm_ndarray indexes, // int32 2D output array, C-contiguous
     std::vector<py::ssize_t>
         mask_shape, // shape of array from which cumsum was computed
     sycl::queue exec_q,


### PR DESCRIPTION
`dpctl` used to utilize int64 data type temporary to compute running sum of flattened mask array. For smaller arrays, where int32 would suffice, this resulted in suboptimal performance. 

This PR adds support for int32 in advanced Boolean indexing implementation function, and changes orchestrating Pyton code to allocated temporary of int32 data type if the number of elements in the mask array is less than a threshold.

- [x] Have you provided a meaningful PR description?
- [x] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [x] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
