### PR TITLE
Service improvements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,6 +71,10 @@ file(GLOB _cmake_scripts ${CMAKE_SOURCE_DIR}/cmake/*.cmake)
 install(FILES ${_cmake_scripts}
     DESTINATION dpctl/resources/cmake
 )
+install(FILES
+  ${CMAKE_SOURCE_DIR}/cmake/dpctl-config.cmake
+  DESTINATION lib/cmake/dpctl
+)
 
 if (DPCTL_GENERATE_DOCS)
     add_subdirectory(docs)

--- a/cmake/dpctl-config.cmake
+++ b/cmake/dpctl-config.cmake
@@ -6,14 +6,17 @@
 #
 # ``Dpctl_FOUND``
 #   True if DPCTL was found.
-# ``Dpctl_INCLUDE_DIRS``
-#   The include directories needed to use Dpctl.
+# ``Dpctl_INCLUDE_DIR``
+#   The include directory needed to use dpctl.
+# ``Dpctl_TENSOR_INCLUDE_DIR``
+#   The include directory for tensor kernels implementation.
 # ``Dpctl_VERSION``
-#   The version of DPCTL found.
+#   The version of dpctl found.
 #
-# The module will also explicitly define one cache variable:
+# The module will also explicitly define two cache variables:
 #
 # ``Dpctl_INCLUDE_DIR``
+# ``Dpctl_TENSOR_INCLUDE_DIR``
 #
 
 if(NOT Dpctl_FOUND)

--- a/cmake/dpctl-config.cmake
+++ b/cmake/dpctl-config.cmake
@@ -22,7 +22,7 @@ if(NOT Dpctl_FOUND)
 
   if(Python_EXECUTABLE)
     execute_process(COMMAND "${Python_EXECUTABLE}"
-      -c "import dpctl; print(dpctl.get_include())"
+      -m dpctl --include-dir
       OUTPUT_VARIABLE _dpctl_include_dir
       OUTPUT_STRIP_TRAILING_WHITESPACE
       ERROR_QUIET

--- a/dpctl/tests/test_service.py
+++ b/dpctl/tests/test_service.py
@@ -173,13 +173,30 @@ def test_syclinterface():
         raise RuntimeError("Unsupported system")
 
 
+def test_main_include_dir():
+    res = subprocess.run(
+        [sys.executable, "-m", "dpctl", "--include-dir"], capture_output=True
+    )
+    assert res.returncode == 0
+    assert res.stdout
+    dir_path = res.stdout.decode("utf-8").strip()
+    assert os.path.exists(dir_path)
+
+
 def test_main_includes():
     res = subprocess.run(
         [sys.executable, "-m", "dpctl", "--includes"], capture_output=True
     )
     assert res.returncode == 0
     assert res.stdout
-    assert res.stdout.decode("utf-8").startswith("-I")
+    flags = res.stdout.decode("utf-8")
+    res = subprocess.run(
+        [sys.executable, "-m", "dpctl", "--include-dir"], capture_output=True
+    )
+    assert res.returncode == 0
+    assert res.stdout
+    dir = res.stdout.decode("utf-8")
+    assert flags == "-I " + dir
 
 
 def test_main_library():
@@ -189,6 +206,34 @@ def test_main_library():
     assert res.returncode == 0
     assert res.stdout
     assert res.stdout.decode("utf-8").startswith("-L")
+
+
+def test_tensor_includes():
+    res = subprocess.run(
+        [sys.executable, "-m", "dpctl", "--tensor-includes"],
+        capture_output=True,
+    )
+    assert res.returncode == 0
+    assert res.stdout
+    flags = res.stdout.decode("utf-8")
+    res = subprocess.run(
+        [sys.executable, "-m", "dpctl", "--tensor-include-dir"],
+        capture_output=True,
+    )
+    assert res.returncode == 0
+    assert res.stdout
+    dir = res.stdout.decode("utf-8")
+    assert flags == "-I " + dir
+
+
+def test_main_library_dir():
+    res = subprocess.run(
+        [sys.executable, "-m", "dpctl", "--library-dir"], capture_output=True
+    )
+    assert res.returncode == 0
+    assert res.stdout
+    dir_path = res.stdout.decode("utf-8").strip()
+    assert os.path.exists(dir_path)
 
 
 def test_cmakedir():

--- a/dpctl/tests/test_service.py
+++ b/dpctl/tests/test_service.py
@@ -243,7 +243,7 @@ def test_cmakedir():
     assert res.returncode == 0
     assert res.stdout
     cmake_dir = res.stdout.decode("utf-8").strip()
-    assert os.path.exists(os.path.join(cmake_dir, "FindDpctl.cmake"))
+    assert os.path.exists(os.path.join(cmake_dir, "dpctl-config.cmake"))
 
 
 def test_main_full_list():


### PR DESCRIPTION
`dpctl/__main__.py` no longer triggers loading of libsycl library for queries

`python -m dpctl --includes` will no longer load SYCL runtime libraries.

Module file acquired three more options

      --include-dir
      --tensor-include-dir
      --library-dir

This would output absolute path to directory of include headers,
tensor include headers, and directory containing DPCTLSyclInterface
library.

`FindDpctl.cmake` has been renamed to `dpctl-config.cmake`. 

This PR also installs `dpctl-config.cmake` to `${PREFIX}/lib/cmake` folder, making `find_package(Dpctl)` work out of the box with `dpctl` installed in the Python environment. 

With local build of `dpctl`,  downstream projects can hint CMake to finding Dpctl package by
using standard mechanism:

```
-DDpctl_ROOT=$(python -m dpctl --cmakedir)
```

- [x] Have you provided a meaningful PR description?
- [x] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
