### PR TITLE
Use partition_type_property descriptor in DPCTLDevice_GetParentDevice

### DIFF
--- a/libsyclinterface/source/dpctl_sycl_device_interface.cpp
+++ b/libsyclinterface/source/dpctl_sycl_device_interface.cpp
@@ -543,6 +543,18 @@ DPCTLDevice_GetParentDevice(__dpctl_keep const DPCTLSyclDeviceRef DRef)
 {
     auto D = unwrap<device>(DRef);
     if (D) {
+        bool is_unpartitioned = false;
+        try {
+            auto pp =
+                D->get_info<sycl::info::device::partition_type_property>();
+            is_unpartitioned =
+                (pp == sycl::info::partition_property::no_partition);
+        } catch (std::exception const &e) {
+            error_handler(e, __FILE__, __func__, __LINE__);
+            return nullptr;
+        }
+        if (is_unpartitioned)
+            return nullptr;
         try {
             const auto &parent_D = D->get_info<info::device::parent_device>();
             return wrap<device>(new device(parent_D));


### PR DESCRIPTION
Use `partition_type_property` descriptor in `DPCTLDevice_GetParentDevice`.

This allows to test that the device is an unpartitioned device without raising and handling the C++ exception.

If `info::device::partition_type_property` is `info::partition_property::no_partition` then retrieving 
the `parent_device` descriptor will throw.

This change reduces the clutter of expected [ERR] messages in `DPCTL_VERBOSITY=error` mode.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
