### PR TITLE
Use cmake_minimum_required with min...max

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,7 @@
 cmake_minimum_required(VERSION 3.21...3.27 FATAL_ERROR)
 
 project(dpctl
+    VERSION 0.15
     LANGUAGES CXX
     DESCRIPTION "Python interface for XPU programming"
 )

--- a/examples/pybind11/external_usm_allocation/CMakeLists.txt
+++ b/examples/pybind11/external_usm_allocation/CMakeLists.txt
@@ -1,6 +1,7 @@
-cmake_minimum_required(VERSION 3.21)
+cmake_minimum_required(VERSION 3.21...3.27 FATAL_ERROR)
 
-project(external_usm_allocation LANGUAGES CXX)
+project(external_usm_allocation VERSION 0.1 LANGUAGES CXX
+  DESCRIPTION "Example of passing external C++ USM allocation to Python")
 
 set(DPCTL_CMAKE_MODULES_PATH "${CMAKE_SOURCE_DIR}/../../../cmake")
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${DPCTL_CMAKE_MODULES_PATH})
@@ -13,14 +14,13 @@ set(CMAKE_CXX_STANDARD_REQUIRED True)
 include(FetchContent)
 FetchContent_Declare(
   pybind11
-  URL https://github.com/pybind/pybind11/archive/refs/tags/v2.10.2.tar.gz
-  URL_HASH SHA256=93bd1e625e43e03028a3ea7389bba5d3f9f2596abc074b068e70f4ef9b1314ae
+  URL https://github.com/pybind/pybind11/archive/refs/tags/v2.11.1.tar.gz
+  URL_HASH SHA256=d475978da0cdc2d43b73f30910786759d593a9d8ee05b1b6846d1eb16c6d2e0c
 )
 FetchContent_MakeAvailable(pybind11)
 
-find_package(PythonExtensions REQUIRED)
+find_package(Python REQUIRED COMPONENTS Development.Module NumPy)
 find_package(Dpctl REQUIRED)
-find_package(NumPy REQUIRED)
 
 set(py_module_name _external_usm_alloc)
 pybind11_add_module(${py_module_name}

--- a/examples/pybind11/onemkl_gemv/CMakeLists.txt
+++ b/examples/pybind11/onemkl_gemv/CMakeLists.txt
@@ -1,6 +1,7 @@
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.22...3.27 FATAL_ERROR)
 
-project(example_use_mkl_gemm LANGUAGES CXX)
+project(example_use_mkl_gemm VERSION 0.1 LANGUAGES CXX
+  DESCRIPTION "Example of using Python wrapper to oneMKL function")
 set(DPCTL_CMAKE_MODULES_PATH "${CMAKE_SOURCE_DIR}/../../../cmake")
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${DPCTL_CMAKE_MODULES_PATH})
 find_package(IntelDPCPP REQUIRED PATHS ${DPCTL_CMAKE_MODULES_PATH} NO_DEFAULT_PATH)
@@ -17,12 +18,12 @@ include(GNUInstallDirs)
 include(FetchContent)
 FetchContent_Declare(
   pybind11
-  URL https://github.com/pybind/pybind11/archive/refs/tags/v2.10.2.tar.gz
-  URL_HASH SHA256=93bd1e625e43e03028a3ea7389bba5d3f9f2596abc074b068e70f4ef9b1314ae
+  URL https://github.com/pybind/pybind11/archive/refs/tags/v2.11.1.tar.gz
+  URL_HASH SHA256=d475978da0cdc2d43b73f30910786759d593a9d8ee05b1b6846d1eb16c6d2e0c
 )
 FetchContent_MakeAvailable(pybind11)
 
-find_package(PythonExtensions REQUIRED)
+find_package(Python REQUIRED COMPONENTS Development.Module NumPy)
 find_package(Dpctl REQUIRED)
 
 find_library(mkl_core NAMES mkl_core PATHS ${MKL_LIBRARY_DIR} REQUIRED)

--- a/examples/pybind11/use_dpctl_sycl_kernel/CMakeLists.txt
+++ b/examples/pybind11/use_dpctl_sycl_kernel/CMakeLists.txt
@@ -1,6 +1,7 @@
-cmake_minimum_required(VERSION 3.21)
+cmake_minimum_required(VERSION 3.21...3.27 FATAL_ERROR)
 
-project(use_queue_device LANGUAGES CXX)
+project(use_queue_device VERSION 0.1 LANGUAGES CXX
+  DESCRIPTION "Example of using dpctl.program.SyclKernel <-> sycl::kernel type casting")
 
 set(DPCTL_CMAKE_MODULES_PATH "${CMAKE_SOURCE_DIR}/../../../cmake")
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${DPCTL_CMAKE_MODULES_PATH})
@@ -19,9 +20,8 @@ FetchContent_Declare(
 )
 FetchContent_MakeAvailable(pybind11)
 
-find_package(PythonExtensions REQUIRED)
+find_package(Python REQUIRED COMPONENTS Development.Module NumPy)
 find_package(Dpctl REQUIRED)
-find_package(NumPy REQUIRED)
 
 set(py_module_name _use_kernel)
 pybind11_add_module(${py_module_name}

--- a/examples/pybind11/use_dpctl_sycl_queue/CMakeLists.txt
+++ b/examples/pybind11/use_dpctl_sycl_queue/CMakeLists.txt
@@ -1,6 +1,7 @@
-cmake_minimum_required(VERSION 3.21)
+cmake_minimum_required(VERSION 3.21...3.27 FATAL_ERROR)
 
-project(use_queue_device LANGUAGES CXX)
+project(use_queue_device VERSION 0.1 LANGUAGES CXX
+  DESCRIPTION "Example of using dpctl.SyclQueue <-> sycl::queue type caster")
 
 set(DPCTL_CMAKE_MODULES_PATH "${CMAKE_SOURCE_DIR}/../../../cmake")
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${DPCTL_CMAKE_MODULES_PATH})
@@ -13,14 +14,13 @@ set(CMAKE_CXX_STANDARD_REQUIRED True)
 include(FetchContent)
 FetchContent_Declare(
   pybind11
-  URL https://github.com/pybind/pybind11/archive/refs/tags/v2.10.2.tar.gz
-  URL_HASH SHA256=93bd1e625e43e03028a3ea7389bba5d3f9f2596abc074b068e70f4ef9b1314ae
+  URL https://github.com/pybind/pybind11/archive/refs/tags/v2.11.1.tar.gz
+  URL_HASH SHA256=d475978da0cdc2d43b73f30910786759d593a9d8ee05b1b6846d1eb16c6d2e0c
 )
 FetchContent_MakeAvailable(pybind11)
 
-find_package(PythonExtensions REQUIRED)
+find_package(Python REQUIRED COMPONENTS Development.Module NumPy)
 find_package(Dpctl REQUIRED)
-find_package(NumPy REQUIRED)
 
 set(py_module_name _use_queue_device)
 pybind11_add_module(${py_module_name}

--- a/libsyclinterface/cmake/modules/GetProjectVersion.cmake
+++ b/libsyclinterface/cmake/modules/GetProjectVersion.cmake
@@ -29,7 +29,7 @@
 # VERSION_MINOR
 # VERSION
 # SEMVER
-cmake_minimum_required( VERSION 3.14.0 )
+cmake_minimum_required(VERSION 3.14...3.27 FATAL_ERROR )
 
 function(get_version)
     # Use git describe to get latest tag name


### PR DESCRIPTION
Use `cmake_minumum_required(VERSION min_version...policy_version FATAL_ERROR)`.

Also update from using `find_package(PythonExtensions)` to `find_package(Python COMPONENTS ...)`.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
