### PR TITLE
Changes to elementwise function tests that use complex data types

### DIFF
--- a/dpctl/tests/conftest.py
+++ b/dpctl/tests/conftest.py
@@ -20,6 +20,7 @@
 import os
 import sys
 
+import pytest
 from _device_attributes_checks import (
     check,
     device_selector,
@@ -38,3 +39,28 @@ __all__ = [
     "suppress_invalid_numpy_warnings",
     "valid_filter",
 ]
+
+
+def pytest_configure(config):
+    config.addinivalue_line(
+        "markers",
+        "broken_complex: Specified again to remove warnings ",
+    )
+
+
+def pytest_addoption(parser):
+    parser.addoption(
+        "--runcomplex",
+        action="store_true",
+        default=False,
+        help="run broken complex tests",
+    )
+
+
+def pytest_collection_modifyitems(config, items):
+    if config.getoption("--runcomplex"):
+        return
+    skip_complex = pytest.mark.skip(reason="need --runcomplex option to run")
+    for item in items:
+        if "broken_complex" in item.keywords:
+            item.add_marker(skip_complex)

--- a/dpctl/tests/conftest.py
+++ b/dpctl/tests/conftest.py
@@ -53,14 +53,17 @@ def pytest_addoption(parser):
         "--runcomplex",
         action="store_true",
         default=False,
-        help="run broken complex tests",
+        help="run broken complex tests on Windows",
     )
 
 
 def pytest_collection_modifyitems(config, items):
     if config.getoption("--runcomplex"):
         return
-    skip_complex = pytest.mark.skip(reason="need --runcomplex option to run")
+    skip_complex = pytest.mark.skipif(
+        os.name == "nt",
+        reason="need --runcomplex option to run on Windows",
+    )
     for item in items:
         if "broken_complex" in item.keywords:
             item.add_marker(skip_complex)

--- a/dpctl/tests/elementwise/test_abs.py
+++ b/dpctl/tests/elementwise/test_abs.py
@@ -23,13 +23,7 @@ import pytest
 import dpctl.tensor as dpt
 from dpctl.tests.helper import get_queue_or_skip, skip_if_dtype_not_supported
 
-from .utils import (
-    _all_dtypes,
-    _complex_fp_dtypes,
-    _no_complex_dtypes,
-    _real_fp_dtypes,
-    _usm_types,
-)
+from .utils import _all_dtypes, _complex_fp_dtypes, _real_fp_dtypes, _usm_types
 
 
 @pytest.mark.parametrize("dtype", _all_dtypes)
@@ -131,26 +125,21 @@ def test_abs_complex(dtype):
             )
 
 
-@pytest.mark.parametrize("dtype", _no_complex_dtypes)
-def test_abs_out_overlap(dtype):
-    q = get_queue_or_skip()
-    skip_if_dtype_not_supported(dtype, q)
+def test_abs_out_overlap():
+    get_queue_or_skip()
 
-    X = dpt.linspace(0, 35, 60, dtype=dtype, sycl_queue=q)
-    X = dpt.reshape(X, (3, 5, 4))
-
-    Xnp = dpt.asnumpy(X)
-    Ynp = np.abs(Xnp, out=Xnp)
-
+    X = dpt.arange(-3, 3, 1, dtype="i4")
+    expected = dpt.asarray([3, 2, 1, 0, 1, 2], dtype="i4")
     Y = dpt.abs(X, out=X)
-    assert Y is X
-    assert np.allclose(dpt.asnumpy(X), Xnp)
 
-    Ynp = np.abs(Xnp, out=Xnp[::-1])
+    assert Y is X
+    assert dpt.all(expected == X)
+
+    X = dpt.arange(-3, 3, 1, dtype="i4")
+    expected = expected[::-1]
     Y = dpt.abs(X, out=X[::-1])
     assert Y is not X
-    assert np.allclose(dpt.asnumpy(X), Xnp)
-    assert np.allclose(dpt.asnumpy(Y), Ynp)
+    assert dpt.all(expected == X)
 
 
 @pytest.mark.parametrize("dtype", _real_fp_dtypes)

--- a/dpctl/tests/elementwise/test_exp.py
+++ b/dpctl/tests/elementwise/test_exp.py
@@ -216,26 +216,3 @@ def test_exp_complex_special_cases(dtype):
     tol = 8 * dpt.finfo(dtype).resolution
     assert_allclose(dpt.asnumpy(dpt.real(Y)), np.real(Ynp), atol=tol, rtol=tol)
     assert_allclose(dpt.asnumpy(dpt.imag(Y)), np.imag(Ynp), atol=tol, rtol=tol)
-
-
-@pytest.mark.parametrize("dtype", ["f2", "f4", "f8", "c8", "c16"])
-def test_exp_out_overlap(dtype):
-    q = get_queue_or_skip()
-    skip_if_dtype_not_supported(dtype, q)
-
-    X = dpt.linspace(0, 1, 15, dtype=dtype, sycl_queue=q)
-    X = dpt.reshape(X, (3, 5))
-
-    Xnp = dpt.asnumpy(X)
-    Ynp = np.exp(Xnp, out=Xnp)
-
-    Y = dpt.exp(X, out=X)
-    tol = 8 * dpt.finfo(Y.dtype).resolution
-    assert Y is X
-    assert_allclose(dpt.asnumpy(X), Xnp, atol=tol, rtol=tol)
-
-    Ynp = np.exp(Xnp, out=Xnp[::-1])
-    Y = dpt.exp(X, out=X[::-1])
-    assert Y is not X
-    assert_allclose(dpt.asnumpy(X), Xnp, atol=tol, rtol=tol)
-    assert_allclose(dpt.asnumpy(Y), Ynp, atol=tol, rtol=tol)

--- a/dpctl/tests/elementwise/test_hyperbolic.py
+++ b/dpctl/tests/elementwise/test_hyperbolic.py
@@ -15,7 +15,6 @@
 #  limitations under the License.
 
 import itertools
-import os
 
 import numpy as np
 import pytest

--- a/dpctl/tests/elementwise/test_hyperbolic.py
+++ b/dpctl/tests/elementwise/test_hyperbolic.py
@@ -271,7 +271,7 @@ def test_hyper_real_special_cases(np_call, dpt_call, dtype):
     assert_allclose(dpt.asnumpy(dpt_call(yf)), Y_np, atol=tol, rtol=tol)
 
 
-@pytest.mark.skipif(os.name == "nt", reason="Known problems on Windows")
+@pytest.mark.broken_complex
 @pytest.mark.parametrize("np_call, dpt_call", _all_funcs)
 @pytest.mark.parametrize("dtype", ["c8", "c16"])
 def test_hyper_complex_special_cases(np_call, dpt_call, dtype):

--- a/dpctl/tests/elementwise/test_hyperbolic.py
+++ b/dpctl/tests/elementwise/test_hyperbolic.py
@@ -294,29 +294,3 @@ def test_hyper_complex_special_cases(np_call, dpt_call, dtype):
     assert_allclose(
         dpt.asnumpy(dpt.imag(dpt_call(Xc))), np.imag(Ynp), atol=tol, rtol=tol
     )
-
-
-@pytest.mark.parametrize("np_call, dpt_call", _all_funcs)
-@pytest.mark.parametrize("dtype", ["f2", "f4", "f8", "c8", "c16"])
-def test_hyper_out_overlap(np_call, dpt_call, dtype):
-    q = get_queue_or_skip()
-    skip_if_dtype_not_supported(dtype, q)
-
-    X = dpt.linspace(-np.pi / 2, np.pi / 2, 60, dtype=dtype, sycl_queue=q)
-    X = dpt.reshape(X, (3, 5, 4))
-
-    tol = 8 * dpt.finfo(dtype).resolution
-    Xnp = dpt.asnumpy(X)
-    with np.errstate(all="ignore"):
-        Ynp = np_call(Xnp, out=Xnp)
-
-    Y = dpt_call(X, out=X)
-    assert Y is X
-    assert_allclose(dpt.asnumpy(X), Xnp, atol=tol, rtol=tol)
-
-    with np.errstate(all="ignore"):
-        Ynp = np_call(Xnp, out=Xnp[::-1])
-    Y = dpt_call(X, out=X[::-1])
-    assert Y is not X
-    assert_allclose(dpt.asnumpy(X), Xnp, atol=tol, rtol=tol)
-    assert_allclose(dpt.asnumpy(Y), Ynp, atol=tol, rtol=tol)

--- a/dpctl/tests/elementwise/test_log.py
+++ b/dpctl/tests/elementwise/test_log.py
@@ -128,27 +128,3 @@ def test_log_special_cases():
     )
 
     assert_equal(dpt.asnumpy(Y), expected)
-
-
-@pytest.mark.parametrize("dtype", ["f2", "f4", "f8", "c8", "c16"])
-def test_log_out_overlap(dtype):
-    q = get_queue_or_skip()
-    skip_if_dtype_not_supported(dtype, q)
-
-    X = dpt.linspace(5, 35, 60, dtype=dtype, sycl_queue=q)
-    X = dpt.reshape(X, (3, 5, 4))
-
-    Xnp = dpt.asnumpy(X)
-    Ynp = np.log(Xnp, out=Xnp)
-
-    Y = dpt.log(X, out=X)
-    assert Y is X
-
-    tol = 8 * dpt.finfo(Y.dtype).resolution
-    assert_allclose(dpt.asnumpy(X), Xnp, atol=tol, rtol=tol)
-
-    Ynp = np.log(Xnp, out=Xnp[::-1])
-    Y = dpt.log(X, out=X[::-1])
-    assert Y is not X
-    assert_allclose(dpt.asnumpy(X), Xnp, atol=tol, rtol=tol)
-    assert_allclose(dpt.asnumpy(Y), Ynp, atol=tol, rtol=tol)

--- a/dpctl/tests/elementwise/test_round.py
+++ b/dpctl/tests/elementwise/test_round.py
@@ -213,26 +213,3 @@ def test_round_complex_special_cases(dtype):
     tol = 8 * dpt.finfo(dtype).resolution
     assert_allclose(dpt.asnumpy(dpt.real(Y)), np.real(Ynp), atol=tol, rtol=tol)
     assert_allclose(dpt.asnumpy(dpt.imag(Y)), np.imag(Ynp), atol=tol, rtol=tol)
-
-
-@pytest.mark.parametrize("dtype", ["f2", "f4", "f8", "c8", "c16"])
-def test_round_out_overlap(dtype):
-    q = get_queue_or_skip()
-    skip_if_dtype_not_supported(dtype, q)
-
-    X = dpt.linspace(0, 1, 15, dtype=dtype, sycl_queue=q)
-    X = dpt.reshape(X, (3, 5))
-
-    Xnp = dpt.asnumpy(X)
-    Ynp = np.round(Xnp, out=Xnp)
-
-    Y = dpt.round(X, out=X)
-    tol = 8 * dpt.finfo(Y.dtype).resolution
-    assert Y is X
-    assert_allclose(dpt.asnumpy(X), Xnp, atol=tol, rtol=tol)
-
-    Ynp = np.round(Xnp, out=Xnp[::-1])
-    Y = dpt.round(X, out=X[::-1])
-    assert Y is not X
-    assert_allclose(dpt.asnumpy(X), Xnp, atol=tol, rtol=tol)
-    assert_allclose(dpt.asnumpy(Y), Ynp, atol=tol, rtol=tol)

--- a/dpctl/tests/elementwise/test_sqrt.py
+++ b/dpctl/tests/elementwise/test_sqrt.py
@@ -122,30 +122,6 @@ def test_sqrt_order(dtype):
             assert_allclose(dpt.asnumpy(Y), expected_Y, atol=tol, rtol=tol)
 
 
-@pytest.mark.parametrize("dtype", ["f2", "f4", "f8", "c8", "c16"])
-def test_sqrt_out_overlap(dtype):
-    q = get_queue_or_skip()
-    skip_if_dtype_not_supported(dtype, q)
-
-    X = dpt.linspace(0, 35, 60, dtype=dtype, sycl_queue=q)
-    X = dpt.reshape(X, (3, 5, 4))
-
-    Xnp = dpt.asnumpy(X)
-    Ynp = np.sqrt(Xnp, out=Xnp)
-
-    Y = dpt.sqrt(X, out=X)
-    assert Y is X
-
-    tol = 8 * dpt.finfo(Y.dtype).resolution
-    assert_allclose(dpt.asnumpy(X), Xnp, atol=tol, rtol=tol)
-
-    Ynp = np.sqrt(Xnp, out=Xnp[::-1])
-    Y = dpt.sqrt(X, out=X[::-1])
-    assert Y is not X
-    assert_allclose(dpt.asnumpy(X), Xnp, atol=tol, rtol=tol)
-    assert_allclose(dpt.asnumpy(Y), Ynp, atol=tol, rtol=tol)
-
-
 @pytest.mark.usefixtures("suppress_invalid_numpy_warnings")
 def test_sqrt_special_cases():
     q = get_queue_or_skip()

--- a/dpctl/tests/elementwise/test_square.py
+++ b/dpctl/tests/elementwise/test_square.py
@@ -97,29 +97,3 @@ def test_square_special_cases(dtype):
             rtol=tol,
             equal_nan=True,
         )
-
-
-@pytest.mark.parametrize("dtype", ["f2", "f4", "f8", "c8", "c16"])
-def test_square_out_overlap(dtype):
-    q = get_queue_or_skip()
-    skip_if_dtype_not_supported(dtype, q)
-
-    X = dpt.linspace(0, 35, 60, dtype=dtype, sycl_queue=q)
-    X = dpt.reshape(X, (3, 5, 4))
-
-    Xnp = dpt.asnumpy(X)
-    Ynp = np.square(Xnp, out=Xnp)
-
-    Y = dpt.square(X, out=X)
-    assert Y is X
-    assert np.allclose(dpt.asnumpy(X), Xnp)
-
-    X = dpt.linspace(0, 35, 60, dtype=dtype, sycl_queue=q)
-    X = dpt.reshape(X, (3, 5, 4))
-    Xnp = dpt.asnumpy(X)
-
-    Ynp = np.square(Xnp, out=Xnp[::-1])
-    Y = dpt.square(X, out=X[::-1])
-    assert Y is not X
-    assert np.allclose(dpt.asnumpy(X), Xnp)
-    assert np.allclose(dpt.asnumpy(Y), Ynp)

--- a/dpctl/tests/elementwise/test_trigonometric.py
+++ b/dpctl/tests/elementwise/test_trigonometric.py
@@ -15,7 +15,6 @@
 #  limitations under the License.
 
 import itertools
-import os
 
 import numpy as np
 import pytest

--- a/dpctl/tests/elementwise/test_trigonometric.py
+++ b/dpctl/tests/elementwise/test_trigonometric.py
@@ -268,7 +268,7 @@ def test_trig_real_special_cases(np_call, dpt_call, dtype):
     assert_allclose(dpt.asnumpy(dpt_call(yf)), Y_np, atol=tol, rtol=tol)
 
 
-@pytest.mark.skipif(os.name == "nt", reason="Known problem on Windows")
+@pytest.mark.broken_complex
 @pytest.mark.parametrize("np_call, dpt_call", _all_funcs)
 @pytest.mark.parametrize("dtype", ["c8", "c16"])
 def test_trig_complex_special_cases(np_call, dpt_call, dtype):

--- a/dpctl/tests/elementwise/test_trigonometric.py
+++ b/dpctl/tests/elementwise/test_trigonometric.py
@@ -291,38 +291,3 @@ def test_trig_complex_special_cases(np_call, dpt_call, dtype):
     assert_allclose(
         dpt.asnumpy(dpt.imag(dpt_call(Xc))), np.imag(Ynp), atol=tol, rtol=tol
     )
-
-
-@pytest.mark.parametrize("np_call, dpt_call", _all_funcs)
-@pytest.mark.parametrize("dtype", ["f2", "f4", "f8", "c8", "c16"])
-def test_trig_out_overlap(np_call, dpt_call, dtype):
-    q = get_queue_or_skip()
-    skip_if_dtype_not_supported(dtype, q)
-
-    if os.name == "nt" and dpt.isdtype(dpt.dtype(dtype), "complex floating"):
-        pytest.skip("Know problems on Windows")
-
-    if np_call == np.tan:
-        X = dpt.linspace(-np.pi / 2, np.pi / 2, 64, dtype=dtype, sycl_queue=q)[
-            2:-2
-        ]
-        tol = 50 * dpt.finfo(dtype).resolution
-    else:
-        X = dpt.linspace(-np.pi / 2, np.pi / 2, 60, dtype=dtype, sycl_queue=q)
-        tol = 8 * dpt.finfo(dtype).resolution
-    X = dpt.reshape(X, (3, 5, 4))
-
-    Xnp = dpt.asnumpy(X)
-    with np.errstate(all="ignore"):
-        Ynp = np_call(Xnp, out=Xnp)
-
-    Y = dpt_call(X, out=X)
-    assert Y is X
-    assert_allclose(dpt.asnumpy(X), Xnp, atol=tol, rtol=tol)
-
-    with np.errstate(all="ignore"):
-        Ynp = np_call(Xnp, out=Xnp[::-1])
-    Y = dpt_call(X, out=X[::-1])
-    assert Y is not X
-    assert_allclose(dpt.asnumpy(X), Xnp, atol=tol, rtol=tol)
-    assert_allclose(dpt.asnumpy(Y), Ynp, atol=tol, rtol=tol)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ omit = [
 
 [tool.pytest.ini.options]
 markers = [
-    "broken_complex: mark a test that is skipped due to complex implementation",
+    "broken_complex: mark a test that is skipped on Windows due to complex implementation",
 ]
 minversion = "6.0"
 norecursedirs= [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,9 @@ omit = [
 ]
 
 [tool.pytest.ini.options]
+markers = [
+    "broken_complex: mark a test that is skipped due to complex implementation",
+]
 minversion = "6.0"
 norecursedirs= [
     ".*", "*.egg*", "build", "dist", "conda-recipe",


### PR DESCRIPTION
This PR simplifies the `test_[func]_out_overlap` testing for elementwise funcs in dpctl by removing most of these tests, which were redundant, leaving only a test for overlap in `test_abs.py`.

This PR also modifies `pyproject.toml` and `conftest.py` to add a new pytest marker and complementary option, `broken_complex`, which skips some tests by default due to known issues on some platforms (esp. Windows).

- [X] Have you provided a meaningful PR description?
- [X] Have you added a test, reproducer or referred to an issue with a reproducer?
- [X] Have you tested your changes locally for CPU and GPU devices?
- [X] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [X] If this PR is a work in progress, are you opening the PR as a draft?
