### PR TITLE
Use SYCL_CACHE_PERSISTENT=1 to cache jitted kernels to disk

### DIFF
--- a/.github/workflows/conda-package.yml
+++ b/.github/workflows/conda-package.yml
@@ -193,7 +193,7 @@ jobs:
           gdb --batch -ex r -ex 'info sharedlibrary' -ex 'set print elements 1000' -ex bt --args ${CONDA_PREFIX}/bin/python -m pytest -q -ra --disable-warnings --pyargs dpctl.tests.elementwise.test_trigonometric::test_trig_order -vv || true
       - name: Run tests
         env:
-          SYCL_QUEUE_THREAD_POOL_SIZE: 6
+          SYCL_CACHE_PERSISTENT: 1
         run: |
           . $CONDA/etc/profile.d/conda.sh
           conda activate test_dpctl
@@ -311,8 +311,7 @@ jobs:
       - name: Run tests
         shell: cmd /C CALL {0}
         env:
-          DPCTL_VERBOSITY: error
-          SYCL_QUEUE_THREAD_POOL_SIZE: 6
+          SYCL_CACHE_PERSISTENT: 1
         run: >-
           conda activate dpctl_test && python -m pytest -v -s --pyargs ${{ env.MODULE_NAME }}
 
@@ -630,7 +629,7 @@ jobs:
         id: run-array-api-tests
         shell: bash -l {0}
         env:
-          SYCL_QUEUE_THREAD_POOL_SIZE: 6
+          SYCL_CACHE_PERSISTENT: 1
         run: |
           FILE=/home/runner/work/.report.json
           . $CONDA/etc/profile.d/conda.sh

--- a/.github/workflows/generate-coverage.yaml
+++ b/.github/workflows/generate-coverage.yaml
@@ -92,6 +92,8 @@ jobs:
 
       - name: Build dpctl with coverage
         shell: bash -l {0}
+        env:
+          SYCL_CACHE_PERSISTENT: 1
         run: |
           source /opt/intel/oneapi/setvars.sh
           python scripts/gen_coverage.py --verbose

--- a/.github/workflows/os-llvm-sycl-build.yml
+++ b/.github/workflows/os-llvm-sycl-build.yml
@@ -159,8 +159,7 @@ jobs:
       - name: Run dpctl/tests
         shell: bash -l {0}
         env:
-          SYCL_QUEUE_THREAD_POOL_SIZE: 6
+          SYCL_CACHE_PERSISTENT: 1
         run: |
           source set_allvars.sh
-          # skip test due to https://github.com/intel/llvm/issues/9264
-          python -m pytest -v dpctl/tests -k "not test_event_backend"
+          python -m pytest -v dpctl/tests


### PR DESCRIPTION
This PR modifies GitHub Action scripts to use `SYCL_CACHE_PERSISTENT=1` to enable caching jitted kernels to disk.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
