### PR TITLE
``dpctl.tensor.where`` output preserves memory order of inputs

### DIFF
--- a/dpctl/tensor/_copy_utils.py
+++ b/dpctl/tensor/_copy_utils.py
@@ -427,12 +427,16 @@ def _empty_like_triple_orderK(X1, X2, X3, dt, res_shape, usm_type, dev):
     nd1 = X1.ndim
     nd2 = X2.ndim
     nd3 = X3.ndim
-    if nd1 > nd2 and nd1 > nd3 and X1.shape == res_shape:
-        return _empty_like_orderK(X1, dt, usm_type, dev)
-    elif nd1 < nd2 and nd3 < nd2 and X2.shape == res_shape:
-        return _empty_like_orderK(X2, dt, usm_type, dev)
-    elif nd1 < nd3 and nd2 < nd3 and X3.shape == res_shape:
-        return _empty_like_orderK(X3, dt, usm_type, dev)
+    if X1.shape == res_shape and X2.shape == res_shape and len(res_shape) > nd3:
+        return _empty_like_pair_orderK(X1, X2, dt, res_shape, usm_type, dev)
+    elif (
+        X2.shape == res_shape and X3.shape == res_shape and len(res_shape) > nd1
+    ):
+        return _empty_like_pair_orderK(X2, X3, dt, res_shape, usm_type, dev)
+    elif (
+        X1.shape == res_shape and X3.shape == res_shape and len(res_shape) > nd2
+    ):
+        return _empty_like_pair_orderK(X1, X3, dt, res_shape, usm_type, dev)
     fl1 = X1.flags
     fl2 = X2.flags
     fl3 = X3.flags

--- a/dpctl/tensor/_copy_utils.py
+++ b/dpctl/tensor/_copy_utils.py
@@ -352,7 +352,7 @@ def _empty_like_orderK(X, dt, usm_type=None, dev=None):
     st = list(X.strides)
     perm = sorted(
         range(X.ndim),
-        key=lambda d: builtins.abs(st[d] if X.shape[d] > 1 else 0),
+        key=lambda d: builtins.abs(st[d]) if X.shape[d] > 1 else 0,
         reverse=True,
     )
     inv_perm = sorted(range(X.ndim), key=lambda i: perm[i])

--- a/dpctl/tensor/_copy_utils.py
+++ b/dpctl/tensor/_copy_utils.py
@@ -351,7 +351,9 @@ def _empty_like_orderK(X, dt, usm_type=None, dev=None):
         )
     st = list(X.strides)
     perm = sorted(
-        range(X.ndim), key=lambda d: builtins.abs(st[d]), reverse=True
+        range(X.ndim),
+        key=lambda d: builtins.abs(st[d] if X.shape[d] > 1 else 0),
+        reverse=True,
     )
     inv_perm = sorted(range(X.ndim), key=lambda i: perm[i])
     sh = X.shape
@@ -395,9 +397,14 @@ def _empty_like_pair_orderK(X1, X2, dt, res_shape, usm_type, dev):
     max_ndim = max(nd1, nd2)
     st1 += [0] * (max_ndim - len(st1))
     st2 += [0] * (max_ndim - len(st2))
+    sh1 = list(X1.shape) + [0] * (max_ndim - nd1)
+    sh2 = list(X2.shape) + [0] * (max_ndim - nd2)
     perm = sorted(
         range(max_ndim),
-        key=lambda d: (builtins.abs(st1[d]), builtins.abs(st2[d])),
+        key=lambda d: (
+            builtins.abs(st1[d]) if sh1[d] > 1 else 0,
+            builtins.abs(st2[d]) if sh2[d] > 1 else 0,
+        ),
         reverse=True,
     )
     inv_perm = sorted(range(max_ndim), key=lambda i: perm[i])
@@ -455,12 +462,15 @@ def _empty_like_triple_orderK(X1, X2, X3, dt, res_shape, usm_type, dev):
     st1 += [0] * (max_ndim - len(st1))
     st2 += [0] * (max_ndim - len(st2))
     st3 += [0] * (max_ndim - len(st3))
+    sh1 = list(X1.shape) + [0] * (max_ndim - nd1)
+    sh2 = list(X2.shape) + [0] * (max_ndim - nd2)
+    sh3 = list(X3.shape) + [0] * (max_ndim - nd3)
     perm = sorted(
         range(max_ndim),
         key=lambda d: (
-            builtins.abs(st1[d]),
-            builtins.abs(st2[d]),
-            builtins.abs(st3[d]),
+            builtins.abs(st1[d]) if sh1[d] > 1 else 0,
+            builtins.abs(st2[d]) if sh2[d] > 1 else 0,
+            builtins.abs(st3[d]) if sh3[d] > 1 else 0,
         ),
         reverse=True,
     )

--- a/dpctl/tensor/_search_functions.py
+++ b/dpctl/tensor/_search_functions.py
@@ -139,13 +139,13 @@ def where(condition, x1, x2):
         deps.append(copy2_ev)
         wait_list.append(ht_copy2_ev)
 
-    condition = dpt.broadcast_to(condition, res_shape)
-    x1 = dpt.broadcast_to(x1, res_shape)
-    x2 = dpt.broadcast_to(x2, res_shape)
-
     dst = _empty_like_triple_orderK(
         condition, x1, x2, dst_dtype, res_shape, dst_usm_type, exec_q
     )
+
+    condition = dpt.broadcast_to(condition, res_shape)
+    x1 = dpt.broadcast_to(x1, res_shape)
+    x2 = dpt.broadcast_to(x2, res_shape)
 
     hev, _ = ti._where(
         condition=condition,

--- a/dpctl/tensor/_search_functions.py
+++ b/dpctl/tensor/_search_functions.py
@@ -19,6 +19,7 @@ import dpctl.tensor as dpt
 import dpctl.tensor._tensor_impl as ti
 from dpctl.tensor._manipulation_functions import _broadcast_shapes
 
+from ._copy_utils import _empty_like_orderK, _empty_like_triple_orderK
 from ._type_utils import _all_data_types, _can_cast
 
 
@@ -121,7 +122,7 @@ def where(condition, x1, x2):
     deps = []
     wait_list = []
     if x1_dtype != dst_dtype:
-        _x1 = dpt.empty_like(x1, dtype=dst_dtype)
+        _x1 = _empty_like_orderK(x1, dst_dtype)
         ht_copy1_ev, copy1_ev = ti._copy_usm_ndarray_into_usm_ndarray(
             src=x1, dst=_x1, sycl_queue=exec_q
         )
@@ -130,7 +131,7 @@ def where(condition, x1, x2):
         wait_list.append(ht_copy1_ev)
 
     if x2_dtype != dst_dtype:
-        _x2 = dpt.empty_like(x2, dtype=dst_dtype)
+        _x2 = _empty_like_orderK(x2, dst_dtype)
         ht_copy2_ev, copy2_ev = ti._copy_usm_ndarray_into_usm_ndarray(
             src=x2, dst=_x2, sycl_queue=exec_q
         )
@@ -142,25 +143,8 @@ def where(condition, x1, x2):
     x1 = dpt.broadcast_to(x1, res_shape)
     x2 = dpt.broadcast_to(x2, res_shape)
 
-    # dst is F-contiguous when all inputs are F contiguous
-    # otherwise, defaults to C-contiguous
-    if all(
-        (
-            condition.flags.fnc,
-            x1.flags.fnc,
-            x2.flags.fnc,
-        )
-    ):
-        order = "F"
-    else:
-        order = "C"
-
-    dst = dpt.empty(
-        res_shape,
-        dtype=dst_dtype,
-        order=order,
-        usm_type=dst_usm_type,
-        sycl_queue=exec_q,
+    dst = _empty_like_triple_orderK(
+        condition, x1, x2, dst_dtype, res_shape, dst_usm_type, exec_q
     )
 
     hev, _ = ti._where(

--- a/dpctl/tests/test_usm_ndarray_search_functions.py
+++ b/dpctl/tests/test_usm_ndarray_search_functions.py
@@ -406,3 +406,9 @@ def test_where_order():
         condition = dpt.zeros(test_sh2, dtype="?", order="C")[:20, ::-2].mT
         res = dpt.where(condition, ar1, ar2)
         assert res.strides == (-1, n)
+
+        ar1 = dpt.ones(n, dtype=dt1, order="C")
+        ar2 = dpt.broadcast_to(dpt.ones(n, dtype=dt2, order="C"), test_sh)
+        condition = dpt.zeros(n, dtype="?", order="C")
+        res = dpt.where(condition, ar1, ar2)
+        assert res.strides == (20, 1)


### PR DESCRIPTION
This PR adjusts the behavior of ``dpctl.tensor.where`` to preserve the memory layout of its inputs. This improves the access pattern of the kernel.

Performance of old behavior:
```
In [1]: import dpctl.tensor as dpt, numpy as np

In [2]: dt = dpt.int32

In [3]: sh = (8160, 8160)

In [4]: ar1 = dpt.ones(sh, dtype=dt, order="C")[:4080, ::-2].mT

In [5]: ar2 = dpt.zeros(sh, dtype=dt, order="C")[:4080, ::-2].mT

In [6]: condition = dpt.zeros(sh, dtype=dt, order="C")[:4080, ::-2].mT

In [7]: res = dpt.where(condition, ar1, ar2)
CPU times: user 143 ms, sys: 53.4 ms, total: 196 ms
Wall time: 220 ms

In [8]: %time res = dpt.where(condition, ar1, ar2)
CPU times: user 48.3 ms, sys: 67.6 ms, total: 116 ms
Wall time: 119 ms

In [9]: %time res = dpt.where(condition, ar1, ar2)
CPU times: user 81.5 ms, sys: 31.1 ms, total: 113 ms
Wall time: 114 ms
```

New behavior:
```
In [9]: %time res = dpt.where(condition, ar1, ar2)
CPU times: user 26.9 ms, sys: 198 µs, total: 27.1 ms
Wall time: 27.8 ms

In [10]: %time res = dpt.where(condition, ar1, ar2)
CPU times: user 16.1 ms, sys: 13.8 ms, total: 29.9 ms
Wall time: 30.9 ms

In [11]: %time res = dpt.where(condition, ar1, ar2)
CPU times: user 23.3 ms, sys: 1.43 ms, total: 24.7 ms
Wall time: 26.7 ms
```

which is an improvement of ~4x in certain cases.

``_empty_like_triple_orderK`` is introduced for this purpose and a test was added to ensure that the output strides are as expected.

- [X] Have you provided a meaningful PR description?
- [X] Have you added a test, reproducer or referred to an issue with a reproducer?
- [X] Have you tested your changes locally for CPU and GPU devices?
- [X] Have you made sure that new changes do not introduce compiler warnings?
- [X] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
