### PR TITLE
Addressed Coverity issue about handling bools in floor_divide

### DIFF
--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/floor_divide.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/floor_divide.hpp
@@ -57,7 +57,12 @@ struct FloorDivideFunctor
 
     resT operator()(const argT1 &in1, const argT2 &in2)
     {
-        if constexpr (std::is_integral_v<argT1> || std::is_integral_v<argT2>) {
+        if constexpr (std::is_same_v<argT1, bool> &&
+                      std::is_same_v<argT2, bool>) {
+            return (in2) ? static_cast<resT>(in1) : resT(0);
+        }
+        else if constexpr (std::is_integral_v<argT1> ||
+                           std::is_integral_v<argT2>) {
             if (in2 == argT2(0)) {
                 return resT(0);
             }
@@ -81,7 +86,16 @@ struct FloorDivideFunctor
     sycl::vec<resT, vec_sz> operator()(const sycl::vec<argT1, vec_sz> &in1,
                                        const sycl::vec<argT2, vec_sz> &in2)
     {
-        if constexpr (std::is_integral_v<resT>) {
+        if constexpr (std::is_same_v<argT1, bool> &&
+                      std::is_same_v<argT2, bool>) {
+            sycl::vec<resT, vec_sz> res;
+#pragma unroll
+            for (int i = 0; i < vec_sz; ++i) {
+                res[i] = (in2[i]) ? static_cast<resT>(in1[i]) : resT(0);
+            }
+            return res;
+        }
+        else if constexpr (std::is_integral_v<resT>) {
             sycl::vec<resT, vec_sz> res;
 #pragma unroll
             for (int i = 0; i < vec_sz; ++i) {


### PR DESCRIPTION
Coverity flaged `floor_divide` functor for boolean input types.

```
114040 [Operands don't affect result] (static_checker_CONSTANT_EXPRESSION_RESULT)
The expression's value does not depend on the operands; often, this represents an inadvertent logic error.

In dpctl::​tensor::​kernels::​floor_divide::​FloorDivideFunctor<bool, bool, signed char>::​operator ()(bool const &, bool const &): An operation with non-constant operands that computes a result with constant value ([CWE-569](http://cwe.mitre.org/data/definitions/569.html))
```

Wrote dedicated simpler code for handling boolean inputs.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
