### PR TITLE
Allow for newer version of DPC++ compiler

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -1,5 +1,6 @@
 {% set required_compiler_version = "2024.0" %}
-{% set max_compiler_version = "2024.0.1" %}
+{% set excluded_compiler_version1 = "2024.0.1" %}
+{% set excluded_compiler_version2 = "2024.0.2" %}
 
 package:
     name: dpctl
@@ -17,7 +18,7 @@ build:
 requirements:
     build:
         - {{ compiler('cxx') }}
-        - {{ compiler('dpcpp') }} >={{ required_compiler_version }},<{{ max_compiler_version }}  # [not osx]
+        - {{ compiler('dpcpp') }} >={{ required_compiler_version }},!={{ excluded_compiler_version1 }},!={{ excluded_compiler_version2 }}  # [not osx]
         - sysroot_linux-64 >=2.28  # [linux]
     host:
         - setuptools


### PR DESCRIPTION
This change modifies `"meta.yaml"` to disallow 2024.0.1 and 2024.0.2 but allow for newer versions

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
