### PR TITLE
Fix boolean reductions for #1327

### DIFF
--- a/dpctl/tensor/libtensor/source/boolean_reductions.hpp
+++ b/dpctl/tensor/libtensor/source/boolean_reductions.hpp
@@ -235,7 +235,8 @@ py_boolean_reduction(dpctl::tensor::usm_ndarray src,
         std::get<2>(iter_red_metadata_packing_triple_);
 
     py::ssize_t *iter_shape_and_strides = packed_shapes_and_strides;
-    py::ssize_t *red_shape_stride = packed_shapes_and_strides + (3 * iter_nd);
+    py::ssize_t *red_shape_stride =
+        packed_shapes_and_strides + 3 * simplified_iter_shape.size();
 
     std::vector<sycl::event> all_deps;
     all_deps.reserve(depends.size() + 1);
@@ -244,7 +245,7 @@ py_boolean_reduction(dpctl::tensor::usm_ndarray src,
     all_deps.push_back(copy_metadata_ev);
 
     auto red_ev =
-        fn(exec_q, dst_nelems, red_nelems, src_data, dst_data, dst_nd,
+        fn(exec_q, dst_nelems, red_nelems, src_data, dst_data, iter_nd,
            iter_shape_and_strides, iter_src_offset, iter_dst_offset,
            simplified_red_nd, red_shape_stride, red_src_offset, all_deps);
 

--- a/dpctl/tests/test_usm_ndarray_utility_functions.py
+++ b/dpctl/tests/test_usm_ndarray_utility_functions.py
@@ -148,3 +148,20 @@ def test_arg_validation_boolean_reductions(func):
         func(d)
     with pytest.raises(AxisError):
         func(x, axis=-3)
+
+
+def test_boolean_reductions_3d_gh_1327():
+    get_queue_or_skip()
+
+    size = 24
+    x = dpt.reshape(dpt.arange(-10, size - 10, 1, dtype="i4"), (2, 3, 4))
+    res = dpt.all(x, axis=0)
+    res_np = np.full(res.shape, True, dtype="?")
+    res_np[2, 2] = False
+
+    assert (dpt.asnumpy(res) == res_np).all()
+
+    x = dpt.ones((2, 3, 4, 5), dtype="i4")
+    res = dpt.any(x, axis=0)
+
+    assert (dpt.asnumpy(res) == np.full(res.shape, True, dtype="?")).all()


### PR DESCRIPTION
Closes #1327 

This PR fixes a typo in the Python binding common to both boolean reductions (any, all).

The binding was calling the implementations of these functions with ``dst_nd`` rather than ``iter_nd``.

``dst_nd`` and ``iter_nd`` often ended up being the same for small-dimensional arrays, which masked the problem.

- [X] Have you provided a meaningful PR description?
- [X] Have you added a test, reproducer or referred to an issue with a reproducer?
- [X] Have you tested your changes locally for CPU and GPU devices?
- [X] Have you made sure that new changes do not introduce compiler warnings?
- [X] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
