### PR TITLE
Fix generated -DNOTFOUND for compiling elementwise functions

### DIFF
--- a/dpctl/tensor/CMakeLists.txt
+++ b/dpctl/tensor/CMakeLists.txt
@@ -223,7 +223,11 @@ set(_compiler_definitions "USE_SYCL_FOR_COMPLEX_TYPES")
 
 foreach(_src_fn ${_elementwise_sources})
   get_source_file_property(_cmpl_options_defs ${_src_fn} COMPILE_DEFINITIONS)
-  set(_combined_options_defs ${_cmpl_options_defs} "${_compiler_definitions}")
+  if(${_cmpl_options_defs})
+     set(_combined_options_defs ${_cmpl_options_defs} "${_compiler_definitions}")
+  else()
+     set(_combined_options_defs "${_compiler_definitions}")
+  endif()
   set_source_files_properties(
      ${_src_fn}
      PROPERTIES COMPILE_DEFINITIONS "${_combined_options_defs}"


### PR DESCRIPTION
E.g.

```
[123/222] $BUILD_PREFIX/bin/icpx -D_tensor_elementwise_impl_EXPORTS -DNOTFOUND -DUSE_SYCL_FOR_COMPLEX_TYPES \
     -I$BUILD_PREFIX/include \
     .... \
     -c $SRC_DIR/dpctl/tensor/libtensor/source/elementwise_functions/acos.cpp
```

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
