### PR TITLE
Shift tuple support when axis=None for dpctl.tensor.roll

### DIFF
--- a/dpctl/tensor/_manipulation_functions.py
+++ b/dpctl/tensor/_manipulation_functions.py
@@ -885,6 +885,9 @@ def moveaxis(X, source, destination):
             "the same number of elements"
         )
 
+    if source == destination:
+        return X
+
     ind = [n for n in range(X.ndim) if n not in source]
 
     for src, dst in sorted(zip(destination, source)):

--- a/dpctl/tensor/_manipulation_functions.py
+++ b/dpctl/tensor/_manipulation_functions.py
@@ -426,6 +426,9 @@ def roll(X, shift, axis=None):
     if not isinstance(X, dpt.usm_ndarray):
         raise TypeError(f"Expected usm_ndarray type, got {type(X)}.")
     if axis is None:
+        # get the combined shift value for all axes
+        if type(shift) is tuple:
+            shift = sum(shift)
         res = dpt.empty(
             X.shape, dtype=X.dtype, usm_type=X.usm_type, sycl_queue=X.sycl_queue
         )

--- a/dpctl/tests/test_usm_ndarray_manipulation.py
+++ b/dpctl/tests/test_usm_ndarray_manipulation.py
@@ -590,6 +590,8 @@ def test_roll_empty():
     "data",
     [
         [2, None],
+        [(0, 1), None],
+        [(-1, 0), None],
         [-2, None],
         [2, 0],
         [-2, 0],
@@ -617,6 +619,8 @@ def test_roll_1d(data):
     "data",
     [
         [1, None],
+        [(2, 1), None],
+        [(-1, 2), None],
         [1, 0],
         [1, 1],
         [1, ()],


### PR DESCRIPTION
This PR suggests adding support for the case when `shift is tuple` and `axis=None` for `dpctl.tensor.roll` .
The previous implementation raised `TypeError` exception cause `copy_usm_ndarray_for_reshape` expects shift as an integer.
```
import dpctl.tensor as dpt

a = dpt.ones((5,2))
dpt.roll(a,shift=(1,2))

TypeError: _copy_usm_ndarray_for_reshape(): incompatible function arguments. The following argument types are supported:
    1. (src: dpctl::tensor::usm_ndarray, dst: dpctl::tensor::usm_ndarray, shift: int, sycl_queue: dpctl.SyclQueue, depends: List[dpctl.SyclEvent] = []) -> Tuple[dpctl.SyclEvent, dpctl.SyclEvent]

```

Additionally, the PR adds a check for the equality of the `source` and `destination`  parameters to return the input array `X` without having to move its axes in `dpctl.tensor.moveaxis`.


- [X] Have you provided a meaningful PR description?
- [X] Have you added a test, reproducer or referred to an issue with a reproducer?
- [X] Have you tested your changes locally for CPU and GPU devices?
- [X] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
