### PR TITLE
Fix for gh-1468 in arithmetic reduction when type promotion is needed

### DIFF
--- a/dpctl/tensor/_reduction.py
+++ b/dpctl/tensor/_reduction.py
@@ -445,7 +445,7 @@ def _comparison_over_axis(x, axis, keepdims, _reduction_fn):
 
 
 def max(x, axis=None, keepdims=False):
-    """max(x, axis=None, dtype=None, keepdims=False)
+    """max(x, axis=None, keepdims=False)
 
     Calculates the maximum value of the input array `x`.
 
@@ -473,7 +473,7 @@ def max(x, axis=None, keepdims=False):
 
 
 def min(x, axis=None, keepdims=False):
-    """min(x, axis=None, dtype=None, keepdims=False)
+    """min(x, axis=None, keepdims=False)
 
     Calculates the minimum value of the input array `x`.
 
@@ -550,7 +550,7 @@ def _search_over_axis(x, axis, keepdims, _reduction_fn):
 
 
 def argmax(x, axis=None, keepdims=False):
-    """argmax(x, axis=None, dtype=None, keepdims=False)
+    """argmax(x, axis=None, keepdims=False)
 
     Returns the indices of the maximum values of the input array `x` along a
     specified axis.
@@ -582,7 +582,7 @@ def argmax(x, axis=None, keepdims=False):
 
 
 def argmin(x, axis=None, keepdims=False):
-    """argmin(x, axis=None, dtype=None, keepdims=False)
+    """argmin(x, axis=None, keepdims=False)
 
     Returns the indices of the minimum values of the input array `x` along a
     specified axis.

--- a/dpctl/tensor/_reduction.py
+++ b/dpctl/tensor/_reduction.py
@@ -114,15 +114,12 @@ def _reduction_over_axis(
                 res_shape = res_shape + (1,) * red_nd
                 inv_perm = sorted(range(nd), key=lambda d: perm[d])
                 res_shape = tuple(res_shape[i] for i in inv_perm)
-            return dpt.astype(
-                dpt.full(
-                    res_shape,
-                    _identity,
-                    dtype=dtype,
-                    usm_type=res_usm_type,
-                    sycl_queue=q,
-                ),
-                res_dt,
+            return dpt.full(
+                res_shape,
+                _identity,
+                dtype=res_dt,
+                usm_type=res_usm_type,
+                sycl_queue=q,
             )
     if red_nd == 0:
         return dpt.astype(x, res_dt, copy=False)

--- a/dpctl/tests/test_tensor_sum.py
+++ b/dpctl/tests/test_tensor_sum.py
@@ -329,3 +329,12 @@ def test_prod_arg_out_dtype_matrix(arg_dtype, out_dtype):
     assert isinstance(r, dpt.usm_ndarray)
     assert r.dtype == dpt.dtype(out_dtype)
     assert dpt.all(r == 1)
+
+
+def test_gh_1468():
+    "See https://github.com/IntelPython/dpctl/issues/1468"
+    get_queue_or_skip()
+
+    a = dpt.full((2, 3, 4), 123456789, dtype=dpt.int32)
+    t = dpt.sum(a, dtype="f4")
+    assert t > 0


### PR DESCRIPTION
Closes gh-1468

This PR changes `_reduce_over_axis` when an implementation to reduce using requested `dtype` for given input type does not exist. The change casts input array into a temporary array of requested `dtype` and calls reduction on the temporary (silent assumption that implementation to reduce input array using the same input dtype is available).

- [x] Have you provided a meaningful PR description?
- [x] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
