### PR TITLE
Require 2023.2 compiler package and runtime

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -13,7 +13,7 @@ build:
 requirements:
     build:
         - {{ compiler('cxx') }}
-        - {{ compiler('dpcpp') }} >=2023.1  # [not osx]
+        - {{ compiler('dpcpp') }} >=2023.2  # [not osx]
         - sysroot_linux-64 >=2.28  # [linux]
     host:
         - setuptools
@@ -28,8 +28,7 @@ requirements:
     run:
         - python
         - {{ pin_compatible('numpy', min_pin='x.x', max_pin='x') }}
-        - {{ pin_compatible('dpcpp-cpp-rt', min_pin='x.x', max_pin='x') }}  # [py<=39]
-        - dpcpp-cpp-rt >=2023.1  # [py>39]
+        - dpcpp-cpp-rt >=2023.2
         - level-zero  # [linux]
 
 test:


### PR DESCRIPTION
`libSyclInterface.so` library compiled with DPC++ 2023.2 compiler requires DPC++ compiler runtime 2023.2. as evidenced by this import error encountered by @AlexanderKalistratov :

```
ImportError: /home/akalistr/miniconda3/envs/dpbench-dev/lib/python3.10/site-packages/dpctl/libDPCTLSyclInterface.so.0: undefined symbol: _ZN4sycl3_V16detail14tls_code_loc_tC1ERKNS1_13code_locationE
```


- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
