### PR TITLE
Fixed constexpr significant bits value for double

### DIFF
--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/sqrt.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/sqrt.hpp
@@ -150,11 +150,11 @@ private:
 
     int get_normal_scale_double(const double &v) const
     {
-        constexpr int float_significant_bits = 53;
+        constexpr int double_significant_bits = 52;
         constexpr std::uint64_t exponent_mask = 0x7ff;
         constexpr int exponent_bias = 1023;
         const int scale = static_cast<int>(
-            (sycl::bit_cast<std::uint64_t>(v) >> float_significant_bits) &
+            (sycl::bit_cast<std::uint64_t>(v) >> double_significant_bits) &
             exponent_mask);
         return scale - exponent_bias;
     }


### PR DESCRIPTION
Fixed `constexpr` significant bits value for `double` type.

Renamed variable for clarity.

This is commit is cherry-picked from gh-1383

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
