### PR TITLE
Addressed "Very high" Coverity issue: dereferencing null pointer

### DIFF
--- a/libsyclinterface/source/dpctl_sycl_queue_interface.cpp
+++ b/libsyclinterface/source/dpctl_sycl_queue_interface.cpp
@@ -121,7 +121,7 @@ bool set_kernel_arg(handler &cgh,
     return arg_set;
 }
 
-static std::unique_ptr<property_list> create_property_list(int properties)
+std::unique_ptr<property_list> create_property_list(int properties)
 {
     std::unique_ptr<property_list> propList;
     int _prop = properties;

--- a/libsyclinterface/source/dpctl_sycl_queue_interface.cpp
+++ b/libsyclinterface/source/dpctl_sycl_queue_interface.cpp
@@ -121,7 +121,7 @@ bool set_kernel_arg(handler &cgh,
     return arg_set;
 }
 
-std::unique_ptr<property_list> create_property_list(int properties)
+static std::unique_ptr<property_list> create_property_list(int properties)
 {
     std::unique_ptr<property_list> propList;
     int _prop = properties;
@@ -142,6 +142,9 @@ std::unique_ptr<property_list> create_property_list(int properties)
         _prop = _prop ^ DPCTL_IN_ORDER;
         propList =
             std::make_unique<property_list>(sycl::property::queue::in_order());
+    }
+    else {
+        propList = std::make_unique<property_list>();
     }
 
     if (_prop) {
@@ -185,7 +188,7 @@ DPCTLQueue_Create(__dpctl_keep const DPCTLSyclContextRef CRef,
     }
     auto propList = create_property_list(properties);
 
-    if (propList && handler) {
+    if (handler) {
         try {
             auto Queue = new queue(*ctx, *dev, DPCTL_AsyncErrorHandler(handler),
                                    *propList);
@@ -194,26 +197,9 @@ DPCTLQueue_Create(__dpctl_keep const DPCTLSyclContextRef CRef,
             error_handler(e, __FILE__, __func__, __LINE__);
         }
     }
-    else if (properties) {
-        try {
-            auto Queue = new queue(*ctx, *dev, *propList);
-            q = wrap<queue>(Queue);
-        } catch (std::exception const &e) {
-            error_handler(e, __FILE__, __func__, __LINE__);
-        }
-    }
-    else if (handler) {
-        try {
-            auto Queue =
-                new queue(*ctx, *dev, DPCTL_AsyncErrorHandler(handler));
-            q = wrap<queue>(Queue);
-        } catch (std::exception const &e) {
-            error_handler(e, __FILE__, __func__, __LINE__);
-        }
-    }
     else {
         try {
-            auto Queue = new queue(*ctx, *dev);
+            auto Queue = new queue(*ctx, *dev, *propList);
             q = wrap<queue>(Queue);
         } catch (std::exception const &e) {
             error_handler(e, __FILE__, __func__, __LINE__);


### PR DESCRIPTION
Ensured that `create_property_list` always returns an not-null unique pointer by creating an default-constructed `property_list` for the fall-through.

With this change we no longer need two branches for call to `sycl::queue` constructor, since `propList` is always available.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
