### PR TITLE
Fixed tests from_dlpack and _from_dlpack_strided for USM-host allocations

### DIFF
--- a/dpctl/tests/test_usm_ndarray_dlpack.py
+++ b/dpctl/tests/test_usm_ndarray_dlpack.py
@@ -127,9 +127,11 @@ def test_from_dlpack(shape, typestr, usm_type):
         Y = dpt.from_dlpack(X)
         assert X.shape == Y.shape
         assert X.dtype == Y.dtype
-        assert X.sycl_device == Y.sycl_device
         assert X.usm_type == Y.usm_type
         assert X._pointer == Y._pointer
+        # we can only expect device to round-trip for USM-device and
+        # USM-shared allocations, which are made for specific device
+        assert (Y.usm_type == "host") or (X.sycl_device == Y.sycl_device)
         if Y.ndim:
             V = Y[::-1]
             W = dpt.from_dlpack(V)
@@ -149,9 +151,11 @@ def test_from_dlpack_strides(mod, typestr, usm_type):
             Y = dpt.from_dlpack(X)
             assert X.shape == Y.shape
             assert X.dtype == Y.dtype
-            assert X.sycl_device == Y.sycl_device
             assert X.usm_type == Y.usm_type
             assert X._pointer == Y._pointer
+            # we can only expect device to round-trip for USM-device and
+            # USM-shared allocations, which are made for specific device
+            assert (Y.usm_type == "host") or (X.sycl_device == Y.sycl_device)
             if Y.ndim:
                 V = Y[::-1]
                 W = dpt.from_dlpack(V)


### PR DESCRIPTION
Since USM-host allocation, unlike USM-device and USM-shared allocations, is not associated with any particular device, only with the host, it is unreasonable to expect that ``sycl::get_pointer_device(ptr, ctx)`` will return the same device that is stored in the `sycl_queue` attribute of `dpctl.tensor.usm_ndarray` instance.

The tests are adjusted to bypass that check for USM-host allocations.

- [x] Have you provided a meaningful PR description?
- [x] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
