### PR TITLE
Fix subtract for boolean inputs

### DIFF
--- a/dpctl/tensor/_elementwise_funcs.py
+++ b/dpctl/tensor/_elementwise_funcs.py
@@ -21,6 +21,7 @@ from ._type_utils import (
     _acceptance_fn_divide,
     _acceptance_fn_negative,
     _acceptance_fn_reciprocal,
+    _acceptance_fn_subtract,
 )
 
 # U01: ==== ABS    (x)
@@ -1676,6 +1677,7 @@ subtract = BinaryElementwiseFunc(
     ti._subtract,
     _subtract_docstring_,
     binary_inplace_fn=ti._subtract_inplace,
+    acceptance_fn=_acceptance_fn_subtract,
 )
 
 

--- a/dpctl/tensor/_type_utils.py
+++ b/dpctl/tensor/_type_utils.py
@@ -173,7 +173,7 @@ def _acceptance_fn_subtract(
     # subtract is not defined for boolean data type
     if arg1_dtype.char == "?" and arg2_dtype.char == "?":
         raise ValueError(
-            "The `negative` function, the `-` operator, is not supported "
+            "The `subtract` function, the `-` operator, is not supported "
             "for inputs of data type bool, use the `^` operator,  the "
             "`bitwise_xor`, or the `logical_xor` function instead"
         )

--- a/dpctl/tensor/_type_utils.py
+++ b/dpctl/tensor/_type_utils.py
@@ -167,7 +167,9 @@ def _acceptance_fn_negative(arg_dtype, buf_dt, res_dt, sycl_dev):
         return True
 
 
-def _acceptance_fn_subtract(arg1_dtype, arg2_dtype, buf1_dt, buf2_dt, res_dt, sycl_dev):
+def _acceptance_fn_subtract(
+    arg1_dtype, arg2_dtype, buf1_dt, buf2_dt, res_dt, sycl_dev
+):
     # subtract is not defined for boolean data type
     if arg1_dtype.char == "?" and arg2_dtype.char == "?":
         raise ValueError(

--- a/dpctl/tensor/_type_utils.py
+++ b/dpctl/tensor/_type_utils.py
@@ -167,6 +167,18 @@ def _acceptance_fn_negative(arg_dtype, buf_dt, res_dt, sycl_dev):
         return True
 
 
+def _acceptance_fn_subtract(arg1_dtype, arg2_dtype, buf1_dt, buf2_dt, res_dt, sycl_dev):
+    # subtract is not defined for boolean data type
+    if arg1_dtype.char == "?" and arg2_dtype.char == "?":
+        raise ValueError(
+            "The `negative` function, the `-` operator, is not supported "
+            "for inputs of data type bool, use the `^` operator,  the "
+            "`bitwise_xor`, or the `logical_xor` function instead"
+        )
+    else:
+        return True
+
+
 def _find_buf_dtype(arg_dtype, query_fn, sycl_dev, acceptance_fn):
     res_dt = query_fn(arg_dtype)
     if res_dt:

--- a/dpctl/tests/elementwise/test_subtract.py
+++ b/dpctl/tests/elementwise/test_subtract.py
@@ -69,6 +69,14 @@ def test_subtract_dtype_matrix(op1_dtype, op2_dtype):
     assert (dpt.asnumpy(r2) == np.full(r2.shape, 0, dtype=r2.dtype)).all()
 
 
+def test_subtract_bool():
+    get_queue_or_skip()
+    ar1 = dpt.ones(127, dtype='?')
+    ar2 = dpt.ones_like(ar1, dtype='?')
+    with pytest.raises(ValueError):
+        dpt.subtract(ar1, ar2)
+
+
 @pytest.mark.parametrize("op1_usm_type", _usm_types)
 @pytest.mark.parametrize("op2_usm_type", _usm_types)
 def test_subtract_usm_type_matrix(op1_usm_type, op2_usm_type):
@@ -151,7 +159,7 @@ def test_subtract_broadcasting():
     ).all()
 
 
-@pytest.mark.parametrize("arr_dt", _all_dtypes)
+@pytest.mark.parametrize("arr_dt", _all_dtypes[1:])
 def test_subtract_python_scalar(arr_dt):
     q = get_queue_or_skip()
     skip_if_dtype_not_supported(arr_dt, q)

--- a/dpctl/tests/elementwise/test_subtract.py
+++ b/dpctl/tests/elementwise/test_subtract.py
@@ -71,8 +71,8 @@ def test_subtract_dtype_matrix(op1_dtype, op2_dtype):
 
 def test_subtract_bool():
     get_queue_or_skip()
-    ar1 = dpt.ones(127, dtype='?')
-    ar2 = dpt.ones_like(ar1, dtype='?')
+    ar1 = dpt.ones(127, dtype="?")
+    ar2 = dpt.ones_like(ar1, dtype="?")
     with pytest.raises(ValueError):
         dpt.subtract(ar1, ar2)
 


### PR DESCRIPTION
The change makes `BinaryElementwiseFunc` instance for `dpt.subtract` use acceptance function, that raises an exception for promotion with `dpt.bool` as starting data type. Changes apply to the case where both arguments are of `dpt.bool` data type.

A test is added.

- [x] Have you provided a meaningful PR description?
- [x] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [x] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
