### PR TITLE
Fix nonzero result dtype win

### DIFF
--- a/dpctl/tensor/_copy_utils.py
+++ b/dpctl/tensor/_copy_utils.py
@@ -586,7 +586,7 @@ def _nonzero_impl(ary):
         mask_nelems, dtype=cumsum_dt, sycl_queue=exec_q, order="C"
     )
     mask_count = ti.mask_positions(ary, cumsum, sycl_queue=exec_q)
-    indexes_dt = ti.default_device_int_type(exec_q.sycl_device)
+    indexes_dt = ti.default_device_index_type(exec_q.sycl_device)
     indexes = dpt.empty(
         (ary.ndim, mask_count),
         dtype=indexes_dt,

--- a/dpctl/tensor/libtensor/source/device_support_queries.cpp
+++ b/dpctl/tensor/libtensor/source/device_support_queries.cpp
@@ -71,6 +71,11 @@ std::string _default_device_bool_type(sycl::device)
     return "b1";
 }
 
+std::string _default_device_index_type(sycl::device)
+{
+    return "i8";
+}
+
 sycl::device _extract_device(py::object arg)
 {
     auto const &api = dpctl::detail::dpctl_capi::get();
@@ -113,6 +118,12 @@ std::string default_device_complex_type(py::object arg)
 {
     sycl::device d = _extract_device(arg);
     return _default_device_complex_type(d);
+}
+
+std::string default_device_index_type(py::object arg)
+{
+    sycl::device d = _extract_device(arg);
+    return _default_device_index_type(d);
 }
 
 } // namespace py_internal

--- a/dpctl/tensor/libtensor/source/device_support_queries.hpp
+++ b/dpctl/tensor/libtensor/source/device_support_queries.hpp
@@ -41,6 +41,7 @@ extern std::string default_device_fp_type(py::object);
 extern std::string default_device_int_type(py::object);
 extern std::string default_device_bool_type(py::object);
 extern std::string default_device_complex_type(py::object);
+extern std::string default_device_index_type(py::object);
 
 } // namespace py_internal
 } // namespace tensor

--- a/dpctl/tensor/libtensor/source/tensor_py.cpp
+++ b/dpctl/tensor/libtensor/source/tensor_py.cpp
@@ -297,8 +297,12 @@ PYBIND11_MODULE(_tensor_impl, m)
 
     m.def("default_device_complex_type",
           dpctl::tensor::py_internal::default_device_complex_type,
-          "Gives default complex floating point type support by device.",
+          "Gives default complex floating point type supported by device.",
           py::arg("dev"));
+
+    m.def("default_device_index_type",
+          dpctl::tensor::py_internal::default_device_index_type,
+          "Gives default index type supported by device.", py::arg("dev"));
 
     auto tril_fn = [](dpctl::tensor::usm_ndarray src,
                       dpctl::tensor::usm_ndarray dst, py::ssize_t k,

--- a/dpctl/tests/test_usm_ndarray_indexing.py
+++ b/dpctl/tests/test_usm_ndarray_indexing.py
@@ -22,6 +22,7 @@ from numpy.testing import assert_array_equal
 
 import dpctl
 import dpctl.tensor as dpt
+import dpctl.tensor._tensor_impl as ti
 from dpctl.utils import ExecutionPlacementError
 
 _all_dtypes = [
@@ -1353,7 +1354,7 @@ def test_nonzero_dtype():
     x = dpt.ones((3, 4))
     idx, idy = dpt.nonzero(x)
     # create array using device's
-    # default integral data type
-    ref = dpt.arange(8)
-    assert idx.dtype == ref.dtype
-    assert idy.dtype == ref.dtype
+    # default index data type
+    index_dt = dpt.dtype(ti.default_device_index_type(x.sycl_queue))
+    assert idx.dtype == index_dt
+    assert idy.dtype == index_dt


### PR DESCRIPTION
This PR closes gh-1335.

It introduced array API notion of (device-specific) [default index data type](https://data-apis.org/array-api/draft/API_specification/data_types.html#default-data-types), and ensure that `dpctl.tensor.nonzero` 
output arrays are created of this data type.

Relevant test was adjusted accordingly.

- [x] Have you provided a meaningful PR description?
- [x] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
