### PR TITLE
flake8 6.1.0 fixes

### DIFF
--- a/docs/generate_rst.py
+++ b/docs/generate_rst.py
@@ -170,7 +170,7 @@ def _is_class_property(o):
     Returns:
         [type]: [description]
     """
-    return isinstance(o, property) or (type(o) == _getset_descriptor)
+    return isinstance(o, property) or (type(o) is _getset_descriptor)
 
 
 def _is_class_method(o):

--- a/dpctl/tests/test_sycl_event.py
+++ b/dpctl/tests/test_sycl_event.py
@@ -275,4 +275,4 @@ def test_cpython_api_SyclEvent_Make():
     make_e_fn = callable_maker(make_e_fn_ptr)
 
     ev2 = make_e_fn(ev.addressof_ref())
-    assert type(ev) == type(ev2)
+    assert type(ev) is type(ev2)

--- a/dpctl/tests/test_sycl_usm.py
+++ b/dpctl/tests/test_sycl_usm.py
@@ -169,7 +169,7 @@ def test_pickling(memory_ctor):
     mobj.copy_from_host(host_src_obj)
 
     mobj_reconstructed = pickle.loads(pickle.dumps(mobj))
-    assert type(mobj) == type(
+    assert type(mobj) is type(
         mobj_reconstructed
     ), "Pickling should preserve type"
     assert (


### PR DESCRIPTION
This PR aims to fix dpctl's flake8 style conformity and the flake8 CI, which have both been changed by flake8 releasing version 6.1.0.

Checks for equality between types (i.e., ``type(x) == type(y)``) have been changed to use the `is` keyword to that end.

- [X] Have you provided a meaningful PR description?
- [X] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
