### PR TITLE
dpctl.tensor.abs fixed for signed zeros

### DIFF
--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/abs.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/abs.hpp
@@ -65,14 +65,15 @@ template <typename argT, typename resT> struct AbsFunctor
     {
 
         if constexpr (std::is_same_v<argT, bool> ||
-                      (std::is_integral<argT>::value &&
-                       std::is_unsigned<argT>::value))
-        {
+                      std::is_unsigned<argT>::value) {
             static_assert(std::is_same_v<resT, argT>);
             return x;
         }
-        else {
+        else if (std::is_integral<argT>::value || is_complex<argT>::value) {
             return std::abs(x);
+        }
+        else {
+            return (x == argT(0)) ? resT(0) : resT(std::abs(x));
         }
     }
 };

--- a/dpctl/tests/elementwise/test_abs.py
+++ b/dpctl/tests/elementwise/test_abs.py
@@ -135,3 +135,11 @@ def test_abs_out_overlap(dtype):
     assert Y is not X
     assert np.allclose(dpt.asnumpy(X), Xnp)
     assert np.allclose(dpt.asnumpy(Y), Ynp)
+
+
+def test_abs_signed_zero():
+    get_queue_or_skip()
+
+    x = dpt.abs(dpt.asarray(-0.0, dtype="f4"))
+
+    assert bool(dpt.signbit(x)) is False


### PR DESCRIPTION
This PR fixes the behavior of ``abs`` for signed zeros.

Previous behavior:
```
In [1]: import dpctl.tensor as dpt, numpy as np

In [2]: dpt.abs(dpt.asarray(-0.))
Out[2]: usm_ndarray(-0.)
```

Now:
```
In [1]: import dpctl.tensor as dpt, numpy as np

In [2]: dpt.abs(dpt.asarray(-0.))
Out[2]: usm_ndarray(0.)
```

- [X] Have you provided a meaningful PR description?
- [X] Have you added a test, reproducer or referred to an issue with a reproducer?
- [X] Have you tested your changes locally for CPU and GPU devices?
- [X] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
