### PR TITLE
Require dpcpp compiler 2024.0 and runtime >=2024.0

### DIFF
--- a/.github/workflows/conda-package.yml
+++ b/.github/workflows/conda-package.yml
@@ -48,8 +48,9 @@ jobs:
           echo "WHEELS_OUTPUT_FOLDER=$GITHUB_WORKSPACE${{ runner.os == 'Linux' && '/' || '\\' }}" >> $GITHUB_ENV
       - name: Build conda package
         run: |
-          CHANNELS="-c intel/label/validation -c intel -c conda-forge --override-channels"
-          VERSIONS="--python ${{ matrix.python }}"
+          # use bootstrap channel to pull NumPy linked with OpenBLAS
+          CHANNELS="-c dppy/label/bootstrap -c intel/label/validation -c intel -c conda-forge --override-channels"
+          VERSIONS="--python ${{ matrix.python }} --numpy 1.23"
           TEST="--no-test"
           conda build \
             $TEST \

--- a/.github/workflows/conda-package.yml
+++ b/.github/workflows/conda-package.yml
@@ -393,36 +393,6 @@ jobs:
           ANACONDA_TOKEN: ${{ secrets.ANACONDA_TOKEN }}
         run: anaconda --token ${{ env.ANACONDA_TOKEN }} upload --user dppy --label dev ${{ env.PACKAGE_NAME }}-*.whl --version ${{ env.PACKAGE_VERSION }}
 
-  cleanup_packages:
-    name: Clean up anaconda packages
-    needs: [upload_linux, upload_windows]
-    runs-on: 'ubuntu-latest'
-    defaults:
-      run:
-        shell: bash -el {0}
-    steps:
-      - uses: conda-incubator/setup-miniconda@v2
-        with:
-          run-post: false
-          channel-priority: "disabled"
-          channels: conda-forge
-          python-version: '3.11'
-
-      - name: Install anaconda-client
-        run: conda install anaconda-client
-
-      - name: Checkout repo
-        uses: actions/checkout@v2
-        with:
-          repository: IntelPython/devops-tools
-          fetch-depth: 0
-
-      - name: Cleanup old packages
-        run: |
-          python scripts/cleanup-old-packages.py \
-          --verbose --force --token ${{ secrets.ANACONDA_TOKEN }} \
-          --package dppy/${{ env.PACKAGE_NAME }} --label dev
-
   test_examples_linux:
     needs: build_linux
     runs-on:  ${{ matrix.runner }}
@@ -700,3 +670,33 @@ jobs:
           allow-repeats: true
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           repo-token-user-login: 'github-actions[bot]'
+
+  cleanup_packages:
+    name: Clean up anaconda packages
+    needs: [upload_linux, upload_windows]
+    runs-on: 'ubuntu-latest'
+    defaults:
+      run:
+        shell: bash -el {0}
+    steps:
+      - uses: conda-incubator/setup-miniconda@v2
+        with:
+          run-post: false
+          channel-priority: "disabled"
+          channels: conda-forge
+          python-version: '3.11'
+
+      - name: Install anaconda-client
+        run: conda install anaconda-client
+
+      - name: Checkout repo
+        uses: actions/checkout@v3
+        with:
+          repository: IntelPython/devops-tools
+          fetch-depth: 0
+
+      - name: Cleanup old packages
+        run: |
+          python scripts/cleanup-old-packages.py \
+          --verbose --force --token ${{ secrets.ANACONDA_TOKEN }} \
+          --package dppy/${{ env.PACKAGE_NAME }} --label dev

--- a/.github/workflows/conda-package.yml
+++ b/.github/workflows/conda-package.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Build conda package
         run: |
           # use bootstrap channel to pull NumPy linked with OpenBLAS
-          CHANNELS="-c dppy/label/bootstrap -c intel/label/validation -c intel -c conda-forge --override-channels"
+          CHANNELS="-c dppy/label/bootstrap -c intel -c conda-forge --override-channels"
           VERSIONS="--python ${{ matrix.python }} --numpy 1.23"
           TEST="--no-test"
           conda build \
@@ -105,7 +105,7 @@ jobs:
       - name: Build conda package
         env:
           OVERRIDE_INTEL_IPO: 1   # IPO requires more resources that GH actions VM provides
-        run: conda build --no-test --python ${{ matrix.python }} -c intel/label/validation -c intel  -c conda-forge --override-channels conda-recipe
+        run: conda build --no-test --python ${{ matrix.python }} -c intel  -c conda-forge --override-channels conda-recipe
       - name: Upload artifact
         uses: actions/upload-artifact@v3
         with:
@@ -128,7 +128,7 @@ jobs:
         runner: [ubuntu-20.04]
     continue-on-error: ${{ matrix.experimental }}
     env:
-      CHANNELS: -c intel/label/validation -c intel -c conda-forge --override-channels
+      CHANNELS: -c intel -c conda-forge --override-channels
 
     steps:
       - name: Download artifact
@@ -213,7 +213,7 @@ jobs:
     continue-on-error: ${{ matrix.experimental }}
     env:
       workdir: '${{ github.workspace }}'
-      CHANNELS: -c intel/label/validation -c intel -c conda-forge --override-channels
+      CHANNELS: -c intel -c conda-forge --override-channels
 
     steps:
       - name: Download artifact
@@ -272,7 +272,7 @@ jobs:
             ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}-
       - name: Install opencl_rt
         shell: cmd /C CALL {0}
-        run: conda install -n dpctl_test opencl_rt -c intel/label/validation -c intel --override-channels
+        run: conda install -n dpctl_test opencl_rt -c intel --override-channels
       - name: Install dpctl
         shell: cmd /C CALL {0}
         run: |
@@ -403,7 +403,7 @@ jobs:
         runner: [ubuntu-20.04]
     continue-on-error: ${{ matrix.experimental }}
     env:
-      CHANNELS: -c intel/label/validation -c intel -c conda-forge --override-channels
+      CHANNELS: -c intel -c conda-forge --override-channels
 
     steps:
       - name: Install conda-build
@@ -461,7 +461,7 @@ jobs:
         shell: bash -l {0}
         run: |
           source $CONDA/etc/profile.d/conda.sh
-          CHANNELS="-c $GITHUB_WORKSPACE/channel -c dppy/label/dev -c intel/label/validation -c intel -c conda-forge --override-channels"
+          CHANNELS="-c $GITHUB_WORKSPACE/channel -c dppy/label/dev -c intel -c conda-forge --override-channels"
           export PACKAGE_VERSION=$(python -c "${VER_SCRIPT1} ${VER_SCRIPT2}")
           conda install -n examples -y ${CHANNELS} dpctl=${PACKAGE_VERSION} dpnp">=0.10.1" || exit 1
       - name: Build and run examples of pybind11 extensions
@@ -546,7 +546,7 @@ jobs:
         runner: [ubuntu-20.04]
     continue-on-error: ${{ matrix.experimental }}
     env:
-      CHANNELS: -c intel/label/validation -c intel -c conda-forge --override-channels
+      CHANNELS: -c intel -c conda-forge --override-channels
     steps:
       - name: Cache array API tests
         id: cache-array-api-tests

--- a/.github/workflows/conda-package.yml
+++ b/.github/workflows/conda-package.yml
@@ -48,7 +48,7 @@ jobs:
           echo "WHEELS_OUTPUT_FOLDER=$GITHUB_WORKSPACE${{ runner.os == 'Linux' && '/' || '\\' }}" >> $GITHUB_ENV
       - name: Build conda package
         run: |
-          CHANNELS="-c intel -c conda-forge --override-channels"
+          CHANNELS="-c intel/label/validation -c intel -c conda-forge --override-channels"
           VERSIONS="--python ${{ matrix.python }}"
           TEST="--no-test"
           conda build \
@@ -104,7 +104,7 @@ jobs:
       - name: Build conda package
         env:
           OVERRIDE_INTEL_IPO: 1   # IPO requires more resources that GH actions VM provides
-        run: conda build --no-test --python ${{ matrix.python }} -c intel -c conda-forge --override-channels conda-recipe
+        run: conda build --no-test --python ${{ matrix.python }} -c intel/label/validation -c intel  -c conda-forge --override-channels conda-recipe
       - name: Upload artifact
         uses: actions/upload-artifact@v3
         with:
@@ -127,7 +127,7 @@ jobs:
         runner: [ubuntu-20.04]
     continue-on-error: ${{ matrix.experimental }}
     env:
-      CHANNELS: -c intel -c conda-forge --override-channels
+      CHANNELS: -c intel/label/validation -c intel -c conda-forge --override-channels
 
     steps:
       - name: Download artifact
@@ -212,7 +212,7 @@ jobs:
     continue-on-error: ${{ matrix.experimental }}
     env:
       workdir: '${{ github.workspace }}'
-      CHANNELS: -c intel -c conda-forge --override-channels
+      CHANNELS: -c intel/label/validation -c intel -c conda-forge --override-channels
 
     steps:
       - name: Download artifact
@@ -271,7 +271,7 @@ jobs:
             ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}-
       - name: Install opencl_rt
         shell: cmd /C CALL {0}
-        run: conda install -n dpctl_test opencl_rt -c intel --override-channels
+        run: conda install -n dpctl_test opencl_rt -c intel/label/validation -c intel --override-channels
       - name: Install dpctl
         shell: cmd /C CALL {0}
         run: |
@@ -432,7 +432,7 @@ jobs:
         runner: [ubuntu-20.04]
     continue-on-error: ${{ matrix.experimental }}
     env:
-      CHANNELS: -c intel -c conda-forge --override-channels
+      CHANNELS: -c intel/label/validation -c intel -c conda-forge --override-channels
 
     steps:
       - name: Install conda-build
@@ -490,7 +490,7 @@ jobs:
         shell: bash -l {0}
         run: |
           source $CONDA/etc/profile.d/conda.sh
-          CHANNELS="-c $GITHUB_WORKSPACE/channel -c dppy/label/dev -c intel -c conda-forge --override-channels"
+          CHANNELS="-c $GITHUB_WORKSPACE/channel -c dppy/label/dev -c intel/label/validation -c intel -c conda-forge --override-channels"
           export PACKAGE_VERSION=$(python -c "${VER_SCRIPT1} ${VER_SCRIPT2}")
           conda install -n examples -y ${CHANNELS} dpctl=${PACKAGE_VERSION} dpnp">=0.10.1" || exit 1
       - name: Build and run examples of pybind11 extensions
@@ -575,7 +575,7 @@ jobs:
         runner: [ubuntu-20.04]
     continue-on-error: ${{ matrix.experimental }}
     env:
-      CHANNELS: -c intel -c conda-forge --override-channels
+      CHANNELS: -c intel/label/validation -c intel -c conda-forge --override-channels
     steps:
       - name: Cache array API tests
         id: cache-array-api-tests

--- a/.github/workflows/generate-coverage.yaml
+++ b/.github/workflows/generate-coverage.yaml
@@ -90,19 +90,7 @@ jobs:
         run: |
           pip install numpy"<1.26.0" cython setuptools pytest pytest-cov scikit-build cmake coverage[toml]
 
-      - name: Build dpctl with coverage for oneAPI 2023
-        if: env.USE_2023 == '1'
-        shell: bash -l {0}
-        run: |
-          source /opt/intel/oneapi/setvars.sh
-          export ARGS="--not-oneapi --compiler-root ${CMPLR_ROOT}"
-          export ARGS="${ARGS} --c-compiler ${CMPLR_ROOT}/linux/bin/icx"
-          export ARGS="${ARGS} --cxx-compiler ${CMPLR_ROOT}/linux/bin/icpx"
-          export ARGS="${ARGS} --bin-llvm ${CMPLR_ROOT}/linux/bin-llvm"
-          python scripts/gen_coverage.py ${ARGS}
-
-      - name: Build dpctl with coverage for default oneAPI
-        if: env.USE_2023 != '1'
+      - name: Build dpctl with coverage
         shell: bash -l {0}
         run: |
           source /opt/intel/oneapi/setvars.sh

--- a/.github/workflows/generate-coverage.yaml
+++ b/.github/workflows/generate-coverage.yaml
@@ -12,6 +12,8 @@ jobs:
     env:
       ONEAPI_ROOT: /opt/intel/oneapi
       GTEST_ROOT: /home/runner/work/googletest-1.13.0/install
+      # Use oneAPI compiler 2023 to work around an issue
+      USE_2023: 1
 
     steps:
       - name: Cancel Previous Runs
@@ -27,10 +29,17 @@ jobs:
           sudo add-apt-repository "deb https://apt.repos.intel.com/oneapi all main"
           sudo apt-get update
 
-      - name: Install Intel OneAPI
+      - name: Install Intel OneAPI 2023
+        if: env.USE_2023 == '1'
         run: |
           sudo apt-get install intel-oneapi-compiler-dpcpp-cpp-2023.2.1
           sudo apt-get install intel-oneapi-tbb-2021.10.0
+
+      - name: Install latest Intel OneAPI
+        if: env.USE_2023 != '1'
+        run: |
+          sudo apt-get install intel-oneapi-compiler-dpcpp-cpp
+          sudo apt-get install intel-oneapi-tbb
 
       - name: Install CMake and Ninja
         run: |
@@ -81,7 +90,19 @@ jobs:
         run: |
           pip install numpy"<1.26.0" cython setuptools pytest pytest-cov scikit-build cmake coverage[toml]
 
-      - name: Build dpctl with coverage
+      - name: Build dpctl with coverage for oneAPI 2023
+        if: env.USE_2023 == '1'
+        shell: bash -l {0}
+        run: |
+          source /opt/intel/oneapi/setvars.sh
+          export ARGS="--not-oneapi --compiler-root ${CMPLR_ROOT}"
+          export ARGS="${ARGS} --c-compiler ${CMPLR_ROOT}/linux/bin/icx"
+          export ARGS="${ARGS} --cxx-compiler ${CMPLR_ROOT}/linux/bin/icpx"
+          export ARGS="${ARGS} --bin-llvm ${CMPLR_ROOT}/linux/bin-llvm"
+          python scripts/gen_coverage.py ${ARGS}
+
+      - name: Build dpctl with coverage for default oneAPI
+        if: env.USE_2023 != '1'
         shell: bash -l {0}
         run: |
           source /opt/intel/oneapi/setvars.sh

--- a/.github/workflows/generate-coverage.yaml
+++ b/.github/workflows/generate-coverage.yaml
@@ -29,8 +29,8 @@ jobs:
 
       - name: Install Intel OneAPI
         run: |
-          sudo apt-get install intel-oneapi-compiler-dpcpp-cpp
-          sudo apt-get install intel-oneapi-tbb
+          sudo apt-get install intel-oneapi-compiler-dpcpp-cpp-2023.2.1
+          sudo apt-get install intel-oneapi-tbb-2021.10.0
 
       - name: Install CMake and Ninja
         run: |

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -1,3 +1,5 @@
+{% set required_compiler_version = "2024.0" %}
+
 package:
     name: dpctl
     version: {{ GIT_DESCRIBE_TAG }}
@@ -14,7 +16,7 @@ build:
 requirements:
     build:
         - {{ compiler('cxx') }}
-        - {{ compiler('dpcpp') }} >=2023.2  # [not osx]
+        - {{ compiler('dpcpp') }} >={{ required_compiler_version }}  # [not osx]
         - sysroot_linux-64 >=2.28  # [linux]
     host:
         - setuptools
@@ -29,7 +31,7 @@ requirements:
     run:
         - python
         - {{ pin_compatible('numpy', min_pin='x.x', upper_bound='1.26') }}
-        - dpcpp-cpp-rt >=2023.2
+        - dpcpp-cpp-rt >={{ required_compiler_version }}
         - level-zero  # [linux]
 
 test:

--- a/scripts/gen_coverage.py
+++ b/scripts/gen_coverage.py
@@ -195,8 +195,8 @@ if __name__ == "__main__":
         args.cxx_compiler = "icpx"
         args.compiler_root = None
         icx_path = subprocess.check_output(["which", "icx"])
-        bin_dir = os.path.dirname(os.path.dirname(icx_path))
-        args.bin_llvm = os.path.join(bin_dir.decode("utf-8"), "bin-llvm")
+        bin_dir = os.path.dirname(icx_path)
+        args.bin_llvm = os.path.join(bin_dir.decode("utf-8"), "compiler")
     else:
         args_to_validate = [
             "c_compiler",

--- a/scripts/gen_coverage.py
+++ b/scripts/gen_coverage.py
@@ -196,7 +196,13 @@ if __name__ == "__main__":
         args.compiler_root = None
         icx_path = subprocess.check_output(["which", "icx"])
         bin_dir = os.path.dirname(icx_path)
-        args.bin_llvm = os.path.join(bin_dir.decode("utf-8"), "compiler")
+        compiler_dir = os.path.join(bin_dir.decode("utf-8"), "compiler")
+        if os.path.exists(compiler_dir):
+            args.bin_llvm = os.path.join(bin_dir.decode("utf-8"), "compiler")
+        else:
+            bin_dir = os.path.dirname(bin_dir)
+            args.bin_llvm = os.path.join(bin_dir.decode("utf-8"), "bin-llvm")
+        assert os.path.exists(args.bin_llvm)
     else:
         args_to_validate = [
             "c_compiler",

--- a/scripts/gen_docs.py
+++ b/scripts/gen_docs.py
@@ -134,8 +134,8 @@ if __name__ == "__main__":
         args.cxx_compiler = "icpx"
         args.compiler_root = None
         icx_path = subprocess.check_output(["which", "icx"])
-        bin_dir = os.path.dirname(os.path.dirname(icx_path))
-        args.bin_llvm = os.path.join(bin_dir.decode("utf-8"), "bin-llvm")
+        bin_dir = os.path.dirname(icx_path)
+        args.bin_llvm = os.path.join(bin_dir.decode("utf-8"), "compiler")
     else:
         args_to_validate = [
             "c_compiler",


### PR DESCRIPTION
Require dpcpp compiler 2024.0 and runtime >=2024.0

Also introduced jinja variable to keep those two in sync.

This is to be merged once DPC++=2024.0.0 compiler conda packages become available and we are ready to make the transition.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
