### PR TITLE
usm_ndarray.real and usm_ndarray.imag now set flags correctly

### DIFF
--- a/dpctl/tensor/_usmarray.pyx
+++ b/dpctl/tensor/_usmarray.pyx
@@ -662,7 +662,7 @@ cdef class usm_ndarray:
         """
         if self.nd_ < 2:
             raise ValueError(
-                "array.mT requires array to have at least 2-dimensons."
+                "array.mT requires array to have at least 2 dimensions."
             )
         return _m_transpose(self)
 
@@ -1216,14 +1216,14 @@ cdef usm_ndarray _real_view(usm_ndarray ary):
     offset_elems = ary.get_offset() * 2
     r = usm_ndarray.__new__(
         usm_ndarray,
-        _make_int_tuple(ary.nd_, ary.shape_),
+        _make_int_tuple(ary.nd_, ary.shape_) if ary.nd_ > 0 else tuple(),
         dtype=_make_typestr(r_typenum_),
         strides=tuple(2 * si for si in ary.strides),
         buffer=ary.base_,
         offset=offset_elems,
         order=('C' if (ary.flags_ & USM_ARRAY_C_CONTIGUOUS) else 'F')
     )
-    r.flags_ = ary.flags_
+    r.flags_ |= (ary.flags_ & USM_ARRAY_WRITABLE)
     r.array_namespace_ = ary.array_namespace_
     return r
 
@@ -1248,14 +1248,14 @@ cdef usm_ndarray _imag_view(usm_ndarray ary):
     offset_elems = 2 * ary.get_offset() + 1
     r = usm_ndarray.__new__(
         usm_ndarray,
-        _make_int_tuple(ary.nd_, ary.shape_),
+        _make_int_tuple(ary.nd_, ary.shape_) if ary.nd_ > 0 else tuple(),
         dtype=_make_typestr(r_typenum_),
         strides=tuple(2 * si for si in ary.strides),
         buffer=ary.base_,
         offset=offset_elems,
         order=('C' if (ary.flags_ & USM_ARRAY_C_CONTIGUOUS) else 'F')
     )
-    r.flags_ = ary.flags_
+    r.flags_ |= (ary.flags_ & USM_ARRAY_WRITABLE)
     r.array_namespace_ = ary.array_namespace_
     return r
 

--- a/dpctl/tests/test_usm_ndarray_ctor.py
+++ b/dpctl/tests/test_usm_ndarray_ctor.py
@@ -1438,16 +1438,25 @@ def test_real_imag_views():
     n, m = 2, 3
     try:
         X = dpt.usm_ndarray((n, m), "c8")
+        X_scalar = dpt.usm_ndarray((), dtype="c8")
     except dpctl.SyclDeviceCreationError:
         pytest.skip("No SYCL devices available")
     Xnp_r = np.arange(n * m, dtype="f4").reshape((n, m))
     Xnp_i = np.arange(n * m, 2 * n * m, dtype="f4").reshape((n, m))
     Xnp = Xnp_r + 1j * Xnp_i
     X[:] = Xnp
-    assert np.array_equal(dpt.to_numpy(X.real), Xnp.real)
+    X_real = X.real
+    X_imag = X.imag
+    assert np.array_equal(dpt.to_numpy(X_real), Xnp.real)
     assert np.array_equal(dpt.to_numpy(X.imag), Xnp.imag)
+    assert not X_real.flags["C"] and not X_real.flags["F"]
+    assert not X_imag.flags["C"] and not X_imag.flags["F"]
+    assert X_real.strides == X_imag.strides
     assert np.array_equal(dpt.to_numpy(X[1:].real), Xnp[1:].real)
     assert np.array_equal(dpt.to_numpy(X[1:].imag), Xnp[1:].imag)
+
+    X_scalar[...] = complex(n * m, 2 * n * m)
+    assert X_scalar.real and X_scalar.imag
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
The ``real`` and ``imag`` properties of ``usm_ndarray`` were setting the flags of the returned view incorrectly.

In most cases, the output was not contiguous, but the input was, which caused most functions to behave incorrectly on views into the real or imaginary parts of complex arrays.

This PR corrects that, and also allows ``real`` and ``imag`` to work on 0-dimensional arrays.

- [X] Have you provided a meaningful PR description?
- [X] Have you added a test, reproducer or referred to an issue with a reproducer?
- [X] Have you tested your changes locally for CPU and GPU devices?
- [X] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [X] If this PR is a work in progress, are you opening the PR as a draft?
