### PR TITLE
Added submit_keep_args_alive

### DIFF
--- a/dpctl/_backend.pxd
+++ b/dpctl/_backend.pxd
@@ -403,6 +403,13 @@ cdef extern from "syclinterface/dpctl_sycl_queue_interface.h":
         void *Dest,
         const void *Src,
         size_t Count)
+    cdef DPCTLSyclEventRef DPCTLQueue_MemcpyWithEvents(
+        const DPCTLSyclQueueRef Q,
+        void *Dest,
+        const void *Src,
+        size_t Count,
+        const DPCTLSyclEventRef *depEvents,
+        size_t depEventsCount)
     cdef DPCTLSyclEventRef DPCTLQueue_Memset(
         const DPCTLSyclQueueRef Q,
         void *Dest,

--- a/dpctl/_host_task_util.hpp
+++ b/dpctl/_host_task_util.hpp
@@ -29,6 +29,7 @@
 ///
 //===----------------------------------------------------------------------===//
 
+#pragma once
 #include "Python.h"
 #include "syclinterface/dpctl_data_types.h"
 #include "syclinterface/dpctl_sycl_type_casters.hpp"

--- a/dpctl/_host_task_util.hpp
+++ b/dpctl/_host_task_util.hpp
@@ -2,7 +2,7 @@
 //
 //                      Data Parallel Control (dpctl)
 //
-// Copyright 2020-2022 Intel Corporation
+// Copyright 2020-2023 Intel Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -31,28 +31,27 @@
 
 #include "Python.h"
 #include "syclinterface/dpctl_data_types.h"
+#include "syclinterface/dpctl_sycl_type_casters.hpp"
 #include <CL/sycl.hpp>
 
-int async_dec_ref(DPCTLSyclQueueRef QRef,
-                  PyObject **obj_array,
-                  size_t obj_array_size,
-                  DPCTLSyclEventRef *ERefs,
-                  size_t nERefs)
+DPCTLSyclEventRef async_dec_ref(DPCTLSyclQueueRef QRef,
+                                PyObject **obj_array,
+                                size_t obj_array_size,
+                                DPCTLSyclEventRef *depERefs,
+                                size_t nDepERefs,
+                                int *status)
 {
+    using dpctl::syclinterface::unwrap;
+    using dpctl::syclinterface::wrap;
 
-    sycl::queue *q = reinterpret_cast<sycl::queue *>(QRef);
+    sycl::queue *q = unwrap<sycl::queue>(QRef);
 
-    std::vector<PyObject *> obj_vec;
-    obj_vec.reserve(obj_array_size);
-    for (size_t obj_id = 0; obj_id < obj_array_size; ++obj_id) {
-        obj_vec.push_back(obj_array[obj_id]);
-    }
+    std::vector<PyObject *> obj_vec(obj_array, obj_array + obj_array_size);
 
     try {
-        q->submit([&](sycl::handler &cgh) {
-            for (size_t ev_id = 0; ev_id < nERefs; ++ev_id) {
-                cgh.depends_on(
-                    *(reinterpret_cast<sycl::event *>(ERefs[ev_id])));
+        sycl::event ht_ev = q->submit([&](sycl::handler &cgh) {
+            for (size_t ev_id = 0; ev_id < nDepERefs; ++ev_id) {
+                cgh.depends_on(*(unwrap<sycl::event>(depERefs[ev_id])));
             }
             cgh.host_task([obj_array_size, obj_vec]() {
                 // if the main thread has not finilized the interpreter yet
@@ -66,9 +65,21 @@ int async_dec_ref(DPCTLSyclQueueRef QRef,
                 }
             });
         });
+
+        constexpr int result_ok = 0;
+
+        *status = result_ok;
+        auto e_ptr = new sycl::event(ht_ev);
+        return wrap<sycl::event>(e_ptr);
     } catch (const std::exception &e) {
-        return 1;
+        constexpr int result_std_exception = 1;
+
+        *status = result_std_exception;
+        return nullptr;
     }
 
-    return 0;
+    constexpr int result_other_abnormal = 2;
+
+    *status = result_other_abnormal;
+    return nullptr;
 }

--- a/dpctl/_sycl_queue.pxd
+++ b/dpctl/_sycl_queue.pxd
@@ -94,7 +94,7 @@ cdef public api class SyclQueue (_SyclQueue) [
     cpdef void wait(self)
     cdef DPCTLSyclQueueRef get_queue_ref(self)
     cpdef memcpy(self, dest, src, size_t count)
-    cpdef SyclEvent memcpy_async(self, dest, src, size_t count)
+    cpdef SyclEvent memcpy_async(self, dest, src, size_t count, list dEvents=*)
     cpdef prefetch(self, ptr, size_t count=*)
     cpdef mem_advise(self, ptr, size_t count, int mem)
     cpdef SyclEvent submit_barrier(self, dependent_events=*)

--- a/dpctl/_sycl_queue.pxd
+++ b/dpctl/_sycl_queue.pxd
@@ -75,6 +75,14 @@ cdef public api class SyclQueue (_SyclQueue) [
         object args,
         list dEvents
     )
+    cpdef SyclEvent submit_async(
+        self,
+        SyclKernel kernel,
+        list args,
+        list gS,
+        list lS=*,
+        list dEvents=*
+    )
     cpdef SyclEvent submit(
         self,
         SyclKernel kernel,

--- a/dpctl/_sycl_queue.pxd
+++ b/dpctl/_sycl_queue.pxd
@@ -86,6 +86,7 @@ cdef public api class SyclQueue (_SyclQueue) [
     cpdef void wait(self)
     cdef DPCTLSyclQueueRef get_queue_ref(self)
     cpdef memcpy(self, dest, src, size_t count)
+    cpdef SyclEvent memcpy_async(self, dest, src, size_t count)
     cpdef prefetch(self, ptr, size_t count=*)
     cpdef mem_advise(self, ptr, size_t count, int mem)
     cpdef SyclEvent submit_barrier(self, dependent_events=*)

--- a/dpctl/_sycl_queue.pxd
+++ b/dpctl/_sycl_queue.pxd
@@ -70,6 +70,11 @@ cdef public api class SyclQueue (_SyclQueue) [
     cpdef SyclContext get_sycl_context(self)
     cpdef SyclDevice get_sycl_device(self)
     cdef  DPCTLSyclQueueRef get_queue_ref(self)
+    cpdef SyclEvent _submit_keep_args_alive(
+        self,
+        object args,
+        list dEvents
+    )
     cpdef SyclEvent submit(
         self,
         SyclKernel kernel,

--- a/dpctl/_sycl_queue.pyx
+++ b/dpctl/_sycl_queue.pyx
@@ -905,23 +905,6 @@ cdef class SyclQueue(_SyclQueue):
             raise SyclKernelSubmitError(
                 "Kernel submission to Sycl queue failed."
             )
-        # increment reference counts to list of arguments
-        Py_INCREF(args)
-
-        # schedule decrement
-        args_raw = <PyObject *>args
-
-        ret = -1
-        htERef = async_dec_ref(self.get_queue_ref(), &args_raw, 1, &Eref, 1, &ret)
-        if ret:
-            # async task submission failed, decrement ref counts and wait
-            Py_DECREF(args)
-            with nogil:
-                 DPCTLEvent_Wait(Eref)
-                 DPCTLEvent_Wait(htERef)
-
-        # we are not returning host-task event at the moment
-        DPCTLEvent_Delete(htERef)
 
         return SyclEvent._create(Eref)
 

--- a/dpctl/_sycl_queue.pyx
+++ b/dpctl/_sycl_queue.pyx
@@ -173,7 +173,7 @@ cdef DPCTLSyclEventRef _memcpy_impl(
      size_t byte_count,
      DPCTLSyclEventRef *dep_events,
      size_t dep_events_count
-):
+) except *:
     cdef void *c_dst_ptr = NULL
     cdef void *c_src_ptr = NULL
     cdef DPCTLSyclEventRef ERef = NULL

--- a/dpctl/_sycl_queue.pyx
+++ b/dpctl/_sycl_queue.pyx
@@ -771,6 +771,7 @@ cdef class SyclQueue(_SyclQueue):
         free(depEvents)
         if (status != 0):
             with nogil: DPCTLEvent_Wait(htERef)
+            DPCTLEvent_Delete(htERef)
             raise RuntimeError("Could not submit keep_args_alive host_task")
 
         return SyclEvent._create(htERef)

--- a/dpctl/_sycl_queue.pyx
+++ b/dpctl/_sycl_queue.pyx
@@ -934,6 +934,29 @@ cdef class SyclQueue(_SyclQueue):
         with nogil: DPCTLEvent_Wait(ERef)
         DPCTLEvent_Delete(ERef)
 
+    cpdef SyclEvent memcpy_async(self, dest, src, size_t count):
+        cdef void *c_dest
+        cdef void *c_src
+        cdef DPCTLSyclEventRef ERef = NULL
+
+        if isinstance(dest, _Memory):
+            c_dest = <void*>(<_Memory>dest).memory_ptr
+        else:
+            raise TypeError("Parameter `dest` should have type _Memory.")
+
+        if isinstance(src, _Memory):
+            c_src = <void*>(<_Memory>src).memory_ptr
+        else:
+            raise TypeError("Parameter `src` should have type _Memory.")
+
+        ERef = DPCTLQueue_Memcpy(self._queue_ref, c_dest, c_src, count)
+        if (ERef is NULL):
+            raise RuntimeError(
+                "SyclQueue.memcpy operation encountered an error"
+            )
+
+        return SyclEvent._create(ERef)
+
     cpdef prefetch(self, mem, size_t count=0):
         cdef void *ptr
         cdef DPCTLSyclEventRef ERef = NULL

--- a/dpctl/_sycl_queue.pyx
+++ b/dpctl/_sycl_queue.pyx
@@ -776,7 +776,7 @@ cdef class SyclQueue(_SyclQueue):
         return SyclEvent._create(htERef)
 
 
-    cpdef SyclEvent submit(
+    cpdef SyclEvent submit_async(
         self,
         SyclKernel kernel,
         list args,
@@ -907,6 +907,18 @@ cdef class SyclQueue(_SyclQueue):
             )
 
         return SyclEvent._create(Eref)
+
+    cpdef SyclEvent submit(
+        self,
+        SyclKernel kernel,
+        list args,
+        list gS,
+        list lS=None,
+        list dEvents=None
+    ):
+        cdef SyclEvent e = self.submit_async(kernel, args, gS, lS, dEvents)
+        e.wait()
+        return e
 
     cpdef void wait(self):
         with nogil: DPCTLQueue_Wait(self._queue_ref)

--- a/dpctl/tests/test_sycl_event.py
+++ b/dpctl/tests/test_sycl_event.py
@@ -202,7 +202,12 @@ def test_sycl_timer():
         m1.copy_from_device(m2)
         # host operation
         [x**2 for x in range(128 * 1024)]
-    host_dt, device_dt = timer.dt
+    elapsed = timer.dt
+    host_dt, device_dt = elapsed
+    assert isinstance(repr(elapsed), str)
+    assert isinstance(str(elapsed), str)
+    assert host_dt == elapsed.host_dt
+    assert device_dt == elapsed.device_dt
     assert host_dt > device_dt or (host_dt > 0 and device_dt >= 0)
     q_no_profiling = dpctl.SyclQueue()
     assert q_no_profiling.has_enable_profiling is False

--- a/dpctl/tests/test_sycl_kernel_submit.py
+++ b/dpctl/tests/test_sycl_kernel_submit.py
@@ -114,7 +114,7 @@ def test_create_program_from_source(ctype_str, dtype, ctypes_ctor):
         )
 
 
-def test_async_submit():
+def test_submit_async():
     try:
         q = dpctl.SyclQueue("opencl")
     except dpctl.SyclQueueCreationError:
@@ -182,7 +182,7 @@ def test_async_submit():
 
     async_detected = False
     for attempt in range(5):
-        e1 = q.submit(
+        e1 = q.submit_async(
             kern1Kernel,
             [
                 first_row,
@@ -192,7 +192,7 @@ def test_async_submit():
                 n,
             ],
         )
-        e2 = q.submit(
+        e2 = q.submit_async(
             kern2Kernel,
             [
                 second_row,
@@ -202,7 +202,7 @@ def test_async_submit():
                 n,
             ],
         )
-        e3 = q.submit(
+        e3 = q.submit_async(
             kern3Kernel,
             [third_row, first_row, second_row],
             [

--- a/dpctl/tests/test_sycl_kernel_submit.py
+++ b/dpctl/tests/test_sycl_kernel_submit.py
@@ -214,6 +214,9 @@ def test_async_submit():
         e3_st = e3.execution_status
         e2_st = e2.execution_status
         e1_st = e1.execution_status
+        ht_e = q._submit_keep_args_alive(
+            [first_row, second_row, third_row], [e1, e2, e3]
+        )
         are_complete = [
             e == status_complete
             for e in (
@@ -223,6 +226,7 @@ def test_async_submit():
             )
         ]
         e3.wait()
+        ht_e.wait()
         if not all(are_complete):
             async_detected = True
             break

--- a/dpctl/tests/test_sycl_queue_memcpy.py
+++ b/dpctl/tests/test_sycl_queue_memcpy.py
@@ -109,10 +109,10 @@ def test_memcpy_async():
     dst_buf2 = bytearray(n)
 
     e = q.memcpy_async(dst_buf, src_buf, n)
-    e2 = q.memcpy_async(dst_buf2, src_buf, n)
+    e2 = q.memcpy_async(dst_buf2, src_buf, n, [e])
 
-    e2.wait()
     e.wait()
+    e2.wait()
     assert dst_buf == src_buf
     assert dst_buf2 == src_buf
 

--- a/dpctl/tests/test_sycl_queue_memcpy.py
+++ b/dpctl/tests/test_sycl_queue_memcpy.py
@@ -44,7 +44,77 @@ def test_memcpy_copy_usm_to_usm():
 
     q.memcpy(mobj2, mobj1, 3)
 
-    assert mv2[:3], b"123"
+    assert mv2[:3] == b"123"
+
+
+def test_memcpy_copy_host_to_usm():
+    try:
+        q = dpctl.SyclQueue()
+    except dpctl.SyclQueueCreationError:
+        pytest.skip("Default constructor for SyclQueue failed")
+    usm_obj = _create_memory(q)
+
+    canary = bytearray(b"123456789")
+    host_obj = memoryview(canary)
+
+    q.memcpy(usm_obj, host_obj, len(canary))
+
+    mv2 = memoryview(usm_obj)
+
+    assert mv2[: len(canary)] == canary
+
+
+def test_memcpy_copy_usm_to_host():
+    try:
+        q = dpctl.SyclQueue()
+    except dpctl.SyclQueueCreationError:
+        pytest.skip("Default constructor for SyclQueue failed")
+    usm_obj = _create_memory(q)
+    mv2 = memoryview(usm_obj)
+
+    n = 9
+    for id in range(n):
+        mv2[id] = ord("a") + id
+
+    host_obj = bytearray(b" " * n)
+
+    q.memcpy(host_obj, usm_obj, n)
+
+    assert host_obj == b"abcdefghi"
+
+
+def test_memcpy_copy_host_to_host():
+    try:
+        q = dpctl.SyclQueue()
+    except dpctl.SyclQueueCreationError:
+        pytest.skip("Default constructor for SyclQueue failed")
+
+    src_buf = b"abcdefghijklmnopqrstuvwxyz"
+    dst_buf = bytearray(len(src_buf))
+
+    q.memcpy(dst_buf, src_buf, len(src_buf))
+
+    assert dst_buf == src_buf
+
+
+def test_memcpy_async():
+    try:
+        q = dpctl.SyclQueue()
+    except dpctl.SyclQueueCreationError:
+        pytest.skip("Default constructor for SyclQueue failed")
+
+    src_buf = b"abcdefghijklmnopqrstuvwxyz"
+    n = len(src_buf)
+    dst_buf = bytearray(n)
+    dst_buf2 = bytearray(n)
+
+    e = q.memcpy_async(dst_buf, src_buf, n)
+    e2 = q.memcpy_async(dst_buf2, src_buf, n)
+
+    e2.wait()
+    e.wait()
+    assert dst_buf == src_buf
+    assert dst_buf2 == src_buf
 
 
 def test_memcpy_type_error():
@@ -56,8 +126,8 @@ def test_memcpy_type_error():
 
     with pytest.raises(TypeError) as cm:
         q.memcpy(None, mobj, 3)
-    assert "`dest`" in str(cm.value)
+    assert "_Memory" in str(cm.value)
 
     with pytest.raises(TypeError) as cm:
         q.memcpy(mobj, None, 3)
-    assert "`src`" in str(cm.value)
+    assert "_Memory" in str(cm.value)

--- a/libsyclinterface/include/dpctl_sycl_queue_interface.h
+++ b/libsyclinterface/include/dpctl_sycl_queue_interface.h
@@ -295,6 +295,29 @@ DPCTLQueue_Memcpy(__dpctl_keep const DPCTLSyclQueueRef QRef,
                   size_t Count);
 
 /*!
+ * @brief C-API wrapper for ``sycl::queue::memcpy``.
+ *
+ * @param    QRef           An opaque pointer to the ``sycl::queue``.
+ * @param    Dest           An USM pointer to the destination memory.
+ * @param    Src            An USM pointer to the source memory.
+ * @param    Count          A number of bytes to copy.
+ * @param    DepEvents      A pointer to array of DPCTLSyclEventRef opaque
+ *                          pointers to dependent events.
+ * @param    DepEventsCount A number of dependent events.
+ * @return   An opaque pointer to the ``sycl::event`` returned by the
+ *           ``sycl::queue::memcpy`` function.
+ * @ingroup QueueInterface
+ */
+DPCTL_API
+__dpctl_give DPCTLSyclEventRef
+DPCTLQueue_MemcpyWithEvents(__dpctl_keep const DPCTLSyclQueueRef QRef,
+                            void *Dest,
+                            const void *Src,
+                            size_t Count,
+                            __dpctl_keep const DPCTLSyclEventRef *DepEvents,
+                            size_t DepEventsCount);
+
+/*!
  * @brief C-API wrapper for ``sycl::queue::prefetch``.
  *
  * @param    QRef           An opaque pointer to the ``sycl::queue``.


### PR DESCRIPTION
Added `dpctl.SyclQueue._submit_keep_args_alive(args, events)` that increments reference count of `args` object (typically a sequence of arguments an asynchronous task is operating on), ensuring that `args` object is not garbage collected until after `events` signal that tasks working on these objects complete their execution.

- [x] Have you provided a meaningful PR description?
- [x] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [x] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
