### PR TITLE
Fix bad order=K code logic in tensor.asarray 

### DIFF
--- a/dpctl/tensor/_copy_utils.py
+++ b/dpctl/tensor/_copy_utils.py
@@ -24,7 +24,7 @@ import dpctl.memory as dpm
 import dpctl.tensor as dpt
 import dpctl.tensor._tensor_impl as ti
 import dpctl.utils
-from dpctl.tensor._ctors import _get_dtype
+from dpctl.tensor._data_types import _get_dtype
 from dpctl.tensor._device import normalize_queue_device
 
 __doc__ = (
@@ -354,11 +354,11 @@ def _empty_like_orderK(X, dt, usm_type=None, dev=None):
         range(X.ndim), key=lambda d: builtins.abs(st[d]), reverse=True
     )
     inv_perm = sorted(range(X.ndim), key=lambda i: perm[i])
-    st_sorted = [st[i] for i in perm]
     sh = X.shape
     sh_sorted = tuple(sh[i] for i in perm)
     R = dpt.empty(sh_sorted, dtype=dt, usm_type=usm_type, device=dev, order="C")
-    if min(st_sorted) < 0:
+    if min(st) < 0:
+        st_sorted = [st[i] for i in perm]
         sl = tuple(
             slice(None, None, -1)
             if st_sorted[i] < 0

--- a/dpctl/tensor/_data_types.py
+++ b/dpctl/tensor/_data_types.py
@@ -14,7 +14,25 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
+from numpy import bool_ as np_bool_
+from numpy import complexfloating as np_complexfloating
 from numpy import dtype
+from numpy import floating as np_floating
+from numpy import integer as np_integer
+from numpy import issubdtype as np_issubdtype
+
+from dpctl.tensor._tensor_impl import (
+    default_device_bool_type as ti_default_device_bool_type,
+)
+from dpctl.tensor._tensor_impl import (
+    default_device_complex_type as ti_default_device_complex_type,
+)
+from dpctl.tensor._tensor_impl import (
+    default_device_fp_type as ti_default_device_fp_type,
+)
+from dpctl.tensor._tensor_impl import (
+    default_device_int_type as ti_default_device_int_type,
+)
 
 bool = dtype("bool")
 int8 = dtype("int8")
@@ -72,6 +90,32 @@ def isdtype(dtype_, kind):
 
     else:
         raise TypeError(f"Unsupported data type kind: {kind}")
+
+
+def _get_dtype(inp_dt, sycl_obj, ref_type=None):
+    """
+    Type inference utility to construct data type
+    object with defaults based on reference type.
+
+    _get_dtype is used by dpctl.tensor.asarray
+    to infer data type of the output array from the
+    input sequence.
+    """
+    if inp_dt is None:
+        if ref_type in [None, float] or np_issubdtype(ref_type, np_floating):
+            fp_dt = ti_default_device_fp_type(sycl_obj)
+            return dtype(fp_dt)
+        if ref_type in [bool, np_bool_]:
+            bool_dt = ti_default_device_bool_type(sycl_obj)
+            return dtype(bool_dt)
+        if ref_type is int or np_issubdtype(ref_type, np_integer):
+            int_dt = ti_default_device_int_type(sycl_obj)
+            return dtype(int_dt)
+        if ref_type is complex or np_issubdtype(ref_type, np_complexfloating):
+            cfp_dt = ti_default_device_complex_type(sycl_obj)
+            return dtype(cfp_dt)
+        raise TypeError(f"Reference type {ref_type} not recognized.")
+    return dtype(inp_dt)
 
 
 __all__ = [

--- a/dpctl/tests/test_tensor_asarray.py
+++ b/dpctl/tests/test_tensor_asarray.py
@@ -383,3 +383,15 @@ def test_ulonglong_gh_1167():
     assert x.dtype == dpt.uint64
     x = dpt.asarray(9223372036854775808, dtype="u8")
     assert x.dtype == dpt.uint64
+
+
+def test_orderK_gh_1350():
+    get_queue_or_skip()
+    a = dpt.empty((2, 3, 4), dtype="u1")
+    b = dpt.permute_dims(a, (2, 0, 1))
+    c = dpt.asarray(b, copy=True, order="K")
+
+    assert c.shape == b.shape
+    assert c.strides == b.strides
+    assert c._element_offset == 0
+    assert not c._pointer == b._pointer


### PR DESCRIPTION
Closes gh-1350

`dpctl.tensor.asarray` implementation of `order='K'` keyword processing was replaced with call to tested `_empty_like_orderK` utility to fix the issue reported in gh-1350.

Few routines had to be shuffled to avoid import failure due to circular import dependencies.

- [x] Have you provided a meaningful PR description?
- [x] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
