### PR TITLE
Fix for incorrect result in reduction over axis=0

### DIFF
--- a/dpctl/tensor/libtensor/source/sum_reductions.cpp
+++ b/dpctl/tensor/libtensor/source/sum_reductions.cpp
@@ -218,7 +218,9 @@ std::pair<sycl::event, sycl::event> py_sum_over_axis(
                 return std::make_pair(keep_args_event, sum_over_axis_contig_ev);
             }
         }
-        else if (is_src_f_contig & is_dst_c_contig) {
+        else if (is_src_f_contig &&
+                 ((is_dst_c_contig && dst_nd == 1) || dst.is_f_contiguous()))
+        {
             auto fn = sum_over_axis0_contig_atomic_dispatch_table[src_typeid]
                                                                  [dst_typeid];
             if (fn != nullptr) {

--- a/dpctl/tests/test_tensor_sum.py
+++ b/dpctl/tests/test_tensor_sum.py
@@ -172,3 +172,18 @@ def test_largish_reduction(arg_dtype, n):
 
     assert dpt.all(dpt.equal(y1, y2))
     assert dpt.all(dpt.equal(y1, n * m))
+
+
+def test_axis0_bug():
+    "gh-1391"
+    get_queue_or_skip()
+
+    sh = (1, 2, 3)
+    a = dpt.arange(sh[0] * sh[1] * sh[2], dtype="i4")
+    a = dpt.reshape(a, sh)
+    aT = dpt.permute_dims(a, (2, 1, 0))
+
+    s = dpt.sum(aT, axis=2)
+    expected = dpt.asarray([[0, 3], [1, 4], [2, 5]])
+
+    assert dpt.all(s == expected)


### PR DESCRIPTION
Closes gh-1391

The specialized reduce_over_axis0 kernel should be called if both src/dst are F-contiguous, or when src is F-contig, and dst is C-contig but 1D (usually it is also F-contig in this case though).

- [x] Have you provided a meaningful PR description?
- [x] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
