### PR TITLE
Fix out of bound access in gemm thread k kernels

### DIFF
--- a/dpctl/tensor/libtensor/include/kernels/linalg_functions/gemm.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/linalg_functions/gemm.hpp
@@ -804,12 +804,13 @@ public:
         size_t global_s_offset = i * k + t_shift;
 
         sycl::vec<resT, m_groups> private_sum(identity_);
+        constexpr sycl::vec<resT, m_groups> vec_identity_(identity_);
         for (size_t t = local_s; t < local_B_block.size(); t += delta_k) {
-            if (t + t_shift < k) {
-                private_sum +=
-                    (static_cast<resT>(lhs[lhs_indexer(global_s_offset + t)]) *
-                     local_B_block[t]);
-            }
+            private_sum += ((i < n) && (t + t_shift < k))
+                               ? (static_cast<resT>(
+                                      lhs[lhs_indexer(global_s_offset + t)]) *
+                                  local_B_block[t])
+                               : vec_identity_;
         }
 
         size_t workspace_i_shift = local_i * delta_k;
@@ -936,11 +937,11 @@ public:
 
         resT private_sum(identity_);
         for (size_t t = local_s; t < local_B_block.size(); t += delta_k) {
-            if (t + t_shift < k) {
-                private_sum +=
-                    (static_cast<resT>(lhs[lhs_indexer(global_s_offset + t)]) *
-                     local_B_block[t]);
-            }
+            private_sum += ((i < n) && (t + t_shift < k))
+                               ? (static_cast<resT>(
+                                      lhs[lhs_indexer(global_s_offset + t)]) *
+                                  local_B_block[t])
+                               : identity_;
         }
 
         size_t workspace_i_shift = local_i * delta_k;
@@ -1743,12 +1744,13 @@ public:
         size_t global_s_offset = i * k + t_shift;
 
         sycl::vec<resT, m_groups> private_sum(identity_);
+        constexpr sycl::vec<resT, m_groups> vec_identity_(identity_);
         for (size_t t = local_s; t < local_B_block.size(); t += delta_k) {
-            if (t + t_shift < k) {
-                private_sum +=
-                    (static_cast<resT>(lhs[lhs_indexer(global_s_offset + t)]) *
-                     local_B_block[t]);
-            }
+            private_sum += ((i < n) && (t + t_shift < k))
+                               ? (static_cast<resT>(
+                                      lhs[lhs_indexer(global_s_offset + t)]) *
+                                  local_B_block[t])
+                               : vec_identity_;
         }
 
         size_t workspace_i_shift = local_i * delta_k;
@@ -1872,11 +1874,11 @@ public:
 
         resT private_sum(identity_);
         for (size_t t = local_s; t < local_B_block.size(); t += delta_k) {
-            if (t + t_shift < k) {
-                private_sum +=
-                    (static_cast<resT>(lhs[lhs_indexer(global_s_offset + t)]) *
-                     local_B_block[t]);
-            }
+            private_sum += ((i < n) && (t + t_shift < k))
+                               ? (static_cast<resT>(
+                                      lhs[lhs_indexer(global_s_offset + t)]) *
+                                  local_B_block[t])
+                               : identity_;
         }
 
         size_t workspace_i_shift = local_i * delta_k;
@@ -3923,13 +3925,14 @@ public:
         size_t global_s_offset = i * k + t_shift;
 
         sycl::vec<resT, m_groups> private_sum(identity_);
+        constexpr sycl::vec<resT, m_groups> vec_identity_(identity_);
         for (size_t t = local_s; t < local_B_block.size(); t += delta_k) {
-            if (t + t_shift < k) {
-                private_sum +=
-                    (static_cast<resT>(
-                         lhs[lhs_offset + lhs_indexer(global_s_offset + t)]) *
-                     local_B_block[t]);
-            }
+            private_sum +=
+                ((i < n) && (t + t_shift < k))
+                    ? (static_cast<resT>(
+                           lhs[lhs_offset + lhs_indexer(global_s_offset + t)]) *
+                       local_B_block[t])
+                    : vec_identity_;
         }
 
         size_t workspace_i_shift = local_i * delta_k;
@@ -4083,12 +4086,12 @@ public:
 
         resT private_sum(identity_);
         for (size_t t = local_s; t < local_B_block.size(); t += delta_k) {
-            if (t + t_shift < k) {
-                private_sum +=
-                    (static_cast<resT>(
-                         lhs[lhs_offset + lhs_indexer(global_s_offset + t)]) *
-                     local_B_block[t]);
-            }
+            private_sum +=
+                ((i < n) && (t + t_shift < k))
+                    ? (static_cast<resT>(
+                           lhs[lhs_offset + lhs_indexer(global_s_offset + t)]) *
+                       local_B_block[t])
+                    : identity_;
         }
 
         size_t workspace_i_shift = local_i * delta_k;
@@ -5024,13 +5027,14 @@ public:
         size_t global_s_offset = i * k + t_shift;
 
         sycl::vec<resT, m_groups> private_sum(identity_);
+        constexpr sycl::vec<resT, m_groups> vec_identity_(identity_);
         for (size_t t = local_s; t < local_B_block.size(); t += delta_k) {
-            if (t + t_shift < k) {
-                private_sum +=
-                    (static_cast<resT>(
-                         lhs[lhs_offset + lhs_indexer(global_s_offset + t)]) *
-                     local_B_block[t]);
-            }
+            private_sum +=
+                ((i < n) && (t + t_shift < k))
+                    ? (static_cast<resT>(
+                           lhs[lhs_offset + lhs_indexer(global_s_offset + t)]) *
+                       local_B_block[t])
+                    : vec_identity_;
         }
 
         size_t workspace_i_shift = local_i * delta_k;
@@ -5171,12 +5175,12 @@ public:
 
         resT private_sum(identity_);
         for (size_t t = local_s; t < local_B_block.size(); t += delta_k) {
-            if (t + t_shift < k) {
-                private_sum +=
-                    (static_cast<resT>(
-                         lhs[lhs_offset + lhs_indexer(global_s_offset + t)]) *
-                     local_B_block[t]);
-            }
+            private_sum +=
+                ((i < n) && ((t + t_shift < k)))
+                    ? (static_cast<resT>(
+                           lhs[lhs_offset + lhs_indexer(global_s_offset + t)]) *
+                       local_B_block[t])
+                    : identity_;
         }
 
         size_t workspace_i_shift = local_i * delta_k;

--- a/dpctl/tensor/libtensor/include/kernels/linalg_functions/gemm.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/linalg_functions/gemm.hpp
@@ -3512,10 +3512,10 @@ public:
 
     void operator()(sycl::nd_item<1> it) const
     {
-        size_t m_id =
-            it.get_global_linear_id() / (it.get_global_range(0) / batch_nelems);
-        size_t gr_id =
-            it.get_group_linear_id() % (it.get_group_range(0) / batch_nelems);
+        const size_t n_groups_per_batch = it.get_group_range(0) / batch_nelems;
+        const size_t m_id = it.get_group_linear_id() / n_groups_per_batch;
+        const size_t gr_id =
+            it.get_group_linear_id() - m_id * n_groups_per_batch;
 
         const auto &three_offsets_ =
             batch_indexer(static_cast<py::ssize_t>(m_id));
@@ -3700,10 +3700,10 @@ public:
 
     void operator()(sycl::nd_item<1> it) const
     {
-        size_t m_id =
-            it.get_global_linear_id() / (it.get_global_range(0) / batch_nelems);
-        size_t gr_id =
-            it.get_group_linear_id() % (it.get_group_range(0) / batch_nelems);
+        const size_t n_groups_per_batch = it.get_group_range(0) / batch_nelems;
+        const size_t m_id = it.get_group_linear_id() / n_groups_per_batch;
+        const size_t gr_id =
+            it.get_group_linear_id() - m_id * n_groups_per_batch;
 
         const auto &three_offsets_ =
             batch_indexer(static_cast<py::ssize_t>(m_id));
@@ -3871,10 +3871,10 @@ public:
         // batch_nelems) for lhs, offset = m_id * (n * k) for rhs, offset =
         // m_id
         // * (k * m) for res, offset = m_id * (n * m)
-        size_t m_id =
-            it.get_global_linear_id() / (it.get_global_range(0) / batch_nelems);
-        size_t gr_id =
-            it.get_group_linear_id() % (it.get_group_range(0) / batch_nelems);
+        const size_t n_groups_per_batch = it.get_group_range(0) / batch_nelems;
+        const size_t m_id = it.get_group_linear_id() / n_groups_per_batch;
+        const size_t gr_id =
+            it.get_group_linear_id() - m_id * n_groups_per_batch;
         size_t lid = it.get_local_linear_id();
 
         const auto &three_offsets_ =
@@ -4034,10 +4034,10 @@ public:
         // batch_nelems) for lhs, offset = m_id * (n * k) for rhs, offset =
         // m_id
         // * (k * m) for res, offset = m_id * (n * m)
-        size_t m_id =
-            it.get_global_linear_id() / (it.get_global_range(0) / batch_nelems);
-        size_t gr_id =
-            it.get_group_linear_id() % (it.get_group_range(0) / batch_nelems);
+        const size_t n_groups_per_batch = it.get_group_range(0) / batch_nelems;
+        const size_t m_id = it.get_group_linear_id() / n_groups_per_batch;
+        const size_t gr_id =
+            it.get_group_linear_id() - m_id * n_groups_per_batch;
         size_t lid = it.get_local_linear_id();
 
         const auto &three_offsets_ =
@@ -4631,10 +4631,10 @@ public:
 
     void operator()(sycl::nd_item<1> it) const
     {
-        size_t m_id =
-            it.get_global_linear_id() / (it.get_global_range(0) / batch_nelems);
-        size_t gr_id =
-            it.get_group_linear_id() % (it.get_group_range(0) / batch_nelems);
+        const size_t n_groups_per_batch = it.get_group_range(0) / batch_nelems;
+        const size_t m_id = it.get_group_linear_id() / n_groups_per_batch;
+        const size_t gr_id =
+            it.get_group_linear_id() - m_id * n_groups_per_batch;
 
         const auto &three_offsets_ =
             batch_indexer(static_cast<py::ssize_t>(m_id));
@@ -4816,10 +4816,10 @@ public:
 
     void operator()(sycl::nd_item<1> it) const
     {
-        size_t m_id =
-            it.get_global_linear_id() / (it.get_global_range(0) / batch_nelems);
-        size_t gr_id =
-            it.get_group_linear_id() % (it.get_group_range(0) / batch_nelems);
+        const size_t n_groups_per_batch = it.get_group_range(0) / batch_nelems;
+        const size_t m_id = it.get_group_linear_id() / n_groups_per_batch;
+        const size_t gr_id =
+            it.get_group_linear_id() - m_id * n_groups_per_batch;
 
         const auto &three_offsets_ =
             batch_indexer(static_cast<py::ssize_t>(m_id));
@@ -4978,10 +4978,10 @@ public:
 
     void operator()(sycl::nd_item<1> it) const
     {
-        size_t m_id =
-            it.get_global_linear_id() / (it.get_global_range(0) / batch_nelems);
-        size_t gr_id =
-            it.get_group_linear_id() % (it.get_group_range(0) / batch_nelems);
+        const size_t n_groups_per_batch = it.get_group_range(0) / batch_nelems;
+        const size_t m_id = it.get_group_linear_id() / n_groups_per_batch;
+        const size_t gr_id =
+            it.get_group_linear_id() - m_id * n_groups_per_batch;
         size_t lid = it.get_local_linear_id();
 
         const auto &three_offsets_ =
@@ -5125,10 +5125,10 @@ public:
 
     void operator()(sycl::nd_item<1> it) const
     {
-        size_t m_id =
-            it.get_global_linear_id() / (it.get_global_range(0) / batch_nelems);
-        size_t gr_id =
-            it.get_group_linear_id() % (it.get_group_range(0) / batch_nelems);
+        const size_t n_groups_per_batch = it.get_group_range(0) / batch_nelems;
+        const size_t m_id = it.get_group_linear_id() / n_groups_per_batch;
+        const size_t gr_id =
+            it.get_group_linear_id() - m_id * n_groups_per_batch;
         size_t lid = it.get_local_linear_id();
 
         const auto &three_offsets_ =

--- a/dpctl/tests/test_usm_ndarray_linalg.py
+++ b/dpctl/tests/test_usm_ndarray_linalg.py
@@ -19,7 +19,6 @@ import itertools
 import numpy as np
 import pytest
 
-import dpctl
 import dpctl.tensor as dpt
 from dpctl.tests.helper import get_queue_or_skip, skip_if_dtype_not_supported
 
@@ -68,38 +67,18 @@ def test_matrix_transpose_arg_validation():
     assert isinstance(dpt.matrix_transpose(X), dpt.usm_ndarray)
 
 
-# @pytest.mark.parametrize("dtype", _numeric_types)
-# def test_matmul_simple(dtype):
-#     q = get_queue_or_skip()
-#     skip_if_dtype_not_supported(dtype, q)
-
-#     n, m = 235, 17
-#     m1 = dpt.ones((m, n), dtype=dtype)
-#     m2 = dpt.ones((n, m), dtype=dtype)
-
-#     for k in [1, 2, 3, 4, 7, 8, 9, 15, 16, 17]:
-#         r = dpt.matmul(m1[:k, :], m2[:, :k])
-#         assert dpt.all(r == dpt.full((k, k), n, dtype=dtype))
-
-
-@pytest.mark.parametrize("dtype", _numeric_types[::-1])
-def test_matmul_simple2(dtype):
+@pytest.mark.parametrize("dtype", _numeric_types)
+def test_matmul_simple(dtype):
     q = get_queue_or_skip()
     skip_if_dtype_not_supported(dtype, q)
-    dev = q.sycl_device
-    if dev.is_cpu:
-        cpu_count = dev.max_compute_units
-        sub_devs = dev.create_sub_devices(partition=min(2, cpu_count // 2))
-        ctx = dpctl.SyclContext(sub_devs[0])
-        q = dpctl.SyclQueue(ctx, sub_devs[0])
 
     n, m = 235, 17
-    m1 = dpt.ones((m, n), dtype=dtype, sycl_queue=q)
-    m2 = dpt.ones((n, m), dtype=dtype, sycl_queue=q)
+    m1 = dpt.ones((m, n), dtype=dtype)
+    m2 = dpt.ones((n, m), dtype=dtype)
 
     for k in [1, 2, 3, 4, 7, 8, 9, 15, 16, 17]:
         r = dpt.matmul(m1[:k, :], m2[:, :k])
-        assert dpt.all(r == dpt.full((k, k), n, dtype=dtype, sycl_queue=q))
+        assert dpt.all(r == dpt.full((k, k), n, dtype=dtype))
 
 
 @pytest.mark.parametrize("dtype", _numeric_types)
@@ -261,7 +240,7 @@ def test_matmul_broadcasting():
     assert r.shape == (7, 11, 13)
 
 
-@pytest.mark.parametrize("dtype", ["i4", "i8", "f4", "c8"][::-1])
+@pytest.mark.parametrize("dtype", ["i4", "i8", "f4", "c8"])
 def test_matmul_strided(dtype):
     get_queue_or_skip()
 
@@ -271,12 +250,30 @@ def test_matmul_strided(dtype):
         m1_size = m1_size * el
 
     m1 = dpt.remainder(dpt.arange(1, m1_size + 1, dtype="i8"), 13)
-    m1 = dpt.reshape(dpt.astype(m1, dtype), (14, 22, 32))[::2, ::-2, ::2]
-    m2 = dpt.ones((14, 16, 13), dtype=dtype)[::2, :, :]
+    m1_orig = dpt.reshape(dpt.astype(m1, dtype), m1_shape)
+    m2_orig = dpt.ones((14, 16, 13), dtype=dtype)
 
+    m1 = m1_orig[::2, ::-2, ::2]
+    m2 = m2_orig[::2, :, :]
     r = dpt.matmul(m1, m2)
 
-    assert r.shape == (7, 11, 13)
+    assert r.shape == m1.shape[:2] + m2.shape[-1:]
+    ref = np.matmul(dpt.asnumpy(m1), dpt.asnumpy(m2))
+    assert np.allclose(dpt.asnumpy(r), ref)
+
+    m1 = m1_orig[::2, ::2, ::-2]
+    m2 = m2_orig[::2, :, :]
+    r = dpt.matmul(m1, m2)
+
+    assert r.shape == m1.shape[:2] + m2.shape[-1:]
+    ref = np.matmul(dpt.asnumpy(m1), dpt.asnumpy(m2))
+    assert np.allclose(dpt.asnumpy(r), ref)
+
+    m1 = m1_orig[::-2, ::2, ::2]
+    m2 = m2_orig[::-2, :, :]
+    r = dpt.matmul(m1, m2)
+
+    assert r.shape == m1.shape[:2] + m2.shape[-1:]
     ref = np.matmul(dpt.asnumpy(m1), dpt.asnumpy(m2))
     assert np.allclose(dpt.asnumpy(r), ref)
 


### PR DESCRIPTION
This PR fixes flaw in kernels cause out-of-bound memory access by only accessing memory if indexes are in range.

It also reverses work-arounds making CPU dispatching different from GPU dispatching
Added tests for strided inputs to test negative strides for first operand, second operand and the batching.

- [x] Have you provided a meaningful PR description?
- [x] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
