### PR TITLE
Closes gh-1344

### DIFF
--- a/dpctl/apis/include/dpctl_capi.h
+++ b/dpctl/apis/include/dpctl_capi.h
@@ -28,7 +28,11 @@
 // Ordering of includes is important here. dpctl_sycl_types defines types
 // used by dpctl's Python C-API headers.
 #include "syclinterface/dpctl_sycl_types.h"
+#ifdef __cplusplus
 #define CYTHON_EXTERN_C extern "C"
+#else
+#define CYTHON_EXTERN_C
+#endif
 #include "../_sycl_device.h"
 #include "../_sycl_device_api.h"
 #include "../_sycl_context.h"


### PR DESCRIPTION
Define `CYTHON_EXTERN_C` as empty for C compilers.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
