### PR TITLE
Tweaked test_intel_device_info

### DIFF
--- a/dpctl/tests/test_utils.py
+++ b/dpctl/tests/test_utils.py
@@ -21,7 +21,6 @@ import pytest
 
 import dpctl
 import dpctl.utils
-from dpctl.enum_types import backend_type
 
 
 def test_get_execution_queue_input_validation():
@@ -132,9 +131,7 @@ def test_intel_device_info():
         pytest.skip("Default device could not be created")
     descr = dpctl.utils.intel_device_info(d)
     assert isinstance(descr, dict)
-    assert ("device_id" in descr) or (
-        not d.has_aspect_cpu and not d.backend == backend_type.level_zero
-    )
+    assert ("device_id" in descr) or not descr
     allowed_names = [
         "device_id",
         "gpu_slices",


### PR DESCRIPTION
Tweaked `test_intel_device_info` to allow for empty returned dictionary for some CPUs, like in virtual machines in public CI (see syclos build [log](https://github.com/IntelPython/dpctl/actions/runs/6529939196/job/17728364009) of gh-1443).

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
