### PR TITLE
Fix some array api test cases

### DIFF
--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/logaddexp.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/logaddexp.hpp
@@ -62,8 +62,13 @@ template <typename argT1, typename argT2, typename resT> struct LogAddExpFunctor
     resT operator()(const argT1 &in1, const argT2 &in2)
     {
         resT max = std::max<resT>(in1, in2);
-        if (std::isnan(max) || std::isinf(max)) {
-            return max;
+        if (std::isnan(max)) {
+            return std::numeric_limits<resT>::quiet_NaN();
+        }
+        else {
+            if (std::isinf(max)) {
+                return std::numeric_limits<resT>::infinity();
+            }
         }
         resT min = std::min<resT>(in1, in2);
         return max + std::log1p(std::exp(min - max));
@@ -79,8 +84,11 @@ template <typename argT1, typename argT2, typename resT> struct LogAddExpFunctor
 #pragma unroll
         for (int i = 0; i < vec_sz; ++i) {
             resT max = std::max<resT>(in1[i], in2[i]);
-            if (std::isnan(max) || std::isinf(max)) {
-                res[i] = max;
+            if (std::isnan(max)) {
+                res[i] = std::numeric_limits<resT>::quiet_NaN();
+            }
+            else if (std::isinf(max)) {
+                res[i] = std::numeric_limits<resT>::infinity();
             }
             else {
                 res[i] = max + std::log1p(std::exp(std::abs(diff[i])));

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/logaddexp.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/logaddexp.hpp
@@ -61,10 +61,10 @@ template <typename argT1, typename argT2, typename resT> struct LogAddExpFunctor
 
     resT operator()(const argT1 &in1, const argT2 &in2)
     {
-        if (std::isnan(in1) || std::isnan(in2)) {
-            return std::numeric_limits<resT>::quiet_NaN();
-        }
         resT max = std::max<resT>(in1, in2);
+        if (std::isnan(max) || std::isinf(max)) {
+            return max;
+        }
         resT min = std::min<resT>(in1, in2);
         return max + std::log1p(std::exp(min - max));
     }
@@ -78,11 +78,11 @@ template <typename argT1, typename argT2, typename resT> struct LogAddExpFunctor
 
 #pragma unroll
         for (int i = 0; i < vec_sz; ++i) {
-            if (std::isnan(in1[i]) || std::isnan(in2[i])) {
-                res[i] = std::numeric_limits<resT>::quiet_NaN();
+            resT max = std::max<resT>(in1[i], in2[i]);
+            if (std::isnan(max) || std::isinf(max)) {
+                res[i] = max;
             }
             else {
-                resT max = std::max<resT>(in1[i], in2[i]);
                 res[i] = max + std::log1p(std::exp(std::abs(diff[i])));
             }
         }


### PR DESCRIPTION
This PR fixes an array API test case for ``logaddexp`` that fails for mixed nan and number operands.

It also applies a previous fix used for ``astype`` with ``order="K"`` to ``copy``.

- [X] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [X] Have you tested your changes locally for CPU and GPU devices?
- [X] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [X] If this PR is a work in progress, are you opening the PR as a draft?
