### PR TITLE
Add checks to ensure test suite passes even if no devices are available

### DIFF
--- a/dpctl/tests/elementwise/test_abs.py
+++ b/dpctl/tests/elementwise/test_abs.py
@@ -71,6 +71,7 @@ def test_abs_usm_type(usm_type):
 
 
 def test_abs_types_prop():
+    get_queue_or_skip()
     types = dpt.abs.types_
     assert types is None
     types = dpt.abs.types

--- a/dpctl/tests/elementwise/test_add.py
+++ b/dpctl/tests/elementwise/test_add.py
@@ -259,6 +259,7 @@ def test_add_canary_mock_array():
 
 
 def test_add_types_property():
+    get_queue_or_skip()
     types = dpt.add.types_
     assert types is None
     types = dpt.add.types

--- a/dpctl/tests/elementwise/test_elementwise_classes.py
+++ b/dpctl/tests/elementwise/test_elementwise_classes.py
@@ -15,6 +15,7 @@
 #  limitations under the License.
 
 import dpctl.tensor as dpt
+from dpctl.tests.helper import get_queue_or_skip
 
 unary_fn = dpt.negative
 binary_fn = dpt.divide
@@ -29,6 +30,7 @@ def test_unary_class_getters():
 
 
 def test_unary_class_types_property():
+    get_queue_or_skip()
     loop_types = unary_fn.types
     assert isinstance(loop_types, list)
     assert len(loop_types) > 0
@@ -62,6 +64,7 @@ def test_binary_class_getters():
 
 
 def test_binary_class_types_property():
+    get_queue_or_skip()
     loop_types = binary_fn.types
     assert isinstance(loop_types, list)
     assert len(loop_types) > 0

--- a/dpctl/tests/elementwise/test_type_utils.py
+++ b/dpctl/tests/elementwise/test_type_utils.py
@@ -241,7 +241,10 @@ def test_can_cast_device():
 
 def test_acceptance_fns():
     """Check type promotion acceptance functions"""
-    dev = dpctl.SyclDevice()
+    try:
+        dev = dpctl.SyclDevice()
+    except dpctl.SyclDeviceCreationError:
+        pytest.skip("Default device is not available")
     assert tu._acceptance_fn_reciprocal(
         dpt.float32, dpt.float32, dpt.float32, dev
     )

--- a/dpctl/tests/test_tensor_statistical_functions.py
+++ b/dpctl/tests/test_tensor_statistical_functions.py
@@ -234,6 +234,7 @@ def test_stat_function_errors():
     with pytest.raises(TypeError):
         dpt.mean(d)
 
+    get_queue_or_skip()
     x = dpt.empty(1, dtype="f4")
     with pytest.raises(TypeError):
         dpt.var(x, axis=d)

--- a/dpctl/tests/test_usm_ndarray_ctor.py
+++ b/dpctl/tests/test_usm_ndarray_ctor.py
@@ -430,6 +430,7 @@ def test_ctor_invalid_shape():
 
 
 def test_ctor_invalid_order():
+    get_queue_or_skip()
     with pytest.raises(ValueError):
         dpt.usm_ndarray((5, 5, 3), order="Z")
 

--- a/dpctl/tests/test_usm_ndarray_indexing.py
+++ b/dpctl/tests/test_usm_ndarray_indexing.py
@@ -1302,7 +1302,7 @@ def test_nonzero():
 
 def test_nonzero_f_contig():
     "See gh-1370"
-    get_queue_or_skip
+    get_queue_or_skip()
 
     mask = dpt.zeros((5, 5), dtype="?", order="F")
     mask[2, 3] = True
@@ -1319,7 +1319,7 @@ def test_nonzero_compacting():
     Test with input where dimensionality
     of iteration space is compacted from 3d to 2d
     """
-    get_queue_or_skip
+    get_queue_or_skip()
 
     mask = dpt.zeros((5, 5, 5), dtype="?", order="F")
     mask[3, 2, 1] = True

--- a/dpctl/tests/test_usm_ndarray_linalg.py
+++ b/dpctl/tests/test_usm_ndarray_linalg.py
@@ -114,6 +114,7 @@ def test_matmul_nilpotent2(dtype):
 
 
 def test_matmul_null_axis():
+    get_queue_or_skip()
     n = 3
 
     A_mat = dpt.ones((n, 0), dtype="f4")

--- a/dpctl/tests/test_usm_ndarray_sorting.py
+++ b/dpctl/tests/test_usm_ndarray_sorting.py
@@ -97,6 +97,7 @@ def test_sort_2d(dtype):
 
 
 def test_sort_strides():
+    get_queue_or_skip()
 
     fl = dpt.roll(
         dpt.concat((dpt.ones(10000, dtype="i4"), dpt.zeros(10000, dtype="i4"))),

--- a/dpctl/tests/test_usm_ndarray_unique.py
+++ b/dpctl/tests/test_usm_ndarray_unique.py
@@ -295,10 +295,29 @@ def test_set_function_outputs():
 def test_set_functions_compute_follows_data():
     # tests that all intermediate calls and allocations
     # are compatible with an input with an arbitrary queue
+    get_queue_or_skip()
     q = dpctl.SyclQueue()
     x = dpt.arange(10, dtype="i4", sycl_queue=q)
 
-    assert isinstance(dpt.unique_values(x), dpctl.tensor.usm_ndarray)
-    assert dpt.unique_counts(x)
-    assert dpt.unique_inverse(x)
-    assert dpt.unique_all(x)
+    uv = dpt.unique_values(x)
+    assert isinstance(uv, dpctl.tensor.usm_ndarray)
+    assert uv.sycl_queue == q
+    uv, uc = dpt.unique_counts(x)
+    assert isinstance(uv, dpctl.tensor.usm_ndarray)
+    assert isinstance(uc, dpctl.tensor.usm_ndarray)
+    assert uv.sycl_queue == q
+    assert uc.sycl_queue == q
+    uv, inv_ind = dpt.unique_inverse(x)
+    assert isinstance(uv, dpctl.tensor.usm_ndarray)
+    assert isinstance(inv_ind, dpctl.tensor.usm_ndarray)
+    assert uv.sycl_queue == q
+    assert inv_ind.sycl_queue == q
+    uv, ind, inv_ind, uc = dpt.unique_all(x)
+    assert isinstance(uv, dpctl.tensor.usm_ndarray)
+    assert isinstance(ind, dpctl.tensor.usm_ndarray)
+    assert isinstance(inv_ind, dpctl.tensor.usm_ndarray)
+    assert isinstance(uc, dpctl.tensor.usm_ndarray)
+    assert uv.sycl_queue == q
+    assert ind.sycl_queue == q
+    assert inv_ind.sycl_queue == q
+    assert uc.sycl_queue == q


### PR DESCRIPTION
Adds checks for tests to fail if no device is available to DPC++ runtime. 

Checked using the following input on a machine with not CUDA card:

```
ONEAPI_DEVICE_SELECTOR=cuda:gpu python -m pytest -s dpctl/tests
```

- [x] Have you provided a meaningful PR description?
- [x] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [x] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
