### PR TITLE
Explicitly project ref-values to range of short integral types

### DIFF
--- a/dpctl/tests/test_usm_ndarray_linalg.py
+++ b/dpctl/tests/test_usm_ndarray_linalg.py
@@ -41,6 +41,20 @@ _numeric_types = [
 ]
 
 
+def _map_int_to_type(n, dt):
+    assert isinstance(n, int)
+    assert n > 0
+    if dt == dpt.int8:
+        return ((n + 128) % 256) - 128
+    elif dt == dpt.uint8:
+        return n % 256
+    elif dt == dpt.int16:
+        return ((n + 32768) % 65536) - 32768
+    elif dt == dpt.uint16:
+        return n % 65536
+    return n
+
+
 def test_matrix_transpose():
     get_queue_or_skip()
 
@@ -702,8 +716,8 @@ def test_vecdot_1d(dtype):
     v2 = dpt.ones(n, dtype=dtype)
 
     r = dpt.vecdot(v1, v2)
-
-    assert r == n
+    expected_value = _map_int_to_type(n, r.dtype)
+    assert r == expected_value
 
 
 @pytest.mark.parametrize("dtype", _numeric_types)
@@ -722,7 +736,8 @@ def test_vecdot_3d(dtype):
         m1,
         m2,
     )
-    assert dpt.all(r == n)
+    expected_value = _map_int_to_type(n, r.dtype)
+    assert dpt.all(r == expected_value)
 
 
 @pytest.mark.parametrize("dtype", _numeric_types)
@@ -741,7 +756,8 @@ def test_vecdot_axis(dtype):
         m1,
         m2,
     )
-    assert dpt.all(r == n)
+    expected_value = _map_int_to_type(n, r.dtype)
+    assert dpt.all(r == expected_value)
 
 
 @pytest.mark.parametrize("dtype", _numeric_types)
@@ -775,6 +791,7 @@ def test_vecdot_strided(dtype):
         m1,
         m2,
     )
+    ref = _map_int_to_type(ref, r.dtype)
     assert dpt.all(r == ref)
 
 


### PR DESCRIPTION
This resolves NumPy warning issued upon `rhs_array == scalar` where scalar is Python integer not range of the array's dtype when running tests from `test_usm_ndarray_linalg.py` test file.

Presently we issue warnings from 

```
tests/test_usm_ndarray_linalg.py::test_vecdot_1d[i1]
tests/test_usm_ndarray_linalg.py::test_vecdot_1d[u1]
tests/test_usm_ndarray_linalg.py::test_vecdot_3d[i1]
tests/test_usm_ndarray_linalg.py::test_vecdot_3d[u1]
tests/test_usm_ndarray_linalg.py::test_vecdot_axis[i1]
tests/test_usm_ndarray_linalg.py::test_vecdot_axis[u1]
tests/test_usm_ndarray_linalg.py::test_vecdot_strided[i1]
tests/test_usm_ndarray_linalg.py::test_vecdot_strided[u1]
```

This PR resolves all of them. The warning goes like:

```
  /usr/share/miniconda/envs/test_dpctl/lib/python3.11/site-packages/dpctl/tensor/_ctors.py:641: DeprecationWarning: NumPy will stop allowing conversion of out-of-bound Python integers to integer arrays.  The conversion of 384 to int8 will fail in the future.
  For the old behavior, usually:
      np.array(value).astype(dtype)
  will give the desired result (the cast overflows).
    np.asarray(obj, dtype=dtype),
```

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
