### PR TITLE
Boolean reduction performance improvements

### DIFF
--- a/.github/workflows/generate-coverage.yaml
+++ b/.github/workflows/generate-coverage.yaml
@@ -79,7 +79,7 @@ jobs:
       - name: Install dpctl dependencies
         shell: bash -l {0}
         run: |
-          pip install numpy cython setuptools pytest pytest-cov scikit-build cmake coverage[toml]
+          pip install numpy"<1.26.0" cython setuptools pytest pytest-cov scikit-build cmake coverage[toml]
 
       - name: Build dpctl with coverage
         shell: bash -l {0}

--- a/.github/workflows/os-llvm-sycl-build.yml
+++ b/.github/workflows/os-llvm-sycl-build.yml
@@ -108,7 +108,7 @@ jobs:
       - name: Install dpctl dependencies
         shell: bash -l {0}
         run: |
-          pip install numpy cython setuptools pytest scikit-build cmake ninja
+          pip install numpy"<1.26.0" cython setuptools pytest scikit-build cmake ninja
 
       - name: Checkout repo
         uses: actions/checkout@v3

--- a/dpctl/tensor/libtensor/source/boolean_reductions.cpp
+++ b/dpctl/tensor/libtensor/source/boolean_reductions.cpp
@@ -58,7 +58,9 @@ using dpctl::tensor::kernels::boolean_reduction_strided_impl_fn_ptr;
 static boolean_reduction_strided_impl_fn_ptr
     all_reduction_strided_dispatch_vector[td_ns::num_types];
 static boolean_reduction_contig_impl_fn_ptr
-    all_reduction_contig_dispatch_vector[td_ns::num_types];
+    all_reduction_axis1_contig_dispatch_vector[td_ns::num_types];
+static boolean_reduction_contig_impl_fn_ptr
+    all_reduction_axis0_contig_dispatch_vector[td_ns::num_types];
 
 void populate_all_dispatch_vectors(void)
 {
@@ -74,11 +76,19 @@ void populate_all_dispatch_vectors(void)
 
     using dpctl::tensor::kernels::boolean_reduction_contig_impl_fn_ptr;
 
-    using dpctl::tensor::kernels::AllContigFactory;
+    using dpctl::tensor::kernels::AllAxis1ContigFactory;
     DispatchVectorBuilder<boolean_reduction_contig_impl_fn_ptr,
-                          AllContigFactory, td_ns::num_types>
+                          AllAxis1ContigFactory, td_ns::num_types>
         all_dvb2;
-    all_dvb2.populate_dispatch_vector(all_reduction_contig_dispatch_vector);
+    all_dvb2.populate_dispatch_vector(
+        all_reduction_axis1_contig_dispatch_vector);
+
+    using dpctl::tensor::kernels::AllAxis0ContigFactory;
+    DispatchVectorBuilder<boolean_reduction_contig_impl_fn_ptr,
+                          AllAxis0ContigFactory, td_ns::num_types>
+        all_dvb3;
+    all_dvb3.populate_dispatch_vector(
+        all_reduction_axis0_contig_dispatch_vector);
 };
 
 } // namespace impl
@@ -91,7 +101,9 @@ static boolean_reduction_strided_impl_fn_ptr
     any_reduction_strided_dispatch_vector[td_ns::num_types];
 using dpctl::tensor::kernels::boolean_reduction_contig_impl_fn_ptr;
 static boolean_reduction_contig_impl_fn_ptr
-    any_reduction_contig_dispatch_vector[td_ns::num_types];
+    any_reduction_axis1_contig_dispatch_vector[td_ns::num_types];
+static boolean_reduction_contig_impl_fn_ptr
+    any_reduction_axis0_contig_dispatch_vector[td_ns::num_types];
 
 void populate_any_dispatch_vectors(void)
 {
@@ -107,11 +119,19 @@ void populate_any_dispatch_vectors(void)
 
     using dpctl::tensor::kernels::boolean_reduction_contig_impl_fn_ptr;
 
-    using dpctl::tensor::kernels::AnyContigFactory;
+    using dpctl::tensor::kernels::AnyAxis1ContigFactory;
     DispatchVectorBuilder<boolean_reduction_contig_impl_fn_ptr,
-                          AnyContigFactory, td_ns::num_types>
+                          AnyAxis1ContigFactory, td_ns::num_types>
         any_dvb2;
-    any_dvb2.populate_dispatch_vector(any_reduction_contig_dispatch_vector);
+    any_dvb2.populate_dispatch_vector(
+        any_reduction_axis1_contig_dispatch_vector);
+
+    using dpctl::tensor::kernels::AnyAxis0ContigFactory;
+    DispatchVectorBuilder<boolean_reduction_contig_impl_fn_ptr,
+                          AnyAxis0ContigFactory, td_ns::num_types>
+        any_dvb3;
+    any_dvb3.populate_dispatch_vector(
+        any_reduction_axis0_contig_dispatch_vector);
 };
 
 } // namespace impl
@@ -124,16 +144,18 @@ void init_boolean_reduction_functions(py::module_ m)
     // ALL
     {
         impl::populate_all_dispatch_vectors();
-        using impl::all_reduction_contig_dispatch_vector;
+        using impl::all_reduction_axis0_contig_dispatch_vector;
+        using impl::all_reduction_axis1_contig_dispatch_vector;
         using impl::all_reduction_strided_dispatch_vector;
 
         auto all_pyapi = [&](arrayT src, int trailing_dims_to_reduce,
                              arrayT dst, sycl::queue exec_q,
                              const event_vecT &depends = {}) {
-            return py_boolean_reduction(src, trailing_dims_to_reduce, dst,
-                                        exec_q, depends,
-                                        all_reduction_contig_dispatch_vector,
-                                        all_reduction_strided_dispatch_vector);
+            return py_boolean_reduction(
+                src, trailing_dims_to_reduce, dst, exec_q, depends,
+                all_reduction_axis1_contig_dispatch_vector,
+                all_reduction_axis0_contig_dispatch_vector,
+                all_reduction_strided_dispatch_vector);
         };
         m.def("_all", all_pyapi, "", py::arg("src"),
               py::arg("trailing_dims_to_reduce"), py::arg("dst"),
@@ -143,16 +165,18 @@ void init_boolean_reduction_functions(py::module_ m)
     // ANY
     {
         impl::populate_any_dispatch_vectors();
-        using impl::any_reduction_contig_dispatch_vector;
+        using impl::any_reduction_axis0_contig_dispatch_vector;
+        using impl::any_reduction_axis1_contig_dispatch_vector;
         using impl::any_reduction_strided_dispatch_vector;
 
         auto any_pyapi = [&](arrayT src, int trailing_dims_to_reduce,
                              arrayT dst, sycl::queue exec_q,
                              const event_vecT &depends = {}) {
-            return py_boolean_reduction(src, trailing_dims_to_reduce, dst,
-                                        exec_q, depends,
-                                        any_reduction_contig_dispatch_vector,
-                                        any_reduction_strided_dispatch_vector);
+            return py_boolean_reduction(
+                src, trailing_dims_to_reduce, dst, exec_q, depends,
+                any_reduction_axis1_contig_dispatch_vector,
+                any_reduction_axis0_contig_dispatch_vector,
+                any_reduction_strided_dispatch_vector);
         };
         m.def("_any", any_pyapi, "", py::arg("src"),
               py::arg("trailing_dims_to_reduce"), py::arg("dst"),


### PR DESCRIPTION
This PR makes changes to boolean reductions which align with #1364

Namely, the traversal pattern of work groups in boolean reductions has been changed to be fastest over the iteration dimension, rather than the reduction dimension, and a specialized kernel for reductions over `axis 0` in matrices has been added.

The original contiguous boolean reduction kernel has also been renamed to make the difference more apparent.

- [X] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [X] Have you tested your changes locally for CPU and GPU devices?
- [X] Have you made sure that new changes do not introduce compiler warnings?
- [x] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
