### PR TITLE
Reduction performance

### DIFF
--- a/dpctl/tensor/libtensor/include/kernels/reductions.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/reductions.hpp
@@ -610,13 +610,12 @@ public:
 
     void operator()(sycl::nd_item<1> it) const
     {
-
-        const size_t red_gws_ = it.get_global_range(0) / iter_gws_;
-        const size_t iter_gid = it.get_global_id(0) / red_gws_;
-        const size_t n_reduction_groups = it.get_group_range(0) / iter_gws_;
-        const size_t reduction_batch_id = it.get_group(0) % n_reduction_groups;
         const size_t reduction_lid = it.get_local_id(0);
         const size_t wg = it.get_local_range(0); //   0 <= reduction_lid < wg
+
+        const size_t iter_gid = it.get_group(0) % iter_gws_;
+        const size_t reduction_batch_id = it.get_group(0) / iter_gws_;
+        const size_t n_reduction_groups = it.get_group_range(0) / iter_gws_;
 
         // work-items sums over input with indices
         //   inp_data_id = reduction_batch_id * wg * reductions_per_wi + m * wg

--- a/dpctl/tensor/libtensor/include/kernels/reductions.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/reductions.hpp
@@ -342,20 +342,6 @@ sycl::event sum_reduction_over_group_with_atomics_strided_impl(
                 (reduction_nelems + reductions_per_wi * wg - 1) /
                 (reductions_per_wi * wg);
 
-            if (reduction_groups > 1) {
-                const size_t &max_wg =
-                    d.get_info<sycl::info::device::max_work_group_size>();
-
-                if (reduction_nelems < preferrered_reductions_per_wi * max_wg) {
-                    wg = max_wg;
-                    reductions_per_wi =
-                        std::max<size_t>(1, (reduction_nelems + wg - 1) / wg);
-                    reduction_groups =
-                        (reduction_nelems + reductions_per_wi * wg - 1) /
-                        (reductions_per_wi * wg);
-                }
-            }
-
             auto globalRange =
                 sycl::range<1>{iter_nelems * reduction_groups * wg};
             auto localRange = sycl::range<1>{wg};
@@ -479,20 +465,6 @@ sycl::event sum_reduction_axis1_over_group_with_atomics_contig_impl(
                 (reduction_nelems + reductions_per_wi * wg - 1) /
                 (reductions_per_wi * wg);
 
-            if (reduction_groups > 1) {
-                const size_t &max_wg =
-                    d.get_info<sycl::info::device::max_work_group_size>();
-
-                if (reduction_nelems < preferrered_reductions_per_wi * max_wg) {
-                    wg = max_wg;
-                    reductions_per_wi =
-                        std::max<size_t>(1, (reduction_nelems + wg - 1) / wg);
-                    reduction_groups =
-                        (reduction_nelems + reductions_per_wi * wg - 1) /
-                        (reductions_per_wi * wg);
-                }
-            }
-
             auto globalRange =
                 sycl::range<1>{iter_nelems * reduction_groups * wg};
             auto localRange = sycl::range<1>{wg};
@@ -573,20 +545,6 @@ sycl::event sum_reduction_axis0_over_group_with_atomics_contig_impl(
             size_t reduction_groups =
                 (reduction_nelems + reductions_per_wi * wg - 1) /
                 (reductions_per_wi * wg);
-
-            if (reduction_groups > 1) {
-                const size_t &max_wg =
-                    d.get_info<sycl::info::device::max_work_group_size>();
-
-                if (reduction_nelems < preferrered_reductions_per_wi * max_wg) {
-                    wg = max_wg;
-                    reductions_per_wi =
-                        std::max<size_t>(1, (reduction_nelems + wg - 1) / wg);
-                    reduction_groups =
-                        (reduction_nelems + reductions_per_wi * wg - 1) /
-                        (reductions_per_wi * wg);
-                }
-            }
 
             auto globalRange =
                 sycl::range<1>{iter_nelems * reduction_groups * wg};


### PR DESCRIPTION
This PR improves performance of reduction kernel with atomics

  1. Contig implementation kernel gets a dedicated name (easier to spot in the output of onetrace)
  2. Increases work-group size multiple of the size of sub-group
  3. Changes the order in which workgroups tile the array from "along reduction axis" moves fastest to "along iteration axis" moves fastest.
  4. Introduces a dedicated implementation for reduction over axis0 and deploys it.

Performance in the main trunk:

```
    In [1]: import dpctl.tensor as dpt

    In [2]: x = dpt.reshape(dpt.asarray(1, dtype="f4")/dpt.square(\
                           dpt.arange(1, 1282200*128 + 1, dtype="f4")), (1282200, 128))

    In [3]: %time y = dpt.sum(x, axis=0)
    CPU times: user 309 ms, sys: 128 ms, total: 437 ms
    Wall time: 473 ms

    In [4]: %time y = dpt.sum(x, axis=0)
    CPU times: user 132 ms, sys: 160 ms, total: 292 ms
    Wall time: 316 ms

    In [5]: %time y = dpt.sum(x, axis=0)
    CPU times: user 104 ms, sys: 185 ms, total: 289 ms
    Wall time: 312 ms
```

After this change:

```
    In [1]: import dpctl.tensor as dpt

    In [2]: x = dpt.reshape(dpt.asarray(1, dtype="f4")/dpt.square(\
                           dpt.arange(1, 1282200*128 + 1, dtype="f4")), (1282200, 128))

    In [3]: %time y = dpt.sum(x, axis=0)
    CPU times: user 136 ms, sys: 9.52 ms, total: 145 ms
    Wall time: 158 ms

    In [4]: %time y = dpt.sum(x, axis=0)
    CPU times: user 18.8 ms, sys: 17.3 ms, total: 36.1 ms
    Wall time: 42 ms

    In [5]: %time y = dpt.sum(x, axis=0)
    CPU times: user 19.2 ms, sys: 16.9 ms, total: 36.1 ms
    Wall time: 38.4 ms

    In [6]: %time y = dpt.sum(x, axis=0)
    CPU times: user 1.69 ms, sys: 35.2 ms, total: 36.9 ms
    Wall time: 39.4 ms
```

 

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
