### PR TITLE
Fix dpctl.tensor.isdtype function signature

### DIFF
--- a/.github/workflows/conda-package.yml
+++ b/.github/workflows/conda-package.yml
@@ -642,7 +642,7 @@ jobs:
           python -c "import dpctl; dpctl.lsplatform()"
           export ARRAY_API_TESTS_MODULE=dpctl.tensor
           cd /home/runner/work/array-api-tests
-          pytest --json-report --json-report-file=$FILE --skips-file ${GITHUB_WORKSPACE}/.github/workflows/array-api-skips.txt array_api_tests/ || true
+          pytest --json-report --json-report-file=$FILE --disable-deadline --skips-file ${GITHUB_WORKSPACE}/.github/workflows/array-api-skips.txt array_api_tests/ || true
       - name: Set Github environment variables
         shell: bash -l {0}
         run: |

--- a/dpctl/tensor/__init__.py
+++ b/dpctl/tensor/__init__.py
@@ -51,7 +51,6 @@ from dpctl.tensor._data_types import (
     int16,
     int32,
     int64,
-    isdtype,
     uint8,
     uint16,
     uint32,
@@ -188,7 +187,7 @@ from ._set_functions import (
 )
 from ._sorting import argsort, sort
 from ._testing import allclose
-from ._type_utils import can_cast, finfo, iinfo, result_type
+from ._type_utils import can_cast, finfo, iinfo, isdtype, result_type
 
 __all__ = [
     "Device",

--- a/dpctl/tensor/_data_types.py
+++ b/dpctl/tensor/_data_types.py
@@ -50,48 +50,6 @@ complex64 = dtype("complex64")
 complex128 = dtype("complex128")
 
 
-def isdtype(dtype_, kind):
-    """isdtype(dtype, kind)
-
-    Returns a boolean indicating whether a provided `dtype` is
-    of a specified data type `kind`.
-
-    See [array API](array_api) for more information.
-
-    [array_api]: https://data-apis.org/array-api/latest/
-    """
-
-    if not isinstance(dtype_, dtype):
-        raise TypeError(f"Expected instance of `dpt.dtype`, got {dtype_}")
-
-    if isinstance(kind, dtype):
-        return dtype_ == kind
-
-    elif isinstance(kind, str):
-        if kind == "bool":
-            return dtype_ == dtype("bool")
-        elif kind == "signed integer":
-            return dtype_.kind == "i"
-        elif kind == "unsigned integer":
-            return dtype_.kind == "u"
-        elif kind == "integral":
-            return dtype_.kind in "iu"
-        elif kind == "real floating":
-            return dtype_.kind == "f"
-        elif kind == "complex floating":
-            return dtype_.kind == "c"
-        elif kind == "numeric":
-            return dtype_.kind in "iufc"
-        else:
-            raise ValueError(f"Unrecognized data type kind: {kind}")
-
-    elif isinstance(kind, tuple):
-        return any(isdtype(dtype_, k) for k in kind)
-
-    else:
-        raise TypeError(f"Unsupported data type kind: {kind}")
-
-
 def _get_dtype(inp_dt, sycl_obj, ref_type=None):
     """
     Type inference utility to construct data type
@@ -121,7 +79,6 @@ def _get_dtype(inp_dt, sycl_obj, ref_type=None):
 __all__ = [
     "dtype",
     "_get_dtype",
-    "isdtype",
     "bool",
     "int8",
     "uint8",

--- a/dpctl/tensor/_type_utils.py
+++ b/dpctl/tensor/_type_utils.py
@@ -662,6 +662,48 @@ def _supported_dtype(dtypes):
     return True
 
 
+def isdtype(dtype, kind):
+    """isdtype(dtype, kind)
+
+    Returns a boolean indicating whether a provided `dtype` is
+    of a specified data type `kind`.
+
+    See [array API](array_api) for more information.
+
+    [array_api]: https://data-apis.org/array-api/latest/
+    """
+
+    if not isinstance(dtype, np.dtype):
+        raise TypeError(f"Expected instance of `dpt.dtype`, got {dtype}")
+
+    if isinstance(kind, dtype):
+        return dtype == kind
+
+    elif isinstance(kind, str):
+        if kind == "bool":
+            return dtype == np.dtype("bool")
+        elif kind == "signed integer":
+            return dtype.kind == "i"
+        elif kind == "unsigned integer":
+            return dtype.kind == "u"
+        elif kind == "integral":
+            return dtype.kind in "iu"
+        elif kind == "real floating":
+            return dtype.kind == "f"
+        elif kind == "complex floating":
+            return dtype.kind == "c"
+        elif kind == "numeric":
+            return dtype.kind in "iufc"
+        else:
+            raise ValueError(f"Unrecognized data type kind: {kind}")
+
+    elif isinstance(kind, tuple):
+        return any(isdtype(dtype, k) for k in kind)
+
+    else:
+        raise TypeError(f"Unsupported data type kind: {kind}")
+
+
 __all__ = [
     "_find_buf_dtype",
     "_find_buf_dtype2",
@@ -676,6 +718,7 @@ __all__ = [
     "can_cast",
     "finfo",
     "iinfo",
+    "isdtype",
     "result_type",
     "WeakBooleanType",
     "WeakIntegralType",

--- a/dpctl/tensor/_type_utils.py
+++ b/dpctl/tensor/_type_utils.py
@@ -676,7 +676,7 @@ def isdtype(dtype, kind):
     if not isinstance(dtype, np.dtype):
         raise TypeError(f"Expected instance of `dpt.dtype`, got {dtype}")
 
-    if isinstance(kind, dtype):
+    if isinstance(kind, np.dtype):
         return dtype == kind
 
     elif isinstance(kind, str):


### PR DESCRIPTION
This pull request moves `isdtype` to `_type_utils.py` to make the function signature match what is required by the array API specification.

Additionally experiments with using the `--disable-deadline` when running array API tests, as some tests fail for exceeding the deadline.

- [X] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [X] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
