### PR TITLE
Fix array API test failure caused by issue reported in gh-1512

### DIFF
--- a/dpctl/tensor/_ctors.py
+++ b/dpctl/tensor/_ctors.py
@@ -632,17 +632,13 @@ def asarray(
                 usm_type=usm_type,
                 order=order,
             )
-
-        raise NotImplementedError(
-            "Converting Python sequences is not implemented"
-        )
     if copy is False:
         raise ValueError(
             f"Converting {type(obj)} to usm_ndarray requires a copy"
         )
     # obj is a scalar, create 0d array
     return _asarray_from_numpy_ndarray(
-        np.asarray(obj),
+        np.asarray(obj, dtype=dtype),
         dtype=dtype,
         usm_type=usm_type,
         sycl_queue=sycl_queue,

--- a/dpctl/tests/test_tensor_asarray.py
+++ b/dpctl/tests/test_tensor_asarray.py
@@ -164,6 +164,21 @@ def test_asarray_input_validation():
     with pytest.raises(ValueError):
         # sequence is not rectangular
         dpt.asarray([[1], 2])
+    with pytest.raises(OverflowError):
+        # Python int too large for type
+        dpt.asarray(-9223372036854775809, dtype="i4")
+    with pytest.raises(ValueError):
+        # buffer to usm_ndarray requires a copy
+        dpt.asarray(memoryview(np.arange(5)), copy=False)
+    with pytest.raises(ValueError):
+        # Numpy array to usm_ndarray requires a copy
+        dpt.asarray(np.arange(5), copy=False)
+    with pytest.raises(ValueError):
+        # Python sequence to usm_ndarray requires a copy
+        dpt.asarray([1, 2, 3], copy=False)
+    with pytest.raises(ValueError):
+        # Python scalar to usm_ndarray requires a copy
+        dpt.asarray(5, copy=False)
 
 
 def test_asarray_input_validation2():


### PR DESCRIPTION
This pull request adjusts `dpt.asarray` such that the `dtype` argument is passed to `np.asarray` call when called with a Python scalar as input

This guarantees the expected `OverflowError` is thrown.

Additionally, this PR adds tests for this behavior, for `copy=False` errors to `test_tensor_asarray`, and removes a superfluous `NotImplementedError` for Python sequences from `asarray`.

Closes gh-1512

- [X] Have you provided a meaningful PR description?
- [X] Have you added a test, reproducer or referred to an issue with a reproducer?
- [X] Have you tested your changes locally for CPU and GPU devices?
- [X] Have you made sure that new changes do not introduce compiler warnings?
- [X] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
