### PR TITLE
Fix dpctl.tensor.put race condition

### DIFF
--- a/dpctl/tensor/_indexing_functions.py
+++ b/dpctl/tensor/_indexing_functions.py
@@ -146,7 +146,7 @@ def put(x, indices, vals, /, *, axis=None, mode="wrap", unique_only=False):
           Default: `"wrap"`.
        unique_only:
           If True, only unique indices will be used.
-          This will prevent a race condition when indices repeat,
+          This will prevent a undefined behavior when indices repeat,
           but may negatively impact performance.
     """
     if not isinstance(x, dpt.usm_ndarray):
@@ -179,6 +179,10 @@ def put(x, indices, vals, /, *, axis=None, mode="wrap", unique_only=False):
                 indices.dtype
             )
         )
+    if not isinstance(unique_only, bool):
+        raise TypeError("`unique_only` expected `bool`, got `{}`".format(
+            type(unique_only)
+        ))
 
     not_unique = False
     if unique_only:


### PR DESCRIPTION
As shown in #1360 `dpctl.tensor.put` has a race condition if `indices` has non-unique values
This PR solves this issue by removing unnecessary indices 

- [x] Have you provided a meaningful PR description?
- [x] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
