### PR TITLE
Remove deprecated FindPythonLibs

### DIFF
--- a/cmake/FindDpctl.cmake
+++ b/cmake/FindDpctl.cmake
@@ -17,15 +17,8 @@
 #
 
 if(NOT Dpctl_FOUND)
-  set(_find_extra_args)
-  if(Dpctl_FIND_REQUIRED)
-    list(APPEND _find_extra_args REQUIRED)
-  endif()
-  if(Dpctl_FIND_QUIET)
-    list(APPEND _find_extra_args QUIET)
-  endif()
-  find_package(PythonInterp ${_find_extra_args})
-  find_package(PythonLibs ${_find_extra_args})
+  find_package(Python 3.9 REQUIRED
+    COMPONENTS Interpreter Development.Module)
 
   if(PYTHON_EXECUTABLE)
     execute_process(COMMAND "${PYTHON_EXECUTABLE}"


### PR DESCRIPTION
FindPythonLibs is deprecated since cmake 3.18 and was removed in cmake 3.27. It results in build errors for projects that uses 3.27 and dpctl.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?

```
-- pybind11 v2.10.2
CMake Warning (dev) at _skbuild/linux-x86_64-3.11/cmake-build/_deps/pybind11-src/tools/FindPythonLibsNew.cmake:98 (find_package):
  Policy CMP0148 is not set: The FindPythonInterp and FindPythonLibs modules
  are removed.  Run "cmake --help-policy CMP0148" for policy details.  Use
  the cmake_policy command to set the policy and suppress this warning.

Call Stack (most recent call first):
  _skbuild/linux-x86_64-3.11/cmake-build/_deps/pybind11-src/tools/pybind11Tools.cmake:50 (find_package)
  _skbuild/linux-x86_64-3.11/cmake-build/_deps/pybind11-src/tools/pybind11Common.cmake:180 (include)
  _skbuild/linux-x86_64-3.11/cmake-build/_deps/pybind11-src/CMakeLists.txt:208 (include)
This warning is for project developers.  Use -Wno-dev to suppress it.

-- Found PythonInterp: /home/yevhenii/.miniconda3/envs/conda-build/bin/python (found suitable version "3.11.5", minimum required is "3.6")
-- Found PythonLibs: /home/yevhenii/.miniconda3/envs/conda-build/lib/libpython3.11.so
-- Performing Test HAS_INTEL_IPO
-- Performing Test HAS_INTEL_IPO - Success
CMake Warning (dev) at /home/yevhenii/.miniconda3/envs/conda-build/lib/python3.11/site-packages/skbuild/resources/cmake/FindPythonExtensions.cmake:245 (find_package):
  Policy CMP0148 is not set: The FindPythonInterp and FindPythonLibs modules
  are removed.  Run "cmake --help-policy CMP0148" for policy details.  Use
  the cmake_policy command to set the policy and suppress this warning.

Call Stack (most recent call first):
  dpctl/CMakeLists.txt:2 (find_package)
This warning is for project developers.  Use -Wno-dev to suppress it.

-- Found PythonInterp: /home/yevhenii/.miniconda3/envs/conda-build/bin/python (found version "3.11.5")
CMake Warning (dev) at /home/yevhenii/.miniconda3/envs/conda-build/lib/python3.11/site-packages/skbuild/resources/cmake/FindPythonExtensions.cmake:252 (find_package):
  Policy CMP0148 is not set: The FindPythonInterp and FindPythonLibs modules
  are removed.  Run "cmake --help-policy CMP0148" for policy details.  Use
  the cmake_policy command to set the policy and suppress this warning.

Call Stack (most recent call first):
  dpctl/CMakeLists.txt:2 (find_package)
This warning is for project developers.  Use -Wno-dev to suppress it.
```
But it looks like expected behavior: https://github.com/pybind/pybind11/issues/4785

- [ ] Have you checked performance impact of proposed changes?
- [x] If this PR is a work in progress, are you opening the PR as a draft?
