### PR TITLE
Do not use link-huge-device-code option

### DIFF
--- a/dpctl/tensor/CMakeLists.txt
+++ b/dpctl/tensor/CMakeLists.txt
@@ -219,10 +219,6 @@ set(_linker_options "LINKER:${DPCTL_LDFLAGS}")
 foreach(python_module_name ${_py_trgts})
     target_compile_options(${python_module_name} PRIVATE -fno-sycl-id-queries-fit-in-int)
     target_link_options(${python_module_name} PRIVATE -fsycl-device-code-split=per_kernel)
-    if(UNIX)
-        # this option is supported on Linux only
-        target_link_options(${python_module_name} PRIVATE -fsycl-link-huge-device-code)
-    endif()
     target_include_directories(${python_module_name}
         PRIVATE
         ${CMAKE_CURRENT_SOURCE_DIR}/../include


### PR DESCRIPTION
This PR remove use of `-fsycl-link-huge-device-code` link option when building tensor_impl modules on Linux.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
