### PR TITLE
Removes redundant output types from logical and comparison functions

### DIFF
--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/expm1.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/expm1.hpp
@@ -135,28 +135,9 @@ sycl::event expm1_contig_impl(sycl::queue exec_q,
                               char *res_p,
                               const std::vector<sycl::event> &depends = {})
 {
-    sycl::event expm1_ev = exec_q.submit([&](sycl::handler &cgh) {
-        cgh.depends_on(depends);
-        constexpr size_t lws = 64;
-        constexpr unsigned int vec_sz = 4;
-        constexpr unsigned int n_vecs = 2;
-        static_assert(lws % vec_sz == 0);
-        auto gws_range = sycl::range<1>(
-            ((nelems + n_vecs * lws * vec_sz - 1) / (lws * n_vecs * vec_sz)) *
-            lws);
-        auto lws_range = sycl::range<1>(lws);
-
-        using resTy = typename Expm1OutputType<argTy>::value_type;
-        const argTy *arg_tp = reinterpret_cast<const argTy *>(arg_p);
-        resTy *res_tp = reinterpret_cast<resTy *>(res_p);
-
-        cgh.parallel_for<
-            class expm1_contig_kernel<argTy, resTy, vec_sz, n_vecs>>(
-            sycl::nd_range<1>(gws_range, lws_range),
-            Expm1ContigFunctor<argTy, resTy, vec_sz, n_vecs>(arg_tp, res_tp,
-                                                             nelems));
-    });
-    return expm1_ev;
+    return elementwise_common::unary_contig_impl<
+        argTy, Expm1OutputType, Expm1ContigFunctor, expm1_contig_kernel>(
+        exec_q, nelems, arg_p, res_p, depends);
 }
 
 template <typename fnT, typename T> struct Expm1ContigFactory
@@ -213,26 +194,10 @@ expm1_strided_impl(sycl::queue exec_q,
                    const std::vector<sycl::event> &depends,
                    const std::vector<sycl::event> &additional_depends)
 {
-    sycl::event comp_ev = exec_q.submit([&](sycl::handler &cgh) {
-        cgh.depends_on(depends);
-        cgh.depends_on(additional_depends);
-
-        using resTy = typename Expm1OutputType<argTy>::value_type;
-        using IndexerT =
-            typename dpctl::tensor::offset_utils::TwoOffsets_StridedIndexer;
-
-        IndexerT arg_res_indexer(nd, arg_offset, res_offset, shape_and_strides);
-
-        const argTy *arg_tp = reinterpret_cast<const argTy *>(arg_p);
-        resTy *res_tp = reinterpret_cast<resTy *>(res_p);
-
-        sycl::range<1> gRange{nelems};
-
-        cgh.parallel_for<expm1_strided_kernel<argTy, resTy, IndexerT>>(
-            gRange, Expm1StridedFunctor<argTy, resTy, IndexerT>(
-                        arg_tp, res_tp, arg_res_indexer));
-    });
-    return comp_ev;
+    return elementwise_common::unary_strided_impl<
+        argTy, Expm1OutputType, Expm1StridedFunctor, expm1_strided_kernel>(
+        exec_q, nelems, nd, shape_and_strides, arg_p, arg_offset, res_p,
+        res_offset, depends, additional_depends);
 }
 
 template <typename fnT, typename T> struct Expm1StridedFactory

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/greater.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/greater.hpp
@@ -63,20 +63,8 @@ template <typename argT1, typename argT2, typename resT> struct GreaterFunctor
 
     resT operator()(const argT1 &in1, const argT2 &in2)
     {
-        if constexpr (std::is_same_v<argT1, std::complex<float>> &&
-                      std::is_same_v<argT2, float>)
-        {
-            float real1 = std::real(in1);
-            return (real1 == in2) ? (std::imag(in1) > 0.0f) : real1 > in2;
-        }
-        else if constexpr (std::is_same_v<argT1, float> &&
-                           std::is_same_v<argT2, std::complex<float>>)
-        {
-            float real2 = std::real(in2);
-            return (in1 == real2) ? (0.0f > std::imag(in2)) : in1 > real2;
-        }
-        else if constexpr (tu_ns::is_complex<argT1>::value ||
-                           tu_ns::is_complex<argT2>::value)
+        if constexpr (tu_ns::is_complex<argT1>::value ||
+                      tu_ns::is_complex<argT2>::value)
         {
             static_assert(std::is_same_v<argT1, argT2>);
             using realT = typename argT1::value_type;
@@ -174,10 +162,6 @@ template <typename T1, typename T2> struct GreaterOutputType
                                         T2,
                                         std::complex<double>,
                                         bool>,
-        td_ns::
-            BinaryTypeMapResultEntry<T1, float, T2, std::complex<float>, bool>,
-        td_ns::
-            BinaryTypeMapResultEntry<T1, std::complex<float>, T2, float, bool>,
         td_ns::DefaultResultEntry<void>>::result_type;
 };
 
@@ -199,32 +183,10 @@ sycl::event greater_contig_impl(sycl::queue exec_q,
                                 py::ssize_t res_offset,
                                 const std::vector<sycl::event> &depends = {})
 {
-    sycl::event comp_ev = exec_q.submit([&](sycl::handler &cgh) {
-        cgh.depends_on(depends);
-
-        size_t lws = 64;
-        constexpr unsigned int vec_sz = 4;
-        constexpr unsigned int n_vecs = 2;
-        const size_t n_groups =
-            ((nelems + lws * n_vecs * vec_sz - 1) / (lws * n_vecs * vec_sz));
-        const auto gws_range = sycl::range<1>(n_groups * lws);
-        const auto lws_range = sycl::range<1>(lws);
-
-        using resTy = typename GreaterOutputType<argTy1, argTy2>::value_type;
-
-        const argTy1 *arg1_tp =
-            reinterpret_cast<const argTy1 *>(arg1_p) + arg1_offset;
-        const argTy2 *arg2_tp =
-            reinterpret_cast<const argTy2 *>(arg2_p) + arg2_offset;
-        resTy *res_tp = reinterpret_cast<resTy *>(res_p) + res_offset;
-
-        cgh.parallel_for<
-            greater_contig_kernel<argTy1, argTy2, resTy, vec_sz, n_vecs>>(
-            sycl::nd_range<1>(gws_range, lws_range),
-            GreaterContigFunctor<argTy1, argTy2, resTy, vec_sz, n_vecs>(
-                arg1_tp, arg2_tp, res_tp, nelems));
-    });
-    return comp_ev;
+    return elementwise_common::binary_contig_impl<
+        argTy1, argTy2, GreaterOutputType, GreaterContigFunctor,
+        greater_contig_kernel>(exec_q, nelems, arg1_p, arg1_offset, arg2_p,
+                               arg2_offset, res_p, res_offset, depends);
 }
 
 template <typename fnT, typename T1, typename T2> struct GreaterContigFactory
@@ -272,28 +234,11 @@ greater_strided_impl(sycl::queue exec_q,
                      const std::vector<sycl::event> &depends,
                      const std::vector<sycl::event> &additional_depends)
 {
-    sycl::event comp_ev = exec_q.submit([&](sycl::handler &cgh) {
-        cgh.depends_on(depends);
-        cgh.depends_on(additional_depends);
-
-        using resTy = typename GreaterOutputType<argTy1, argTy2>::value_type;
-
-        using IndexerT =
-            typename dpctl::tensor::offset_utils::ThreeOffsets_StridedIndexer;
-
-        IndexerT indexer{nd, arg1_offset, arg2_offset, res_offset,
-                         shape_and_strides};
-
-        const argTy1 *arg1_tp = reinterpret_cast<const argTy1 *>(arg1_p);
-        const argTy2 *arg2_tp = reinterpret_cast<const argTy2 *>(arg2_p);
-        resTy *res_tp = reinterpret_cast<resTy *>(res_p);
-
-        cgh.parallel_for<
-            greater_strided_kernel<argTy1, argTy2, resTy, IndexerT>>(
-            {nelems}, GreaterStridedFunctor<argTy1, argTy2, resTy, IndexerT>(
-                          arg1_tp, arg2_tp, res_tp, indexer));
-    });
-    return comp_ev;
+    return elementwise_common::binary_strided_impl<
+        argTy1, argTy2, GreaterOutputType, GreaterStridedFunctor,
+        greater_strided_kernel>(exec_q, nelems, nd, shape_and_strides, arg1_p,
+                                arg1_offset, arg2_p, arg2_offset, res_p,
+                                res_offset, depends, additional_depends);
 }
 
 template <typename fnT, typename T1, typename T2> struct GreaterStridedFactory

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/greater_equal.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/greater_equal.hpp
@@ -64,20 +64,8 @@ struct GreaterEqualFunctor
 
     resT operator()(const argT1 &in1, const argT2 &in2)
     {
-        if constexpr (std::is_same_v<argT1, std::complex<float>> &&
-                      std::is_same_v<argT2, float>)
-        {
-            float real1 = std::real(in1);
-            return (real1 == in2) ? (std::imag(in1) >= 0.0f) : real1 >= in2;
-        }
-        else if constexpr (std::is_same_v<argT1, float> &&
-                           std::is_same_v<argT2, std::complex<float>>)
-        {
-            float real2 = std::real(in2);
-            return (in1 == real2) ? (0.0f >= std::imag(in2)) : in1 >= real2;
-        }
-        else if constexpr (tu_ns::is_complex<argT1>::value ||
-                           tu_ns::is_complex<argT2>::value)
+        if constexpr (tu_ns::is_complex<argT1>::value ||
+                      tu_ns::is_complex<argT2>::value)
         {
             static_assert(std::is_same_v<argT1, argT2>);
             using realT = typename argT1::value_type;
@@ -175,10 +163,6 @@ template <typename T1, typename T2> struct GreaterEqualOutputType
                                         T2,
                                         std::complex<double>,
                                         bool>,
-        td_ns::
-            BinaryTypeMapResultEntry<T1, float, T2, std::complex<float>, bool>,
-        td_ns::
-            BinaryTypeMapResultEntry<T1, std::complex<float>, T2, float, bool>,
         td_ns::DefaultResultEntry<void>>::result_type;
 };
 
@@ -201,33 +185,11 @@ greater_equal_contig_impl(sycl::queue exec_q,
                           py::ssize_t res_offset,
                           const std::vector<sycl::event> &depends = {})
 {
-    sycl::event comp_ev = exec_q.submit([&](sycl::handler &cgh) {
-        cgh.depends_on(depends);
-
-        size_t lws = 64;
-        constexpr unsigned int vec_sz = 4;
-        constexpr unsigned int n_vecs = 2;
-        const size_t n_groups =
-            ((nelems + lws * n_vecs * vec_sz - 1) / (lws * n_vecs * vec_sz));
-        const auto gws_range = sycl::range<1>(n_groups * lws);
-        const auto lws_range = sycl::range<1>(lws);
-
-        using resTy =
-            typename GreaterEqualOutputType<argTy1, argTy2>::value_type;
-
-        const argTy1 *arg1_tp =
-            reinterpret_cast<const argTy1 *>(arg1_p) + arg1_offset;
-        const argTy2 *arg2_tp =
-            reinterpret_cast<const argTy2 *>(arg2_p) + arg2_offset;
-        resTy *res_tp = reinterpret_cast<resTy *>(res_p) + res_offset;
-
-        cgh.parallel_for<
-            greater_equal_contig_kernel<argTy1, argTy2, resTy, vec_sz, n_vecs>>(
-            sycl::nd_range<1>(gws_range, lws_range),
-            GreaterEqualContigFunctor<argTy1, argTy2, resTy, vec_sz, n_vecs>(
-                arg1_tp, arg2_tp, res_tp, nelems));
-    });
-    return comp_ev;
+    return elementwise_common::binary_contig_impl<
+        argTy1, argTy2, GreaterEqualOutputType, GreaterEqualContigFunctor,
+        greater_equal_contig_kernel>(exec_q, nelems, arg1_p, arg1_offset,
+                                     arg2_p, arg2_offset, res_p, res_offset,
+                                     depends);
 }
 
 template <typename fnT, typename T1, typename T2>
@@ -278,30 +240,11 @@ greater_equal_strided_impl(sycl::queue exec_q,
                            const std::vector<sycl::event> &depends,
                            const std::vector<sycl::event> &additional_depends)
 {
-    sycl::event comp_ev = exec_q.submit([&](sycl::handler &cgh) {
-        cgh.depends_on(depends);
-        cgh.depends_on(additional_depends);
-
-        using resTy =
-            typename GreaterEqualOutputType<argTy1, argTy2>::value_type;
-
-        using IndexerT =
-            typename dpctl::tensor::offset_utils::ThreeOffsets_StridedIndexer;
-
-        IndexerT indexer{nd, arg1_offset, arg2_offset, res_offset,
-                         shape_and_strides};
-
-        const argTy1 *arg1_tp = reinterpret_cast<const argTy1 *>(arg1_p);
-        const argTy2 *arg2_tp = reinterpret_cast<const argTy2 *>(arg2_p);
-        resTy *res_tp = reinterpret_cast<resTy *>(res_p);
-
-        cgh.parallel_for<
-            greater_equal_strided_kernel<argTy1, argTy2, resTy, IndexerT>>(
-            {nelems},
-            GreaterEqualStridedFunctor<argTy1, argTy2, resTy, IndexerT>(
-                arg1_tp, arg2_tp, res_tp, indexer));
-    });
-    return comp_ev;
+    return elementwise_common::binary_strided_impl<
+        argTy1, argTy2, GreaterEqualOutputType, GreaterEqualStridedFunctor,
+        greater_equal_strided_kernel>(
+        exec_q, nelems, nd, shape_and_strides, arg1_p, arg1_offset, arg2_p,
+        arg2_offset, res_p, res_offset, depends, additional_depends);
 }
 
 template <typename fnT, typename T1, typename T2>

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/hypot.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/hypot.hpp
@@ -168,7 +168,7 @@ template <typename fnT, typename T1, typename T2> struct HypotTypeMapFactory
 };
 
 template <typename T1, typename T2, typename resT, typename IndexerT>
-class hypot_strided_strided_kernel;
+class hypot_strided_kernel;
 
 template <typename argTy1, typename argTy2>
 sycl::event
@@ -187,9 +187,9 @@ hypot_strided_impl(sycl::queue exec_q,
 {
     return elementwise_common::binary_strided_impl<
         argTy1, argTy2, HypotOutputType, HypotStridedFunctor,
-        hypot_strided_strided_kernel>(
-        exec_q, nelems, nd, shape_and_strides, arg1_p, arg1_offset, arg2_p,
-        arg2_offset, res_p, res_offset, depends, additional_depends);
+        hypot_strided_kernel>(exec_q, nelems, nd, shape_and_strides, arg1_p,
+                              arg1_offset, arg2_p, arg2_offset, res_p,
+                              res_offset, depends, additional_depends);
 }
 
 template <typename fnT, typename T1, typename T2> struct HypotStridedFactory

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/less.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/less.hpp
@@ -62,20 +62,8 @@ template <typename argT1, typename argT2, typename resT> struct LessFunctor
 
     resT operator()(const argT1 &in1, const argT2 &in2)
     {
-        if constexpr (std::is_same_v<argT1, std::complex<float>> &&
-                      std::is_same_v<argT2, float>)
-        {
-            float real1 = std::real(in1);
-            return (real1 == in2) ? (std::imag(in1) < 0.0f) : real1 < in2;
-        }
-        else if constexpr (std::is_same_v<argT1, float> &&
-                           std::is_same_v<argT2, std::complex<float>>)
-        {
-            float real2 = std::real(in2);
-            return (in1 == real2) ? (0.0f < std::imag(in2)) : in1 < real2;
-        }
-        else if constexpr (tu_ns::is_complex<argT1>::value ||
-                           tu_ns::is_complex<argT2>::value)
+        if constexpr (tu_ns::is_complex<argT1>::value ||
+                      tu_ns::is_complex<argT2>::value)
         {
             static_assert(std::is_same_v<argT1, argT2>);
             using realT = typename argT1::value_type;
@@ -173,10 +161,6 @@ template <typename T1, typename T2> struct LessOutputType
                                         T2,
                                         std::complex<double>,
                                         bool>,
-        td_ns::
-            BinaryTypeMapResultEntry<T1, float, T2, std::complex<float>, bool>,
-        td_ns::
-            BinaryTypeMapResultEntry<T1, std::complex<float>, T2, float, bool>,
         td_ns::DefaultResultEntry<void>>::result_type;
 };
 
@@ -198,32 +182,10 @@ sycl::event less_contig_impl(sycl::queue exec_q,
                              py::ssize_t res_offset,
                              const std::vector<sycl::event> &depends = {})
 {
-    sycl::event comp_ev = exec_q.submit([&](sycl::handler &cgh) {
-        cgh.depends_on(depends);
-
-        size_t lws = 64;
-        constexpr unsigned int vec_sz = 4;
-        constexpr unsigned int n_vecs = 2;
-        const size_t n_groups =
-            ((nelems + lws * n_vecs * vec_sz - 1) / (lws * n_vecs * vec_sz));
-        const auto gws_range = sycl::range<1>(n_groups * lws);
-        const auto lws_range = sycl::range<1>(lws);
-
-        using resTy = typename LessOutputType<argTy1, argTy2>::value_type;
-
-        const argTy1 *arg1_tp =
-            reinterpret_cast<const argTy1 *>(arg1_p) + arg1_offset;
-        const argTy2 *arg2_tp =
-            reinterpret_cast<const argTy2 *>(arg2_p) + arg2_offset;
-        resTy *res_tp = reinterpret_cast<resTy *>(res_p) + res_offset;
-
-        cgh.parallel_for<
-            less_contig_kernel<argTy1, argTy2, resTy, vec_sz, n_vecs>>(
-            sycl::nd_range<1>(gws_range, lws_range),
-            LessContigFunctor<argTy1, argTy2, resTy, vec_sz, n_vecs>(
-                arg1_tp, arg2_tp, res_tp, nelems));
-    });
-    return comp_ev;
+    return elementwise_common::binary_contig_impl<
+        argTy1, argTy2, LessOutputType, LessContigFunctor, less_contig_kernel>(
+        exec_q, nelems, arg1_p, arg1_offset, arg2_p, arg2_offset, res_p,
+        res_offset, depends);
 }
 
 template <typename fnT, typename T1, typename T2> struct LessContigFactory
@@ -270,27 +232,11 @@ less_strided_impl(sycl::queue exec_q,
                   const std::vector<sycl::event> &depends,
                   const std::vector<sycl::event> &additional_depends)
 {
-    sycl::event comp_ev = exec_q.submit([&](sycl::handler &cgh) {
-        cgh.depends_on(depends);
-        cgh.depends_on(additional_depends);
-
-        using resTy = typename LessOutputType<argTy1, argTy2>::value_type;
-
-        using IndexerT =
-            typename dpctl::tensor::offset_utils::ThreeOffsets_StridedIndexer;
-
-        IndexerT indexer{nd, arg1_offset, arg2_offset, res_offset,
-                         shape_and_strides};
-
-        const argTy1 *arg1_tp = reinterpret_cast<const argTy1 *>(arg1_p);
-        const argTy2 *arg2_tp = reinterpret_cast<const argTy2 *>(arg2_p);
-        resTy *res_tp = reinterpret_cast<resTy *>(res_p);
-
-        cgh.parallel_for<less_strided_kernel<argTy1, argTy2, resTy, IndexerT>>(
-            {nelems}, LessStridedFunctor<argTy1, argTy2, resTy, IndexerT>(
-                          arg1_tp, arg2_tp, res_tp, indexer));
-    });
-    return comp_ev;
+    return elementwise_common::binary_strided_impl<
+        argTy1, argTy2, LessOutputType, LessStridedFunctor,
+        less_strided_kernel>(exec_q, nelems, nd, shape_and_strides, arg1_p,
+                             arg1_offset, arg2_p, arg2_offset, res_p,
+                             res_offset, depends, additional_depends);
 }
 
 template <typename fnT, typename T1, typename T2> struct LessStridedFactory

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/less_equal.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/less_equal.hpp
@@ -63,20 +63,8 @@ template <typename argT1, typename argT2, typename resT> struct LessEqualFunctor
 
     resT operator()(const argT1 &in1, const argT2 &in2)
     {
-        if constexpr (std::is_same_v<argT1, std::complex<float>> &&
-                      std::is_same_v<argT2, float>)
-        {
-            float real1 = std::real(in1);
-            return (real1 == in2) ? (std::imag(in1) <= 0.0f) : real1 <= in2;
-        }
-        else if constexpr (std::is_same_v<argT1, float> &&
-                           std::is_same_v<argT2, std::complex<float>>)
-        {
-            float real2 = std::real(in2);
-            return (in1 == real2) ? (0.0f <= std::imag(in2)) : in1 <= real2;
-        }
-        else if constexpr (tu_ns::is_complex<argT1>::value ||
-                           tu_ns::is_complex<argT2>::value)
+        if constexpr (tu_ns::is_complex<argT1>::value ||
+                      tu_ns::is_complex<argT2>::value)
         {
             static_assert(std::is_same_v<argT1, argT2>);
             using realT = typename argT1::value_type;
@@ -174,10 +162,6 @@ template <typename T1, typename T2> struct LessEqualOutputType
                                         T2,
                                         std::complex<double>,
                                         bool>,
-        td_ns::
-            BinaryTypeMapResultEntry<T1, float, T2, std::complex<float>, bool>,
-        td_ns::
-            BinaryTypeMapResultEntry<T1, std::complex<float>, T2, float, bool>,
         td_ns::DefaultResultEntry<void>>::result_type;
 };
 
@@ -199,32 +183,10 @@ sycl::event less_equal_contig_impl(sycl::queue exec_q,
                                    py::ssize_t res_offset,
                                    const std::vector<sycl::event> &depends = {})
 {
-    sycl::event comp_ev = exec_q.submit([&](sycl::handler &cgh) {
-        cgh.depends_on(depends);
-
-        size_t lws = 64;
-        constexpr unsigned int vec_sz = 4;
-        constexpr unsigned int n_vecs = 2;
-        const size_t n_groups =
-            ((nelems + lws * n_vecs * vec_sz - 1) / (lws * n_vecs * vec_sz));
-        const auto gws_range = sycl::range<1>(n_groups * lws);
-        const auto lws_range = sycl::range<1>(lws);
-
-        using resTy = typename LessEqualOutputType<argTy1, argTy2>::value_type;
-
-        const argTy1 *arg1_tp =
-            reinterpret_cast<const argTy1 *>(arg1_p) + arg1_offset;
-        const argTy2 *arg2_tp =
-            reinterpret_cast<const argTy2 *>(arg2_p) + arg2_offset;
-        resTy *res_tp = reinterpret_cast<resTy *>(res_p) + res_offset;
-
-        cgh.parallel_for<
-            less_equal_contig_kernel<argTy1, argTy2, resTy, vec_sz, n_vecs>>(
-            sycl::nd_range<1>(gws_range, lws_range),
-            LessEqualContigFunctor<argTy1, argTy2, resTy, vec_sz, n_vecs>(
-                arg1_tp, arg2_tp, res_tp, nelems));
-    });
-    return comp_ev;
+    return elementwise_common::binary_contig_impl<
+        argTy1, argTy2, LessEqualOutputType, LessEqualContigFunctor,
+        less_equal_contig_kernel>(exec_q, nelems, arg1_p, arg1_offset, arg2_p,
+                                  arg2_offset, res_p, res_offset, depends);
 }
 
 template <typename fnT, typename T1, typename T2> struct LessEqualContigFactory
@@ -273,28 +235,11 @@ less_equal_strided_impl(sycl::queue exec_q,
                         const std::vector<sycl::event> &depends,
                         const std::vector<sycl::event> &additional_depends)
 {
-    sycl::event comp_ev = exec_q.submit([&](sycl::handler &cgh) {
-        cgh.depends_on(depends);
-        cgh.depends_on(additional_depends);
-
-        using resTy = typename LessEqualOutputType<argTy1, argTy2>::value_type;
-
-        using IndexerT =
-            typename dpctl::tensor::offset_utils::ThreeOffsets_StridedIndexer;
-
-        IndexerT indexer{nd, arg1_offset, arg2_offset, res_offset,
-                         shape_and_strides};
-
-        const argTy1 *arg1_tp = reinterpret_cast<const argTy1 *>(arg1_p);
-        const argTy2 *arg2_tp = reinterpret_cast<const argTy2 *>(arg2_p);
-        resTy *res_tp = reinterpret_cast<resTy *>(res_p);
-
-        cgh.parallel_for<
-            less_equal_strided_kernel<argTy1, argTy2, resTy, IndexerT>>(
-            {nelems}, LessEqualStridedFunctor<argTy1, argTy2, resTy, IndexerT>(
-                          arg1_tp, arg2_tp, res_tp, indexer));
-    });
-    return comp_ev;
+    return elementwise_common::binary_strided_impl<
+        argTy1, argTy2, LessEqualOutputType, LessEqualStridedFunctor,
+        less_equal_strided_kernel>(
+        exec_q, nelems, nd, shape_and_strides, arg1_p, arg1_offset, arg2_p,
+        arg2_offset, res_p, res_offset, depends, additional_depends);
 }
 
 template <typename fnT, typename T1, typename T2> struct LessEqualStridedFactory

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/logaddexp.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/logaddexp.hpp
@@ -173,7 +173,7 @@ template <typename fnT, typename T1, typename T2> struct LogAddExpTypeMapFactory
 };
 
 template <typename T1, typename T2, typename resT, typename IndexerT>
-class logaddexp_strided_strided_kernel;
+class logaddexp_strided_kernel;
 
 template <typename argTy1, typename argTy2>
 sycl::event
@@ -188,13 +188,13 @@ logaddexp_strided_impl(sycl::queue exec_q,
                        char *res_p,
                        py::ssize_t res_offset,
                        const std::vector<sycl::event> &depends,
-                       const std::vector<sycl::event> &logaddexpitional_depends)
+                       const std::vector<sycl::event> &additional_depends)
 {
     return elementwise_common::binary_strided_impl<
         argTy1, argTy2, LogAddExpOutputType, LogAddExpStridedFunctor,
-        logaddexp_strided_strided_kernel>(
-        exec_q, nelems, nd, shape_and_strides, arg1_p, arg1_offset, arg2_p,
-        arg2_offset, res_p, res_offset, depends, logaddexpitional_depends);
+        logaddexp_strided_kernel>(exec_q, nelems, nd, shape_and_strides, arg1_p,
+                                  arg1_offset, arg2_p, arg2_offset, res_p,
+                                  res_offset, depends, additional_depends);
 }
 
 template <typename fnT, typename T1, typename T2> struct LogAddExpStridedFactory

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/logical_or.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/logical_or.hpp
@@ -152,10 +152,6 @@ template <typename T1, typename T2> struct LogicalOrOutputType
                                         T2,
                                         std::complex<double>,
                                         bool>,
-        td_ns::
-            BinaryTypeMapResultEntry<T1, float, T2, std::complex<float>, bool>,
-        td_ns::
-            BinaryTypeMapResultEntry<T1, std::complex<float>, T2, float, bool>,
         td_ns::DefaultResultEntry<void>>::result_type;
 };
 
@@ -177,32 +173,10 @@ sycl::event logical_or_contig_impl(sycl::queue exec_q,
                                    py::ssize_t res_offset,
                                    const std::vector<sycl::event> &depends = {})
 {
-    sycl::event comp_ev = exec_q.submit([&](sycl::handler &cgh) {
-        cgh.depends_on(depends);
-
-        size_t lws = 64;
-        constexpr unsigned int vec_sz = 4;
-        constexpr unsigned int n_vecs = 2;
-        const size_t n_groups =
-            ((nelems + lws * n_vecs * vec_sz - 1) / (lws * n_vecs * vec_sz));
-        const auto gws_range = sycl::range<1>(n_groups * lws);
-        const auto lws_range = sycl::range<1>(lws);
-
-        using resTy = typename LogicalOrOutputType<argTy1, argTy2>::value_type;
-
-        const argTy1 *arg1_tp =
-            reinterpret_cast<const argTy1 *>(arg1_p) + arg1_offset;
-        const argTy2 *arg2_tp =
-            reinterpret_cast<const argTy2 *>(arg2_p) + arg2_offset;
-        resTy *res_tp = reinterpret_cast<resTy *>(res_p) + res_offset;
-
-        cgh.parallel_for<
-            logical_or_contig_kernel<argTy1, argTy2, resTy, vec_sz, n_vecs>>(
-            sycl::nd_range<1>(gws_range, lws_range),
-            LogicalOrContigFunctor<argTy1, argTy2, resTy, vec_sz, n_vecs>(
-                arg1_tp, arg2_tp, res_tp, nelems));
-    });
-    return comp_ev;
+    return elementwise_common::binary_contig_impl<
+        argTy1, argTy2, LogicalOrOutputType, LogicalOrContigFunctor,
+        logical_or_contig_kernel>(exec_q, nelems, arg1_p, arg1_offset, arg2_p,
+                                  arg2_offset, res_p, res_offset, depends);
 }
 
 template <typename fnT, typename T1, typename T2> struct LogicalOrContigFactory
@@ -252,28 +226,11 @@ logical_or_strided_impl(sycl::queue exec_q,
                         const std::vector<sycl::event> &depends,
                         const std::vector<sycl::event> &additional_depends)
 {
-    sycl::event comp_ev = exec_q.submit([&](sycl::handler &cgh) {
-        cgh.depends_on(depends);
-        cgh.depends_on(additional_depends);
-
-        using resTy = typename LogicalOrOutputType<argTy1, argTy2>::value_type;
-
-        using IndexerT =
-            typename dpctl::tensor::offset_utils::ThreeOffsets_StridedIndexer;
-
-        IndexerT indexer{nd, arg1_offset, arg2_offset, res_offset,
-                         shape_and_strides};
-
-        const argTy1 *arg1_tp = reinterpret_cast<const argTy1 *>(arg1_p);
-        const argTy2 *arg2_tp = reinterpret_cast<const argTy2 *>(arg2_p);
-        resTy *res_tp = reinterpret_cast<resTy *>(res_p);
-
-        cgh.parallel_for<
-            logical_or_strided_kernel<argTy1, argTy2, resTy, IndexerT>>(
-            {nelems}, LogicalOrStridedFunctor<argTy1, argTy2, resTy, IndexerT>(
-                          arg1_tp, arg2_tp, res_tp, indexer));
-    });
-    return comp_ev;
+    return elementwise_common::binary_strided_impl<
+        argTy1, argTy2, LogicalOrOutputType, LogicalOrStridedFunctor,
+        logical_or_strided_kernel>(
+        exec_q, nelems, nd, shape_and_strides, arg1_p, arg1_offset, arg2_p,
+        arg2_offset, res_p, res_offset, depends, additional_depends);
 }
 
 template <typename fnT, typename T1, typename T2> struct LogicalOrStridedFactory

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/logical_xor.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/logical_xor.hpp
@@ -154,10 +154,6 @@ template <typename T1, typename T2> struct LogicalXorOutputType
                                         T2,
                                         std::complex<double>,
                                         bool>,
-        td_ns::
-            BinaryTypeMapResultEntry<T1, float, T2, std::complex<float>, bool>,
-        td_ns::
-            BinaryTypeMapResultEntry<T1, std::complex<float>, T2, float, bool>,
         td_ns::DefaultResultEntry<void>>::result_type;
 };
 
@@ -180,32 +176,10 @@ logical_xor_contig_impl(sycl::queue exec_q,
                         py::ssize_t res_offset,
                         const std::vector<sycl::event> &depends = {})
 {
-    sycl::event comp_ev = exec_q.submit([&](sycl::handler &cgh) {
-        cgh.depends_on(depends);
-
-        size_t lws = 64;
-        constexpr unsigned int vec_sz = 4;
-        constexpr unsigned int n_vecs = 2;
-        const size_t n_groups =
-            ((nelems + lws * n_vecs * vec_sz - 1) / (lws * n_vecs * vec_sz));
-        const auto gws_range = sycl::range<1>(n_groups * lws);
-        const auto lws_range = sycl::range<1>(lws);
-
-        using resTy = typename LogicalXorOutputType<argTy1, argTy2>::value_type;
-
-        const argTy1 *arg1_tp =
-            reinterpret_cast<const argTy1 *>(arg1_p) + arg1_offset;
-        const argTy2 *arg2_tp =
-            reinterpret_cast<const argTy2 *>(arg2_p) + arg2_offset;
-        resTy *res_tp = reinterpret_cast<resTy *>(res_p) + res_offset;
-
-        cgh.parallel_for<
-            logical_xor_contig_kernel<argTy1, argTy2, resTy, vec_sz, n_vecs>>(
-            sycl::nd_range<1>(gws_range, lws_range),
-            LogicalXorContigFunctor<argTy1, argTy2, resTy, vec_sz, n_vecs>(
-                arg1_tp, arg2_tp, res_tp, nelems));
-    });
-    return comp_ev;
+    return elementwise_common::binary_contig_impl<
+        argTy1, argTy2, LogicalXorOutputType, LogicalXorContigFunctor,
+        logical_xor_contig_kernel>(exec_q, nelems, arg1_p, arg1_offset, arg2_p,
+                                   arg2_offset, res_p, res_offset, depends);
 }
 
 template <typename fnT, typename T1, typename T2> struct LogicalXorContigFactory
@@ -256,28 +230,11 @@ logical_xor_strided_impl(sycl::queue exec_q,
                          const std::vector<sycl::event> &depends,
                          const std::vector<sycl::event> &additional_depends)
 {
-    sycl::event comp_ev = exec_q.submit([&](sycl::handler &cgh) {
-        cgh.depends_on(depends);
-        cgh.depends_on(additional_depends);
-
-        using resTy = typename LogicalXorOutputType<argTy1, argTy2>::value_type;
-
-        using IndexerT =
-            typename dpctl::tensor::offset_utils::ThreeOffsets_StridedIndexer;
-
-        IndexerT indexer{nd, arg1_offset, arg2_offset, res_offset,
-                         shape_and_strides};
-
-        const argTy1 *arg1_tp = reinterpret_cast<const argTy1 *>(arg1_p);
-        const argTy2 *arg2_tp = reinterpret_cast<const argTy2 *>(arg2_p);
-        resTy *res_tp = reinterpret_cast<resTy *>(res_p);
-
-        cgh.parallel_for<
-            logical_xor_strided_kernel<argTy1, argTy2, resTy, IndexerT>>(
-            {nelems}, LogicalXorStridedFunctor<argTy1, argTy2, resTy, IndexerT>(
-                          arg1_tp, arg2_tp, res_tp, indexer));
-    });
-    return comp_ev;
+    return elementwise_common::binary_strided_impl<
+        argTy1, argTy2, LogicalXorOutputType, LogicalXorStridedFunctor,
+        logical_xor_strided_kernel>(
+        exec_q, nelems, nd, shape_and_strides, arg1_p, arg1_offset, arg2_p,
+        arg2_offset, res_p, res_offset, depends, additional_depends);
 }
 
 template <typename fnT, typename T1, typename T2>

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/positive.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/positive.hpp
@@ -128,27 +128,10 @@ sycl::event positive_contig_impl(sycl::queue exec_q,
                                  char *res_p,
                                  const std::vector<sycl::event> &depends = {})
 {
-    sycl::event positive_ev = exec_q.submit([&](sycl::handler &cgh) {
-        cgh.depends_on(depends);
-
-        size_t lws = 64;
-        constexpr unsigned int vec_sz = 4;
-        constexpr unsigned int n_vecs = 2;
-        const size_t n_groups =
-            ((nelems + lws * n_vecs * vec_sz - 1) / (lws * n_vecs * vec_sz));
-        const auto gws_range = sycl::range<1>(n_groups * lws);
-        const auto lws_range = sycl::range<1>(lws);
-
-        using resTy = typename PositiveOutputType<argTy>::value_type;
-        const argTy *arg_tp = reinterpret_cast<const argTy *>(arg_p);
-        resTy *res_tp = reinterpret_cast<resTy *>(res_p);
-
-        cgh.parallel_for<positive_contig_kernel<argTy, resTy, vec_sz, n_vecs>>(
-            sycl::nd_range<1>(gws_range, lws_range),
-            PositiveContigFunctor<argTy, resTy, vec_sz, n_vecs>(arg_tp, res_tp,
-                                                                nelems));
-    });
-    return positive_ev;
+    return elementwise_common::unary_contig_impl<argTy, PositiveOutputType,
+                                                 PositiveContigFunctor,
+                                                 positive_contig_kernel>(
+        exec_q, nelems, arg_p, res_p, depends);
 }
 
 template <typename fnT, typename T> struct PositiveContigFactory
@@ -209,24 +192,11 @@ positive_strided_impl(sycl::queue exec_q,
                       const std::vector<sycl::event> &depends,
                       const std::vector<sycl::event> &additional_depends)
 {
-    sycl::event positive_ev = exec_q.submit([&](sycl::handler &cgh) {
-        cgh.depends_on(depends);
-        cgh.depends_on(additional_depends);
-
-        using resTy = typename PositiveOutputType<argTy>::value_type;
-        using IndexerT =
-            typename dpctl::tensor::offset_utils::TwoOffsets_StridedIndexer;
-
-        IndexerT indexer{nd, arg_offset, res_offset, shape_and_strides};
-
-        const argTy *arg_tp = reinterpret_cast<const argTy *>(arg_p);
-        resTy *res_tp = reinterpret_cast<resTy *>(res_p);
-
-        cgh.parallel_for<positive_strided_kernel<argTy, resTy, IndexerT>>(
-            {nelems}, PositiveStridedFunctor<argTy, resTy, IndexerT>(
-                          arg_tp, res_tp, indexer));
-    });
-    return positive_ev;
+    return elementwise_common::unary_strided_impl<argTy, PositiveOutputType,
+                                                  PositiveStridedFunctor,
+                                                  positive_strided_kernel>(
+        exec_q, nelems, nd, shape_and_strides, arg_p, arg_offset, res_p,
+        res_offset, depends, additional_depends);
 }
 
 template <typename fnT, typename T> struct PositiveStridedFactory

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/pow.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/pow.hpp
@@ -247,7 +247,7 @@ template <typename fnT, typename T1, typename T2> struct PowTypeMapFactory
 };
 
 template <typename T1, typename T2, typename resT, typename IndexerT>
-class pow_strided_strided_kernel;
+class pow_strided_kernel;
 
 template <typename argTy1, typename argTy2>
 sycl::event pow_strided_impl(sycl::queue exec_q,
@@ -264,8 +264,7 @@ sycl::event pow_strided_impl(sycl::queue exec_q,
                              const std::vector<sycl::event> &additional_depends)
 {
     return elementwise_common::binary_strided_impl<
-        argTy1, argTy2, PowOutputType, PowStridedFunctor,
-        pow_strided_strided_kernel>(
+        argTy1, argTy2, PowOutputType, PowStridedFunctor, pow_strided_kernel>(
         exec_q, nelems, nd, shape_and_strides, arg1_p, arg1_offset, arg2_p,
         arg2_offset, res_p, res_offset, depends, additional_depends);
 }


### PR DESCRIPTION
This pull request simplifies the comparison functions by removing unnecessary output type specializations for ``float`` and ``std::complex<float>``.

This reduces the amount of code generation, in hopes of decreasing the binary size.

This PR also fixes typos throughout the elementwise functions and implements the templates from ``elementwise_common`` where they were not being used.

- [X] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [X] Have you tested your changes locally for CPU and GPU devices?
- [X] Have you made sure that new changes do not introduce compiler warnings?
- [X] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
