### PR TITLE
Implements ``types`` property for elementwise functions

### DIFF
--- a/dpctl/tests/elementwise/test_abs.py
+++ b/dpctl/tests/elementwise/test_abs.py
@@ -76,6 +76,15 @@ def test_abs_usm_type(usm_type):
     assert np.allclose(dpt.asnumpy(Y), expected_Y)
 
 
+def test_abs_types_prop():
+    types = dpt.abs.types_
+    assert types is None
+    types = dpt.abs.types
+    assert isinstance(types, list)
+    assert len(types) > 0
+    assert types == dpt.abs.types_
+
+
 @pytest.mark.parametrize("dtype", _all_dtypes[1:])
 def test_abs_order(dtype):
     q = get_queue_or_skip()

--- a/dpctl/tests/elementwise/test_add.py
+++ b/dpctl/tests/elementwise/test_add.py
@@ -258,6 +258,15 @@ def test_add_canary_mock_array():
         dpt.add(a, c)
 
 
+def test_add_types_property():
+    types = dpt.add.types_
+    assert types is None
+    types = dpt.add.types
+    assert isinstance(types, list)
+    assert len(types) > 0
+    assert types == dpt.add.types_
+
+
 def test_add_errors():
     get_queue_or_skip()
     try:


### PR DESCRIPTION
This PR implements a ``types`` property for elementwise function. This property returns a list of strings indicating the types an elementwise function can accept without casting, and what type it will output.

The lists are lazily initialized, and stored on a new member on the elementwise function object.

- [X] Have you provided a meaningful PR description?
- [X] Have you added a test, reproducer or referred to an issue with a reproducer?
- [X] Have you tested your changes locally for CPU and GPU devices?
- [X] Have you made sure that new changes do not introduce compiler warnings?
- [] Have you checked performance impact of proposed changes?
- [X] If this PR is a work in progress, are you opening the PR as a draft?
