### PR TITLE
Correct address_space when casting ref of local variable to multi_ptr

### DIFF
--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/expm1.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/expm1.hpp
@@ -116,7 +116,7 @@ template <typename argT, typename resT> struct Expm1Functor
             // x, y finite numbers
             realT cosY_val;
             auto cosY_val_multi_ptr = sycl::address_space_cast<
-                sycl::access::address_space::global_space,
+                sycl::access::address_space::private_space,
                 sycl::access::decorated::yes>(&cosY_val);
             const realT sinY_val = sycl::sincos(y, cosY_val_multi_ptr);
             const realT sinhalfY_val = std::sin(y / 2);


### PR DESCRIPTION
Used ``address_space_cast<address_space::private_space,...>`` on a local variable.

To create the `sycl::multi_ptr` from a local variable (in private memory) we should be using ``address_space::private_space``.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
