### PR TITLE
Adds and implements utilities for validating array size and writable flag

### DIFF
--- a/dpctl/apis/include/dpctl4pybind11.hpp
+++ b/dpctl/apis/include/dpctl4pybind11.hpp
@@ -1072,7 +1072,7 @@ bool queues_are_compatible(const sycl::queue &exec_q,
     return true;
 }
 
-/*! @brief Check if all allocation queues of  usm_ndarays are the same as
+/*! @brief Check if all allocation queues of usm_ndarays are the same as
     the execution queue */
 template <std::size_t num>
 bool queues_are_compatible(const sycl::queue &exec_q,

--- a/dpctl/tensor/libtensor/include/utils/output_validation.hpp
+++ b/dpctl/tensor/libtensor/include/utils/output_validation.hpp
@@ -37,16 +37,35 @@ namespace tensor
 namespace validation
 {
 
-/*! @brief Raises a value error if a function would attempt to write
-    to an array which is read-only.
+/*! @brief Raises a value error if an array is read-only.
 
-    This should always be called on an array before it will be written to.*/
+    This should be called with an array before writing.*/
 struct CheckWritable
 {
     static void throw_if_not_writable(const dpctl::tensor::usm_ndarray &arr)
     {
         if (!arr.is_writable()) {
             throw py::value_error("output array is read-only.");
+        }
+        return;
+    }
+};
+
+/*! @brief Raises a value error if an array's memory is not sufficiently ample
+    to accommodate an input number of elements.
+
+    This should be called with an array before writing.*/
+struct AmpleMemory
+{
+    template <typename T>
+    static void throw_if_not_ample(const dpctl::tensor::usm_ndarray &arr,
+                                   T nelems)
+    {
+        auto arr_offsets = arr.get_minmax_offsets();
+        T range = static_cast<T>(arr_offsets.second - arr_offsets.first);
+        if (range + 1 < nelems) {
+            throw py::value_error("Memory addressed by the output array is not "
+                                  "sufficiently ample.");
         }
         return;
     }

--- a/dpctl/tensor/libtensor/include/utils/output_validation.hpp
+++ b/dpctl/tensor/libtensor/include/utils/output_validation.hpp
@@ -1,0 +1,57 @@
+//===- output_validation.hpp - Utilities for output array validation
+//-*-C++-*===//
+//
+//                      Data Parallel Control (dpctl)
+//
+// Copyright 2020-2022 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// This file defines utilities for determining if an array is a valid output
+/// array.
+//===----------------------------------------------------------------------===//
+
+#pragma once
+#include "dpctl4pybind11.hpp"
+#include <pybind11/pybind11.h>
+
+namespace dpctl
+{
+
+namespace tensor
+{
+
+namespace validation
+{
+
+/*! @brief Raises a value error if a function would attempt to write
+    to an array which is read-only.
+
+    This should always be called on an array before it will be written to.*/
+struct CheckWritable
+{
+    static void throw_if_not_writable(const dpctl::tensor::usm_ndarray &arr)
+    {
+        if (!arr.is_writable()) {
+            throw py::value_error("output array is read-only.");
+        }
+        return;
+    }
+};
+
+} // namespace validation
+} // namespace tensor
+} // namespace dpctl

--- a/dpctl/tensor/libtensor/source/accumulators.cpp
+++ b/dpctl/tensor/libtensor/source/accumulators.cpp
@@ -35,6 +35,7 @@
 #include "simplify_iteration_space.hpp"
 #include "utils/memory_overlap.hpp"
 #include "utils/offset_utils.hpp"
+#include "utils/output_validation.hpp"
 #include "utils/type_dispatch.hpp"
 
 namespace dpctl
@@ -102,6 +103,8 @@ size_t py_mask_positions(const dpctl::tensor::usm_ndarray &mask,
                          sycl::queue &exec_q,
                          const std::vector<sycl::event> &depends)
 {
+    dpctl::tensor::validation::CheckWritable::throw_if_not_writable(cumsum);
+
     // cumsum is 1D
     if (cumsum.get_ndim() != 1) {
         throw py::value_error("Result array must be one-dimensional.");
@@ -273,6 +276,8 @@ size_t py_cumsum_1d(const dpctl::tensor::usm_ndarray &src,
         throw py::value_error(
             "Execution queue is not compatible with allocation queues");
     }
+
+    dpctl::tensor::validation::CheckWritable::throw_if_not_writable(cumsum);
 
     if (src_size == 0) {
         return 0;

--- a/dpctl/tensor/libtensor/source/boolean_advanced_indexing.cpp
+++ b/dpctl/tensor/libtensor/source/boolean_advanced_indexing.cpp
@@ -174,19 +174,8 @@ py_extract(const dpctl::tensor::usm_ndarray &src,
         throw py::value_error("Inconsistent array dimensions");
     }
 
-    // ensure that dst is sufficiently ample
-    auto dst_offsets = dst.get_minmax_offsets();
-    // destination must be ample enough to accommodate all elements
-    {
-        size_t range =
-            static_cast<size_t>(dst_offsets.second - dst_offsets.first);
-        if (range + 1 < static_cast<size_t>(ortho_nelems * masked_dst_nelems)) {
-            throw py::value_error(
-                "Memory addressed by the destination array can not "
-                "accommodate all the "
-                "array elements.");
-        }
-    }
+    dpctl::tensor::validation::AmpleMemory::throw_if_not_ample(
+        dst, ortho_nelems * masked_dst_nelems);
 
     auto const &overlap = dpctl::tensor::overlap::MemoryOverlap();
     // check that dst does not intersect with src, not with cumsum.
@@ -507,19 +496,8 @@ py_place(const dpctl::tensor::usm_ndarray &dst,
         throw py::value_error("Inconsistent array dimensions");
     }
 
-    // ensure that dst is sufficiently ample
-    auto dst_offsets = dst.get_minmax_offsets();
-    // destination must be ample enough to accommodate all elements
-    {
-        size_t range =
-            static_cast<size_t>(dst_offsets.second - dst_offsets.first);
-        if (range + 1 < static_cast<size_t>(ortho_nelems * masked_dst_nelems)) {
-            throw py::value_error(
-                "Memory addressed by the destination array can not "
-                "accommodate all the "
-                "array elements.");
-        }
-    }
+    dpctl::tensor::validation::AmpleMemory::throw_if_not_ample(
+        dst, ortho_nelems * masked_dst_nelems);
 
     auto const &overlap = dpctl::tensor::overlap::MemoryOverlap();
     // check that dst does not intersect with src, not with cumsum.
@@ -794,18 +772,8 @@ py_nonzero(const dpctl::tensor::usm_ndarray
         throw py::value_error("Arrays are expected to ave no memory overlap");
     }
 
-    // ensure that dst is sufficiently ample
-    auto indexes_offsets = indexes.get_minmax_offsets();
-    // destination must be ample enough to accommodate all elements
-    {
-        size_t range =
-            static_cast<size_t>(indexes_offsets.second - indexes_offsets.first);
-        if (range + 1 < static_cast<size_t>(nz_elems * _ndim)) {
-            throw py::value_error(
-                "Memory addressed by the destination array can not "
-                "accommodate all the array elements.");
-        }
-    }
+    dpctl::tensor::validation::AmpleMemory::throw_if_not_ample(
+        indexes, nz_elems * _ndim);
 
     std::vector<sycl::event> host_task_events;
     host_task_events.reserve(2);

--- a/dpctl/tensor/libtensor/source/boolean_advanced_indexing.cpp
+++ b/dpctl/tensor/libtensor/source/boolean_advanced_indexing.cpp
@@ -37,6 +37,7 @@
 #include "simplify_iteration_space.hpp"
 #include "utils/memory_overlap.hpp"
 #include "utils/offset_utils.hpp"
+#include "utils/output_validation.hpp"
 #include "utils/type_dispatch.hpp"
 
 namespace dpctl
@@ -118,6 +119,8 @@ py_extract(const dpctl::tensor::usm_ndarray &src,
            sycl::queue &exec_q,
            const std::vector<sycl::event> &depends)
 {
+    dpctl::tensor::validation::CheckWritable::throw_if_not_writable(dst);
+
     int src_nd = src.get_ndim();
     if ((axis_start < 0 || axis_end > src_nd || axis_start >= axis_end)) {
         throw py::value_error("Specified axes_start and axes_end are invalid.");
@@ -452,6 +455,8 @@ py_place(const dpctl::tensor::usm_ndarray &dst,
          sycl::queue &exec_q,
          const std::vector<sycl::event> &depends)
 {
+    dpctl::tensor::validation::CheckWritable::throw_if_not_writable(dst);
+
     int dst_nd = dst.get_ndim();
     if ((axis_start < 0 || axis_end > dst_nd || axis_start >= axis_end)) {
         throw py::value_error("Specified axes_start and axes_end are invalid.");
@@ -725,6 +730,8 @@ py_nonzero(const dpctl::tensor::usm_ndarray
         throw py::value_error(
             "Execution queue is not compatible with allocation queues");
     }
+
+    dpctl::tensor::validation::CheckWritable::throw_if_not_writable(indexes);
 
     int cumsum_nd = cumsum.get_ndim();
     if (cumsum_nd != 1 || !cumsum.is_c_contiguous()) {

--- a/dpctl/tensor/libtensor/source/clip.cpp
+++ b/dpctl/tensor/libtensor/source/clip.cpp
@@ -37,6 +37,7 @@
 #include "simplify_iteration_space.hpp"
 #include "utils/memory_overlap.hpp"
 #include "utils/offset_utils.hpp"
+#include "utils/output_validation.hpp"
 #include "utils/type_dispatch.hpp"
 
 namespace dpctl
@@ -86,6 +87,8 @@ py_clip(const dpctl::tensor::usm_ndarray &src,
         throw py::value_error(
             "Execution queue is not compatible with allocation queues");
     }
+
+    dpctl::tensor::validation::CheckWritable::throw_if_not_writable(dst);
 
     int nd = src.get_ndim();
     int min_nd = min.get_ndim();

--- a/dpctl/tensor/libtensor/source/clip.cpp
+++ b/dpctl/tensor/libtensor/source/clip.cpp
@@ -155,19 +155,7 @@ py_clip(const dpctl::tensor::usm_ndarray &src,
                               "have the same data type");
     }
 
-    // ensure that dst is sufficiently ample
-    auto dst_offsets = dst.get_minmax_offsets();
-    // destination must be ample enough to accommodate all elements
-    {
-        size_t range =
-            static_cast<size_t>(dst_offsets.second - dst_offsets.first);
-        if (range + 1 < static_cast<size_t>(nelems)) {
-            throw py::value_error(
-                "Memory addressed by the destination array can not "
-                "accommodate all the "
-                "array elements.");
-        }
-    }
+    dpctl::tensor::validation::AmpleMemory::throw_if_not_ample(dst, nelems);
 
     char *src_data = src.get_data();
     char *min_data = min.get_data();

--- a/dpctl/tensor/libtensor/source/copy_and_cast_usm_to_usm.cpp
+++ b/dpctl/tensor/libtensor/source/copy_and_cast_usm_to_usm.cpp
@@ -101,17 +101,7 @@ copy_usm_ndarray_into_usm_ndarray(const dpctl::tensor::usm_ndarray &src,
         return std::make_pair(sycl::event(), sycl::event());
     }
 
-    // destination must be ample enough to accommodate all elements
-    {
-        auto dst_offsets = dst.get_minmax_offsets();
-        size_t range =
-            static_cast<size_t>(dst_offsets.second - dst_offsets.first);
-        if (range + 1 < src_nelems) {
-            throw py::value_error(
-                "Destination array can not accommodate all the "
-                "elements of source array.");
-        }
-    }
+    dpctl::tensor::validation::AmpleMemory::throw_if_not_ample(dst, src_nelems);
 
     // check compatibility of execution queue and allocation queue
     if (!dpctl::utils::queues_are_compatible(exec_q, {src, dst})) {

--- a/dpctl/tensor/libtensor/source/copy_and_cast_usm_to_usm.cpp
+++ b/dpctl/tensor/libtensor/source/copy_and_cast_usm_to_usm.cpp
@@ -37,6 +37,7 @@
 #include "dpctl4pybind11.hpp"
 #include "kernels/copy_and_cast.hpp"
 #include "utils/memory_overlap.hpp"
+#include "utils/output_validation.hpp"
 #include "utils/type_dispatch.hpp"
 #include "utils/type_utils.hpp"
 
@@ -117,6 +118,8 @@ copy_usm_ndarray_into_usm_ndarray(const dpctl::tensor::usm_ndarray &src,
         throw py::value_error(
             "Execution queue is not compatible with allocation queues");
     }
+
+    dpctl::tensor::validation::CheckWritable::throw_if_not_writable(dst);
 
     int src_typenum = src.get_typenum();
     int dst_typenum = dst.get_typenum();

--- a/dpctl/tensor/libtensor/source/copy_for_reshape.cpp
+++ b/dpctl/tensor/libtensor/source/copy_for_reshape.cpp
@@ -88,17 +88,7 @@ copy_usm_ndarray_for_reshape(const dpctl::tensor::usm_ndarray &src,
         return std::make_pair(sycl::event(), sycl::event());
     }
 
-    // destination must be ample enough to accommodate all elements
-    {
-        auto dst_offsets = dst.get_minmax_offsets();
-        py::ssize_t range =
-            static_cast<py::ssize_t>(dst_offsets.second - dst_offsets.first);
-        if (range + 1 < src_nelems) {
-            throw py::value_error(
-                "Destination array can not accommodate all the "
-                "elements of source array.");
-        }
-    }
+    dpctl::tensor::validation::AmpleMemory::throw_if_not_ample(dst, src_nelems);
 
     // check same contexts
     if (!dpctl::utils::queues_are_compatible(exec_q, {src, dst})) {

--- a/dpctl/tensor/libtensor/source/copy_for_reshape.cpp
+++ b/dpctl/tensor/libtensor/source/copy_for_reshape.cpp
@@ -29,6 +29,7 @@
 #include "copy_for_reshape.hpp"
 #include "dpctl4pybind11.hpp"
 #include "kernels/copy_and_cast.hpp"
+#include "utils/output_validation.hpp"
 #include "utils/type_dispatch.hpp"
 #include <pybind11/pybind11.h>
 
@@ -104,6 +105,8 @@ copy_usm_ndarray_for_reshape(const dpctl::tensor::usm_ndarray &src,
         throw py::value_error(
             "Execution queue is not compatible with allocation queues");
     }
+
+    dpctl::tensor::validation::CheckWritable::throw_if_not_writable(dst);
 
     if (src_nelems == 1) {
         // handle special case of 1-element array

--- a/dpctl/tensor/libtensor/source/copy_for_roll.cpp
+++ b/dpctl/tensor/libtensor/source/copy_for_roll.cpp
@@ -111,17 +111,7 @@ copy_usm_ndarray_for_roll_1d(const dpctl::tensor::usm_ndarray &src,
         return std::make_pair(sycl::event(), sycl::event());
     }
 
-    // destination must be ample enough to accommodate all elements
-    {
-        auto dst_offsets = dst.get_minmax_offsets();
-        py::ssize_t range =
-            static_cast<py::ssize_t>(dst_offsets.second - dst_offsets.first);
-        if (range + 1 < src_nelems) {
-            throw py::value_error(
-                "Destination array can not accommodate all the "
-                "elements of source array.");
-        }
-    }
+    dpctl::tensor::validation::AmpleMemory::throw_if_not_ample(dst, src_nelems);
 
     // check same contexts
     if (!dpctl::utils::queues_are_compatible(exec_q, {src, dst})) {
@@ -301,17 +291,7 @@ copy_usm_ndarray_for_roll_nd(const dpctl::tensor::usm_ndarray &src,
         return std::make_pair(sycl::event(), sycl::event());
     }
 
-    // destination must be ample enough to accommodate all elements
-    {
-        auto dst_offsets = dst.get_minmax_offsets();
-        py::ssize_t range =
-            static_cast<py::ssize_t>(dst_offsets.second - dst_offsets.first);
-        if (range + 1 < src_nelems) {
-            throw py::value_error(
-                "Destination array can not accommodate all the "
-                "elements of source array.");
-        }
-    }
+    dpctl::tensor::validation::AmpleMemory::throw_if_not_ample(dst, src_nelems);
 
     // check for compatible queues
     if (!dpctl::utils::queues_are_compatible(exec_q, {src, dst})) {

--- a/dpctl/tensor/libtensor/source/copy_for_roll.cpp
+++ b/dpctl/tensor/libtensor/source/copy_for_roll.cpp
@@ -29,6 +29,7 @@
 #include "copy_for_roll.hpp"
 #include "dpctl4pybind11.hpp"
 #include "kernels/copy_and_cast.hpp"
+#include "utils/output_validation.hpp"
 #include "utils/type_dispatch.hpp"
 #include <pybind11/pybind11.h>
 
@@ -127,6 +128,8 @@ copy_usm_ndarray_for_roll_1d(const dpctl::tensor::usm_ndarray &src,
         throw py::value_error(
             "Execution queue is not compatible with allocation queues");
     }
+
+    dpctl::tensor::validation::CheckWritable::throw_if_not_writable(dst);
 
     if (src_nelems == 1) {
         // handle special case of 1-element array

--- a/dpctl/tensor/libtensor/source/copy_numpy_ndarray_into_usm_ndarray.cpp
+++ b/dpctl/tensor/libtensor/source/copy_numpy_ndarray_into_usm_ndarray.cpp
@@ -31,6 +31,7 @@
 #include <pybind11/pybind11.h>
 
 #include "kernels/copy_and_cast.hpp"
+#include "utils/output_validation.hpp"
 #include "utils/type_dispatch.hpp"
 
 #include "copy_numpy_ndarray_into_usm_ndarray.hpp"
@@ -105,6 +106,8 @@ void copy_numpy_ndarray_into_usm_ndarray(
         throw py::value_error("Execution queue is not compatible with the "
                               "allocation queue");
     }
+
+    dpctl::tensor::validation::CheckWritable::throw_if_not_writable(dst);
 
     // here we assume that NumPy's type numbers agree with ours for types
     // supported in both

--- a/dpctl/tensor/libtensor/source/copy_numpy_ndarray_into_usm_ndarray.cpp
+++ b/dpctl/tensor/libtensor/source/copy_numpy_ndarray_into_usm_ndarray.cpp
@@ -89,18 +89,7 @@ void copy_numpy_ndarray_into_usm_ndarray(
         return;
     }
 
-    auto dst_offsets = dst.get_minmax_offsets();
-    // destination must be ample enough to accommodate all elements of source
-    // array
-    {
-        size_t range =
-            static_cast<size_t>(dst_offsets.second - dst_offsets.first);
-        if (range + 1 < src_nelems) {
-            throw py::value_error(
-                "Destination array can not accommodate all the "
-                "elements of source array.");
-        }
-    }
+    dpctl::tensor::validation::AmpleMemory::throw_if_not_ample(dst, src_nelems);
 
     if (!dpctl::utils::queues_are_compatible(exec_q, {dst})) {
         throw py::value_error("Execution queue is not compatible with the "

--- a/dpctl/tensor/libtensor/source/elementwise_functions/elementwise_functions.hpp
+++ b/dpctl/tensor/libtensor/source/elementwise_functions/elementwise_functions.hpp
@@ -38,6 +38,7 @@
 #include "simplify_iteration_space.hpp"
 #include "utils/memory_overlap.hpp"
 #include "utils/offset_utils.hpp"
+#include "utils/output_validation.hpp"
 #include "utils/type_dispatch.hpp"
 
 namespace py = pybind11;
@@ -69,10 +70,6 @@ py_unary_ufunc(const dpctl::tensor::usm_ndarray &src,
                const contig_dispatchT &contig_dispatch_vector,
                const strided_dispatchT &strided_dispatch_vector)
 {
-    if (!dst.is_writable()) {
-        throw py::value_error("Output array is read-only.");
-    }
-
     int src_typenum = src.get_typenum();
     int dst_typenum = dst.get_typenum();
 
@@ -93,6 +90,8 @@ py_unary_ufunc(const dpctl::tensor::usm_ndarray &src,
         throw py::value_error(
             "Execution queue is not compatible with allocation queues");
     }
+
+    dpctl::tensor::validation::CheckWritable::throw_if_not_writable(dst);
 
     // check that dimensions are the same
     int src_nd = src.get_ndim();
@@ -324,9 +323,6 @@ std::pair<sycl::event, sycl::event> py_binary_ufunc(
     const contig_row_matrix_dispatchT
         &contig_row_matrix_broadcast_dispatch_table)
 {
-    if (!dst.is_writable()) {
-        throw py::value_error("Output array is read-only.");
-    }
     // check type_nums
     int src1_typenum = src1.get_typenum();
     int src2_typenum = src2.get_typenum();
@@ -349,6 +345,8 @@ std::pair<sycl::event, sycl::event> py_binary_ufunc(
         throw py::value_error(
             "Execution queue is not compatible with allocation queues");
     }
+
+    dpctl::tensor::validation::CheckWritable::throw_if_not_writable(dst);
 
     // check shapes, broadcasting is assumed done by caller
     // check that dimensions are the same
@@ -655,9 +653,7 @@ py_binary_inplace_ufunc(const dpctl::tensor::usm_ndarray &lhs,
                         const contig_row_matrix_dispatchT
                             &contig_row_matrix_broadcast_dispatch_table)
 {
-    if (!lhs.is_writable()) {
-        throw py::value_error("Output array is read-only.");
-    }
+    dpctl::tensor::validation::CheckWritable::throw_if_not_writable(lhs);
 
     // check type_nums
     int rhs_typenum = rhs.get_typenum();

--- a/dpctl/tensor/libtensor/source/elementwise_functions/elementwise_functions.hpp
+++ b/dpctl/tensor/libtensor/source/elementwise_functions/elementwise_functions.hpp
@@ -680,7 +680,7 @@ py_binary_inplace_ufunc(const dpctl::tensor::usm_ndarray &lhs,
         return std::make_pair(sycl::event(), sycl::event());
     }
 
-    dpctl::tensor::validation::AmpleMemory::throw_if_not_ample(rhs, rhs_nelems);
+    dpctl::tensor::validation::AmpleMemory::throw_if_not_ample(lhs, rhs_nelems);
 
     // check memory overlap
     auto const &same_logical_tensors =

--- a/dpctl/tensor/libtensor/source/elementwise_functions/elementwise_functions.hpp
+++ b/dpctl/tensor/libtensor/source/elementwise_functions/elementwise_functions.hpp
@@ -118,18 +118,7 @@ py_unary_ufunc(const dpctl::tensor::usm_ndarray &src,
         return std::make_pair(sycl::event(), sycl::event());
     }
 
-    // ensure that output is ample enough to accommodate all elements
-    auto dst_offsets = dst.get_minmax_offsets();
-    // destination must be ample enough to accommodate all elements
-    {
-        size_t range =
-            static_cast<size_t>(dst_offsets.second - dst_offsets.first);
-        if (range + 1 < src_nelems) {
-            throw py::value_error(
-                "Destination array can not accommodate all the "
-                "elements of source array.");
-        }
-    }
+    dpctl::tensor::validation::AmpleMemory::throw_if_not_ample(dst, src_nelems);
 
     // check memory overlap
     auto const &overlap = dpctl::tensor::overlap::MemoryOverlap();
@@ -376,18 +365,7 @@ std::pair<sycl::event, sycl::event> py_binary_ufunc(
         return std::make_pair(sycl::event(), sycl::event());
     }
 
-    // ensure that output is ample enough to accommodate all elements
-    auto dst_offsets = dst.get_minmax_offsets();
-    // destination must be ample enough to accommodate all elements
-    {
-        size_t range =
-            static_cast<size_t>(dst_offsets.second - dst_offsets.first);
-        if (range + 1 < src_nelems) {
-            throw py::value_error(
-                "Destination array can not accommodate all the "
-                "elements of source array.");
-        }
-    }
+    dpctl::tensor::validation::AmpleMemory::throw_if_not_ample(dst, src_nelems);
 
     auto const &overlap = dpctl::tensor::overlap::MemoryOverlap();
     auto const &same_logical_tensors =
@@ -702,18 +680,7 @@ py_binary_inplace_ufunc(const dpctl::tensor::usm_ndarray &lhs,
         return std::make_pair(sycl::event(), sycl::event());
     }
 
-    // ensure that output is ample enough to accommodate all elements
-    auto lhs_offsets = lhs.get_minmax_offsets();
-    // destination must be ample enough to accommodate all elements
-    {
-        size_t range =
-            static_cast<size_t>(lhs_offsets.second - lhs_offsets.first);
-        if (range + 1 < rhs_nelems) {
-            throw py::value_error(
-                "Destination array can not accommodate all the "
-                "elements of source array.");
-        }
-    }
+    dpctl::tensor::validation::AmpleMemory::throw_if_not_ample(rhs, rhs_nelems);
 
     // check memory overlap
     auto const &same_logical_tensors =

--- a/dpctl/tensor/libtensor/source/eye_ctor.cpp
+++ b/dpctl/tensor/libtensor/source/eye_ctor.cpp
@@ -31,6 +31,7 @@
 
 #include "eye_ctor.hpp"
 #include "kernels/constructors.hpp"
+#include "utils/output_validation.hpp"
 #include "utils/type_dispatch.hpp"
 
 namespace py = pybind11;
@@ -65,6 +66,8 @@ usm_ndarray_eye(py::ssize_t k,
         throw py::value_error("Execution queue is not compatible with the "
                               "allocation queue");
     }
+
+    dpctl::tensor::validation::CheckWritable::throw_if_not_writable(dst);
 
     auto array_types = td_ns::usm_ndarray_types();
     int dst_typenum = dst.get_typenum();

--- a/dpctl/tensor/libtensor/source/full_ctor.cpp
+++ b/dpctl/tensor/libtensor/source/full_ctor.cpp
@@ -31,6 +31,7 @@
 #include <vector>
 
 #include "kernels/constructors.hpp"
+#include "utils/output_validation.hpp"
 #include "utils/type_dispatch.hpp"
 #include "utils/type_utils.hpp"
 
@@ -125,6 +126,8 @@ usm_ndarray_full(const py::object &py_value,
         throw py::value_error(
             "Execution queue is not compatible with the allocation queue");
     }
+
+    dpctl::tensor::validation::CheckWritable::throw_if_not_writable(dst);
 
     auto array_types = td_ns::usm_ndarray_types();
     int dst_typenum = dst.get_typenum();

--- a/dpctl/tensor/libtensor/source/integer_advanced_indexing.cpp
+++ b/dpctl/tensor/libtensor/source/integer_advanced_indexing.cpp
@@ -352,17 +352,8 @@ usm_ndarray_take(const dpctl::tensor::usm_ndarray &src,
         }
     }
 
-    // destination must be ample enough to accommodate all elements
-    {
-        auto dst_offsets = dst.get_minmax_offsets();
-        size_t range =
-            static_cast<size_t>(dst_offsets.second - dst_offsets.first);
-        if ((range + 1) < (orthog_nelems * ind_nelems)) {
-            throw py::value_error(
-                "Destination array can not accommodate all the "
-                "elements of source array.");
-        }
-    }
+    dpctl::tensor::validation::AmpleMemory::throw_if_not_ample(
+        dst, orthog_nelems * ind_nelems);
 
     int ind_sh_elems = std::max<int>(ind_nd, 1);
 
@@ -641,17 +632,7 @@ usm_ndarray_put(const dpctl::tensor::usm_ndarray &dst,
     py::ssize_t dst_offset = py::ssize_t(0);
     py::ssize_t val_offset = py::ssize_t(0);
 
-    // destination must be ample enough to accommodate all possible elements
-    {
-        auto dst_offsets = dst.get_minmax_offsets();
-        size_t range =
-            static_cast<size_t>(dst_offsets.second - dst_offsets.first);
-        if ((range + 1) < dst_nelems) {
-            throw py::value_error(
-                "Destination array can not accommodate all the "
-                "elements of source array.");
-        }
-    }
+    dpctl::tensor::validation::AmpleMemory::throw_if_not_ample(dst, dst_nelems);
 
     int dst_typenum = dst.get_typenum();
     int val_typenum = val.get_typenum();

--- a/dpctl/tensor/libtensor/source/integer_advanced_indexing.cpp
+++ b/dpctl/tensor/libtensor/source/integer_advanced_indexing.cpp
@@ -35,6 +35,7 @@
 #include "dpctl4pybind11.hpp"
 #include "kernels/integer_advanced_indexing.hpp"
 #include "utils/memory_overlap.hpp"
+#include "utils/output_validation.hpp"
 #include "utils/type_dispatch.hpp"
 #include "utils/type_utils.hpp"
 
@@ -258,6 +259,8 @@ usm_ndarray_take(const dpctl::tensor::usm_ndarray &src,
     if (mode != 0 && mode != 1) {
         throw py::value_error("Mode must be 0 or 1.");
     }
+
+    dpctl::tensor::validation::CheckWritable::throw_if_not_writable(dst);
 
     const dpctl::tensor::usm_ndarray ind_rep = ind[0];
 
@@ -570,9 +573,7 @@ usm_ndarray_put(const dpctl::tensor::usm_ndarray &dst,
         throw py::value_error("Mode must be 0 or 1.");
     }
 
-    if (!dst.is_writable()) {
-        throw py::value_error("Output array is read-only.");
-    }
+    dpctl::tensor::validation::CheckWritable::throw_if_not_writable(dst);
 
     const dpctl::tensor::usm_ndarray ind_rep = ind[0];
 

--- a/dpctl/tensor/libtensor/source/linalg_functions/dot.cpp
+++ b/dpctl/tensor/libtensor/source/linalg_functions/dot.cpp
@@ -248,19 +248,7 @@ py_dot(const dpctl::tensor::usm_ndarray &x1,
         throw py::value_error("dst shape and size mismatch");
     }
 
-    // ensure that dst is sufficiently ample
-    auto dst_offsets = dst.get_minmax_offsets();
-    // destination must be ample enough to accommodate all elements
-    {
-        size_t range =
-            static_cast<size_t>(dst_offsets.second - dst_offsets.first);
-        if (range + 1 < dst_nelems) {
-            throw py::value_error(
-                "Memory addressed by the destination array can not "
-                "accommodate all the "
-                "array elements.");
-        }
-    }
+    dpctl::tensor::validation::AmpleMemory::throw_if_not_ample(dst, dst_nelems);
 
     auto const &overlap = dpctl::tensor::overlap::MemoryOverlap();
     // check that dst does not intersect with x1 or x2

--- a/dpctl/tensor/libtensor/source/linalg_functions/dot.cpp
+++ b/dpctl/tensor/libtensor/source/linalg_functions/dot.cpp
@@ -17,6 +17,7 @@
 #include "simplify_iteration_space.hpp"
 #include "utils/memory_overlap.hpp"
 #include "utils/offset_utils.hpp"
+#include "utils/output_validation.hpp"
 
 namespace dpctl
 {
@@ -175,18 +176,15 @@ py_dot(const dpctl::tensor::usm_ndarray &x1,
        sycl::queue &exec_q,
        const std::vector<sycl::event> &depends)
 {
-
-    if (!dst.is_writable()) {
-        throw py::value_error("Output array is read-only.");
-    }
-
-    if (inner_dims == 0) {
-        throw py::value_error("No inner dimension for dot");
-    }
-
     if (!dpctl::utils::queues_are_compatible(exec_q, {x1, x2, dst})) {
         throw py::value_error(
             "Execution queue is not compatible with allocation queues");
+    }
+
+    dpctl::tensor::validation::CheckWritable::throw_if_not_writable(dst);
+
+    if (inner_dims == 0) {
+        throw py::value_error("No inner dimension for dot");
     }
 
     int x1_nd = x1.get_ndim();

--- a/dpctl/tensor/libtensor/source/linear_sequences.cpp
+++ b/dpctl/tensor/libtensor/source/linear_sequences.cpp
@@ -31,6 +31,7 @@
 #include <vector>
 
 #include "kernels/constructors.hpp"
+#include "utils/output_validation.hpp"
 #include "utils/type_dispatch.hpp"
 #include "utils/type_utils.hpp"
 
@@ -191,6 +192,8 @@ usm_ndarray_linear_sequence_step(const py::object &start,
             "Execution queue is not compatible with the allocation queue");
     }
 
+    dpctl::tensor::validation::CheckWritable::throw_if_not_writable(dst);
+
     auto array_types = td_ns::usm_ndarray_types();
     int dst_typenum = dst.get_typenum();
     int dst_typeid = array_types.typenum_to_lookup_id(dst_typenum);
@@ -238,6 +241,8 @@ usm_ndarray_linear_sequence_affine(const py::object &start,
         throw py::value_error(
             "Execution queue context is not the same as allocation context");
     }
+
+    dpctl::tensor::validation::CheckWritable::throw_if_not_writable(dst);
 
     auto array_types = td_ns::usm_ndarray_types();
     int dst_typenum = dst.get_typenum();

--- a/dpctl/tensor/libtensor/source/reductions/reduction_over_axis.hpp
+++ b/dpctl/tensor/libtensor/source/reductions/reduction_over_axis.hpp
@@ -42,6 +42,7 @@
 #include "simplify_iteration_space.hpp"
 #include "utils/memory_overlap.hpp"
 #include "utils/offset_utils.hpp"
+#include "utils/output_validation.hpp"
 #include "utils/type_dispatch.hpp"
 
 namespace dpctl
@@ -203,6 +204,8 @@ std::pair<sycl::event, sycl::event> py_reduction_over_axis(
         throw py::value_error(
             "Execution queue is not compatible with allocation queues");
     }
+
+    dpctl::tensor::validation::CheckWritable::throw_if_not_writable(dst);
 
     size_t dst_nelems = dst.get_size();
 
@@ -554,6 +557,8 @@ std::pair<sycl::event, sycl::event> py_tree_reduction_over_axis(
             "Execution queue is not compatible with allocation queues");
     }
 
+    dpctl::tensor::validation::CheckWritable::throw_if_not_writable(dst);
+
     size_t dst_nelems = dst.get_size();
 
     if (dst_nelems == 0) {
@@ -849,6 +854,8 @@ std::pair<sycl::event, sycl::event> py_search_over_axis(
             "Execution queue is not compatible with allocation queues");
     }
 
+    dpctl::tensor::validation::CheckWritable::throw_if_not_writable(dst);
+
     size_t dst_nelems = dst.get_size();
 
     if (dst_nelems == 0) {
@@ -1138,6 +1145,8 @@ py_boolean_reduction(const dpctl::tensor::usm_ndarray &src,
         throw py::value_error(
             "Execution queue is not compatible with allocation queues");
     }
+
+    dpctl::tensor::validation::CheckWritable::throw_if_not_writable(dst);
 
     size_t dst_nelems = dst.get_size();
 

--- a/dpctl/tensor/libtensor/source/reductions/reduction_over_axis.hpp
+++ b/dpctl/tensor/libtensor/source/reductions/reduction_over_axis.hpp
@@ -224,17 +224,7 @@ std::pair<sycl::event, sycl::event> py_reduction_over_axis(
         throw py::value_error("Arrays index overlapping segments of memory");
     }
 
-    // destination must be ample enough to accommodate all elements
-    {
-        auto dst_offsets = dst.get_minmax_offsets();
-        size_t range =
-            static_cast<size_t>(dst_offsets.second - dst_offsets.first);
-        if (range + 1 < dst_nelems) {
-            throw py::value_error(
-                "Destination array can not accommodate all the "
-                "elements of source array.");
-        }
-    }
+    dpctl::tensor::validation::AmpleMemory::throw_if_not_ample(dst, dst_nelems);
 
     int src_typenum = src.get_typenum();
     int dst_typenum = dst.get_typenum();
@@ -576,17 +566,7 @@ std::pair<sycl::event, sycl::event> py_tree_reduction_over_axis(
         throw py::value_error("Arrays index overlapping segments of memory");
     }
 
-    // destination must be ample enough to accommodate all elements
-    {
-        auto dst_offsets = dst.get_minmax_offsets();
-        size_t range =
-            static_cast<size_t>(dst_offsets.second - dst_offsets.first);
-        if (range + 1 < dst_nelems) {
-            throw py::value_error(
-                "Destination array can not accommodate all the "
-                "elements of source array.");
-        }
-    }
+    dpctl::tensor::validation::AmpleMemory::throw_if_not_ample(dst, dst_nelems);
 
     int src_typenum = src.get_typenum();
     int dst_typenum = dst.get_typenum();
@@ -873,17 +853,7 @@ std::pair<sycl::event, sycl::event> py_search_over_axis(
         throw py::value_error("Arrays index overlapping segments of memory");
     }
 
-    // destination must be ample enough to accommodate all elements
-    {
-        auto dst_offsets = dst.get_minmax_offsets();
-        size_t range =
-            static_cast<size_t>(dst_offsets.second - dst_offsets.first);
-        if (range + 1 < dst_nelems) {
-            throw py::value_error(
-                "Destination array can not accommodate all the "
-                "elements of source array.");
-        }
-    }
+    dpctl::tensor::validation::AmpleMemory::throw_if_not_ample(dst, dst_nelems);
 
     int src_typenum = src.get_typenum();
     int dst_typenum = dst.get_typenum();
@@ -1160,18 +1130,7 @@ py_boolean_reduction(const dpctl::tensor::usm_ndarray &src,
         throw py::value_error("Arrays are expected to have no memory overlap");
     }
 
-    // ensure that dst is sufficiently ample
-    auto dst_offsets = dst.get_minmax_offsets();
-    // destination must be ample enough to accommodate all elements
-    {
-        size_t range =
-            static_cast<size_t>(dst_offsets.second - dst_offsets.first);
-        if (range + 1 < static_cast<size_t>(dst_nelems)) {
-            throw py::value_error(
-                "Memory addressed by the destination array can not "
-                "accommodate all the array elements.");
-        }
-    }
+    dpctl::tensor::validation::AmpleMemory::throw_if_not_ample(dst, dst_nelems);
 
     const char *src_data = src.get_data();
     char *dst_data = dst.get_data();

--- a/dpctl/tensor/libtensor/source/repeat.cpp
+++ b/dpctl/tensor/libtensor/source/repeat.cpp
@@ -167,19 +167,8 @@ py_repeat_by_sequence(const dpctl::tensor::usm_ndarray &src,
         return std::make_pair(sycl::event(), sycl::event());
     }
 
-    // ensure that dst is sufficiently ample
-    auto dst_offsets = dst.get_minmax_offsets();
-    // destination must be ample enough to accommodate all elements
-    {
-        size_t range =
-            static_cast<size_t>(dst_offsets.second - dst_offsets.first);
-        if (range + 1 < static_cast<size_t>(orthog_nelems * dst_axis_nelems)) {
-            throw py::value_error(
-                "Memory addressed by the destination array can not "
-                "accommodate all the "
-                "array elements.");
-        }
-    }
+    dpctl::tensor::validation::AmpleMemory::throw_if_not_ample(
+        dst, orthog_nelems * dst_axis_nelems);
 
     auto const &overlap = dpctl::tensor::overlap::MemoryOverlap();
     // check that dst does not intersect with src or reps
@@ -420,19 +409,8 @@ py_repeat_by_sequence(const dpctl::tensor::usm_ndarray &src,
         return std::make_pair(sycl::event(), sycl::event());
     }
 
-    // ensure that dst is sufficiently ample
-    auto dst_offsets = dst.get_minmax_offsets();
-    // destination must be ample enough to accommodate all elements
-    {
-        size_t range =
-            static_cast<size_t>(dst_offsets.second - dst_offsets.first);
-        if (range + 1 < static_cast<size_t>(dst.get_size())) {
-            throw py::value_error(
-                "Memory addressed by the destination array can not "
-                "accommodate all the "
-                "array elements.");
-        }
-    }
+    dpctl::tensor::validation::AmpleMemory::throw_if_not_ample(dst,
+                                                               dst.get_size());
 
     auto const &overlap = dpctl::tensor::overlap::MemoryOverlap();
     // check that dst does not intersect with src, cumsum, or reps
@@ -587,20 +565,8 @@ py_repeat_by_scalar(const dpctl::tensor::usm_ndarray &src,
         return std::make_pair(sycl::event(), sycl::event());
     }
 
-    // ensure that dst is sufficiently ample
-    auto dst_offsets = dst.get_minmax_offsets();
-    // destination must be ample enough to accommodate all elements
-    {
-        size_t range =
-            static_cast<size_t>(dst_offsets.second - dst_offsets.first);
-        if (range + 1 <
-            static_cast<size_t>(orthog_nelems * (src_axis_nelems * reps))) {
-            throw py::value_error(
-                "Memory addressed by the destination array can not "
-                "accommodate all the "
-                "array elements.");
-        }
-    }
+    dpctl::tensor::validation::AmpleMemory::throw_if_not_ample(
+        dst, orthog_nelems * (src_axis_nelems * reps));
 
     auto const &overlap = dpctl::tensor::overlap::MemoryOverlap();
     // check that dst does not intersect with src
@@ -801,19 +767,8 @@ py_repeat_by_scalar(const dpctl::tensor::usm_ndarray &src,
         return std::make_pair(sycl::event(), sycl::event());
     }
 
-    // ensure that dst is sufficiently ample
-    auto dst_offsets = dst.get_minmax_offsets();
-    // destination must be ample enough to accommodate all elements
-    {
-        size_t range =
-            static_cast<size_t>(dst_offsets.second - dst_offsets.first);
-        if (range + 1 < static_cast<size_t>(src_sz * reps)) {
-            throw py::value_error(
-                "Memory addressed by the destination array can not "
-                "accommodate all the "
-                "array elements.");
-        }
-    }
+    dpctl::tensor::validation::AmpleMemory::throw_if_not_ample(dst,
+                                                               src_sz * reps);
 
     auto const &overlap = dpctl::tensor::overlap::MemoryOverlap();
     // check that dst does not intersect with src

--- a/dpctl/tensor/libtensor/source/repeat.cpp
+++ b/dpctl/tensor/libtensor/source/repeat.cpp
@@ -35,6 +35,7 @@
 #include "simplify_iteration_space.hpp"
 #include "utils/memory_overlap.hpp"
 #include "utils/offset_utils.hpp"
+#include "utils/output_validation.hpp"
 #include "utils/type_dispatch.hpp"
 
 namespace dpctl
@@ -128,6 +129,8 @@ py_repeat_by_sequence(const dpctl::tensor::usm_ndarray &src,
         throw py::value_error(
             "Execution queue is not compatible with allocation queues");
     }
+
+    dpctl::tensor::validation::CheckWritable::throw_if_not_writable(dst);
 
     size_t reps_sz = reps.get_size();
     size_t cumsum_sz = cumsum.get_size();
@@ -402,6 +405,8 @@ py_repeat_by_sequence(const dpctl::tensor::usm_ndarray &src,
             "Execution queue is not compatible with allocation queues");
     }
 
+    dpctl::tensor::validation::CheckWritable::throw_if_not_writable(dst);
+
     size_t src_sz = src.get_size();
     size_t reps_sz = reps.get_size();
     size_t cumsum_sz = cumsum.get_size();
@@ -548,6 +553,8 @@ py_repeat_by_scalar(const dpctl::tensor::usm_ndarray &src,
         throw py::value_error(
             "Execution queue is not compatible with allocation queues");
     }
+
+    dpctl::tensor::validation::CheckWritable::throw_if_not_writable(dst);
 
     const py::ssize_t *src_shape = src.get_shape_raw();
     const py::ssize_t *dst_shape = dst.get_shape_raw();
@@ -778,6 +785,8 @@ py_repeat_by_scalar(const dpctl::tensor::usm_ndarray &src,
         throw py::value_error(
             "Execution queue is not compatible with allocation queues");
     }
+
+    dpctl::tensor::validation::CheckWritable::throw_if_not_writable(dst);
 
     size_t src_sz = src.get_size();
     size_t dst_sz = dst.get_size();

--- a/dpctl/tensor/libtensor/source/sorting/argsort.cpp
+++ b/dpctl/tensor/libtensor/source/sorting/argsort.cpp
@@ -108,17 +108,8 @@ py_argsort(const dpctl::tensor::usm_ndarray &src,
         throw py::value_error("Arrays index overlapping segments of memory");
     }
 
-    // destination must be ample enough to accommodate all elements
-    {
-        auto dst_offsets = dst.get_minmax_offsets();
-        size_t range =
-            static_cast<size_t>(dst_offsets.second - dst_offsets.first);
-        if (range + 1 < sort_nelems * iter_nelems) {
-            throw py::value_error(
-                "Destination array can not accommodate all the "
-                "elements of source array.");
-        }
-    }
+    dpctl::tensor::validation::AmpleMemory::throw_if_not_ample(
+        dst, sort_nelems * iter_nelems);
 
     int src_typenum = src.get_typenum();
     int dst_typenum = dst.get_typenum();

--- a/dpctl/tensor/libtensor/source/sorting/argsort.cpp
+++ b/dpctl/tensor/libtensor/source/sorting/argsort.cpp
@@ -29,6 +29,7 @@
 
 #include "utils/math_utils.hpp"
 #include "utils/memory_overlap.hpp"
+#include "utils/output_validation.hpp"
 #include "utils/type_dispatch.hpp"
 
 #include "argsort.hpp"
@@ -93,6 +94,8 @@ py_argsort(const dpctl::tensor::usm_ndarray &src,
         throw py::value_error(
             "Execution queue is not compatible with allocation queues");
     }
+
+    dpctl::tensor::validation::CheckWritable::throw_if_not_writable(dst);
 
     if ((iter_nelems == 0) || (sort_nelems == 0)) {
         // Nothing to do

--- a/dpctl/tensor/libtensor/source/sorting/sort.cpp
+++ b/dpctl/tensor/libtensor/source/sorting/sort.cpp
@@ -108,17 +108,8 @@ py_sort(const dpctl::tensor::usm_ndarray &src,
         throw py::value_error("Arrays index overlapping segments of memory");
     }
 
-    // destination must be ample enough to accommodate all elements
-    {
-        auto dst_offsets = dst.get_minmax_offsets();
-        size_t range =
-            static_cast<size_t>(dst_offsets.second - dst_offsets.first);
-        if (range + 1 < sort_nelems * iter_nelems) {
-            throw py::value_error(
-                "Destination array can not accommodate all the "
-                "elements of source array.");
-        }
-    }
+    dpctl::tensor::validation::AmpleMemory::throw_if_not_ample(
+        dst, sort_nelems * iter_nelems);
 
     int src_typenum = src.get_typenum();
     int dst_typenum = dst.get_typenum();

--- a/dpctl/tensor/libtensor/source/sorting/sort.cpp
+++ b/dpctl/tensor/libtensor/source/sorting/sort.cpp
@@ -29,6 +29,7 @@
 
 #include "utils/math_utils.hpp"
 #include "utils/memory_overlap.hpp"
+#include "utils/output_validation.hpp"
 #include "utils/type_dispatch.hpp"
 
 #include "kernels/sorting.hpp"
@@ -93,6 +94,8 @@ py_sort(const dpctl::tensor::usm_ndarray &src,
         throw py::value_error(
             "Execution queue is not compatible with allocation queues");
     }
+
+    dpctl::tensor::validation::CheckWritable::throw_if_not_writable(dst);
 
     if ((iter_nelems == 0) || (sort_nelems == 0)) {
         // Nothing to do

--- a/dpctl/tensor/libtensor/source/triul_ctor.cpp
+++ b/dpctl/tensor/libtensor/source/triul_ctor.cpp
@@ -32,6 +32,7 @@
 #include "kernels/constructors.hpp"
 #include "simplify_iteration_space.hpp"
 #include "utils/memory_overlap.hpp"
+#include "utils/output_validation.hpp"
 #include "utils/type_dispatch.hpp"
 
 namespace py = pybind11;
@@ -116,6 +117,8 @@ usm_ndarray_triul(sycl::queue &exec_q,
         throw py::value_error(
             "Execution queue context is not the same as allocation contexts");
     }
+
+    dpctl::tensor::validation::CheckWritable::throw_if_not_writable(dst);
 
     auto src_strides = src.get_strides_vector();
     auto dst_strides = dst.get_strides_vector();

--- a/dpctl/tensor/libtensor/source/where.cpp
+++ b/dpctl/tensor/libtensor/source/where.cpp
@@ -36,6 +36,7 @@
 #include "simplify_iteration_space.hpp"
 #include "utils/memory_overlap.hpp"
 #include "utils/offset_utils.hpp"
+#include "utils/output_validation.hpp"
 #include "utils/type_dispatch.hpp"
 #include "where.hpp"
 
@@ -72,6 +73,8 @@ py_where(const dpctl::tensor::usm_ndarray &condition,
         throw py::value_error(
             "Execution queue is not compatible with allocation queues");
     }
+
+    dpctl::tensor::validation::CheckWritable::throw_if_not_writable(dst);
 
     int nd = condition.get_ndim();
     int x1_nd = x1.get_ndim();

--- a/dpctl/tensor/libtensor/source/where.cpp
+++ b/dpctl/tensor/libtensor/source/where.cpp
@@ -133,19 +133,7 @@ py_where(const dpctl::tensor::usm_ndarray &condition,
         throw py::value_error("Value arrays must have the same data type");
     }
 
-    // ensure that dst is sufficiently ample
-    auto dst_offsets = dst.get_minmax_offsets();
-    // destination must be ample enough to accommodate all elements
-    {
-        size_t range =
-            static_cast<size_t>(dst_offsets.second - dst_offsets.first);
-        if (range + 1 < static_cast<size_t>(nelems)) {
-            throw py::value_error(
-                "Memory addressed by the destination array can not "
-                "accommodate all the "
-                "array elements.");
-        }
-    }
+    dpctl::tensor::validation::AmpleMemory::throw_if_not_ample(dst, nelems);
 
     char *cond_data = condition.get_data();
     char *x1_data = x1.get_data();


### PR DESCRIPTION
This pull request refactors Python API functions to use new utilities for validating output arrays. These utilities validate that an array is sufficiently ample for a given number of elements (i.e., not the result of broadcasting) and that the array's writable flag is set.

- [X] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [X] Have you tested your changes locally for CPU and GPU devices?
- [X] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
