### PR TITLE
Dedicated kernels for in-place ``dpt.divide`` and ``dpt.floor_divide``

### DIFF
--- a/dpctl/tensor/_elementwise_funcs.py
+++ b/dpctl/tensor/_elementwise_funcs.py
@@ -590,6 +590,7 @@ divide = BinaryElementwiseFunc(
     ti._divide_result_type,
     ti._divide,
     _divide_docstring_,
+    binary_inplace_fn=ti._divide_inplace,
     acceptance_fn=_acceptance_fn_divide,
 )
 
@@ -720,6 +721,7 @@ floor_divide = BinaryElementwiseFunc(
     ti._floor_divide_result_type,
     ti._floor_divide,
     _floor_divide_docstring_,
+    binary_inplace_fn=ti._floor_divide_inplace,
 )
 
 # B11: ==== GREATER       (x1, x2)

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/true_divide.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/true_divide.hpp
@@ -392,6 +392,8 @@ template <typename argT, typename resT> struct TrueDivideInplaceFunctor
 };
 
 // cannot use the out of place table, as it permits real lhs and complex rhs
+// T1 corresponds to the type of the rhs, while T2 corresponds to the lhs
+// the type of the result must be the same as T2
 template <typename T1, typename T2> struct TrueDivideInplaceOutputType
 {
     using value_type = typename std::disjunction< // disjunction is C++17
@@ -433,6 +435,7 @@ struct TrueDivideInplaceTypeMapFactory
     std::enable_if_t<std::is_same<fnT, int>::value, int> get()
     {
         using rT = typename TrueDivideInplaceOutputType<T1, T2>::value_type;
+        static_assert(std::is_same_v<rT, T2> || std::is_same_v<rT, void>);
         return td_ns::GetTypeid<rT>{}.get();
     }
 };

--- a/dpctl/tests/elementwise/test_floor_divide.py
+++ b/dpctl/tests/elementwise/test_floor_divide.py
@@ -21,13 +21,19 @@ import pytest
 
 import dpctl
 import dpctl.tensor as dpt
+from dpctl.tensor._type_utils import _can_cast
 from dpctl.tests.helper import get_queue_or_skip, skip_if_dtype_not_supported
 
-from .utils import _compare_dtypes, _no_complex_dtypes, _usm_types
+from .utils import (
+    _compare_dtypes,
+    _integral_dtypes,
+    _no_complex_dtypes,
+    _usm_types,
+)
 
 
-@pytest.mark.parametrize("op1_dtype", _no_complex_dtypes)
-@pytest.mark.parametrize("op2_dtype", _no_complex_dtypes)
+@pytest.mark.parametrize("op1_dtype", _no_complex_dtypes[1:])
+@pytest.mark.parametrize("op2_dtype", _no_complex_dtypes[1:])
 def test_floor_divide_dtype_matrix(op1_dtype, op2_dtype):
     q = get_queue_or_skip()
     skip_if_dtype_not_supported(op1_dtype, q)
@@ -133,7 +139,7 @@ def test_floor_divide_broadcasting():
     assert (dpt.asnumpy(r2) == expected2.astype(r2.dtype)).all()
 
 
-@pytest.mark.parametrize("arr_dt", _no_complex_dtypes)
+@pytest.mark.parametrize("arr_dt", _no_complex_dtypes[1:])
 def test_floor_divide_python_scalar(arr_dt):
     q = get_queue_or_skip()
     skip_if_dtype_not_supported(arr_dt, q)
@@ -204,7 +210,7 @@ def test_floor_divide_gh_1247():
     )
 
 
-@pytest.mark.parametrize("dtype", _no_complex_dtypes[1:9])
+@pytest.mark.parametrize("dtype", _integral_dtypes)
 def test_floor_divide_integer_zero(dtype):
     q = get_queue_or_skip()
     skip_if_dtype_not_supported(dtype, q)
@@ -255,3 +261,59 @@ def test_floor_divide_special_cases():
     res = dpt.floor_divide(x, y)
     res_np = np.floor_divide(dpt.asnumpy(x), dpt.asnumpy(y))
     np.testing.assert_array_equal(dpt.asnumpy(res), res_np)
+
+
+@pytest.mark.parametrize("dtype", _no_complex_dtypes[1:])
+def test_divide_inplace_python_scalar(dtype):
+    q = get_queue_or_skip()
+    skip_if_dtype_not_supported(dtype, q)
+    X = dpt.zeros((10, 10), dtype=dtype, sycl_queue=q)
+    dt_kind = X.dtype.kind
+    if dt_kind in "ui":
+        X //= int(1)
+    elif dt_kind == "f":
+        X //= float(1)
+
+
+@pytest.mark.parametrize("op1_dtype", _no_complex_dtypes[1:])
+@pytest.mark.parametrize("op2_dtype", _no_complex_dtypes[1:])
+def test_floor_divide_inplace_dtype_matrix(op1_dtype, op2_dtype):
+    q = get_queue_or_skip()
+    skip_if_dtype_not_supported(op1_dtype, q)
+    skip_if_dtype_not_supported(op2_dtype, q)
+
+    sz = 127
+    ar1 = dpt.ones(sz, dtype=op1_dtype, sycl_queue=q)
+    ar2 = dpt.ones_like(ar1, dtype=op2_dtype, sycl_queue=q)
+
+    dev = q.sycl_device
+    _fp16 = dev.has_aspect_fp16
+    _fp64 = dev.has_aspect_fp64
+    # out array only valid if it is inexact
+    if _can_cast(ar2.dtype, ar1.dtype, _fp16, _fp64):
+        ar1 //= ar2
+        assert dpt.all(ar1 == 1)
+
+        ar3 = dpt.ones(sz, dtype=op1_dtype, sycl_queue=q)[::-1]
+        ar4 = dpt.ones(2 * sz, dtype=op2_dtype, sycl_queue=q)[::2]
+        ar3 //= ar4
+        assert dpt.all(ar3 == 1)
+    else:
+        with pytest.raises(TypeError):
+            ar1 //= ar2
+            dpt.floor_divide(ar1, ar2, out=ar1)
+
+    # out is second arg
+    ar1 = dpt.ones(sz, dtype=op1_dtype, sycl_queue=q)
+    ar2 = dpt.ones_like(ar1, dtype=op2_dtype, sycl_queue=q)
+    if _can_cast(ar1.dtype, ar2.dtype, _fp16, _fp64):
+        dpt.floor_divide(ar1, ar2, out=ar2)
+        assert dpt.all(ar2 == 1)
+
+        ar3 = dpt.ones(sz, dtype=op1_dtype, sycl_queue=q)[::-1]
+        ar4 = dpt.ones(2 * sz, dtype=op2_dtype, sycl_queue=q)[::2]
+        dpt.floor_divide(ar3, ar4, out=ar4)
+        dpt.all(ar4 == 1)
+    else:
+        with pytest.raises(TypeError):
+            dpt.floor_divide(ar1, ar2, out=ar2)


### PR DESCRIPTION
This pull request implements kernels for in-place division and floor division, i.e., ``dpt.divide(x, y, out=x)`` and ``dpt.floor_divide(x, y, out=x)``.

This avoids allocating an additional buffer for the output and copying back to the first operand.

- [X] Have you provided a meaningful PR description?
- [X] Have you added a test, reproducer or referred to an issue with a reproducer?
- [X] Have you tested your changes locally for CPU and GPU devices?
- [X] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
