### PR TITLE
Port back fixes from async-ref-count-increment branch

### DIFF
--- a/dpctl/CMakeLists.txt
+++ b/dpctl/CMakeLists.txt
@@ -86,7 +86,7 @@ add_custom_target(_build_time_create_dpctl_include ALL
 )
 
 set(_copied_header_files)
-file(GLOB _syclinterface_h ${CMAKE_SOURCE_DIR}/libsyclinterface/include/*.h)
+file(GLOB _syclinterface_h ${CMAKE_SOURCE_DIR}/libsyclinterface/include/*.h*)
 foreach(hf ${_syclinterface_h})
     get_filename_component(_header_name ${hf} NAME)
     set(_target_header_file ${DPCTL_INCLUDE_DIR}/syclinterface/${_header_name})

--- a/dpctl/tests/test_service.py
+++ b/dpctl/tests/test_service.py
@@ -68,6 +68,18 @@ def test_get_include():
     assert type(incl) is str
     assert incl != ""
     assert os.path.isdir(incl)
+    assert os.path.exists(os.path.join(incl, "dpctl4pybind11.hpp"))
+    assert os.path.exists(os.path.join(incl, "dpctl_capi.h"))
+    assert os.path.exists(os.path.join(incl, "dpctl_sycl_interface.h"))
+    assert os.path.exists(
+        os.path.join(incl, "syclinterface", "Config", "dpctl_config.h")
+    )
+    assert os.path.exists(
+        os.path.join(incl, "syclinterface", "dpctl_sycl_types.h")
+    )
+    assert os.path.exists(
+        os.path.join(incl, "syclinterface", "dpctl_sycl_type_casters.hpp")
+    )
 
 
 def test_get_dpcppversion():

--- a/examples/pybind11/use_dpctl_sycl_kernel/resource/README.md
+++ b/examples/pybind11/use_dpctl_sycl_kernel/resource/README.md
@@ -2,7 +2,7 @@
 
 ```bash
 export TOOLS_DIR=$(dirname $(dirname $(which icx)))/bin-llvm
-$TOOLS_DIR/clang -cc1 -triple spir double_it.cl -finclude-default-header -flto -emit -llvm-bc -o double_it.bc
+$TOOLS_DIR/clang -cc1 -triple spir double_it.cl -finclude-default-header -flto -emit-llvm-bc -o double_it.bc
 $TOOLS_DIR/llvm-spirv double_it.bc -o double_it.spv
 rm double_it.bc
 ```

--- a/libsyclinterface/CMakeLists.txt
+++ b/libsyclinterface/CMakeLists.txt
@@ -1,7 +1,8 @@
-cmake_minimum_required(VERSION 3.10...3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.21...3.22 FATAL_ERROR)
 
 project(
     "libDPCTLSYCLInterface"
+    LANGUAGES C CXX
     DESCRIPTION "A C API for a subset of SYCL"
 )
 
@@ -259,8 +260,7 @@ endif()
 
 # Install all headers
 
-file(GLOB MAIN_HEADERS "${CMAKE_CURRENT_SOURCE_DIR}/include/*.h")
-file(GLOB MAIN_HEADERS "${CMAKE_CURRENT_SOURCE_DIR}/include/*.hpp")
+file(GLOB MAIN_HEADERS "${CMAKE_CURRENT_SOURCE_DIR}/include/*.h" "${CMAKE_CURRENT_SOURCE_DIR}/include/*.hpp")
 file(GLOB SUPPORT_HEADERS "${CMAKE_CURRENT_SOURCE_DIR}/include/Support/*.h")
 file(GLOB CONFIG_HEADERS "${CMAKE_CURRENT_SOURCE_DIR}/include/Config/*.h")
 


### PR DESCRIPTION
This PR ports some fixes from #1395 to main branch with intent to include them in 0.15.0 release:

 - Fixed typo in `examples/pybind11/use_dpctl_sycl_kernel/resource/README.md`
 - Ensure that `libsyclinterface/include/*.hpp` are made available for projects during build time.

---

- [x] Have you provided a meaningful PR description?
- [x] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [x] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
