### PR TITLE
Fixed dpctl.tensor.result_type function for scalars

### DIFF
--- a/dpctl/tensor/_clip.py
+++ b/dpctl/tensor/_clip.py
@@ -24,20 +24,23 @@ from dpctl.tensor._copy_utils import (
     _empty_like_triple_orderK,
 )
 from dpctl.tensor._elementwise_common import (
-    WeakBooleanType,
-    WeakComplexType,
-    WeakFloatingType,
-    WeakIntegralType,
     _get_dtype,
     _get_queue_usm_type,
     _get_shape,
-    _strong_dtype_num_kind,
     _validate_dtype,
-    _weak_type_num_kind,
 )
 from dpctl.tensor._manipulation_functions import _broadcast_shape_impl
 from dpctl.tensor._type_utils import _can_cast, _to_device_supported_dtype
 from dpctl.utils import ExecutionPlacementError
+
+from ._type_utils import (
+    WeakBooleanType,
+    WeakComplexType,
+    WeakFloatingType,
+    WeakIntegralType,
+    _strong_dtype_num_kind,
+    _weak_type_num_kind,
+)
 
 
 def _resolve_one_strong_two_weak_types(st_dtype, dtype1, dtype2, dev):

--- a/dpctl/tests/test_usm_ndarray_manipulation.py
+++ b/dpctl/tests/test_usm_ndarray_manipulation.py
@@ -945,6 +945,11 @@ def test_result_type():
 
     assert dpt.result_type(*X) == np.result_type(*X_np)
 
+    X = [dpt.int32, "int64", 2]
+    X_np = [np.int32, "int64", 2]
+
+    assert dpt.result_type(*X) == np.result_type(*X_np)
+
 
 def test_swapaxes_1d():
     get_queue_or_skip()

--- a/dpctl/tests/test_usm_ndarray_manipulation.py
+++ b/dpctl/tests/test_usm_ndarray_manipulation.py
@@ -940,6 +940,11 @@ def test_result_type():
 
     assert dpt.result_type(*X) == np.result_type(*X_np)
 
+    X = [dpt.ones((2), dtype=dpt.int16, sycl_queue=q), dpt.int32, "int64", 2]
+    X_np = [np.ones((2), dtype=np.int16), np.int32, "int64", 2]
+
+    assert dpt.result_type(*X) == np.result_type(*X_np)
+
 
 def test_swapaxes_1d():
     get_queue_or_skip()

--- a/dpctl/tests/test_usm_ndarray_manipulation.py
+++ b/dpctl/tests/test_usm_ndarray_manipulation.py
@@ -935,13 +935,21 @@ def test_can_cast():
 def test_result_type():
     q = get_queue_or_skip()
 
-    X = [dpt.ones((2), dtype=dpt.int16, sycl_queue=q), dpt.int32, "int64"]
-    X_np = [np.ones((2), dtype=np.int16), np.int32, "int64"]
+    usm_ar = dpt.ones((2), dtype=dpt.int16, sycl_queue=q)
+    np_ar = dpt.asnumpy(usm_ar)
+
+    X = [usm_ar, dpt.int32, "int64", usm_ar]
+    X_np = [np_ar, np.int32, "int64", np_ar]
 
     assert dpt.result_type(*X) == np.result_type(*X_np)
 
-    X = [dpt.ones((2), dtype=dpt.int16, sycl_queue=q), dpt.int32, "int64", 2]
-    X_np = [np.ones((2), dtype=np.int16), np.int32, "int64", 2]
+    X = [usm_ar, dpt.int32, "int64", True]
+    X_np = [np_ar, np.int32, "int64", True]
+
+    assert dpt.result_type(*X) == np.result_type(*X_np)
+
+    X = [usm_ar, dpt.int32, "int64", 2]
+    X_np = [np_ar, np.int32, "int64", 2]
 
     assert dpt.result_type(*X) == np.result_type(*X_np)
 
@@ -949,6 +957,16 @@ def test_result_type():
     X_np = [np.int32, "int64", 2]
 
     assert dpt.result_type(*X) == np.result_type(*X_np)
+
+    X = [usm_ar, dpt.int32, "int64", 2.0]
+    X_np = [np_ar, np.int32, "int64", 2.0]
+
+    assert dpt.result_type(*X).kind == np.result_type(*X_np).kind
+
+    X = [usm_ar, dpt.int32, "int64", 2.0 + 1j]
+    X_np = [np_ar, np.int32, "int64", 2.0 + 1j]
+
+    assert dpt.result_type(*X).kind == np.result_type(*X_np).kind
 
 
 def test_swapaxes_1d():


### PR DESCRIPTION
Added support for weak scalars data type.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
