### PR TITLE
run_test files to output verbose listing of platform config

### DIFF
--- a/conda-recipe/run_test.bat
+++ b/conda-recipe/run_test.bat
@@ -3,8 +3,8 @@
 "%PYTHON%" -c "import dpctl; print(dpctl.__version__)"
 if errorlevel 1 exit 1
 
-"%PYTHON%" -c "import dpctl; dpctl.lsplatform()"
+"%PYTHON%" -m dpctl -f
 if errorlevel 1 exit 1
 
-python -m pytest -q -p no:faulthandler -ra --disable-warnings --pyargs dpctl -vv
+python -m pytest -q -ra --disable-warnings --pyargs dpctl -vv
 if errorlevel 1 exit 1

--- a/conda-recipe/run_test.sh
+++ b/conda-recipe/run_test.sh
@@ -3,5 +3,5 @@
 set -e
 
 ${PYTHON} -c "import dpctl; print(dpctl.__version__)"
-${PYTHON} -c "import dpctl; dpctl.lsplatform(verbosity=2)"
-${PYTHON} -m pytest -q -ra --disable-warnings -p no:faulthandler --cov dpctl --cov-report term-missing --pyargs dpctl -vv
+${PYTHON} -m dpctl -f
+${PYTHON} -m pytest -q -ra --disable-warnings --cov dpctl --cov-report term-missing --pyargs dpctl -vv


### PR DESCRIPTION
Modified "conda-recipe/run_test.bat" and "conda-recipe/run_test.sh" to execute `python -m dpctl -f` for detailed information about available devices and driver versions.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
