### PR TITLE
Fixed qualifier name typo

### DIFF
--- a/dpctl/tests/test_sycl_queue_manager.py
+++ b/dpctl/tests/test_sycl_queue_manager.py
@@ -1,6 +1,6 @@
 #                      Data Parallel Control (dpctl)
 #
-# Copyright 2020-2022 Intel Corporation
+# Copyright 2020-2023 Intel Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -69,7 +69,7 @@ def test_is_in_device_context_inside_nested_device_ctxt_cpu():
     n = cpu.max_compute_units
     n_half = n // 2
     try:
-        d0, d1 = cpu.create_subdevices(partition=[n_half, n - n_half])
+        d0, d1 = cpu.create_sub_devices(partition=[n_half, n - n_half])
     except Exception:
         pytest.skip("Could not create subdevices")
     assert 0 == dpctl.get_num_activated_queues()

--- a/dpctl/tests/test_sycl_queue_manager.py
+++ b/dpctl/tests/test_sycl_queue_manager.py
@@ -70,7 +70,7 @@ def test_is_in_device_context_inside_nested_device_ctxt_cpu():
     n_half = n // 2
     try:
         d0, d1 = cpu.create_sub_devices(partition=[n_half, n - n_half])
-    except Exception:
+    except dpctl.SyclSubDeviceCreationError:
         pytest.skip("Could not create subdevices")
     assert 0 == dpctl.get_num_activated_queues()
     with dpctl.device_context(d0):


### PR DESCRIPTION
`dpctl.SyclDevice.create_subdevice` -> `dpctl.SyclDevice.create_sub_device`. 

The typo was masked by overly broad `except` exception pattern.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
