### PR TITLE
Fix for complex sorting test failure

### DIFF
--- a/dpctl/tensor/libtensor/source/sorting/sorting_common.hpp
+++ b/dpctl/tensor/libtensor/source/sorting/sorting_common.hpp
@@ -41,7 +41,7 @@ template <typename fpT> struct ExtendedRealFPLess
     /* [R, nan] */
     bool operator()(const fpT v1, const fpT v2) const
     {
-        return (!sycl::isnan(v1) && (sycl::isnan(v2) || (v1 < v2)));
+        return (!std::isnan(v1) && (std::isnan(v2) || (v1 < v2)));
     }
 };
 
@@ -49,7 +49,7 @@ template <typename fpT> struct ExtendedRealFPGreater
 {
     bool operator()(const fpT v1, const fpT v2) const
     {
-        return (!sycl::isnan(v2) && (sycl::isnan(v1) || (v2 < v1)));
+        return (!std::isnan(v2) && (std::isnan(v1) || (v2 < v1)));
     }
 };
 
@@ -64,14 +64,14 @@ template <typename cT> struct ExtendedComplexFPLess
         const realT real1 = std::real(v1);
         const realT real2 = std::real(v2);
 
-        const bool r1_nan = sycl::isnan(real1);
-        const bool r2_nan = sycl::isnan(real2);
+        const bool r1_nan = std::isnan(real1);
+        const bool r2_nan = std::isnan(real2);
 
         const realT imag1 = std::imag(v1);
         const realT imag2 = std::imag(v2);
 
-        const bool i1_nan = sycl::isnan(imag1);
-        const bool i2_nan = sycl::isnan(imag2);
+        const bool i1_nan = std::isnan(imag1);
+        const bool i2_nan = std::isnan(imag2);
 
         const int idx1 = ((r1_nan) ? 2 : 0) + ((i1_nan) ? 1 : 0);
         const int idx2 = ((r2_nan) ? 2 : 0) + ((i2_nan) ? 1 : 0);


### PR DESCRIPTION
`test_sort_1d[c16]` and `test_sort_2d[c16]` were failing on GPU devices supporting double precision, 

This PR applies a work-around by using `std::isnan` until the bug is analyzed and fixed. Both failing tests pass now.

Additionally, this PR replaced use of `while` loop in `sort_over_work_group_contig_krn` with use of `for` loop over fixed size interval reducing branching/

- [x] Have you provided a meaningful PR description?
- [x] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [x] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
