### PR TITLE
Closes gh-1250 by fixing stride simplification logic

### DIFF
--- a/dpctl/tensor/libtensor/include/utils/strided_iters.hpp
+++ b/dpctl/tensor/libtensor/include/utils/strided_iters.hpp
@@ -444,10 +444,10 @@ int simplify_iteration_two_strides(const int nd,
                 (strides2[i1] < 0) ? -strides2[i1] : strides2[i1];
             auto abs_str2_i2 =
                 (strides2[i2] < 0) ? -strides2[i2] : strides2[i2];
-            return (abs_str1_i1 > abs_str1_i2) ||
-                   (abs_str1_i1 == abs_str1_i2 &&
-                    (abs_str2_i1 > abs_str2_i2 ||
-                     (abs_str2_i1 == abs_str2_i2 && shape[i1] > shape[i2])));
+            return (abs_str2_i1 > abs_str2_i2) ||
+                   (abs_str2_i1 == abs_str2_i2 &&
+                    (abs_str1_i1 > abs_str1_i2 ||
+                     (abs_str1_i1 == abs_str1_i2 && shape[i1] > shape[i2])));
         });
 
     std::vector<ShapeTy> shape_w;
@@ -600,12 +600,12 @@ int simplify_iteration_three_strides(const int nd,
                              (strides3[i1] < 0) ? -strides3[i1] : strides3[i1];
                          auto abs_str3_i2 =
                              (strides3[i2] < 0) ? -strides3[i2] : strides3[i2];
-                         return (abs_str1_i1 > abs_str1_i2) ||
-                                ((abs_str1_i1 == abs_str1_i2) &&
+                         return (abs_str3_i1 > abs_str3_i2) ||
+                                ((abs_str3_i1 == abs_str3_i2) &&
                                  ((abs_str2_i1 > abs_str2_i2) ||
                                   ((abs_str2_i1 == abs_str2_i2) &&
-                                   ((abs_str3_i1 > abs_str3_i2) ||
-                                    ((abs_str3_i1 == abs_str3_i2) &&
+                                   ((abs_str1_i1 > abs_str1_i2) ||
+                                    ((abs_str1_i1 == abs_str1_i2) &&
                                      (shape[i1] > shape[i2]))))));
                      });
 
@@ -768,14 +768,14 @@ int simplify_iteration_four_strides(const int nd,
                 (strides4[i1] < 0) ? -strides4[i1] : strides4[i1];
             auto abs_str4_i2 =
                 (strides4[i2] < 0) ? -strides4[i2] : strides4[i2];
-            return (abs_str1_i1 > abs_str1_i2) ||
-                   ((abs_str1_i1 == abs_str1_i2) &&
-                    ((abs_str2_i1 > abs_str2_i2) ||
-                     ((abs_str2_i1 == abs_str2_i2) &&
-                      ((abs_str3_i1 > abs_str3_i2) ||
-                       ((abs_str3_i1 == abs_str3_i2) &&
-                        ((abs_str4_i1 > abs_str4_i2) ||
-                         ((abs_str4_i1 == abs_str4_i2) &&
+            return (abs_str4_i1 > abs_str4_i2) ||
+                   ((abs_str4_i1 == abs_str4_i2) &&
+                    ((abs_str3_i1 > abs_str3_i2) ||
+                     ((abs_str3_i1 == abs_str3_i2) &&
+                      ((abs_str2_i1 > abs_str2_i2) ||
+                       ((abs_str2_i1 == abs_str2_i2) &&
+                        ((abs_str1_i1 > abs_str1_i2) ||
+                         ((abs_str1_i1 == abs_str1_i2) &&
                           (shape[i1] > shape[i2]))))))));
         });
 


### PR DESCRIPTION
When simplifying iteration space, first consider strides of output array (last stride argument) since output arrays should never have zero strides.

```
In [4]: from dpctl.tensor._tensor_impl import _contract_iter3

In [5]: sh, st1, st2, st3 = (8192, 8192), (0, 1), (1, 0), (8192, 1) # shape, strides in issue

In [6]: _contract_iter3(sh, st1, st2, st3)
Out[6]: ([8192, 8192], [0, 1], 0, [1, 0], 0, [8192, 1], 0)

In [7]: _contract_iter3(sh, st2, st1, st3)
Out[7]: ([8192, 8192], [1, 0], 0, [0, 1], 0, [8192, 1], 0)
```

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [x] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
