### PR TITLE
Populated changelog of new features since 0.15.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,36 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.15.0]
+## [0.16.0] - MMM. DD, 2024
+
+### Added
+
+* Added reduction functions `dpctl.tensor.min`, `dpctl.tensor.max`, `dpctl.tensor.argmin`, `dpctl.tensor.argmax`, and `dpctl.tensor.prod` per Python Array API specifications: [#1399](https://github.com/IntelPython/dpctl/pull/1399)
+* Added dedicated in-place operations for binary elementwise operations and deployed them in Python operators of `dpctl.tensor.usm_ndarray` type: [#1431](https://github.com/IntelPython/dpctl/pull/1431), [#1447](https://github.com/IntelPython/dpctl/pull/1447)
+* Added new elementwise functions `dpctl.tensor.cbrt`, `dpctl.tensor.rsqrt`, `dpctl.tensor.exp2`, `dpctl.tensor.copysign`, `dpctl.tensor.angle`, and `dpctl.tensor.reciprocal`: [#1443](https://github.com/IntelPython/dpctl/pull/1443), [#1474](https://github.com/IntelPython/dpctl/pull/1474)
+* Added statistical functions `dpctl.tensor.mean`, `dpctl.tensor.std`, `dpctl.tensor.var` per Python Array API specifications: [#1465](https://github.com/IntelPython/dpctl/pull/1465)
+* Added sorting functions `dpctl.tensor.sort` and `dpctl.tensor.argsort`, and set functions `dpctl.tensor.unique_values`, `dpctl.tensor.unique_counts`, `dpctl.tensor.unique_inverse`, `dpctl.tensor.unique_all`: [#1483](https://github.com/IntelPython/dpctl/pull/1483)
+* Added linear algebra functions from the Array API namespace `dpctl.tensor.matrix_transpose`, `dpctl.tensor.matmul`, `dpctl.tensor.vecdot`, and `dpctl.tensor.tensordot`: [#1490](https://github.com/IntelPython/dpctl/pull/1490)
+* Added `dpctl.tensor.clip` function: [#1444](https://github.com/IntelPython/dpctl/pull/1444), [#1505](https://github.com/IntelPython/dpctl/pull/1505)
+* Added custom reduction functions `dpt.logsumexp` (reduction using binary function `dpctl.tensor.logaddexp`), `dpt.reduce_hypot` (reduction using binary function `dpctl.tensor.hypot`): [#1446](https://github.com/IntelPython/dpctl/pull/1446)
+* Added inspection API to query capabilities of Python Array API specification implementation: [#1469](https://github.com/IntelPython/dpctl/pull/1469)
+* Support for compilation for NVIDIA(R) sycl target with use of [CodePlay oneAPI plug-in](https://developer.codeplay.com/products/oneapi/nvidia/home/): [#1411](https://github.com/IntelPython/dpctl/pull/1411), [#1124](https://github.com/IntelPython/dpctl/discussions/1124)
+* Added `dpctl.utils.intel_device_info` function to query additional information about Intel(R) GPU devices: [gh-1428](https://github.com/IntelPython/dpctl/pull/1428) and [gh-1445](https://github.com/IntelPython/dpctl/pull/1445)
+
+### Changed
+
+* Functions `dpctl.tensor.result_type` and `dpctl.tensor.can_cast` became device-aware: [#1488](https://github.com/IntelPython/dpctl/pull/1488), [#1473](https://github.com/IntelPython/dpctl/pull/1473)
+* Implementation of method `dpctl.SyclEvent.wait_for` changed to use ``sycl::event::wait`` instead of ``sycl::event::wait_and_throw``: [gh-1436](https://github.com/IntelPython/dpctl/pull/1436)
+
+
+### Fixed
+
+* Fixed issues with `dpctl.tensor.repeat` support for `axis` keyword: [#1427](https://github.com/IntelPython/dpctl/pull/1427), [#1433](https://github.com/IntelPython/dpctl/pull/1433)
+* Fix for gh-1503 for bug `usm_ndarray.__setitem__`: [#1504](https://github.com/IntelPython/dpctl/pull/1504)
+* Other bug fixes: [#1485](https://github.com/IntelPython/dpctl/pull/1485), [#1477](https://github.com/IntelPython/dpctl/pull/1477)
+
+
+## [0.15.0] - Sep. 29, 2023
 
 ### Added
 


### PR DESCRIPTION
This PR populates `CHANGELOG.md` with entries since 0.15.0 release

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?

--- 

The full list of PRs merged since 0.15.0 tag:

### Full list

- [gh-1424](https://github.com/IntelPython/dpctl/pull/1424) [cmake MNT]
- [gh-1425](https://github.com/IntelPython/dpctl/pull/1425) [CICD]
- [gh-1399](https://github.com/IntelPython/dpctl/pull/1399) (reductions)
- [gh-1427](https://github.com/IntelPython/dpctl/pull/1427) `dpt.repeat` support for `axis=None`
- [gh-1429](https://github.com/IntelPython/dpctl/pull/1429) [CICD MNT]
- [gh-1430](https://github.com/IntelPython/dpctl/pull/1430) `dpt.repeat` bug fix
- [gh-1433](https://github.com/IntelPython/dpctl/pull/1433) [BUG FIX] for `dpt.repeat` for `axis=0`
- [gh-1428](https://github.com/IntelPython/dpctl/pull/1428) and [gh-1445](https://github.com/IntelPython/dpctl/pull/1445) add `dpctl.utils.intel_device_info` function
- [gh-1400](https://github.com/IntelPython/dpctl/pull/1440) [conda MNT] 
- [gh-1431](https://github.com/IntelPython/dpctl/pull/1431) In-place kernels added for `dpt.divide`, `dpt.floor_divide`
- [gh-1435](https://github.com/IntelPython/dpctl/pull/1435) [CICD work]
- [gh-1441](https://github.com/IntelPython/dpctl/pull/1441) [packaging work]
- [gh-1437](https://github.com/IntelPython/dpctl/pull/1437) [CICD work]
- [gh-1436](https://github.com/IntelPython/dpctl/pull/1436) [ change ]  `dpctl.SyclEvent.wait_for` changed to use `sycl::event::wait` instead of `sycl::event::wait_and_throw`
- [gh-1443](https://github.com/IntelPython/dpctl/pull/1443) [feature], new elementwise functions: `dpt.cbrt`, `dpt.rsqrt`, `dpt.exp2`, `dpt.copysign`
- [gh-1450](https://github.com/IntelPython/dpctl/pull/1450) [code MNT]
- [gh-1395](https://github.com/IntelPython/dpctl/pull/1395) [added] `dpctl.SyclQueue._keep_args_alive` method added
- [gh-1452](https://github.com/IntelPython/dpctl/pull/1452) [change] `DPCTLDevice_GetParentDevice` checks property to avoid calling parent_device method and trip exception 
- [gh-1447](https://github.com/IntelPython/dpctl/pull/1447) [feature, in-place binary operations] `dpt.pow`, `dpt.remainder`, `dpt.bitwise_and`, `dpt.bitwise_xor`, `dpt.bitwise_or`, `dpt.bitwise_shift_left`, `dpt.bitwise_shift_right`
- [gh-1444](https://github.com/IntelPython/dpctl/pull/1444) [feature, clip] Added `dpt.clip` function
- [gh-1446](https://github.com/IntelPython/dpctl/pull/1446) [feature, logsumexp, reduce_hypot] Added `dpt.logsumexp`, `dpt.reduce_hypot` functions
- [gh-1458](https://github.com/IntelPython/dpctl/pull/1458) [bug fix in new feature]
- [gh-1459](https://github.com/IntelPython/dpctl/pull/1459) [bug fix]
- [gh-1460](https://github.com/IntelPython/dpctl/pull/1460) [bug fix]
- [gh-1462](https://github.com/IntelPython/dpctl/pull/1462) [bug fix]
- [gh-1463](https://github.com/IntelPython/dpctl/pull/1463) [performance for reductions] Improved performance of `dpt.sum` for small reduced sizes
- [gh-1470](https://github.com/IntelPython/dpctl/pull/1470) [bug fix]
- [gh-1467](https://github.com/IntelPython/dpctl/pull/1467) [bug fix]
- [gh-1469](https://github.com/IntelPython/dpctl/pull/1469) [feature, inspection API] 
- [gh-1465](https://github.com/IntelPython/dpctl/pull/1465) [feature, stat functions]
- [gh-1440](https://github.com/IntelPython/dpctl/pull/1440)
- [gh-1411](https://github.com/IntelPython/dpctl/pull/1411) [ supports CUDA, fixes for Windows offloading]
- [gh-1474](https://github.com/IntelPython/dpctl/pull/1474) [feature, elementwise unary reciprocal]
- [gh-1480](https://github.com/IntelPython/dpctl/pull/1480) [MNT]
- [gh-1484](https://github.com/IntelPython/dpctl/pull/1484) [cmake script work]
- [gh-1478](https://github.com/IntelPython/dpctl/pull/1478)
- [gh-1485](https://github.com/IntelPython/dpctl/pull/1485) [bug-fix]
- [gh-1477](https://github.com/IntelPython/dpctl/pull/1477) [bug-fix]
- [gh-1486](https://github.com/IntelPython/dpctl/pull/1486) [CICD]
- [gh-1476](https://github.com/IntelPython/dpctl/pull/1476) [CICD, Code quality]
- [gh-1475](https://github.com/IntelPython/dpctl/pull/1475) [MNT]
- [gh-1488](https://github.com/IntelPython/dpctl/pull/1488)
- [gh-1487](https://github.com/IntelPython/dpctl/pull/1487) [CICD]
- [gh-1491](https://github.com/IntelPython/dpctl/pull/1491) [CICD]
- [gh-1494](https://github.com/IntelPython/dpctl/pull/1494) [CICD]
- [gh-1483](https://github.com/IntelPython/dpctl/pull/1483) [feature, sort/argsor/set functions]
- [gh-1466](https://github.com/IntelPython/dpctl/pull/1466) [conda ]
- [gh-1473](https://github.com/IntelPython/dpctl/pull/1473) [result_type support for scalars]
- [gh-1496](https://github.com/IntelPython/dpctl/pull/1496) [TypeError -> ValueError in elementwise]
- [gh-1497](https://github.com/IntelPython/dpctl/pull/1497) [MNT]
- [gh-1498](https://github.com/IntelPython/dpctl/pull/1498) [fix in new feature, sorting]
- [gh-1490](https://github.com/IntelPython/dpctl/pull/1490) [feature: matmul, vecdot, tensordot]
- [gh-1500](https://github.com/IntelPython/dpctl/pull/1500) [CICD, security]
- [gh-1498](https://github.com/IntelPython/dpctl/pull/1498) [conda]
- [gh-1501](https://github.com/IntelPython/dpctl/pull/1501) [code quality]
- [gh-1502](https://github.com/IntelPython/dpctl/pull/1502) [CICD]
- [gh-1504](https://github.com/IntelPython/dpctl/pull/1504) [bug fix in copying]
- [gh-1506](https://github.com/IntelPython/dpctl/pull/1506)
- [gh-1505](https://github.com/IntelPython/dpctl/pull/1505)

