### PR TITLE
Compile certain source files in libtensor with no-fast-math

### DIFF
--- a/dpctl/tensor/CMakeLists.txt
+++ b/dpctl/tensor/CMakeLists.txt
@@ -54,6 +54,8 @@ if (WIN32)
   set(_clang_prefix "/clang:")
 endif()
 set_source_files_properties(
+  ${CMAKE_CURRENT_SOURCE_DIR}/libtensor/source/full_ctor.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/libtensor/source/linear_sequences.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/libtensor/source/elementwise_functions.cpp
   PROPERTIES COMPILE_OPTIONS "${_clang_prefix}-fno-fast-math")
 target_compile_options(${python_module_name} PRIVATE -fno-sycl-id-queries-fit-in-int)

--- a/dpctl/tests/test_usm_ndarray_ctor.py
+++ b/dpctl/tests/test_usm_ndarray_ctor.py
@@ -1442,6 +1442,30 @@ def test_full_dtype_inference():
     assert np.issubdtype(dpt.full(10, 0.3 - 2j, dtype=rdt).dtype, np.floating)
 
 
+@pytest.mark.parametrize("dt", ["f2", "f4", "f8"])
+def test_full_special_fp(dt):
+    """See gh-1314"""
+    q = get_queue_or_skip()
+    skip_if_dtype_not_supported(dt, q)
+
+    ar = dpt.full(10, fill_value=dpt.nan)
+    err_msg = f"Failed for fill_value=dpt.nan and dtype {dt}"
+    assert dpt.isnan(ar[0]), err_msg
+
+    ar = dpt.full(10, fill_value=dpt.inf)
+    err_msg = f"Failed for fill_value=dpt.inf and dtype {dt}"
+    assert dpt.isinf(ar[0]) and dpt.greater(ar[0], 0), err_msg
+
+    ar = dpt.full(10, fill_value=-dpt.inf)
+    err_msg = f"Failed for fill_value=-dpt.inf and dtype {dt}"
+    assert dpt.isinf(ar[0]) and dpt.less(ar[0], 0), err_msg
+
+    ar = dpt.full(10, fill_value=dpt.pi)
+    err_msg = f"Failed for fill_value=dpt.pi and dtype {dt}"
+    check = abs(float(ar[0]) - dpt.pi) < 16 * dpt.finfo(ar.dtype).eps
+    assert check, err_msg
+
+
 def test_full_fill_array():
     q = get_queue_or_skip()
 


### PR DESCRIPTION
Closes gh-1314 by compiling Python binding code converting `float('nan')` to a floating-point number using `-fno-fast-math`.

- [x] Have you provided a meaningful PR description?
- [x] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [x] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?

---

To see that this is the right solution, use 

```c++
// filename: nan.cpp
#include "pybind11/pybind11.h"

double fp_id(double x) {
  return x;
}

PYBIND11_MODULE(_nan, m) {
  m.def("fp_id", &fp_id);
}
```

Compile it 

```
icpx nan.cpp --shared -fPIC $(python -m pybind11 --includes) -o _nan.so
```
and test with 

```
python -c "import _nan; print(_nan.fp_id(float('nan')))"
```

With default compilation option `-1` comes out, signaling an uncaught exception. It takes `-fno-fast-math` for it to round-trip correctly. 