### PR TITLE
MAINT: changes to test_log.py to avoid RuntimeErrors

### DIFF
--- a/dpctl/tests/elementwise/test_log.py
+++ b/dpctl/tests/elementwise/test_log.py
@@ -31,8 +31,8 @@ def test_log_out_type(dtype):
     q = get_queue_or_skip()
     skip_if_dtype_not_supported(dtype, q)
 
-    X = dpt.asarray(0, dtype=dtype, sycl_queue=q)
-    expected_dtype = np.log(np.array(0, dtype=dtype)).dtype
+    X = dpt.asarray(1, dtype=dtype, sycl_queue=q)
+    expected_dtype = np.log(np.array(1, dtype=dtype)).dtype
     expected_dtype = _map_to_device_dtype(expected_dtype, q.sycl_device)
     assert dpt.log(X).dtype == expected_dtype
 
@@ -44,7 +44,7 @@ def test_log_output_contig(dtype):
 
     n_seq = 1027
 
-    X = dpt.linspace(0, 13, num=n_seq, dtype=dtype, sycl_queue=q)
+    X = dpt.linspace(1, 13, num=n_seq, dtype=dtype, sycl_queue=q)
     Xnp = dpt.asnumpy(X)
 
     Y = dpt.log(X)
@@ -60,7 +60,7 @@ def test_log_output_strided(dtype):
 
     n_seq = 2 * 1027
 
-    X = dpt.linspace(0, 13, num=n_seq, dtype=dtype, sycl_queue=q)[::-2]
+    X = dpt.linspace(1, 13, num=n_seq, dtype=dtype, sycl_queue=q)[::-2]
     Xnp = dpt.asnumpy(X)
 
     Y = dpt.log(X)
@@ -119,11 +119,15 @@ def test_log_special_cases():
     q = get_queue_or_skip()
 
     X = dpt.asarray(
-        [dpt.nan, -1.0, 0.0, -0.0, dpt.inf, -dpt.inf], dtype="f4", sycl_queue=q
+        [dpt.nan, -dpt.inf, -1.0, -0.0, 0.0, dpt.inf], dtype="f4", sycl_queue=q
     )
-    Xnp = dpt.asnumpy(X)
+    Y = dpt.log(X)
 
-    assert_equal(dpt.asnumpy(dpt.log(X)), np.log(Xnp))
+    expected = np.array(
+        [np.nan, np.nan, np.nan, -np.inf, -np.inf, np.inf], dtype="f4"
+    )
+
+    assert_equal(dpt.asnumpy(Y), expected)
 
 
 @pytest.mark.parametrize("dtype", ["f2", "f4", "f8", "c8", "c16"])


### PR DESCRIPTION
Changed tests to avoid `RuntimeErrors` issued by NumPy for numerical exceptions

Replaced feeding zeros into `dpt.log` where it is not essentially for the property tested. 

When testing special values, hard code expected results, rather than recompute them with `np.log`.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
