### PR TITLE
Stay away from 2024.0.1 compiler package for now

### DIFF
--- a/.github/workflows/conda-package.yml
+++ b/.github/workflows/conda-package.yml
@@ -448,6 +448,8 @@ jobs:
             ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}-
       - name: Install example requirements
         shell: bash -l {0}
+        env:
+          DPCPP_CMPLR: dpcpp_linux-64">=2024.0.0,<2024.0.1"
         run: |
           CHANNELS="${{ env.CHANNELS }}"
           . $CONDA/etc/profile.d/conda.sh
@@ -456,7 +458,7 @@ jobs:
           conda install -n examples -y ninja $CHANNELS || exit 1
           conda install -n examples -y pybind11 cython scikit-build $CHANNELS || exit 1
           conda install -n examples -y mkl-dpcpp mkl-devel-dpcpp dpcpp_cpp_rt $CHANNELS || exit 1
-          conda create -y -n build_env $CHANNELS gcc_linux-64 gxx_linux-64 dpcpp_linux-64 sysroot_linux-64">=2.28"
+          conda create -y -n build_env $CHANNELS gcc_linux-64 gxx_linux-64 ${{ env.DPCPP_CMPLR }} sysroot_linux-64">=2.28"
       - name: Install dpctl
         shell: bash -l {0}
         run: |

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -1,4 +1,5 @@
 {% set required_compiler_version = "2024.0" %}
+{% set max_compiler_version = "2024.0.1" %}
 
 package:
     name: dpctl
@@ -16,7 +17,7 @@ build:
 requirements:
     build:
         - {{ compiler('cxx') }}
-        - {{ compiler('dpcpp') }} >={{ required_compiler_version }}  # [not osx]
+        - {{ compiler('dpcpp') }} >={{ required_compiler_version }},<{{ max_compiler_version }}  # [not osx]
         - sysroot_linux-64 >=2.28  # [linux]
     host:
         - setuptools


### PR DESCRIPTION
The compiler package `dpcpp_linux-64=2024.0.1` has known issues breaking CMake integration with DPC++. 
This PR pins build-time version to 2024.0.1 until the underlying issue gets resolved.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
