### PR TITLE
Removed action parameter per GH warning

### DIFF
--- a/.github/workflows/conda-package.yml
+++ b/.github/workflows/conda-package.yml
@@ -677,7 +677,6 @@ jobs:
             ${{ env.MESSAGE }}
           allow-repeats: true
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          repo-token-user-login: 'github-actions[bot]'
 
   cleanup_packages:
     name: Clean up anaconda packages


### PR DESCRIPTION
The `pr-comment` action generates the following warning:

```
Unexpected input(s) 'repo-token-user-login', valid inputs are ['message', 'message-path', 'message-id', \
       'refresh-message-position', 'repo-owner', 'repo-name', 'repo-token', \
       'allow-repeats', 'proxy-url', 'status', 'message-success', 'message-failure', \
        'message-cancelled', 'message-skipped', 'issue', 'update-only', 'preformatted', 'find', 'replace']
```

This PR repos the offending argument as it is ignored anyway.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
