### PR TITLE
Fix missing string format in isdtype

### DIFF
--- a/dpctl/tensor/_data_types.py
+++ b/dpctl/tensor/_data_types.py
@@ -44,7 +44,7 @@ def isdtype(dtype_, kind):
     """
 
     if not isinstance(dtype_, dtype):
-        raise TypeError("Expected instance of `dpt.dtype`, got {dtype_}")
+        raise TypeError(f"Expected instance of `dpt.dtype`, got {dtype_}")
 
     if isinstance(kind, dtype):
         return dtype_ == kind


### PR DESCRIPTION
Fix a small mistake in `dpt.isdtype` that prevent wrong user input to be correctly displayed in the error message:

> TypeError: Expected instance of `dpt.dtype`, got {dtype_}
