### PR TITLE
Improve raised TypeError by providing exception message

### DIFF
--- a/dpctl/tensor/_copy_utils.py
+++ b/dpctl/tensor/_copy_utils.py
@@ -37,7 +37,7 @@ int32_t_max = 2147483648
 
 def _copy_to_numpy(ary):
     if not isinstance(ary, dpt.usm_ndarray):
-        raise TypeError
+        raise TypeError(f"Expected dpctl.tensor.usm_ndarray, got {type(ary)}")
     nb = ary.usm_data.nbytes
     hh = dpm.MemoryUSMHost(nb, queue=ary.sycl_queue)
     hh.copy_from_device(ary.usm_data)


### PR DESCRIPTION
Closes gh-1457

```

In [1]: import dpctl.tensor as dpt

In [2]: dpt.asnumpy([1,2,3])
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
Cell In[2], line 1
----> 1 dpt.asnumpy([1,2,3])

File ~/repos/dpctl/dpctl/tensor/_copy_utils.py:185, in asnumpy(usm_ary)
    169 def asnumpy(usm_ary):
    170     """
    171     asnumpy(usm_ary)
    172
   (...)
    183             of `usm_ary`
    184     """
--> 185     return _copy_to_numpy(usm_ary)

File ~/repos/dpctl/dpctl/tensor/_copy_utils.py:40, in _copy_to_numpy(ary)
     38 def _copy_to_numpy(ary):
     39     if not isinstance(ary, dpt.usm_ndarray):
---> 40         raise TypeError(
     41             f"Expected dpctl.tensor.usm_ndarray, got {type(ary)}"
     42         )
     43     nb = ary.usm_data.nbytes
     44     hh = dpm.MemoryUSMHost(nb, queue=ary.sycl_queue)

TypeError: Expected dpctl.tensor.usm_ndarray, got <class 'list'>

In [3]: quit
```

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
