### PR TITLE
Replaced few TypeError with ValueError in _elementwise_common

### DIFF
--- a/dpctl/tensor/_elementwise_common.py
+++ b/dpctl/tensor/_elementwise_common.py
@@ -188,7 +188,7 @@ class UnaryElementwiseFunc:
             acceptance_fn=self.acceptance_fn_,
         )
         if res_dt is None:
-            raise TypeError(
+            raise ValueError(
                 f"function '{self.name_}' does not support input type "
                 f"({x.dtype}), "
                 "and the input could not be safely coerced to any "
@@ -209,7 +209,7 @@ class UnaryElementwiseFunc:
                 )
 
             if res_dt != out.dtype:
-                raise TypeError(
+                raise ValueError(
                     f"Output array of type {res_dt} is needed,"
                     f" got {out.dtype}"
                 )
@@ -587,7 +587,7 @@ class BinaryElementwiseFunc:
         )
 
         if res_dt is None:
-            raise TypeError(
+            raise ValueError(
                 f"function '{self.name_}' does not support input types "
                 f"({o1_dtype}, {o2_dtype}), "
                 "and the inputs could not be safely coerced to any "
@@ -608,7 +608,7 @@ class BinaryElementwiseFunc:
                 )
 
             if res_dt != out.dtype:
-                raise TypeError(
+                raise ValueError(
                     f"Output array of type {res_dt} is needed,"
                     f"got {out.dtype}"
                 )

--- a/dpctl/tests/elementwise/test_add.py
+++ b/dpctl/tests/elementwise/test_add.py
@@ -337,7 +337,7 @@ def test_add_dtype_error(
 
     y = dpt.zeros_like(ar1, dtype="int8")
     assert_raises_regex(
-        TypeError, "Output array of type.*is needed", dpt.add, ar1, ar2, y
+        ValueError, "Output array of type.*is needed", dpt.add, ar1, ar2, y
     )
 
 
@@ -384,7 +384,7 @@ def test_add_inplace_dtype_matrix(op1_dtype, op2_dtype):
             dpt.asnumpy(ar3) == np.full(ar3.shape, 2, dtype=ar3.dtype)
         ).all()
     else:
-        with pytest.raises(TypeError):
+        with pytest.raises(ValueError):
             ar1 += ar2
             dpt.add(ar1, ar2, out=ar1)
 
@@ -404,7 +404,7 @@ def test_add_inplace_dtype_matrix(op1_dtype, op2_dtype):
             dpt.asnumpy(ar4) == np.full(ar4.shape, 2, dtype=ar4.dtype)
         ).all()
     else:
-        with pytest.raises(TypeError):
+        with pytest.raises(ValueError):
             dpt.add(ar1, ar2, out=ar2)
 
 

--- a/dpctl/tests/elementwise/test_bitwise_and.py
+++ b/dpctl/tests/elementwise/test_bitwise_and.py
@@ -123,7 +123,7 @@ def test_bitwise_and_inplace_dtype_matrix(op1_dtype, op2_dtype):
         ar3 &= ar4
         assert dpt.all(ar3 == 1)
     else:
-        with pytest.raises(TypeError):
+        with pytest.raises(ValueError):
             ar1 &= ar2
             dpt.bitwise_and(ar1, ar2, out=ar1)
 
@@ -139,5 +139,5 @@ def test_bitwise_and_inplace_dtype_matrix(op1_dtype, op2_dtype):
         dpt.bitwise_and(ar3, ar4, out=ar4)
         dpt.all(ar4 == 1)
     else:
-        with pytest.raises(TypeError):
+        with pytest.raises(ValueError):
             dpt.bitwise_and(ar1, ar2, out=ar2)

--- a/dpctl/tests/elementwise/test_bitwise_left_shift.py
+++ b/dpctl/tests/elementwise/test_bitwise_left_shift.py
@@ -131,7 +131,7 @@ def test_bitwise_left_shift_inplace_dtype_matrix(op1_dtype, op2_dtype):
         ar3 <<= ar4
         assert dpt.all(ar3 == 2)
     else:
-        with pytest.raises(TypeError):
+        with pytest.raises(ValueError):
             ar1 <<= ar2
             dpt.bitwise_left_shift(ar1, ar2, out=ar1)
 
@@ -147,5 +147,5 @@ def test_bitwise_left_shift_inplace_dtype_matrix(op1_dtype, op2_dtype):
         dpt.bitwise_left_shift(ar3, ar4, out=ar4)
         dpt.all(ar4 == 2)
     else:
-        with pytest.raises(TypeError):
+        with pytest.raises(ValueError):
             dpt.bitwise_left_shift(ar1, ar2, out=ar2)

--- a/dpctl/tests/elementwise/test_bitwise_or.py
+++ b/dpctl/tests/elementwise/test_bitwise_or.py
@@ -123,7 +123,7 @@ def test_bitwise_or_inplace_dtype_matrix(op1_dtype, op2_dtype):
         ar3 |= ar4
         assert dpt.all(ar3 == 1)
     else:
-        with pytest.raises(TypeError):
+        with pytest.raises(ValueError):
             ar1 |= ar2
             dpt.bitwise_or(ar1, ar2, out=ar1)
 
@@ -139,5 +139,5 @@ def test_bitwise_or_inplace_dtype_matrix(op1_dtype, op2_dtype):
         dpt.bitwise_or(ar3, ar4, out=ar4)
         dpt.all(ar4 == 1)
     else:
-        with pytest.raises(TypeError):
+        with pytest.raises(ValueError):
             dpt.bitwise_or(ar1, ar2, out=ar2)

--- a/dpctl/tests/elementwise/test_bitwise_right_shift.py
+++ b/dpctl/tests/elementwise/test_bitwise_right_shift.py
@@ -131,7 +131,7 @@ def test_bitwise_right_shift_inplace_dtype_matrix(op1_dtype, op2_dtype):
         ar3 >>= ar4
         assert dpt.all(ar3 == 0)
     else:
-        with pytest.raises(TypeError):
+        with pytest.raises(ValueError):
             ar1 >>= ar2
             dpt.bitwise_right_shift(ar1, ar2, out=ar1)
 
@@ -147,5 +147,5 @@ def test_bitwise_right_shift_inplace_dtype_matrix(op1_dtype, op2_dtype):
         dpt.bitwise_right_shift(ar3, ar4, out=ar4)
         dpt.all(ar4 == 0)
     else:
-        with pytest.raises(TypeError):
+        with pytest.raises(ValueError):
             dpt.bitwise_right_shift(ar1, ar2, out=ar2)

--- a/dpctl/tests/elementwise/test_bitwise_xor.py
+++ b/dpctl/tests/elementwise/test_bitwise_xor.py
@@ -123,7 +123,7 @@ def test_bitwise_xor_inplace_dtype_matrix(op1_dtype, op2_dtype):
         ar3 ^= ar4
         assert dpt.all(ar3 == 0)
     else:
-        with pytest.raises(TypeError):
+        with pytest.raises(ValueError):
             ar1 ^= ar2
             dpt.bitwise_xor(ar1, ar2, out=ar1)
 
@@ -139,5 +139,5 @@ def test_bitwise_xor_inplace_dtype_matrix(op1_dtype, op2_dtype):
         dpt.bitwise_xor(ar3, ar4, out=ar4)
         dpt.all(ar4 == 0)
     else:
-        with pytest.raises(TypeError):
+        with pytest.raises(ValueError):
             dpt.bitwise_xor(ar1, ar2, out=ar2)

--- a/dpctl/tests/elementwise/test_divide.py
+++ b/dpctl/tests/elementwise/test_divide.py
@@ -235,7 +235,7 @@ def test_divide_inplace_dtype_matrix(op1_dtype, op2_dtype):
         ar3 /= ar4
         assert dpt.all(ar3 == 1)
     else:
-        with pytest.raises(TypeError):
+        with pytest.raises(ValueError):
             ar1 /= ar2
             dpt.divide(ar1, ar2, out=ar1)
 
@@ -254,5 +254,5 @@ def test_divide_inplace_dtype_matrix(op1_dtype, op2_dtype):
         dpt.divide(ar3, ar4, out=ar4)
         dpt.all(ar4 == 1)
     else:
-        with pytest.raises(TypeError):
+        with pytest.raises(ValueError):
             dpt.divide(ar1, ar2, out=ar2)

--- a/dpctl/tests/elementwise/test_floor_ceil_trunc.py
+++ b/dpctl/tests/elementwise/test_floor_ceil_trunc.py
@@ -100,7 +100,7 @@ def test_floor_ceil_trunc_error_dtype(dpt_call, dtype):
     x = dpt.zeros(5, dtype=dtype)
     y = dpt.empty_like(x, dtype="b1")
     assert_raises_regex(
-        TypeError, "Output array of type.*is needed", dpt_call, x, y
+        ValueError, "Output array of type.*is needed", dpt_call, x, y
     )
 
 

--- a/dpctl/tests/elementwise/test_floor_divide.py
+++ b/dpctl/tests/elementwise/test_floor_divide.py
@@ -299,7 +299,7 @@ def test_floor_divide_inplace_dtype_matrix(op1_dtype, op2_dtype):
         ar3 //= ar4
         assert dpt.all(ar3 == 1)
     else:
-        with pytest.raises(TypeError):
+        with pytest.raises(ValueError):
             ar1 //= ar2
             dpt.floor_divide(ar1, ar2, out=ar1)
 
@@ -315,5 +315,5 @@ def test_floor_divide_inplace_dtype_matrix(op1_dtype, op2_dtype):
         dpt.floor_divide(ar3, ar4, out=ar4)
         dpt.all(ar4 == 1)
     else:
-        with pytest.raises(TypeError):
+        with pytest.raises(ValueError):
             dpt.floor_divide(ar1, ar2, out=ar2)

--- a/dpctl/tests/elementwise/test_hyperbolic.py
+++ b/dpctl/tests/elementwise/test_hyperbolic.py
@@ -187,7 +187,7 @@ def test_hyper_error_dtype(callable, dtype):
     x = dpt.ones(5, dtype=dtype)
     y = dpt.empty_like(x, dtype="int16")
     assert_raises_regex(
-        TypeError, "Output array of type.*is needed", callable, x, y
+        ValueError, "Output array of type.*is needed", callable, x, y
     )
 
 

--- a/dpctl/tests/elementwise/test_logaddexp.py
+++ b/dpctl/tests/elementwise/test_logaddexp.py
@@ -189,5 +189,10 @@ def test_logaddexp_dtype_error(
 
     y = dpt.zeros_like(ar1, dtype="int8")
     assert_raises_regex(
-        TypeError, "Output array of type.*is needed", dpt.logaddexp, ar1, ar2, y
+        ValueError,
+        "Output array of type.*is needed",
+        dpt.logaddexp,
+        ar1,
+        ar2,
+        y,
     )

--- a/dpctl/tests/elementwise/test_multiply.py
+++ b/dpctl/tests/elementwise/test_multiply.py
@@ -220,7 +220,7 @@ def test_multiply_inplace_dtype_matrix(op1_dtype, op2_dtype):
         ).all()
 
     else:
-        with pytest.raises(TypeError):
+        with pytest.raises(ValueError):
             ar1 *= ar2
 
 

--- a/dpctl/tests/elementwise/test_pow.py
+++ b/dpctl/tests/elementwise/test_pow.py
@@ -198,7 +198,7 @@ def test_pow_inplace_dtype_matrix(op1_dtype, op2_dtype):
         ).all()
 
     else:
-        with pytest.raises(TypeError):
+        with pytest.raises(ValueError):
             ar1 **= ar2
 
 

--- a/dpctl/tests/elementwise/test_remainder.py
+++ b/dpctl/tests/elementwise/test_remainder.py
@@ -246,7 +246,7 @@ def test_remainder_inplace_dtype_matrix(op1_dtype, op2_dtype):
         assert dpt.all(ar3 == dpt.zeros(ar3.shape, dtype=ar3.dtype))
 
     else:
-        with pytest.raises(TypeError):
+        with pytest.raises(ValueError):
             ar1 %= ar2
 
 

--- a/dpctl/tests/elementwise/test_subtract.py
+++ b/dpctl/tests/elementwise/test_subtract.py
@@ -211,7 +211,7 @@ def test_subtract_inplace_dtype_matrix(op1_dtype, op2_dtype):
         assert (dpt.asnumpy(ar3) == np.zeros(ar3.shape, dtype=ar3.dtype)).all()
 
     else:
-        with pytest.raises(TypeError):
+        with pytest.raises(ValueError):
             ar1 -= ar2
 
 

--- a/dpctl/tests/elementwise/test_trigonometric.py
+++ b/dpctl/tests/elementwise/test_trigonometric.py
@@ -194,7 +194,7 @@ def test_trig_error_dtype(callable, dtype):
     x = dpt.zeros(5, dtype=dtype)
     y = dpt.empty_like(x, dtype="int16")
     assert_raises_regex(
-        TypeError, "Output array of type.*is needed", callable, x, y
+        ValueError, "Output array of type.*is needed", callable, x, y
     )
 
 


### PR DESCRIPTION
Used `ValueError` instead of `TypeError` per Python guidelines. 

Inappropriate uses were pointed out by @vtavana (Thank you)

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
