### PR TITLE
Fix for Coverity highlighted issue in scripts

### DIFF
--- a/scripts/gen_coverage.py
+++ b/scripts/gen_coverage.py
@@ -57,7 +57,7 @@ def run(
         "-DDPCTL_BUILD_CAPI_TESTS=ON",
         "-DDPCTL_COVERAGE_REPORT_OUTPUT_DIR=" + setup_dir,
     ]
-    env = None
+    env = dict()
     if bin_llvm:
         env = {
             "PATH": ":".join((os.environ.get("PATH", ""), bin_llvm)),

--- a/scripts/gen_docs.py
+++ b/scripts/gen_docs.py
@@ -59,7 +59,7 @@ def run(
         cmake_args.append("-DDPCTL_ENABLE_DOXYREST=ON")
         cmake_args.append("-DDoxyrest_DIR=" + doxyrest_dir)
 
-    env = None
+    env = dict()
     if bin_llvm:
         env = {
             "PATH": ":".join((os.environ.get("PATH", ""), bin_llvm)),


### PR DESCRIPTION
Initialized env to empty dictionary instead of `None`.

This resolves two Coverity reported issues.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
