### PR TITLE
Adds `nin` and `nout` properties to unary and binary element-wise classes

### DIFF
--- a/dpctl/tensor/_elementwise_common.py
+++ b/dpctl/tensor/_elementwise_common.py
@@ -94,6 +94,20 @@ class UnaryElementwiseFunc:
         return self.result_type_resolver_fn_
 
     @property
+    def nin(self):
+        """
+        Returns the number of arguments treated as inputs.
+        """
+        return 1
+
+    @property
+    def nout(self):
+        """
+        Returns the number of arguments treated as outputs.
+        """
+        return 1
+
+    @property
     def types(self):
         """Returns information about types supported by
         implementation function, using NumPy's character
@@ -530,6 +544,20 @@ class BinaryElementwiseFunc:
         `dpctl.tensor.hypot` with both arrays being of integral data type.
         """
         return self.acceptance_fn_
+
+    @property
+    def nin(self):
+        """
+        Returns the number of arguments treated as inputs.
+        """
+        return 2
+
+    @property
+    def nout(self):
+        """
+        Returns the number of arguments treated as outputs.
+        """
+        return 1
 
     @property
     def types(self):

--- a/dpctl/tests/elementwise/test_elementwise_classes.py
+++ b/dpctl/tests/elementwise/test_elementwise_classes.py
@@ -78,3 +78,27 @@ def test_binary_class_str_repr():
     kl_n = binary_fn.__name__
     assert kl_n in s
     assert kl_n in r
+
+
+def test_unary_class_nin():
+    nin = unary_fn.nin
+    assert isinstance(nin, int)
+    assert nin == 1
+
+
+def test_binary_class_nin():
+    nin = binary_fn.nin
+    assert isinstance(nin, int)
+    assert nin == 2
+
+
+def test_unary_class_nout():
+    nout = unary_fn.nout
+    assert isinstance(nout, int)
+    assert nout == 1
+
+
+def test_binary_class_nout():
+    nout = binary_fn.nout
+    assert isinstance(nout, int)
+    assert nout == 1


### PR DESCRIPTION
The `nin` and `nout` properties return the number of arguments to the element-wise function treated as inputs or outputs, respectively.

`nout` is always 1 for both unary and binary functions, as both cases permit an `out` keyword argument.

- [X] Have you provided a meaningful PR description?
- [X] Have you added a test, reproducer or referred to an issue with a reproducer?
- [X] Have you tested your changes locally for CPU and GPU devices?
- [X] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?