### PR TITLE
Changes `py_dot` dispatching for boolean data

### DIFF
--- a/dpctl/tensor/libtensor/include/kernels/linalg_functions/dot_product.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/linalg_functions/dot_product.hpp
@@ -518,8 +518,12 @@ public:
         }
 
         auto work_group = it.get_group();
+
+        using RedOpT = typename std::conditional<std::is_same_v<outT, bool>,
+                                                 sycl::logical_or<outT>,
+                                                 sycl::plus<outT>>::type;
         outT red_val_over_wg = sycl::reduce_over_group(
-            work_group, local_red_val, outT(0), sycl::plus<outT>());
+            work_group, local_red_val, outT(0), RedOpT());
 
         if (work_group.leader()) {
             // each group writes to a different memory location
@@ -642,7 +646,10 @@ sycl::event dot_product_tree_impl(sycl::queue &exec_q,
         return dot_ev;
     }
     else {
-        using ReductionOpT = sycl::plus<resTy>;
+        using ReductionOpT =
+            typename std::conditional<std::is_same_v<resTy, bool>,
+                                      sycl::logical_or<resTy>,
+                                      sycl::plus<resTy>>::type;
         constexpr resTy identity_val =
             sycl::known_identity<ReductionOpT, resTy>::value;
 
@@ -952,7 +959,10 @@ dot_product_contig_tree_impl(sycl::queue &exec_q,
         return dot_ev;
     }
     else {
-        using ReductionOpT = sycl::plus<resTy>;
+        using ReductionOpT =
+            typename std::conditional<std::is_same_v<resTy, bool>,
+                                      sycl::logical_or<resTy>,
+                                      sycl::plus<resTy>>::type;
         constexpr resTy identity_val =
             sycl::known_identity<ReductionOpT, resTy>::value;
 

--- a/dpctl/tensor/libtensor/include/kernels/linalg_functions/gemm.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/linalg_functions/gemm.hpp
@@ -2353,7 +2353,10 @@ gemm_batch_tree_k_impl(sycl::queue &exec_q,
             depends);
     }
     else {
-        using ReductionOpT = sycl::plus<resTy>;
+        using ReductionOpT =
+            typename std::conditional<std::is_same_v<resTy, bool>,
+                                      sycl::logical_or<resTy>,
+                                      sycl::plus<resTy>>::type;
         constexpr resTy identity_val =
             sycl::known_identity<ReductionOpT, resTy>::value;
 
@@ -2651,7 +2654,10 @@ gemm_batch_tree_nm_impl(sycl::queue &exec_q,
                         lhs_indexer, rhs_indexer, res_indexer, depends);
     }
     else {
-        using ReductionOpT = sycl::plus<resTy>;
+        using ReductionOpT =
+            typename std::conditional<std::is_same_v<resTy, bool>,
+                                      sycl::logical_or<resTy>,
+                                      sycl::plus<resTy>>::type;
         constexpr resTy identity_val =
             sycl::known_identity<ReductionOpT, resTy>::value;
         size_t iter_nelems = batch_nelems * n * m;
@@ -3032,7 +3038,10 @@ gemm_batch_contig_tree_k_impl(sycl::queue &exec_q,
             depends);
     }
     else {
-        using ReductionOpT = sycl::plus<resTy>;
+        using ReductionOpT =
+            typename std::conditional<std::is_same_v<resTy, bool>,
+                                      sycl::logical_or<resTy>,
+                                      sycl::plus<resTy>>::type;
         constexpr resTy identity_val =
             sycl::known_identity<ReductionOpT, resTy>::value;
 
@@ -3233,7 +3242,10 @@ gemm_batch_contig_tree_nm_impl(sycl::queue &exec_q,
                         lhs_indexer, rhs_indexer, res_indexer, depends);
     }
     else {
-        using ReductionOpT = sycl::plus<resTy>;
+        using ReductionOpT =
+            typename std::conditional<std::is_same_v<resTy, bool>,
+                                      sycl::logical_or<resTy>,
+                                      sycl::plus<resTy>>::type;
         constexpr resTy identity_val =
             sycl::known_identity<ReductionOpT, resTy>::value;
         size_t iter_nelems = batch_nelems * n * m;
@@ -3615,7 +3627,10 @@ sycl::event gemm_tree_k_impl(sycl::queue &exec_q,
             res_indexer, depends);
     }
     else {
-        using ReductionOpT = sycl::plus<resTy>;
+        using ReductionOpT =
+            typename std::conditional<std::is_same_v<resTy, bool>,
+                                      sycl::logical_or<resTy>,
+                                      sycl::plus<resTy>>::type;
         constexpr resTy identity_val =
             sycl::known_identity<ReductionOpT, resTy>::value;
 
@@ -3782,7 +3797,10 @@ sycl::event gemm_tree_nm_impl(sycl::queue &exec_q,
                         lhs_indexer, rhs_indexer, res_indexer, depends);
     }
     else {
-        using ReductionOpT = sycl::plus<resTy>;
+        using ReductionOpT =
+            typename std::conditional<std::is_same_v<resTy, bool>,
+                                      sycl::logical_or<resTy>,
+                                      sycl::plus<resTy>>::type;
         constexpr resTy identity_val =
             sycl::known_identity<ReductionOpT, resTy>::value;
 
@@ -4033,7 +4051,10 @@ sycl::event gemm_contig_tree_k_impl(sycl::queue &exec_q,
             res_indexer, depends);
     }
     else {
-        using ReductionOpT = sycl::plus<resTy>;
+        using ReductionOpT =
+            typename std::conditional<std::is_same_v<resTy, bool>,
+                                      sycl::logical_or<resTy>,
+                                      sycl::plus<resTy>>::type;
         constexpr resTy identity_val =
             sycl::known_identity<ReductionOpT, resTy>::value;
 
@@ -4187,7 +4208,10 @@ sycl::event gemm_contig_tree_nm_impl(sycl::queue &exec_q,
                         lhs_indexer, rhs_indexer, res_indexer, depends);
     }
     else {
-        using ReductionOpT = sycl::plus<resTy>;
+        using ReductionOpT =
+            typename std::conditional<std::is_same_v<resTy, bool>,
+                                      sycl::logical_or<resTy>,
+                                      sycl::plus<resTy>>::type;
         constexpr resTy identity_val =
             sycl::known_identity<ReductionOpT, resTy>::value;
 

--- a/dpctl/tensor/libtensor/source/linalg_functions/dot_dispatch.hpp
+++ b/dpctl/tensor/libtensor/source/linalg_functions/dot_dispatch.hpp
@@ -60,7 +60,7 @@ template <typename T1, typename T2> struct DotNoAtomicOutputType
 {
     using value_type = typename std::disjunction< // disjunction is C++17
                                                   // feature, supported by DPC++
-        td_ns::BinaryTypeMapResultEntry<T1, bool, T2, bool, std::uint8_t>,
+        td_ns::BinaryTypeMapResultEntry<T1, bool, T2, bool, bool>,
         td_ns::BinaryTypeMapResultEntry<T1,
                                         std::uint8_t,
                                         T2,


### PR DESCRIPTION
`py_dot` for boolean inputs now gives boolean results.

Boolean arrays input into `matmul`, `tensordot`, or `vecdot` will no longer be copied and cast to uint8, improving performance

Improves performance by about 15% for large arrays:
```
In [9]: y = dpt.zeros((4000, 40), dtype="?")

In [10]: x = dpt.ones((40, 4000), dtype="?")
# imitates old behavior
In [11]: %timeit z = dpt.matmul(x, y, dtype="u1")
1.06 ms ± 16.6 µs per loop (mean ± std. dev. of 7 runs, 1,000 loops each)

In [12]: %timeit z = dpt.matmul(x, y)
871 µs ± 30.5 µs per loop (mean ± std. dev. of 7 runs, 1,000 loops each)
```

- [X] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [X] Have you tested your changes locally for CPU and GPU devices?
- [X] Have you made sure that new changes do not introduce compiler warnings?
- [X] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
