### PR TITLE
Clean-up: removed unused symbol in full_ctor.cpp

### DIFF
--- a/dpctl/tensor/libtensor/source/full_ctor.cpp
+++ b/dpctl/tensor/libtensor/source/full_ctor.cpp
@@ -46,7 +46,6 @@ namespace tensor
 namespace py_internal
 {
 
-using dpctl::tensor::kernels::constructors::lin_space_step_fn_ptr_t;
 using dpctl::utils::keep_args_alive;
 
 using dpctl::tensor::kernels::constructors::full_contig_fn_ptr_t;


### PR DESCRIPTION
Remove `using` statement adding an unused qualifier to the namespace.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
