### PR TITLE
Fixes setting of writable flag for views and writing to read-only arrays with `out` keyword

### DIFF
--- a/dpctl/tensor/_clip.py
+++ b/dpctl/tensor/_clip.py
@@ -440,6 +440,9 @@ def clip(x, /, min=None, max=None, out=None, order="K"):
                     f"{type(out)}"
                 )
 
+            if not out.flags.writable:
+                raise ValueError("provided `out` array is read-only")
+
             if out.shape != x.shape:
                 raise ValueError(
                     "The shape of input and output arrays are "

--- a/dpctl/tensor/_clip.py
+++ b/dpctl/tensor/_clip.py
@@ -262,6 +262,9 @@ def _clip_none(x, val, out, order, _binary_fn):
                 f"output array must be of usm_ndarray type, got {type(out)}"
             )
 
+        if not out.flags.writable:
+            raise ValueError("provided `out` array is read-only")
+
         if out.shape != res_shape:
             raise ValueError(
                 "The shape of input and output arrays are inconsistent. "
@@ -599,6 +602,9 @@ def clip(x, /, min=None, max=None, out=None, order="K"):
                     "output array must be of usm_ndarray type, got "
                     f"{type(out)}"
                 )
+
+            if not out.flags.writable:
+                raise ValueError("provided `out` array is read-only")
 
             if out.shape != res_shape:
                 raise ValueError(

--- a/dpctl/tensor/_elementwise_common.py
+++ b/dpctl/tensor/_elementwise_common.py
@@ -202,6 +202,9 @@ class UnaryElementwiseFunc:
                     f"output array must be of usm_ndarray type, got {type(out)}"
                 )
 
+            if not out.flags.writable:
+                raise ValueError("provided `out` array is read-only")
+
             if out.shape != x.shape:
                 raise ValueError(
                     "The shape of input and output arrays are inconsistent. "
@@ -600,6 +603,9 @@ class BinaryElementwiseFunc:
                 raise TypeError(
                     f"output array must be of usm_ndarray type, got {type(out)}"
                 )
+
+            if not out.flags.writable:
+                raise ValueError("provided `out` array is read-only")
 
             if out.shape != res_shape:
                 raise ValueError(

--- a/dpctl/tensor/_linear_algebra_functions.py
+++ b/dpctl/tensor/_linear_algebra_functions.py
@@ -738,6 +738,9 @@ def matmul(x1, x2, out=None, dtype=None, order="K"):
                 f"output array must be of usm_ndarray type, got {type(out)}"
             )
 
+        if not out.flags.writable:
+            raise ValueError("provided `out` array is read-only")
+
         if out.shape != res_shape:
             raise ValueError(
                 "The shape of input and output arrays are inconsistent. "

--- a/dpctl/tensor/_usmarray.pyx
+++ b/dpctl/tensor/_usmarray.pyx
@@ -62,7 +62,7 @@ cdef object _as_zero_dim_ndarray(object usm_ary):
 
 cdef int _copy_writable(int lhs_flags, int rhs_flags):
     "Copy the WRITABLE flag to lhs_flags from rhs_flags"
-    return (lhs_flag & ~USM_ARRAY_WRITABLE) | (rhs_flag & USM_ARRAY_WRITABLE)
+    return (lhs_flags & ~USM_ARRAY_WRITABLE) | (rhs_flags & USM_ARRAY_WRITABLE)
 
 cdef class usm_ndarray:
     """ usm_ndarray(shape, dtype=None, strides=None, buffer="device", \

--- a/dpctl/tensor/_usmarray.pyx
+++ b/dpctl/tensor/_usmarray.pyx
@@ -731,7 +731,7 @@ cdef class usm_ndarray:
         adv_ind_start_p = _meta[4]
 
         if adv_ind_start_p < 0:
-            res.flags_ ^= (~self.flags_ & USM_ARRAY_WRITABLE)
+            res.flags_ = (res.flags_ & ~USM_ARRAY_WRITABLE) | (self.flags_ & USM_ARRAY_WRITABLE)
             return res
 
         from ._copy_utils import _extract_impl, _nonzero_impl, _take_multi_index
@@ -749,7 +749,7 @@ cdef class usm_ndarray:
             if not matching:
                 raise IndexError("boolean index did not match indexed array in dimensions")
             res = _extract_impl(res, key_, axis=adv_ind_start_p)
-            res.flags_ ^= (~self.flags_ & USM_ARRAY_WRITABLE)
+            res.flags_ = (res.flags_ & ~USM_ARRAY_WRITABLE) | (self.flags_ & USM_ARRAY_WRITABLE)
             return res
 
         if any(ind.dtype == dpt_bool for ind in adv_ind):
@@ -760,11 +760,11 @@ cdef class usm_ndarray:
                 else:
                     adv_ind_int.append(ind)
             res = _take_multi_index(res, tuple(adv_ind_int), adv_ind_start_p)
-            res.flags_ ^= (~self.flags_ & USM_ARRAY_WRITABLE)
+            res.flags_ = (res.flags_ & ~USM_ARRAY_WRITABLE) | (self.flags_ & USM_ARRAY_WRITABLE)
             return res
 
         res = _take_multi_index(res, adv_ind, adv_ind_start_p)
-        res.flags_ ^= (~self.flags_ & USM_ARRAY_WRITABLE)
+        res.flags_ = (res.flags_ & ~USM_ARRAY_WRITABLE) | (self.flags_ & USM_ARRAY_WRITABLE)
         return res
 
     def to_device(self, target, stream=None):
@@ -1228,7 +1228,7 @@ cdef usm_ndarray _real_view(usm_ndarray ary):
         offset=offset_elems,
         order=('C' if (ary.flags_ & USM_ARRAY_C_CONTIGUOUS) else 'F')
     )
-    r.flags_ ^= (~ary.flags_ & USM_ARRAY_WRITABLE)
+    r.flags_ = (r.flags_ & ~USM_ARRAY_WRITABLE) | (ary.flags_ & USM_ARRAY_WRITABLE)
     r.array_namespace_ = ary.array_namespace_
     return r
 
@@ -1260,7 +1260,7 @@ cdef usm_ndarray _imag_view(usm_ndarray ary):
         offset=offset_elems,
         order=('C' if (ary.flags_ & USM_ARRAY_C_CONTIGUOUS) else 'F')
     )
-    r.flags_ ^= (~ary.flags_ & USM_ARRAY_WRITABLE)
+    r.flags_ = (r.flags_ & ~USM_ARRAY_WRITABLE) | (ary.flags_ & USM_ARRAY_WRITABLE)
     r.array_namespace_ = ary.array_namespace_
     return r
 
@@ -1280,7 +1280,7 @@ cdef usm_ndarray _transpose(usm_ndarray ary):
         order=('F' if (ary.flags_ & USM_ARRAY_C_CONTIGUOUS) else 'C'),
         offset=ary.get_offset()
     )
-    r.flags_ ^= (~ary.flags_ & USM_ARRAY_WRITABLE)
+    r.flags_ = (r.flags_ & ~USM_ARRAY_WRITABLE) | (ary.flags_ & USM_ARRAY_WRITABLE)
     return r
 
 
@@ -1297,7 +1297,7 @@ cdef usm_ndarray _m_transpose(usm_ndarray ary):
         order=('F' if (ary.flags_ & USM_ARRAY_C_CONTIGUOUS) else 'C'),
         offset=ary.get_offset()
     )
-    r.flags_ ^= (~ary.flags_ & USM_ARRAY_WRITABLE)
+    r.flags_ = (r.flags_ & ~USM_ARRAY_WRITABLE) | (ary.flags_ & USM_ARRAY_WRITABLE)
     return r
 
 

--- a/dpctl/tests/test_usm_ndarray_ctor.py
+++ b/dpctl/tests/test_usm_ndarray_ctor.py
@@ -129,6 +129,25 @@ def test_usm_ndarray_flags_bug_gh_1334():
     assert r.flags["F"] and r.flags["C"]
 
 
+def test_usm_ndarray_writable_flag_views():
+    get_queue_or_skip()
+    a = dpt.arange(10, dtype="f4")
+    a.flags["W"] = False
+
+    a.shape = (5, 2)
+    assert not a.flags.writable
+    assert not a.T.flags.writable
+    assert not a.mT.flags.writable
+    assert not a.real.flags.writable
+    assert not a[0:3].flags.writable
+
+    a = dpt.arange(10, dtype="c8")
+    a.flags["W"] = False
+
+    assert not a.real.flags.writable
+    assert not a.imag.flags.writable
+
+
 @pytest.mark.parametrize(
     "dtype",
     [


### PR DESCRIPTION
This pull request makes changes to `_usmarray.pyx` to guarantee that the writable flag is handled correctly for views created via `real`, `imag`, `T`, `mT`, and shape-setting and indexing properties.

`__getitem__` now only adjusts the flag after all writing to the result has been performed, fixing the practice of setting elements to a read-only array.

Elementwise functions, `clip`, and `matmul` also now contain early (top-level) checks for the writable flag of a provided `out` array, fixing an edge case where the writable flag would be overridden by copying to the original array. This practice also prevents unnecessary computation and memory allocation.

- [X] Have you provided a meaningful PR description?
- [X] Have you added a test, reproducer or referred to an issue with a reproducer?
- [X] Have you tested your changes locally for CPU and GPU devices?
- [X] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
