### PR TITLE
Added fixed dimensions indexer for three offsets

### DIFF
--- a/dpctl/tensor/libtensor/include/utils/strided_iters.hpp
+++ b/dpctl/tensor/libtensor/include/utils/strided_iters.hpp
@@ -296,6 +296,7 @@ public:
         }
 
         indT i_ = i;
+#pragma unroll
         for (int dim = ndim; --dim > 0;) {
             indT si = shape[dim];
             indT q = i_ / si;


### PR DESCRIPTION
This PR implements fixed-dimensionality indexer for three offsets. These are useful for writing dpctl-based extensions.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
