### PR TITLE
Writable flag views followup

### DIFF
--- a/dpctl/tensor/_usmarray.pyx
+++ b/dpctl/tensor/_usmarray.pyx
@@ -586,10 +586,8 @@ cdef class usm_ndarray:
         return _flags.Flags(self, self.flags_)
 
     cdef _set_writable_flag(self, int flag):
-        cdef int arr_fl = self.flags_
-        arr_fl ^= (arr_fl & USM_ARRAY_WRITABLE)  # unset WRITABLE flag
-        arr_fl |= (USM_ARRAY_WRITABLE if flag else 0)
-        self.flags_ = arr_fl
+        cdef int mask = (USM_ARRAY_WRITABLE if flag else 0)
+        self.flags_ = _copy_writable(self.flags_, mask)
 
     @property
     def usm_type(self):

--- a/dpctl/tests/elementwise/test_elementwise_classes.py
+++ b/dpctl/tests/elementwise/test_elementwise_classes.py
@@ -14,6 +14,8 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
+import pytest
+
 import dpctl.tensor as dpt
 from dpctl.tests.helper import get_queue_or_skip
 
@@ -47,6 +49,15 @@ def test_unary_class_str_repr():
     kl_n = unary_fn.__name__
     assert kl_n in s
     assert kl_n in r
+
+
+def test_unary_read_only_out():
+    get_queue_or_skip()
+    x = dpt.arange(32, dtype=dpt.int32)
+    r = dpt.empty_like(x)
+    r.flags["W"] = False
+    with pytest.raises(ValueError):
+        unary_fn(x, out=r)
 
 
 def test_binary_class_getters():
@@ -105,3 +116,13 @@ def test_binary_class_nout():
     nout = binary_fn.nout
     assert isinstance(nout, int)
     assert nout == 1
+
+
+def test_biary_read_only_out():
+    get_queue_or_skip()
+    x1 = dpt.ones(32, dtype=dpt.float32)
+    x2 = dpt.ones_like(x1)
+    r = dpt.empty_like(x1)
+    r.flags["W"] = False
+    with pytest.raises(ValueError):
+        binary_fn(x1, x2, out=r)

--- a/dpctl/tests/test_tensor_clip.py
+++ b/dpctl/tests/test_tensor_clip.py
@@ -748,3 +748,22 @@ def test_clip_compute_follows_data():
 
     with pytest.raises(ExecutionPlacementError):
         dpt.clip(x, out=res)
+
+
+def test_clip_readonly_out():
+    get_queue_or_skip()
+    x = dpt.arange(32, dtype=dpt.int32)
+    r = dpt.empty_like(x)
+    r.flags["W"] = False
+
+    with pytest.raises(ValueError):
+        dpt.clip(x, min=0, max=10, out=r)
+
+    with pytest.raises(ValueError):
+        dpt.clip(x, max=10, out=r)
+
+    with pytest.raises(ValueError):
+        dpt.clip(x, min=0, out=r)
+
+    with pytest.raises(ValueError):
+        dpt.clip(x, out=r)

--- a/dpctl/tests/test_usm_ndarray_linalg.py
+++ b/dpctl/tests/test_usm_ndarray_linalg.py
@@ -332,6 +332,16 @@ def test_matmul_out():
     assert np.allclose(ref, dpt.asnumpy(res))
 
 
+def test_matmul_readonly_out():
+    get_queue_or_skip()
+    m = dpt.ones((10, 10), dtype=dpt.int32)
+    r = dpt.empty_like(m)
+    r.flags["W"] = False
+
+    with pytest.raises(ValueError):
+        dpt.matmul(m, m, out=r)
+
+
 def test_matmul_dtype():
     get_queue_or_skip()
 


### PR DESCRIPTION
This is a follow-up to gh-1527. 

It changes `usm_ndarray._set_writable_flag` implementation to use `_copy_writable` utility function. 

It also adds tests to verify that read-only array passed to `out` keyword raises `ValueError`.

- [x] Have you provided a meaningful PR description?
- [x] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
