### PR TITLE
Specify permissions in GH Action workflows

### DIFF
--- a/.github/workflows/conda-package.yml
+++ b/.github/workflows/conda-package.yml
@@ -6,6 +6,8 @@ on:
       - master
   pull_request:
 
+permissions: read-all
+
 env:
   PACKAGE_NAME: dpctl
   MODULE_NAME: dpctl
@@ -539,6 +541,8 @@ jobs:
   array-api-conformity:
     needs: build_linux
     runs-on:  ${{ matrix.runner }}
+    permissions:
+      pull-requests: write
 
     strategy:
       matrix:

--- a/.github/workflows/cpp_style_checks.yml
+++ b/.github/workflows/cpp_style_checks.yml
@@ -9,6 +9,8 @@ on:
   push:
     branches: [master]
 
+permissions: read-all
+
 jobs:
   formatting-check:
     name: clang-format

--- a/.github/workflows/generate-coverage.yaml
+++ b/.github/workflows/generate-coverage.yaml
@@ -4,10 +4,14 @@ on:
   push:
     branches: [master]
 
+permissions: read-all
+
 jobs:
   generate-coverage:
     name: Generate coverage and push to Coveralls.io
     runs-on: ubuntu-20.04
+    permissions:
+      pull-requests: write
 
     env:
       ONEAPI_ROOT: /opt/intel/oneapi

--- a/.github/workflows/generate-docs.yml
+++ b/.github/workflows/generate-docs.yml
@@ -6,10 +6,15 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, closed]
 
+permissions: read-all
+
 jobs:
   build-and-deploy:
     name: Build and Deploy Documentation
     runs-on: ubuntu-20.04
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - name: Cancel Previous Runs
         uses: styfle/cancel-workflow-action@0.11.0

--- a/.github/workflows/os-llvm-sycl-build.yml
+++ b/.github/workflows/os-llvm-sycl-build.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches: [master]
 
+permissions: read-all
+
 jobs:
   install-compiler:
     name: Build with nightly build of DPC++ toolchain

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -5,6 +5,8 @@ on:
   push:
     branches: [master]
 
+permissions: read-all
+
 jobs:
   pre-commit:
     runs-on: ubuntu-20.04

--- a/.github/workflows/python_style_checks.yml
+++ b/.github/workflows/python_style_checks.yml
@@ -9,6 +9,8 @@ on:
   push:
     branches: [master]
 
+permissions: read-all
+
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   # The isort job sorts all imports in .py, .pyx, .pxd files


### PR DESCRIPTION
This PR specifies permissions in GitHub Action workflows. Minimal read-all permission is set by default, and specific scope get elevated permission as needed.

This would improve OpenSSF Scorecard value for dpctl

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
