### PR TITLE
Add missing include, missing namespace definition

### DIFF
--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/common.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/common.hpp
@@ -28,6 +28,8 @@
 #include <cstdint>
 #include <pybind11/pybind11.h>
 
+#include "utils/offset_utils.hpp"
+
 namespace dpctl
 {
 namespace tensor
@@ -36,6 +38,8 @@ namespace kernels
 {
 namespace elementwise_common
 {
+
+namespace py = pybind11;
 
 /*! @brief Functor for unary function evaluation on contiguous array */
 template <typename argT,


### PR DESCRIPTION
This PR modifies "libtensor/include/kernels/elementwise_functions/common.hpp" to add missing `#include <pybind11/pybind11.h>` and missing definition of `offset_utils` namespace.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
