### PR TITLE
Attempt to relax pinning of DPC++ compiler to 2024.0

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set required_compiler_version = "2024.0" %}
-{% set max_compiler_version = "2024.0.1" %}
+{% set max_compiler_version = "2025.0a0" %}
 
 package:
     name: dpctl
@@ -31,8 +31,8 @@ requirements:
         - wheel
     run:
         - python
-        - {{ pin_compatible('numpy', min_pin='x.x', upper_bound='1.26') }}
-        - dpcpp-cpp-rt >={{ required_compiler_version }}
+        - {{ pin_compatible('numpy', min_pin='x.x', max_pin='x') }}
+        - {{ pin_compatible('dpcpp-cpp-rt', min_pin='x.x', max_pin='x') }}
         - level-zero  # [linux]
 
 test:


### PR DESCRIPTION
Attempt to relax pinning of the compiler version to 2024.0.0

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [x] If this PR is a work in progress, are you opening the PR as a draft?
