### PR TITLE
conda-recipe-meta-yaml tweaks

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -32,7 +32,7 @@ requirements:
         - wheel
     run:
         - python
-        - {{ pin_compatible('numpy', min_pin='x.x', upper_bound='1.26') }}
+        - {{ pin_compatible('numpy', min_pin='x.x', max_pin='x') }}
         - dpcpp-cpp-rt >={{ required_compiler_version }}
         - level-zero  # [linux]
 


### PR DESCRIPTION
No longer require `numpy < 1.26` in runtime environment.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
