### PR TITLE
Fully enable ``usm_ndarray`` in-place arithmetic operators

### DIFF
--- a/dpctl/tensor/_elementwise_common.py
+++ b/dpctl/tensor/_elementwise_common.py
@@ -301,8 +301,6 @@ def _resolve_weak_types(o1_dtype, o2_dtype, dev):
         o1_kind_num = _weak_type_num_kind(o1_dtype)
         o2_kind_num = _strong_dtype_num_kind(o2_dtype)
         if o1_kind_num > o2_kind_num:
-            if isinstance(o1_dtype, WeakBooleanType):
-                return dpt.bool, o2_dtype
             if isinstance(o1_dtype, WeakIntegralType):
                 return dpt.int64, o2_dtype
             if isinstance(o1_dtype, WeakComplexType):
@@ -322,8 +320,6 @@ def _resolve_weak_types(o1_dtype, o2_dtype, dev):
         o1_kind_num = _strong_dtype_num_kind(o1_dtype)
         o2_kind_num = _weak_type_num_kind(o2_dtype)
         if o2_kind_num > o1_kind_num:
-            if isinstance(o2_dtype, WeakBooleanType):
-                return o1_dtype, dpt.bool
             if isinstance(o2_dtype, WeakIntegralType):
                 return o1_dtype, dpt.int64
             if isinstance(o2_dtype, WeakComplexType):

--- a/dpctl/tensor/_elementwise_common.py
+++ b/dpctl/tensor/_elementwise_common.py
@@ -510,7 +510,8 @@ class BinaryElementwiseFunc:
                                 o2, dtype=o2_dtype, sycl_queue=exec_q
                             )
                         if buf2_dt is None:
-                            src2 = dpt.broadcast_to(src2, res_shape)
+                            if src2.shape != res_shape:
+                                src2 = dpt.broadcast_to(src2, res_shape)
                             ht_, _ = self.binary_inplace_fn_(
                                 lhs=o1, rhs=src2, sycl_queue=exec_q
                             )
@@ -581,9 +582,10 @@ class BinaryElementwiseFunc:
                         sycl_queue=exec_q,
                         order=order,
                     )
-
-            src1 = dpt.broadcast_to(src1, res_shape)
-            src2 = dpt.broadcast_to(src2, res_shape)
+            if src1.shape != res_shape:
+                src1 = dpt.broadcast_to(src1, res_shape)
+            if src2.shape != res_shape:
+                src2 = dpt.broadcast_to(src2, res_shape)
             ht_binary_ev, binary_ev = self.binary_fn_(
                 src1=src1, src2=src2, dst=out, sycl_queue=exec_q
             )
@@ -628,8 +630,8 @@ class BinaryElementwiseFunc:
                         f"Output array of type {res_dt} is needed,"
                         f"got {out.dtype}"
                     )
-
-            src1 = dpt.broadcast_to(src1, res_shape)
+            if src1.shape != res_shape:
+                src1 = dpt.broadcast_to(src1, res_shape)
             buf2 = dpt.broadcast_to(buf2, res_shape)
             ht_binary_ev, binary_ev = self.binary_fn_(
                 src1=src1,
@@ -676,7 +678,8 @@ class BinaryElementwiseFunc:
                     )
 
             buf1 = dpt.broadcast_to(buf1, res_shape)
-            src2 = dpt.broadcast_to(src2, res_shape)
+            if src2.shape != res_shape:
+                src2 = dpt.broadcast_to(src2, res_shape)
             ht_binary_ev, binary_ev = self.binary_fn_(
                 src1=buf1,
                 src2=src2,

--- a/dpctl/tensor/_elementwise_common.py
+++ b/dpctl/tensor/_elementwise_common.py
@@ -78,8 +78,8 @@ class UnaryElementwiseFunc:
                 )
 
             if out.shape != x.shape:
-                raise TypeError(
-                    "The shape of input and output arrays are inconsistent."
+                raise ValueError(
+                    "The shape of input and output arrays are inconsistent. "
                     f"Expected output shape is {x.shape}, got {out.shape}"
                 )
 
@@ -103,7 +103,7 @@ class UnaryElementwiseFunc:
                 dpctl.utils.get_execution_queue((x.sycl_queue, out.sycl_queue))
                 is None
             ):
-                raise TypeError(
+                raise ExecutionPlacementError(
                     "Input and output allocation queues are not compatible"
                 )
 
@@ -471,8 +471,8 @@ class BinaryElementwiseFunc:
                 )
 
             if out.shape != res_shape:
-                raise TypeError(
-                    "The shape of input and output arrays are inconsistent."
+                raise ValueError(
+                    "The shape of input and output arrays are inconsistent. "
                     f"Expected output shape is {o1_shape}, got {out.shape}"
                 )
 
@@ -486,7 +486,7 @@ class BinaryElementwiseFunc:
                 dpctl.utils.get_execution_queue((exec_q, out.sycl_queue))
                 is None
             ):
-                raise TypeError(
+                raise ExecutionPlacementError(
                     "Input and output allocation queues are not compatible"
                 )
 

--- a/dpctl/tensor/_type_utils.py
+++ b/dpctl/tensor/_type_utils.py
@@ -226,27 +226,9 @@ def _find_buf_dtype2(arg1_dtype, arg2_dtype, query_fn, sycl_dev, acceptance_fn):
     return None, None, None
 
 
-def _find_inplace_dtype(lhs_dtype, rhs_dtype, query_fn, sycl_dev):
-    res_dt = query_fn(lhs_dtype, rhs_dtype)
-    if res_dt and res_dt == lhs_dtype:
-        return rhs_dtype
-
-    _fp16 = sycl_dev.has_aspect_fp16
-    _fp64 = sycl_dev.has_aspect_fp64
-    all_dts = _all_data_types(_fp16, _fp64)
-    for buf_dt in all_dts:
-        if _can_cast(rhs_dtype, buf_dt, _fp16, _fp64):
-            res_dt = query_fn(lhs_dtype, buf_dt)
-            if res_dt and res_dt == lhs_dtype:
-                return buf_dt
-
-    return None
-
-
 __all__ = [
     "_find_buf_dtype",
     "_find_buf_dtype2",
-    "_find_inplace_dtype",
     "_to_device_supported_dtype",
     "_acceptance_fn_default",
     "_acceptance_fn_divide",

--- a/dpctl/tensor/_usmarray.pyx
+++ b/dpctl/tensor/_usmarray.pyx
@@ -1286,8 +1286,7 @@ cdef class usm_ndarray:
         return _dispatch_binary_elementwise2(other, "bitwise_xor", self)
 
     def __iadd__(self, other):
-        from ._elementwise_funcs import add
-        return add._inplace(self, other)
+        return dpctl.tensor.add(self, other, out=self)
 
     def __iand__(self, other):
         res = self.__and__(other)
@@ -1325,8 +1324,7 @@ cdef class usm_ndarray:
         return self
 
     def __imul__(self, other):
-        from ._elementwise_funcs import multiply
-        return multiply._inplace(self, other)
+        return dpctl.tensor.multiply(self, other, out=self)
 
     def __ior__(self, other):
         res = self.__or__(other)
@@ -1350,8 +1348,7 @@ cdef class usm_ndarray:
         return self
 
     def __isub__(self, other):
-        from ._elementwise_funcs import subtract
-        return subtract._inplace(self, other)
+        return dpctl.tensor.subtract(self, other, out=self)
 
     def __itruediv__(self, other):
         res = self.__truediv__(other)

--- a/dpctl/tensor/_usmarray.pyx
+++ b/dpctl/tensor/_usmarray.pyx
@@ -1289,25 +1289,13 @@ cdef class usm_ndarray:
         return dpctl.tensor.add(self, other, out=self)
 
     def __iand__(self, other):
-        res = self.__and__(other)
-        if res is NotImplemented:
-            return res
-        self.__setitem__(Ellipsis, res)
-        return self
+        return dpctl.tensor.bitwise_and(self, other, out=self)
 
     def __ifloordiv__(self, other):
-        res = self.__floordiv__(other)
-        if res is NotImplemented:
-            return res
-        self.__setitem__(Ellipsis, res)
-        return self
+        return dpctl.tensor.floor_divide(self, other, out=self)
 
     def __ilshift__(self, other):
-        res = self.__lshift__(other)
-        if res is NotImplemented:
-            return res
-        self.__setitem__(Ellipsis, res)
-        return self
+        return dpctl.tensor.bitwise_left_shift(self, other, out=self)
 
     def __imatmul__(self, other):
         res = self.__matmul__(other)
@@ -1317,52 +1305,28 @@ cdef class usm_ndarray:
         return self
 
     def __imod__(self, other):
-        res = self.__mod__(other)
-        if res is NotImplemented:
-            return res
-        self.__setitem__(Ellipsis, res)
-        return self
+        return dpctl.tensor.remainder(self, other, out=self)
 
     def __imul__(self, other):
         return dpctl.tensor.multiply(self, other, out=self)
 
     def __ior__(self, other):
-        res = self.__or__(other)
-        if res is NotImplemented:
-            return res
-        self.__setitem__(Ellipsis, res)
-        return self
+        return dpctl.tensor.bitwise_or(self, other, out=self)
 
     def __ipow__(self, other):
-        res = self.__pow__(other, None)
-        if res is NotImplemented:
-            return res
-        self.__setitem__(Ellipsis, res)
-        return self
+        return dpctl.tensor.pow(self, other, out=self)
 
     def __irshift__(self, other):
-        res = self.__rshift__(other)
-        if res is NotImplemented:
-            return res
-        self.__setitem__(Ellipsis, res)
-        return self
+        return dpctl.tensor.bitwise_right_shift(self, other, out=self)
 
     def __isub__(self, other):
         return dpctl.tensor.subtract(self, other, out=self)
 
     def __itruediv__(self, other):
-        res = self.__truediv__(other)
-        if res is NotImplemented:
-            return res
-        self.__setitem__(Ellipsis, res)
-        return self
+        return dpctl.tensor.divide(self, other, out=self)
 
     def __ixor__(self, other):
-        res = self.__xor__(other)
-        if res is NotImplemented:
-            return res
-        self.__setitem__(Ellipsis, res)
-        return self
+        return dpctl.tensor.bitwise_xor(self, other, out=self)
 
     def __str__(self):
         return usm_ndarray_str(self)

--- a/dpctl/tensor/libtensor/source/elementwise_functions.hpp
+++ b/dpctl/tensor/libtensor/source/elementwise_functions.hpp
@@ -379,9 +379,12 @@ std::pair<sycl::event, sycl::event> py_binary_ufunc(
         }
     }
 
-    // check memory overlap
     auto const &overlap = dpctl::tensor::overlap::MemoryOverlap();
-    if (overlap(src1, dst) || overlap(src2, dst)) {
+    auto const &same_logical_tensors =
+        dpctl::tensor::overlap::SameLogicalTensors();
+    if ((overlap(src1, dst) && !same_logical_tensors(src1, dst)) ||
+        (overlap(src2, dst) && !same_logical_tensors(src2, dst)))
+    {
         throw py::value_error("Arrays index overlapping segments of memory");
     }
     // check memory overlap
@@ -678,8 +681,10 @@ py_binary_inplace_ufunc(dpctl::tensor::usm_ndarray lhs,
     }
 
     // check memory overlap
+    auto const &same_logical_tensors =
+        dpctl::tensor::overlap::SameLogicalTensors();
     auto const &overlap = dpctl::tensor::overlap::MemoryOverlap();
-    if (overlap(rhs, lhs)) {
+    if (overlap(rhs, lhs) && !same_logical_tensors(rhs, lhs)) {
         throw py::value_error("Arrays index overlapping segments of memory");
     }
     // check memory overlap

--- a/dpctl/tests/elementwise/test_add.py
+++ b/dpctl/tests/elementwise/test_add.py
@@ -381,17 +381,35 @@ def test_add_inplace_dtype_matrix(op1_dtype, op2_dtype):
             dpt.asnumpy(ar1) == np.full(ar1.shape, 2, dtype=ar1.dtype)
         ).all()
 
-        ar3 = dpt.ones(sz, dtype=op1_dtype)
-        ar4 = dpt.ones(2 * sz, dtype=op2_dtype)
-
-        ar3[::-1] += ar4[::2]
+        ar3 = dpt.ones(sz, dtype=op1_dtype)[::-1]
+        ar4 = dpt.ones(2 * sz, dtype=op2_dtype)[::2]
+        ar3 += ar4
         assert (
             dpt.asnumpy(ar3) == np.full(ar3.shape, 2, dtype=ar3.dtype)
         ).all()
-
     else:
         with pytest.raises(TypeError):
             ar1 += ar2
+            dpt.add(ar1, ar2, out=ar1)
+
+    # out is second arg
+    ar1 = dpt.ones(sz, dtype=op1_dtype)
+    ar2 = dpt.ones_like(ar1, dtype=op2_dtype)
+    if _can_cast(ar1.dtype, ar2.dtype, _fp16, _fp64):
+        dpt.add(ar1, ar2, out=ar2)
+        assert (
+            dpt.asnumpy(ar2) == np.full(ar2.shape, 2, dtype=ar2.dtype)
+        ).all()
+
+        ar3 = dpt.ones(sz, dtype=op1_dtype)[::-1]
+        ar4 = dpt.ones(2 * sz, dtype=op2_dtype)[::2]
+        dpt.add(ar3, ar4, out=ar4)
+        assert (
+            dpt.asnumpy(ar4) == np.full(ar4.shape, 2, dtype=ar4.dtype)
+        ).all()
+    else:
+        with pytest.raises(TypeError):
+            dpt.add(ar1, ar2, out=ar2)
 
 
 def test_add_inplace_broadcasting():
@@ -402,6 +420,12 @@ def test_add_inplace_broadcasting():
 
     m += v
     assert (dpt.asnumpy(m) == np.arange(1, 6, dtype="i4")[np.newaxis, :]).all()
+
+    # check case where second arg is out
+    dpt.add(v, m, out=m)
+    assert (
+        dpt.asnumpy(m) == np.arange(10, dtype="i4")[np.newaxis, 1:10:2]
+    ).all()
 
 
 def test_add_inplace_errors():
@@ -441,7 +465,7 @@ def test_add_inplace_errors():
         ar1 += ar2
 
 
-def test_add_inplace_overlap():
+def test_add_inplace_same_tensors():
     get_queue_or_skip()
 
     ar1 = dpt.ones(10, dtype="i4")
@@ -451,7 +475,13 @@ def test_add_inplace_overlap():
     ar1 = dpt.ones(10, dtype="i4")
     ar2 = dpt.ones(10, dtype="i4")
     dpt.add(ar1, ar2, out=ar1)
+    # all ar1 vals should be 2
     assert (dpt.asnumpy(ar1) == np.full(ar1.shape, 2, dtype="i4")).all()
 
     dpt.add(ar2, ar1, out=ar2)
+    # all ar2 vals should be 3
     assert (dpt.asnumpy(ar2) == np.full(ar2.shape, 3, dtype="i4")).all()
+
+    dpt.add(ar1, ar2, out=ar2)
+    # all ar2 vals should be 5
+    assert (dpt.asnumpy(ar2) == np.full(ar2.shape, 5, dtype="i4")).all()

--- a/dpctl/tests/elementwise/test_add.py
+++ b/dpctl/tests/elementwise/test_add.py
@@ -175,7 +175,7 @@ def test_add_broadcasting_new_shape():
     ).all()
 
     r3 = dpt.empty_like(ar1)
-    with pytest.raises(TypeError):
+    with pytest.raises(ValueError):
         dpt.add(ar1, ar2, out=r3)
 
     ar3 = dpt.ones((6, 1), dtype="i4")
@@ -273,7 +273,7 @@ def test_add_errors():
     ar2 = dpt.ones_like(ar1, sycl_queue=gpu_queue)
     y = dpt.empty_like(ar1, sycl_queue=cpu_queue)
     assert_raises_regex(
-        TypeError,
+        ExecutionPlacementError,
         "Input and output allocation queues are not compatible",
         dpt.add,
         ar1,
@@ -285,21 +285,8 @@ def test_add_errors():
     ar2 = dpt.ones_like(ar1, dtype="int32")
     y = dpt.empty(3)
     assert_raises_regex(
-        TypeError,
+        ValueError,
         "The shape of input and output arrays are inconsistent",
-        dpt.add,
-        ar1,
-        ar2,
-        y,
-    )
-
-    ar1 = dpt.ones(2, dtype="float32")
-    ar2 = dpt.ones_like(ar1, dtype="int32")
-    # identical view but a different object
-    y = ar1[:]
-    assert_raises_regex(
-        TypeError,
-        "Input and output arrays have memory overlap",
         dpt.add,
         ar1,
         ar2,
@@ -485,3 +472,48 @@ def test_add_inplace_same_tensors():
     dpt.add(ar1, ar2, out=ar2)
     # all ar2 vals should be 5
     assert (dpt.asnumpy(ar2) == np.full(ar2.shape, 5, dtype="i4")).all()
+
+
+def test_add_str_repr():
+    add_s = str(dpt.add)
+    assert isinstance(add_s, str)
+    assert "add" in add_s
+
+    add_r = repr(dpt.add)
+    assert isinstance(add_r, str)
+    assert "add" in add_r
+
+
+def test_add_cfd():
+    q1 = get_queue_or_skip()
+    q2 = dpctl.SyclQueue(q1.sycl_device)
+
+    x1 = dpt.ones(10, sycl_queue=q1)
+    x2 = dpt.ones(10, sycl_queue=q2)
+    with pytest.raises(ExecutionPlacementError):
+        dpt.add(x1, x2)
+
+    with pytest.raises(ExecutionPlacementError):
+        dpt.add(x1, x1, out=x2)
+
+
+def test_add_out_type_check():
+    get_queue_or_skip()
+
+    x1 = dpt.ones(10)
+    x2 = dpt.ones(10)
+
+    out = range(10)
+
+    with pytest.raises(TypeError):
+        dpt.add(x1, x2, out=out)
+
+
+def test_add_out_need_temporary():
+    get_queue_or_skip()
+
+    x = dpt.ones(10, dtype="u4")
+
+    dpt.add(x[:6], 1, out=x[-6:])
+
+    assert dpt.all(x[:-6] == 1) and dpt.all(x[-6:] == 2)

--- a/dpctl/tests/elementwise/test_floor_ceil_trunc.py
+++ b/dpctl/tests/elementwise/test_floor_ceil_trunc.py
@@ -24,7 +24,6 @@ from numpy.testing import (
     assert_raises_regex,
 )
 
-import dpctl
 import dpctl.tensor as dpt
 from dpctl.tests.helper import get_queue_or_skip, skip_if_dtype_not_supported
 
@@ -90,45 +89,6 @@ def test_floor_ceil_trunc_order(np_call, dpt_call, dtype):
         for ord in ["C", "F", "A", "K"]:
             Y = dpt_call(U, order=ord)
             assert_allclose(dpt.asnumpy(Y), expected_Y)
-
-
-@pytest.mark.parametrize("dpt_call", [dpt.floor, dpt.ceil, dpt.trunc])
-def test_floor_ceil_trunc_errors(dpt_call):
-    get_queue_or_skip()
-    try:
-        gpu_queue = dpctl.SyclQueue("gpu")
-    except dpctl.SyclQueueCreationError:
-        pytest.skip("SyclQueue('gpu') failed, skipping")
-    try:
-        cpu_queue = dpctl.SyclQueue("cpu")
-    except dpctl.SyclQueueCreationError:
-        pytest.skip("SyclQueue('cpu') failed, skipping")
-
-    x = dpt.zeros(2, sycl_queue=gpu_queue)
-    y = dpt.empty_like(x, sycl_queue=cpu_queue)
-    assert_raises_regex(
-        TypeError,
-        "Input and output allocation queues are not compatible",
-        dpt_call,
-        x,
-        y,
-    )
-
-    x = dpt.zeros(2)
-    y = dpt.empty(3)
-    assert_raises_regex(
-        TypeError,
-        "The shape of input and output arrays are inconsistent",
-        dpt_call,
-        x,
-        y,
-    )
-
-    x = dpt.zeros(2, dtype="float32")
-    y = np.empty_like(x)
-    assert_raises_regex(
-        TypeError, "output array must be of usm_ndarray type", dpt_call, x, y
-    )
 
 
 @pytest.mark.parametrize("dpt_call", [dpt.floor, dpt.ceil, dpt.trunc])

--- a/dpctl/tests/elementwise/test_hyperbolic.py
+++ b/dpctl/tests/elementwise/test_hyperbolic.py
@@ -20,7 +20,6 @@ import numpy as np
 import pytest
 from numpy.testing import assert_allclose, assert_raises_regex
 
-import dpctl
 import dpctl.tensor as dpt
 from dpctl.tests.helper import get_queue_or_skip, skip_if_dtype_not_supported
 
@@ -176,45 +175,6 @@ def test_hyper_order(np_call, dpt_call, dtype):
                 np.finfo(expected_Y.dtype).resolution,
             )
             assert_allclose(dpt.asnumpy(Y), expected_Y, atol=tol, rtol=tol)
-
-
-@pytest.mark.parametrize("callable", _dpt_funcs)
-def test_hyper_errors(callable):
-    get_queue_or_skip()
-    try:
-        gpu_queue = dpctl.SyclQueue("gpu")
-    except dpctl.SyclQueueCreationError:
-        pytest.skip("SyclQueue('gpu') failed, skipping")
-    try:
-        cpu_queue = dpctl.SyclQueue("cpu")
-    except dpctl.SyclQueueCreationError:
-        pytest.skip("SyclQueue('cpu') failed, skipping")
-
-    x = dpt.ones(2, sycl_queue=gpu_queue)
-    y = dpt.empty_like(x, sycl_queue=cpu_queue)
-    assert_raises_regex(
-        TypeError,
-        "Input and output allocation queues are not compatible",
-        callable,
-        x,
-        y,
-    )
-
-    x = dpt.ones(2)
-    y = dpt.empty(3)
-    assert_raises_regex(
-        TypeError,
-        "The shape of input and output arrays are inconsistent",
-        callable,
-        x,
-        y,
-    )
-
-    x = dpt.ones(2, dtype="float32")
-    y = np.empty_like(x)
-    assert_raises_regex(
-        TypeError, "output array must be of usm_ndarray type", callable, x, y
-    )
 
 
 @pytest.mark.parametrize("callable", _dpt_funcs)

--- a/dpctl/tests/elementwise/test_trigonometric.py
+++ b/dpctl/tests/elementwise/test_trigonometric.py
@@ -20,7 +20,6 @@ import numpy as np
 import pytest
 from numpy.testing import assert_allclose, assert_raises_regex
 
-import dpctl
 import dpctl.tensor as dpt
 from dpctl.tests.helper import get_queue_or_skip, skip_if_dtype_not_supported
 
@@ -173,45 +172,6 @@ def test_trig_order(np_call, dpt_call, dtype):
                 np.finfo(expected_Y.dtype).resolution,
             )
             assert_allclose(dpt.asnumpy(Y), expected_Y, atol=tol, rtol=tol)
-
-
-@pytest.mark.parametrize("callable", _dpt_funcs)
-def test_trig_errors(callable):
-    get_queue_or_skip()
-    try:
-        gpu_queue = dpctl.SyclQueue("gpu")
-    except dpctl.SyclQueueCreationError:
-        pytest.skip("SyclQueue('gpu') failed, skipping")
-    try:
-        cpu_queue = dpctl.SyclQueue("cpu")
-    except dpctl.SyclQueueCreationError:
-        pytest.skip("SyclQueue('cpu') failed, skipping")
-
-    x = dpt.zeros(2, sycl_queue=gpu_queue)
-    y = dpt.empty_like(x, sycl_queue=cpu_queue)
-    assert_raises_regex(
-        TypeError,
-        "Input and output allocation queues are not compatible",
-        callable,
-        x,
-        y,
-    )
-
-    x = dpt.zeros(2)
-    y = dpt.empty(3)
-    assert_raises_regex(
-        TypeError,
-        "The shape of input and output arrays are inconsistent",
-        callable,
-        x,
-        y,
-    )
-
-    x = dpt.zeros(2, dtype="float32")
-    y = np.empty_like(x)
-    assert_raises_regex(
-        TypeError, "output array must be of usm_ndarray type", callable, x, y
-    )
 
 
 @pytest.mark.parametrize("callable", _dpt_funcs)


### PR DESCRIPTION
This PR completes the implementation of in-place arithmetic operators.

With current behavior, in-place operations simply call the standard implementation and then set the original memory equal to the result. This sometimes leads to unnecessary memory allocation.

By reworking the ``out`` keyword, either input operand array can now be used as the output array, and copies are only required for casting and where race conditions must be considered (i.e., when the ``out`` array overlaps only some of an input).

- [X] Have you provided a meaningful PR description?
- [X] Have you added a test, reproducer or referred to an issue with a reproducer?
- [X] Have you tested your changes locally for CPU and GPU devices?
- [X] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [X] If this PR is a work in progress, are you opening the PR as a draft?
