### PR TITLE
Improved message text in two exceptions

### DIFF
--- a/dpctl/tensor/_elementwise_common.py
+++ b/dpctl/tensor/_elementwise_common.py
@@ -468,7 +468,7 @@ class BinaryElementwiseFunc:
         o1_dtype = _get_dtype(o1, sycl_dev)
         o2_dtype = _get_dtype(o2, sycl_dev)
         if not all(_validate_dtype(o) for o in (o1_dtype, o2_dtype)):
-            raise ValueError("Operands of unsupported types")
+            raise ValueError("Operands have unsupported data types")
 
         o1_dtype, o2_dtype = _resolve_weak_types(o1_dtype, o2_dtype, sycl_dev)
 
@@ -498,7 +498,7 @@ class BinaryElementwiseFunc:
             if out.shape != res_shape:
                 raise ValueError(
                     "The shape of input and output arrays are inconsistent. "
-                    f"Expected output shape is {o1_shape}, got {out.shape}"
+                    f"Expected output shape is {res_shape}, got {out.shape}"
                 )
 
             if res_dt != out.dtype:


### PR DESCRIPTION
Corrected messsage text in two exceptions in "_elementwise_common.py" file as pointed out by @vtavana 

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
