### PR TITLE
Update for cython 3

### DIFF
--- a/.github/workflows/generate-coverage.yaml
+++ b/.github/workflows/generate-coverage.yaml
@@ -79,7 +79,7 @@ jobs:
       - name: Install dpctl dependencies
         shell: bash -l {0}
         run: |
-          pip install numpy cython"<3" setuptools pytest pytest-cov scikit-build cmake coverage[toml]
+          pip install numpy cython setuptools pytest pytest-cov scikit-build cmake coverage[toml]
 
       - name: Build dpctl with coverage
         shell: bash -l {0}

--- a/.github/workflows/generate-docs.yml
+++ b/.github/workflows/generate-docs.yml
@@ -49,7 +49,7 @@ jobs:
         if: ${{ !github.event.pull_request || github.event.action != 'closed' }}
         shell: bash -l {0}
         run: |
-          pip install numpy cython"<3" setuptools scikit-build cmake sphinx sphinx_rtd_theme pydot graphviz sphinxcontrib-programoutput sphinxcontrib-googleanalytics
+          pip install numpy cython setuptools scikit-build cmake sphinx sphinx_rtd_theme pydot graphviz sphinxcontrib-programoutput sphinxcontrib-googleanalytics
       - name: Checkout repo
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/os-llvm-sycl-build.yml
+++ b/.github/workflows/os-llvm-sycl-build.yml
@@ -108,7 +108,7 @@ jobs:
       - name: Install dpctl dependencies
         shell: bash -l {0}
         run: |
-          pip install numpy cython"<3" setuptools pytest scikit-build cmake
+          pip install numpy cython setuptools pytest scikit-build cmake
 
       - name: Checkout repo
         uses: actions/checkout@v3

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -20,7 +20,7 @@ requirements:
         - cmake  >=3.21
         - ninja
         - git
-        - cython  <3
+        - cython
         - python
         - scikit-build
         - numpy

--- a/dpctl/_backend.pxd
+++ b/dpctl/_backend.pxd
@@ -95,7 +95,6 @@ cdef extern from "syclinterface/dpctl_sycl_enum_types.h":
         _usm_device_allocations             'usm_device_allocations',
         _usm_host_allocations               'usm_host_allocations',
         _usm_shared_allocations             'usm_shared_allocations',
-        _usm_restricted_shared_allocations  'usm_restricted_shared_allocations',
         _usm_system_allocations             'usm_system_allocations',
         _usm_atomic_host_allocations        'usm_atomic_host_allocations',
         _usm_atomic_shared_allocations      'usm_atomic_shared_allocations',

--- a/dpctl/_sycl_context.pyx
+++ b/dpctl/_sycl_context.pyx
@@ -68,7 +68,7 @@ cdef class SyclContextCreationError(Exception):
     pass
 
 
-cdef void _context_capsule_deleter(object o):
+cdef void _context_capsule_deleter(object o) noexcept:
     cdef DPCTLSyclContextRef CRef = NULL
     if pycapsule.PyCapsule_IsValid(o, "SyclContextRef"):
         CRef = <DPCTLSyclContextRef> pycapsule.PyCapsule_GetPointer(

--- a/dpctl/_sycl_device.pyx
+++ b/dpctl/_sycl_device.pyx
@@ -598,20 +598,6 @@ cdef class SyclDevice(_SyclDevice):
         return DPCTLDevice_HasAspect(self._device_ref, AT)
 
     @property
-    def has_aspect_usm_restricted_shared_allocations(self):
-        """ Returns True if this device supports USM memory
-        allocated as restricted USM, False otherwise.
-
-        Returns:
-            bool: Indicates that the device supports USM memory allocated using
-            ``sycl::malloc_shared`` as restricted USM.
-
-        .. deprecated:: 0.14
-        """
-        cdef _aspect_type AT = _aspect_type._usm_restricted_shared_allocations
-        return DPCTLDevice_HasAspect(self._device_ref, AT)
-
-    @property
     def has_aspect_usm_system_allocations(self):
         """ Returns True if system allocator may be used instead of SYCL USM
         allocation mechanism for USM-shared allocations on this device,

--- a/dpctl/_sycl_event.pyx
+++ b/dpctl/_sycl_event.pyx
@@ -73,7 +73,7 @@ cdef api SyclEvent SyclEvent_Make(DPCTLSyclEventRef ERef):
     return SyclEvent._create(copied_ERef)
 
 
-cdef void _event_capsule_deleter(object o):
+cdef void _event_capsule_deleter(object o) noexcept:
     cdef DPCTLSyclEventRef ERef = NULL
     if pycapsule.PyCapsule_IsValid(o, "SyclEventRef"):
         ERef = <DPCTLSyclEventRef> pycapsule.PyCapsule_GetPointer(

--- a/dpctl/_sycl_queue.pyx
+++ b/dpctl/_sycl_queue.pyx
@@ -121,7 +121,7 @@ cdef class SyclAsynchronousError(Exception):
     """
 
 
-cdef void default_async_error_handler(int err) nogil except *:
+cdef void default_async_error_handler(int err) except * nogil:
     with gil:
         raise SyclAsynchronousError(err)
 
@@ -159,7 +159,7 @@ cdef int _parse_queue_properties(object prop) except *:
     return res
 
 
-cdef void _queue_capsule_deleter(object o):
+cdef void _queue_capsule_deleter(object o) noexcept:
     cdef DPCTLSyclQueueRef QRef = NULL
     if pycapsule.PyCapsule_IsValid(o, "SyclQueueRef"):
         QRef = <DPCTLSyclQueueRef> pycapsule.PyCapsule_GetPointer(

--- a/dpctl/apis/include/dpctl_capi.h
+++ b/dpctl/apis/include/dpctl_capi.h
@@ -28,6 +28,7 @@
 // Ordering of includes is important here. dpctl_sycl_types defines types
 // used by dpctl's Python C-API headers.
 #include "syclinterface/dpctl_sycl_types.h"
+#define CYTHON_EXTERN_C extern "C"
 #include "../_sycl_device.h"
 #include "../_sycl_device_api.h"
 #include "../_sycl_context.h"

--- a/dpctl/tensor/_dlpack.pyx
+++ b/dpctl/tensor/_dlpack.pyx
@@ -106,7 +106,7 @@ def get_build_dlpack_version():
     return str(DLPACK_VERSION)
 
 
-cdef void _pycapsule_deleter(object dlt_capsule):
+cdef void _pycapsule_deleter(object dlt_capsule) noexcept:
     cdef DLManagedTensor *dlm_tensor = NULL
     if cpython.PyCapsule_IsValid(dlt_capsule, 'dltensor'):
         dlm_tensor = <DLManagedTensor*>cpython.PyCapsule_GetPointer(
@@ -114,7 +114,7 @@ cdef void _pycapsule_deleter(object dlt_capsule):
         dlm_tensor.deleter(dlm_tensor)
 
 
-cdef void _managed_tensor_deleter(DLManagedTensor *dlm_tensor) with gil:
+cdef void _managed_tensor_deleter(DLManagedTensor *dlm_tensor) noexcept with gil:
     if dlm_tensor is not NULL:
         stdlib.free(dlm_tensor.dl_tensor.shape)
         cpython.Py_DECREF(<usm_ndarray>dlm_tensor.manager_ctx)
@@ -122,7 +122,7 @@ cdef void _managed_tensor_deleter(DLManagedTensor *dlm_tensor) with gil:
         stdlib.free(dlm_tensor)
 
 
-cpdef to_dlpack_capsule(usm_ndarray usm_ary) except+:
+cpdef to_dlpack_capsule(usm_ndarray usm_ary):
     """
     to_dlpack_capsule(usm_ary)
 
@@ -288,7 +288,7 @@ cdef class _DLManagedTensorOwner:
         return res
 
 
-cpdef usm_ndarray from_dlpack_capsule(object py_caps) except +:
+cpdef usm_ndarray from_dlpack_capsule(object py_caps):
     """
     from_dlpack_capsule(caps)
 

--- a/dpctl/tests/_device_attributes_checks.py
+++ b/dpctl/tests/_device_attributes_checks.py
@@ -217,13 +217,6 @@ def check_has_aspect_usm_shared_allocations(device):
         pytest.fail("has_aspect_usm_shared_allocations call failed")
 
 
-def check_has_aspect_usm_restricted_shared_allocations(device):
-    try:
-        device.has_aspect_usm_restricted_shared_allocations
-    except Exception:
-        pytest.fail("has_aspect_usm_restricted_shared_allocations call failed")
-
-
 def check_has_aspect_usm_system_allocations(device):
     try:
         device.has_aspect_usm_system_allocations
@@ -688,7 +681,6 @@ list_of_checks = [
     check_has_aspect_usm_device_allocations,
     check_has_aspect_usm_host_allocations,
     check_has_aspect_usm_shared_allocations,
-    check_has_aspect_usm_restricted_shared_allocations,
     check_has_aspect_usm_system_allocations,
     check_has_aspect_usm_atomic_host_allocations,
     check_has_aspect_usm_atomic_shared_allocations,

--- a/libsyclinterface/helper/source/dpctl_utils_helper.cpp
+++ b/libsyclinterface/helper/source/dpctl_utils_helper.cpp
@@ -202,9 +202,6 @@ std::string DPCTL_AspectToStr(aspect aspectTy)
     case aspect::usm_shared_allocations:
         ss << "usm_shared_allocations";
         break;
-    case aspect::usm_restricted_shared_allocations:
-        ss << "usm_restricted_shared_allocations";
-        break;
     case aspect::usm_system_allocations:
         ss << "usm_system_allocations";
         break;
@@ -271,9 +268,6 @@ aspect DPCTL_StrToAspectType(const std::string &aspectTyStr)
     else if (aspectTyStr == "usm_shared_allocations") {
         aspectTy = aspect::usm_shared_allocations;
     }
-    else if (aspectTyStr == "usm_restricted_shared_allocations") {
-        aspectTy = aspect::usm_restricted_shared_allocations;
-    }
     else if (aspectTyStr == "usm_system_allocations") {
         aspectTy = aspect::usm_system_allocations;
     }
@@ -324,8 +318,6 @@ aspect DPCTL_DPCTLAspectTypeToSyclAspect(DPCTLSyclAspectType AspectTy)
         return aspect::usm_host_allocations;
     case DPCTLSyclAspectType::usm_shared_allocations:
         return aspect::usm_shared_allocations;
-    case DPCTLSyclAspectType::usm_restricted_shared_allocations:
-        return aspect::usm_restricted_shared_allocations;
     case DPCTLSyclAspectType::usm_system_allocations:
         return aspect::usm_system_allocations;
     case DPCTLSyclAspectType::usm_atomic_host_allocations:
@@ -370,8 +362,6 @@ DPCTLSyclAspectType DPCTL_SyclAspectToDPCTLAspectType(aspect Aspect)
         return DPCTLSyclAspectType::usm_host_allocations;
     case aspect::usm_shared_allocations:
         return DPCTLSyclAspectType::usm_shared_allocations;
-    case aspect::usm_restricted_shared_allocations:
-        return DPCTLSyclAspectType::usm_restricted_shared_allocations;
     case aspect::usm_system_allocations:
         return DPCTLSyclAspectType::usm_system_allocations;
     case aspect::usm_atomic_host_allocations:

--- a/libsyclinterface/include/dpctl_sycl_enum_types.h
+++ b/libsyclinterface/include/dpctl_sycl_enum_types.h
@@ -127,7 +127,6 @@ typedef enum
     usm_device_allocations,
     usm_host_allocations,
     usm_shared_allocations,
-    usm_restricted_shared_allocations,
     usm_system_allocations,
     usm_atomic_host_allocations,
     usm_atomic_shared_allocations,

--- a/libsyclinterface/tests/test_sycl_device_aspects.cpp
+++ b/libsyclinterface/tests/test_sycl_device_aspects.cpp
@@ -117,8 +117,6 @@ auto build_params()
                            sycl::aspect::usm_host_allocations),
             std::make_pair("usm_shared_allocations",
                            sycl::aspect::usm_shared_allocations),
-            std::make_pair("usm_restricted_shared_allocations",
-                           sycl::aspect::usm_restricted_shared_allocations),
             std::make_pair("usm_system_allocations",
                            sycl::aspect::usm_system_allocations),
             std::make_pair("usm_atomic_host_allocations",

--- a/setup.py
+++ b/setup.py
@@ -178,20 +178,20 @@ skbuild.setup(
     package_data={"dpctl": ["tests/*.*", "tests/helper/*.py"]},
     include_package_data=True,
     zip_safe=False,
-    setup_requires=["Cython<3"],
+    setup_requires=["Cython"],
     install_requires=[
         "numpy",
     ],
     extras_require={
         "docs": [
-            "Cython<3",
+            "Cython",
             "sphinx",
             "sphinx_rtd_theme",
             "pydot",
             "graphviz",
             "sphinxcontrib-programoutput",
         ],
-        "coverage": ["Cython<3", "pytest", "pytest-cov", "coverage", "tomli"],
+        "coverage": ["Cython", "pytest", "pytest-cov", "coverage", "tomli"],
     },
     keywords="dpctl",
     classifiers=[_f for _f in CLASSIFIERS.split("\n") if _f],


### PR DESCRIPTION
This PR closes gh-1277, reverts 03a46e14c2aabae4408139673889d6dd7a0a6f87 to enable Cython 3.0, modifies Cython files per Cython guidance, and removes deprecated in 2023.2 `sycl::aspect::usm_restricted_shared_allocations` and `dpctl.SyclDevice.has_aspect_usm_restricted_shared_allocations` property.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [x] If this PR is a work in progress, are you opening the PR as a draft?
