### PR TITLE
Skip tests for complex types for functions known to fail on Windows

### DIFF
--- a/dpctl/tests/elementwise/test_hyperbolic.py
+++ b/dpctl/tests/elementwise/test_hyperbolic.py
@@ -15,6 +15,7 @@
 #  limitations under the License.
 
 import itertools
+import platform
 
 import numpy as np
 import pytest
@@ -40,6 +41,15 @@ _dpt_funcs = [t[1] for t in _all_funcs]
 def test_hyper_out_type(np_call, dpt_call, dtype):
     q = get_queue_or_skip()
     skip_if_dtype_not_supported(dtype, q)
+
+    dtype = dpt.dtype(dtype)
+    if platform.system() == "Windows" and dpt.isdtype(
+        dtype, "complex floating"
+    ):
+        pytest.skip(
+            "Elementwise functions are known to be broken for "
+            "complex types on Windows"
+        )
 
     a = 1 if np_call == np.arccosh else 0
 
@@ -92,6 +102,12 @@ def test_hyper_real_contig(np_call, dpt_call, dtype):
 def test_hyper_complex_contig(np_call, dpt_call, dtype):
     q = get_queue_or_skip()
     skip_if_dtype_not_supported(dtype, q)
+
+    if platform.system() == "Windows":
+        pytest.skip(
+            "Elementwise functions are known to be broken for "
+            "complex types on Windows"
+        )
 
     n_seq = 100
     n_rep = 137
@@ -150,6 +166,15 @@ def test_hyper_usm_type(np_call, dpt_call, usm_type):
 def test_hyper_order(np_call, dpt_call, dtype):
     q = get_queue_or_skip()
     skip_if_dtype_not_supported(dtype, q)
+
+    dtype = dpt.dtype(dtype)
+    if platform.system() == "Windows" and dpt.isdtype(
+        dtype, "complex floating"
+    ):
+        pytest.skip(
+            "Elementwise functions are known to be broken for "
+            "complex types on Windows"
+        )
 
     arg_dt = np.dtype(dtype)
     input_shape = (4, 4, 4, 4)
@@ -229,6 +254,12 @@ def test_hyper_real_strided(np_call, dpt_call, dtype):
 def test_hyper_complex_strided(np_call, dpt_call, dtype):
     q = get_queue_or_skip()
     skip_if_dtype_not_supported(dtype, q)
+
+    if platform.system() == "Windows":
+        pytest.skip(
+            "Elementwise functions are known to be broken for "
+            "complex types on Windows"
+        )
 
     np.random.seed(42)
     strides = np.array([-4, -3, -2, -1, 1, 2, 3, 4])

--- a/dpctl/tests/elementwise/test_sign.py
+++ b/dpctl/tests/elementwise/test_sign.py
@@ -15,6 +15,7 @@
 #  limitations under the License.
 
 import itertools
+import platform
 
 import numpy as np
 import pytest
@@ -29,6 +30,15 @@ from .utils import _all_dtypes, _no_complex_dtypes, _usm_types
 def test_sign_out_type(dtype):
     q = get_queue_or_skip()
     skip_if_dtype_not_supported(dtype, q)
+
+    dtype = dpt.dtype(dtype)
+    if platform.system() == "Windows" and dpt.isdtype(
+        dtype, "complex floating"
+    ):
+        pytest.skip(
+            "Elementwise functions are known to be broken for "
+            "complex types on Windows"
+        )
 
     arg_dt = np.dtype(dtype)
     X = dpt.asarray(0, dtype=arg_dt, sycl_queue=q)
@@ -64,6 +74,14 @@ def test_sign_order(dtype):
     skip_if_dtype_not_supported(dtype, q)
 
     arg_dt = np.dtype(dtype)
+    if platform.system() == "Windows" and dpt.isdtype(
+        arg_dt, "complex floating"
+    ):
+        pytest.skip(
+            "Elementwise functions are known to be broken for "
+            "complex types on Windows"
+        )
+
     input_shape = (10, 10, 10, 10)
     X = dpt.empty(input_shape, dtype=arg_dt, sycl_queue=q)
     X[..., 0::2] = 1
@@ -85,6 +103,14 @@ def test_sign_complex(dtype):
     skip_if_dtype_not_supported(dtype, q)
 
     arg_dt = np.dtype(dtype)
+    if platform.system() == "Windows" and dpt.isdtype(
+        arg_dt, "complex floating"
+    ):
+        pytest.skip(
+            "Elementwise functions are known to be broken for "
+            "complex types on Windows"
+        )
+
     input_shape = (10, 10, 10, 10)
     X = dpt.empty(input_shape, dtype=arg_dt, sycl_queue=q)
     Xnp = np.random.standard_normal(

--- a/dpctl/tests/elementwise/test_trigonometric.py
+++ b/dpctl/tests/elementwise/test_trigonometric.py
@@ -15,6 +15,7 @@
 #  limitations under the License.
 
 import itertools
+import platform
 
 import numpy as np
 import pytest
@@ -40,6 +41,15 @@ _dpt_funcs = [t[1] for t in _all_funcs]
 def test_trig_out_type(np_call, dpt_call, dtype):
     q = get_queue_or_skip()
     skip_if_dtype_not_supported(dtype, q)
+
+    dtype = dpt.dtype(dtype)
+    if platform.system() == "Windows" and dpt.isdtype(
+        dtype, "complex floating"
+    ):
+        pytest.skip(
+            "Elementwise functions are known to be broken for "
+            "complex types on Windows"
+        )
 
     X = dpt.asarray(0, dtype=dtype, sycl_queue=q)
     expected_dtype = np_call(np.array(0, dtype=dtype)).dtype
@@ -92,6 +102,15 @@ def test_trig_real_contig(np_call, dpt_call, dtype):
 def test_trig_complex_contig(np_call, dpt_call, dtype):
     q = get_queue_or_skip()
     skip_if_dtype_not_supported(dtype, q)
+
+    dtype = dpt.dtype(dtype)
+    if platform.system() == "Windows" and dpt.isdtype(
+        dtype, "complex floating"
+    ):
+        pytest.skip(
+            "Elementwise functions are known to be broken for "
+            "complex types on Windows"
+        )
 
     n_seq = 100
     n_rep = 137
@@ -150,6 +169,14 @@ def test_trig_order(np_call, dpt_call, dtype):
     skip_if_dtype_not_supported(dtype, q)
 
     arg_dt = np.dtype(dtype)
+    if platform.system() == "Windows" and dpt.isdtype(
+        arg_dt, "complex floating"
+    ):
+        pytest.skip(
+            "Elementwise functions are known to be broken for "
+            "complex types on Windows"
+        )
+
     input_shape = (4, 4, 4, 4)
     X = dpt.empty(input_shape, dtype=arg_dt, sycl_queue=q)
     if np_call in _trig_funcs:
@@ -226,6 +253,12 @@ def test_trig_real_strided(np_call, dpt_call, dtype):
 def test_trig_complex_strided(np_call, dpt_call, dtype):
     q = get_queue_or_skip()
     skip_if_dtype_not_supported(dtype, q)
+
+    if platform.system() == "Windows":
+        pytest.skip(
+            "Elementwise functions are known to be broken for "
+            "complex types on Windows"
+        )
 
     np.random.seed(42)
     strides = np.array([-4, -3, -2, -1, 1, 2, 3, 4])


### PR DESCRIPTION
This PR skips elementwise tests in dpctl on Windows for complex types due to known issues to be addressed after 2024 has been released.

The PR targets gold/2021 only.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
