### PR TITLE
Do not use wait and throw

### DIFF
--- a/dpctl/_sycl_context.pyx
+++ b/dpctl/_sycl_context.pyx
@@ -48,7 +48,6 @@ from ._backend cimport (  # noqa: E211
     error_handler_callback,
 )
 from ._sycl_device cimport SyclDevice
-from ._sycl_queue cimport default_async_error_handler
 from ._sycl_device import SyclDeviceCreationError
 
 __all__ = [
@@ -201,8 +200,7 @@ cdef class SyclContext(_SyclContext):
     cdef int _init_context_from_one_device(self, SyclDevice device, int props):
         cdef DPCTLSyclDeviceRef DRef = device.get_device_ref()
         cdef DPCTLSyclContextRef CRef = NULL
-        cdef error_handler_callback * eh_callback = (
-            <error_handler_callback *>&default_async_error_handler)
+        cdef error_handler_callback * eh_callback = NULL
         # look up cached contexts for root devices first
         CRef = DPCTLDeviceMgr_GetCachedContext(DRef)
         if (CRef is NULL):
@@ -219,8 +217,7 @@ cdef class SyclContext(_SyclContext):
         cdef int j = 0
         cdef size_t num_bytes
         cdef DPCTLDeviceVectorRef DVRef = NULL
-        cdef error_handler_callback * eh_callback = (
-            <error_handler_callback *>&default_async_error_handler)
+        cdef error_handler_callback * eh_callback = NULL
         cdef DPCTLSyclContextRef CRef = NULL
         cdef DPCTLSyclDeviceRef *elems
 

--- a/dpctl/_sycl_event.pyx
+++ b/dpctl/_sycl_event.pyx
@@ -218,7 +218,7 @@ cdef class SyclEvent(_SyclEvent):
 
     @staticmethod
     cdef void _wait(SyclEvent event):
-        with nogil: DPCTLEvent_WaitAndThrow(event._event_ref)
+        with nogil: DPCTLEvent_Wait(event._event_ref)
 
     @staticmethod
     def wait_for(event):

--- a/dpctl/_sycl_queue.pxd
+++ b/dpctl/_sycl_queue.pxd
@@ -29,8 +29,6 @@ from ._sycl_event cimport SyclEvent
 from .program._program cimport SyclKernel
 
 
-cdef void default_async_error_handler(int) except * nogil
-
 cdef public api class _SyclQueue [
     object Py_SyclQueueObject, type Py_SyclQueueType
 ]:

--- a/dpctl/_sycl_queue.pyx
+++ b/dpctl/_sycl_queue.pyx
@@ -56,7 +56,6 @@ from ._backend cimport (  # noqa: E211
     _arg_data_type,
     _backend_type,
     _queue_property_type,
-    error_handler_callback,
 )
 from .memory._memory cimport _Memory
 
@@ -112,18 +111,6 @@ cdef class SyclQueueCreationError(Exception):
 
     """
     pass
-
-
-cdef class SyclAsynchronousError(Exception):
-    """
-    A SyclAsynchronousError exception is raised when SYCL operation submission
-    or execution encounters an error.
-    """
-
-
-cdef void default_async_error_handler(int err) except * nogil:
-    with gil:
-        raise SyclAsynchronousError(err)
 
 
 cdef int _parse_queue_properties(object prop) except *:
@@ -404,7 +391,7 @@ cdef class SyclQueue(_SyclQueue):
         QRef = DPCTLQueue_Create(
             CRef,
             DRef,
-            <error_handler_callback *>&default_async_error_handler,
+            NULL,
             props
         )
         if QRef is NULL:
@@ -481,7 +468,7 @@ cdef class SyclQueue(_SyclQueue):
         QRef = DPCTLQueue_Create(
             CRef,
             DRef,
-            <error_handler_callback *>&default_async_error_handler,
+            NULL,
             props
         )
         if (QRef is NULL):
@@ -566,7 +553,7 @@ cdef class SyclQueue(_SyclQueue):
         qref = DPCTLQueue_Create(
             cref,
             dref,
-            <error_handler_callback *>&default_async_error_handler,
+            NULL,
             props
         )
         if qref is NULL:


### PR DESCRIPTION
This PR arises from improve upon behavior noted in gh-1434

- Static method `dpctl.SyclEvent.wait_for` now uses `DPCTLEvent_Wait` instead of `DPCTLEvent_WaitAndThrow`, aligning with `dpctl.SyclEvent.wait` and `dpctl.SyclQueue.wait` methods.
- `dpctl.SyclAsyncException` has been removed
- Constructor calls to `DPCTLQueue_Create` and `DPCTLContext_Create` now pass `NULL` function pointer for the async handler function
- The `dpctl._sycl_queue.default_async_handler` function has been removed.

---

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [x] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
