### PR TITLE
Resolve SYCL-2020 deprecation warning

### DIFF
--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/expm1.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/expm1.hpp
@@ -115,7 +115,10 @@ template <typename argT, typename resT> struct Expm1Functor
 
             // x, y finite numbers
             realT cosY_val;
-            const realT sinY_val = sycl::sincos(y, &cosY_val);
+            auto cosY_val_multi_ptr = sycl::address_space_cast<
+                sycl::access::address_space::global_space,
+                sycl::access::decorated::yes>(&cosY_val);
+            const realT sinY_val = sycl::sincos(y, cosY_val_multi_ptr);
             const realT sinhalfY_val = std::sin(y / 2);
 
             const realT res_re =


### PR DESCRIPTION
This PR resolves the following deprecation warning from SYCLOS compiler:

```
In file included from ~/dpctl/dpctl/tensor/libtensor/source/elementwise_functions.cpp:56:
~/dpctl/dpctl/tensor/libtensor/include/kernels/elementwise_functions/expm1.hpp:118:42: warning: \
    'sincos' is deprecated: SYCL builtin functions with raw pointer arguments have been deprecated. \
    Please use multi_ptr. [-Wdeprecated-declarations]
  118 |             const realT sinY_val = sycl::sincos(y, &cosY_val);
```

The resolution is to convert raw pointer to multi-pointer using `sycl::address_space_cast`.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
