### PR TITLE
Update README for wheel installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ conda install dpctl -c intel
 
 ## Wheel
 
-Wheel package can be installed from PyPi and from Intel(R) channel on Anaconda.
+The `dpctl` can be installed using `pip` obtaining wheel packages either from PyPi or from Intel(R) channel on Anaconda.
 To install `dpctl` wheel package from Intel(R) channel on Anaconda, run the following command:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -43,8 +43,8 @@ to program on XPUs.
 
 # Installing
 
-You can install the library as [conda](https://anaconda.org/intel/dpctl) or
-[wheel](https://pypi.org/project/dpctl/) package. It is also available in the [Intel(R)
+You can install the library using [conda](https://anaconda.org/intel/dpctl) or
+[pip](https://pypi.org/project/dpctl/) package managers. It is also available in the [Intel(R)
 Distribution for
 Python](https://www.intel.com/content/www/us/en/developer/tools/oneapi/distribution-for-python.html)
 (IDP).

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ cloud, use the following command:
 conda install dpctl -c intel
 ```
 
-## Wheel
+## Pip
 
 The `dpctl` can be installed using `pip` obtaining wheel packages either from PyPi or from Intel(R) channel on Anaconda.
 To install `dpctl` wheel package from Intel(R) channel on Anaconda, run the following command:

--- a/README.md
+++ b/README.md
@@ -43,8 +43,8 @@ to program on XPUs.
 
 # Installing
 
-You can install the library with [conda](https://anaconda.org/intel/dpctl) and
-[pip](https://pypi.org/project/dpctl/). It is also available in the [Intel(R)
+You can install the library as [conda](https://anaconda.org/intel/dpctl) or
+[wheel](https://pypi.org/project/dpctl/) package. It is also available in the [Intel(R)
 Distribution for
 Python](https://www.intel.com/content/www/us/en/developer/tools/oneapi/distribution-for-python.html)
 (IDP).
@@ -70,12 +70,13 @@ cloud, use the following command:
 conda install dpctl -c intel
 ```
 
-## PyPi
+## Wheel
 
-To install `dpctl` from PyPi, run the following command:
+Wheel package can be installed from PyPi and from Intel(R) channel on Anaconda.
+To install `dpctl` wheel package from Intel(R) channel on Anaconda, run the following command:
 
 ```bash
-pip3 install dpctl
+python -m pip install --index-url https://pypi.anaconda.org/intel/simple dpctl
 ```
 
 Installing the bleeding edge


### PR DESCRIPTION
wheel package is published on PyPi and on pypi.anaconda.org.
README is part of wheel metadata which is published on PyPi and this update is needed to specify 
 pypi.anaconda.org as recommended installation channel.
 
- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
