### PR TITLE
Added work-around for breaking change in 2024.1 compiler

### DIFF
--- a/libsyclinterface/tests/test_sycl_device_interface.cpp
+++ b/libsyclinterface/tests/test_sycl_device_interface.cpp
@@ -297,9 +297,7 @@ TEST_P(TestDPCTLSyclDeviceInterface, ChkGetPreferredVectorWidthDouble)
         EXPECT_TRUE(vector_width_double != 0);
     }
     else {
-        // FIXME: DPC++ 2023 RT must have a bug, since it returns 1 for
-        // devices without aspect::fp64
-        // EXPECT_TRUE(vector_width_double == 0);
+        EXPECT_TRUE(vector_width_double == 0);
     }
 }
 
@@ -311,7 +309,9 @@ TEST_P(TestDPCTLSyclDeviceInterface, ChkGetPreferredVectorWidthHalf)
     if (DPCTLDevice_HasAspect(DRef, DPCTL_SyclAspectToDPCTLAspectType(
                                         DPCTL_StrToAspectType("fp16"))))
     {
-        EXPECT_TRUE(vector_width_half != 0);
+        // FIXME: zero value incorrectly returned for CPU in 2024.1,
+        // even though aspect::fp16 is true
+        EXPECT_TRUE(vector_width_half != 0 || DPCTLDevice_IsCPU(DRef));
     }
     else {
         EXPECT_TRUE(vector_width_half == 0);
@@ -384,13 +384,14 @@ TEST_P(TestDPCTLSyclDeviceInterface, ChkGetNativeVectorWidthHalf)
     if (DPCTLDevice_HasAspect(DRef, DPCTL_SyclAspectToDPCTLAspectType(
                                         DPCTL_StrToAspectType("fp16"))))
     {
-        EXPECT_TRUE(vector_width_half != 0);
+        // FIXME: zero value incorrectly returned for CPU in 2024.1,
+        // even though aspect::fp16 is true
+        EXPECT_TRUE(vector_width_half != 0 || DPCTLDevice_IsCPU(DRef));
     }
     else {
         EXPECT_TRUE(vector_width_half == 0);
     }
 }
-//
 
 TEST_P(TestDPCTLSyclDeviceInterface, ChkGetMaxReadImageArgs)
 {


### PR DESCRIPTION
"OpenCL:CPU" device started reporting `aspect::fp16` and supporting `sycl::half` type, but vector widths for `sycl::half` type both return zero.

- [x] Have you provided a meaningful PR description?
- [x] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
