### PR TITLE
Fix expm1 for complex special cases

### DIFF
--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/expm1.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/expm1.hpp
@@ -85,7 +85,8 @@ template <typename argT, typename resT> struct Expm1Functor
                         return in;
                     }
                     else {
-                        return (x * resT{std::cos(y), std::sin(y)});
+                        return (resT{std::copysign(x, std::cos(y)),
+                                     std::copysign(x, std::sin(y))});
                     }
                 }
                 else {

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/expm1.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/expm1.hpp
@@ -85,19 +85,19 @@ template <typename argT, typename resT> struct Expm1Functor
                         return in;
                     }
                     else {
-                        return (std::numeric_limits<realT>::infinity() *
-                                    resT{std::cos(y), std::sin(y)} -
-                                realT(1));
+                        return (x * resT{std::cos(y), std::sin(y)});
                     }
                 }
                 else {
                     // negative infinity cases
                     if (!std::isfinite(y)) {
-                        return resT{-1, 0};
+                        // copy sign of y to guarantee
+                        // conj(expm1(x)) == expm1(conj(x))
+                        return resT{realT(-1), std::copysign(realT(0), y)};
                     }
                     else {
-                        return (realT(0) * resT{std::cos(y), std::sin(y)} -
-                                realT(1));
+                        return resT{realT(-1),
+                                    std::copysign(realT(0), std::sin(y))};
                     }
                 }
             }


### PR DESCRIPTION
This PR changes the logic of ``expm1`` for complex data types to better account for special cases (``NaN``s, ``inf``s, etc.). These cases were handled identically to Numpy, but did not conform to the array API.

In addition, this PR slips in changes to silence the remaining warnings in the test suite which were being raised by the elementwise tests.

- [X] Have you provided a meaningful PR description?
- [X] Have you added a test, reproducer or referred to an issue with a reproducer?
- [X] Have you tested your changes locally for CPU and GPU devices?
- [X] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?