### PR TITLE
Require dpcpp compiler 2024.0 and runtime >=2024.0

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -1,3 +1,5 @@
+{% set required_compiler_version = "2024.0" %}
+
 package:
     name: dpctl
     version: {{ GIT_DESCRIBE_TAG }}
@@ -13,7 +15,7 @@ build:
 requirements:
     build:
         - {{ compiler('cxx') }}
-        - {{ compiler('dpcpp') }} >=2023.2  # [not osx]
+        - {{ compiler('dpcpp') }} >={{ required_compiler_version }}  # [not osx]
         - sysroot_linux-64 >=2.28  # [linux]
     host:
         - setuptools
@@ -28,7 +30,7 @@ requirements:
     run:
         - python
         - {{ pin_compatible('numpy', min_pin='x.x', upper_bound='1.26') }}
-        - dpcpp-cpp-rt >=2023.2
+        - dpcpp-cpp-rt >={{ required_compiler_version }}
         - level-zero  # [linux]
 
 test:


### PR DESCRIPTION
Require dpcpp compiler 2024.0 and runtime >=2024.0
Also introduced jinja variable to keep those two in sync.

This PR is opened with base being gold/2021, but will get merged into main branch once dpcpp 2024.0 is available on intel channel.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
