### PR TITLE
Correct typo in an exception text

### DIFF
--- a/dpctl/tensor/_usmarray.pyx
+++ b/dpctl/tensor/_usmarray.pyx
@@ -325,7 +325,7 @@ cdef class usm_ndarray:
         if (_offset + ary_min_displacement < 0 or
            (_offset + ary_max_displacement + 1) * itemsize > _buffer.nbytes):
             self._cleanup()
-            raise ValueError(("buffer='{}' can not accomodate "
+            raise ValueError(("buffer='{}' can not accommodate "
                               "the requested array.").format(buffer))
         is_fp64 = (typenum == UAR_DOUBLE or typenum == UAR_CDOUBLE)
         is_fp16 = (typenum == UAR_HALF)

--- a/dpctl/tensor/libtensor/source/boolean_advanced_indexing.cpp
+++ b/dpctl/tensor/libtensor/source/boolean_advanced_indexing.cpp
@@ -387,14 +387,14 @@ py_extract(dpctl::tensor::usm_ndarray src,
 
     // ensure that dst is sufficiently ample
     auto dst_offsets = dst.get_minmax_offsets();
-    // destination must be ample enough to accomodate all elements
+    // destination must be ample enough to accommodate all elements
     {
         size_t range =
             static_cast<size_t>(dst_offsets.second - dst_offsets.first);
         if (range + 1 < static_cast<size_t>(ortho_nelems * masked_dst_nelems)) {
             throw py::value_error(
                 "Memory addressed by the destination array can not "
-                "accomodate all the "
+                "accommodate all the "
                 "array elements.");
         }
     }
@@ -716,14 +716,14 @@ py_place(dpctl::tensor::usm_ndarray dst,
 
     // ensure that dst is sufficiently ample
     auto dst_offsets = dst.get_minmax_offsets();
-    // destination must be ample enough to accomodate all elements
+    // destination must be ample enough to accommodate all elements
     {
         size_t range =
             static_cast<size_t>(dst_offsets.second - dst_offsets.first);
         if (range + 1 < static_cast<size_t>(ortho_nelems * masked_dst_nelems)) {
             throw py::value_error(
                 "Memory addressed by the destination array can not "
-                "accomodate all the "
+                "accommodate all the "
                 "array elements.");
         }
     }
@@ -999,14 +999,14 @@ py_nonzero(dpctl::tensor::usm_ndarray
 
     // ensure that dst is sufficiently ample
     auto indexes_offsets = indexes.get_minmax_offsets();
-    // destination must be ample enough to accomodate all elements
+    // destination must be ample enough to accommodate all elements
     {
         size_t range =
             static_cast<size_t>(indexes_offsets.second - indexes_offsets.first);
         if (range + 1 < static_cast<size_t>(nz_elems * _ndim)) {
             throw py::value_error(
                 "Memory addressed by the destination array can not "
-                "accomodate all the array elements.");
+                "accommodate all the array elements.");
         }
     }
 

--- a/dpctl/tensor/libtensor/source/boolean_reductions.hpp
+++ b/dpctl/tensor/libtensor/source/boolean_reductions.hpp
@@ -102,14 +102,14 @@ py_boolean_reduction(dpctl::tensor::usm_ndarray src,
 
     // ensure that dst is sufficiently ample
     auto dst_offsets = dst.get_minmax_offsets();
-    // destination must be ample enough to accomodate all elements
+    // destination must be ample enough to accommodate all elements
     {
         size_t range =
             static_cast<size_t>(dst_offsets.second - dst_offsets.first);
         if (range + 1 < static_cast<size_t>(dst_nelems)) {
             throw py::value_error(
                 "Memory addressed by the destination array can not "
-                "accomodate all the array elements.");
+                "accommodate all the array elements.");
         }
     }
 

--- a/dpctl/tensor/libtensor/source/copy_and_cast_usm_to_usm.cpp
+++ b/dpctl/tensor/libtensor/source/copy_and_cast_usm_to_usm.cpp
@@ -100,14 +100,14 @@ copy_usm_ndarray_into_usm_ndarray(dpctl::tensor::usm_ndarray src,
         return std::make_pair(sycl::event(), sycl::event());
     }
 
-    // destination must be ample enough to accomodate all elements
+    // destination must be ample enough to accommodate all elements
     {
         auto dst_offsets = dst.get_minmax_offsets();
         size_t range =
             static_cast<size_t>(dst_offsets.second - dst_offsets.first);
         if (range + 1 < src_nelems) {
             throw py::value_error(
-                "Destination array can not accomodate all the "
+                "Destination array can not accommodate all the "
                 "elements of source array.");
         }
     }

--- a/dpctl/tensor/libtensor/source/copy_for_reshape.cpp
+++ b/dpctl/tensor/libtensor/source/copy_for_reshape.cpp
@@ -88,14 +88,14 @@ copy_usm_ndarray_for_reshape(dpctl::tensor::usm_ndarray src,
         return std::make_pair(sycl::event(), sycl::event());
     }
 
-    // destination must be ample enough to accomodate all elements
+    // destination must be ample enough to accommodate all elements
     {
         auto dst_offsets = dst.get_minmax_offsets();
         py::ssize_t range =
             static_cast<py::ssize_t>(dst_offsets.second - dst_offsets.first);
         if (range + 1 < src_nelems) {
             throw py::value_error(
-                "Destination array can not accomodate all the "
+                "Destination array can not accommodate all the "
                 "elements of source array.");
         }
     }

--- a/dpctl/tensor/libtensor/source/copy_numpy_ndarray_into_usm_ndarray.cpp
+++ b/dpctl/tensor/libtensor/source/copy_numpy_ndarray_into_usm_ndarray.cpp
@@ -89,14 +89,14 @@ void copy_numpy_ndarray_into_usm_ndarray(
     }
 
     auto dst_offsets = dst.get_minmax_offsets();
-    // destination must be ample enough to accomodate all elements of source
+    // destination must be ample enough to accommodate all elements of source
     // array
     {
         size_t range =
             static_cast<size_t>(dst_offsets.second - dst_offsets.first);
         if (range + 1 < src_nelems) {
             throw py::value_error(
-                "Destination array can not accomodate all the "
+                "Destination array can not accommodate all the "
                 "elements of source array.");
         }
     }

--- a/dpctl/tensor/libtensor/source/elementwise_functions.hpp
+++ b/dpctl/tensor/libtensor/source/elementwise_functions.hpp
@@ -113,15 +113,15 @@ py_unary_ufunc(dpctl::tensor::usm_ndarray src,
         return std::make_pair(sycl::event(), sycl::event());
     }
 
-    // ensure that output is ample enough to accomodate all elements
+    // ensure that output is ample enough to accommodate all elements
     auto dst_offsets = dst.get_minmax_offsets();
-    // destination must be ample enough to accomodate all elements
+    // destination must be ample enough to accommodate all elements
     {
         size_t range =
             static_cast<size_t>(dst_offsets.second - dst_offsets.first);
         if (range + 1 < src_nelems) {
             throw py::value_error(
-                "Destination array can not accomodate all the "
+                "Destination array can not accommodate all the "
                 "elements of source array.");
         }
     }
@@ -366,15 +366,15 @@ std::pair<sycl::event, sycl::event> py_binary_ufunc(
         return std::make_pair(sycl::event(), sycl::event());
     }
 
-    // ensure that output is ample enough to accomodate all elements
+    // ensure that output is ample enough to accommodate all elements
     auto dst_offsets = dst.get_minmax_offsets();
-    // destination must be ample enough to accomodate all elements
+    // destination must be ample enough to accommodate all elements
     {
         size_t range =
             static_cast<size_t>(dst_offsets.second - dst_offsets.first);
         if (range + 1 < src_nelems) {
             throw py::value_error(
-                "Destination array can not accomodate all the "
+                "Destination array can not accommodate all the "
                 "elements of source array.");
         }
     }
@@ -664,15 +664,15 @@ py_binary_inplace_ufunc(dpctl::tensor::usm_ndarray lhs,
         return std::make_pair(sycl::event(), sycl::event());
     }
 
-    // ensure that output is ample enough to accomodate all elements
+    // ensure that output is ample enough to accommodate all elements
     auto lhs_offsets = lhs.get_minmax_offsets();
-    // destination must be ample enough to accomodate all elements
+    // destination must be ample enough to accommodate all elements
     {
         size_t range =
             static_cast<size_t>(lhs_offsets.second - lhs_offsets.first);
         if (range + 1 < rhs_nelems) {
             throw py::value_error(
-                "Destination array can not accomodate all the "
+                "Destination array can not accommodate all the "
                 "elements of source array.");
         }
     }

--- a/dpctl/tensor/libtensor/source/sum_reductions.cpp
+++ b/dpctl/tensor/libtensor/source/sum_reductions.cpp
@@ -142,14 +142,14 @@ std::pair<sycl::event, sycl::event> py_sum_over_axis(
         throw py::value_error("Arrays index overlapping segments of memory");
     }
 
-    // destination must be ample enough to accomodate all elements
+    // destination must be ample enough to accommodate all elements
     {
         auto dst_offsets = dst.get_minmax_offsets();
         size_t range =
             static_cast<size_t>(dst_offsets.second - dst_offsets.first);
         if (range + 1 < dst_nelems) {
             throw py::value_error(
-                "Destination array can not accomodate all the "
+                "Destination array can not accommodate all the "
                 "elements of source array.");
         }
     }

--- a/dpctl/tensor/libtensor/source/where.cpp
+++ b/dpctl/tensor/libtensor/source/where.cpp
@@ -132,14 +132,14 @@ py_where(dpctl::tensor::usm_ndarray condition,
 
     // ensure that dst is sufficiently ample
     auto dst_offsets = dst.get_minmax_offsets();
-    // destination must be ample enough to accomodate all elements
+    // destination must be ample enough to accommodate all elements
     {
         size_t range =
             static_cast<size_t>(dst_offsets.second - dst_offsets.first);
         if (range + 1 < static_cast<size_t>(nelems)) {
             throw py::value_error(
                 "Memory addressed by the destination array can not "
-                "accomodate all the "
+                "accommodate all the "
                 "array elements.");
         }
     }

--- a/dpctl/tests/test_usm_ndarray_ctor.py
+++ b/dpctl/tests/test_usm_ndarray_ctor.py
@@ -1602,7 +1602,7 @@ def test_arange(dt):
     elif np.issubdtype(dt, np.complexfloating):
         assert complex(X[47]) == 47.0 + 0.0j
 
-    # choose size larger than maximal value that u1/u2 can accomodate
+    # choose size larger than maximal value that u1/u2 can accommodate
     sz = int(dpt.iinfo(dpt.int8).max)
     X1 = dpt.arange(sz + 1, dtype=dt, sycl_queue=q)
     assert X1.shape == (sz + 1,)


### PR DESCRIPTION
The PR proposes a minor change to get rid of typo in the text of exception and code comments: `accomodate` -> `accommodate` (double m's). 

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
