### PR TITLE
Fix negative for boolean inputs

### DIFF
--- a/dpctl/tensor/_elementwise_funcs.py
+++ b/dpctl/tensor/_elementwise_funcs.py
@@ -17,7 +17,11 @@
 import dpctl.tensor._tensor_elementwise_impl as ti
 
 from ._elementwise_common import BinaryElementwiseFunc, UnaryElementwiseFunc
-from ._type_utils import _acceptance_fn_divide, _acceptance_fn_reciprocal
+from ._type_utils import (
+    _acceptance_fn_divide,
+    _acceptance_fn_negative,
+    _acceptance_fn_reciprocal,
+)
 
 # U01: ==== ABS    (x)
 _abs_docstring_ = """
@@ -1294,7 +1298,11 @@ Return:
 """
 
 negative = UnaryElementwiseFunc(
-    "negative", ti._negative_result_type, ti._negative, _negative_docstring_
+    "negative",
+    ti._negative_result_type,
+    ti._negative,
+    _negative_docstring_,
+    acceptance_fn=_acceptance_fn_negative,
 )
 
 # B20: ==== NOT_EQUAL   (x1, x2)

--- a/dpctl/tensor/_type_utils.py
+++ b/dpctl/tensor/_type_utils.py
@@ -155,6 +155,18 @@ def _acceptance_fn_reciprocal(arg_dtype, buf_dt, res_dt, sycl_dev):
         return True
 
 
+def _acceptance_fn_negative(arg_dtype, buf_dt, res_dt, sycl_dev):
+    # negative is not defined for boolean data type
+    if arg_dtype.char == "?":
+        raise ValueError(
+            "The `negative` function, the `-` operator, is not supported "
+            "for inputs of data type bool, use the `~` operator or the "
+            "`logical_not` function instead"
+        )
+    else:
+        return True
+
+
 def _find_buf_dtype(arg_dtype, query_fn, sycl_dev, acceptance_fn):
     res_dt = query_fn(arg_dtype)
     if res_dt:

--- a/dpctl/tests/elementwise/test_negative.py
+++ b/dpctl/tests/elementwise/test_negative.py
@@ -39,6 +39,13 @@ def test_negative_out_type(dtype):
     assert np.allclose(dpt.asnumpy(r), dpt.asnumpy(dpt.negative(X)))
 
 
+def test_negative_bool():
+    get_queue_or_skip()
+    x = dpt.ones(64, dtype="?")
+    with pytest.raises(ValueError):
+        dpt.negative(x)
+
+
 @pytest.mark.parametrize("usm_type", _usm_types)
 def test_negative_usm_type(usm_type):
     q = get_queue_or_skip()

--- a/dpctl/tests/elementwise/test_type_utils.py
+++ b/dpctl/tests/elementwise/test_type_utils.py
@@ -248,6 +248,7 @@ def test_acceptance_fns():
     assert tu._acceptance_fn_reciprocal(
         dpt.float32, dpt.float32, dpt.float32, dev
     )
+    assert tu._acceptance_fn_negative(dpt.int8, dpt.int16, dpt.int16, dev)
 
 
 def test_weak_types():


### PR DESCRIPTION
@npolina4 pointed out that array API states it should not be supported for Boolean inputs.

There is no dedicated loop for type `bool`, but input `dtype` `bool `gets promoted to integral types, and `negative` function returns result for the promoted type.

The change makes `UnaryElementwiseFunc` instance for negative use acceptance functions, which raises an exception for promotion with `dpt.bool` as starting data type.

A test is added.

- [x] Have you provided a meaningful PR description?
- [x] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [x] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
