### PR TITLE
Cleans up elementwise function docstrings

### DIFF
--- a/dpctl/tensor/_elementwise_funcs.py
+++ b/dpctl/tensor/_elementwise_funcs.py
@@ -35,7 +35,7 @@ Args:
         Input array, expected to have numeric data type.
     out ({None, usm_ndarray}, optional):
         Output array to populate.
-        Array have the correct shape and the expected data type.
+        Array must have the correct shape and the expected data type.
     order ("C","F","A","K", optional):
         Memory layout of the newly output array, if parameter `out` is `None`.
         Default: "K".
@@ -62,7 +62,7 @@ Args:
         Input array, expected to have numeric data type.
     out ({None, usm_ndarray}, optional):
         Output array to populate.
-        Array have the correct shape and the expected data type.
+        Array must have the correct shape and the expected data type.
     order ("C","F","A","K", optional):
         Memory layout of the newly output array, if parameter `out` is `None`.
         Default: "K".
@@ -88,7 +88,7 @@ Args:
         Input array, expected to have numeric data type.
     out ({None, usm_ndarray}, optional):
         Output array to populate.
-        Array have the correct shape and the expected data type.
+        Array must have the correct shape and the expected data type.
     order ("C","F","A","K", optional):
         Memory layout of the newly output array, if parameter `out` is `None`.
         Default: "K".
@@ -118,7 +118,7 @@ Args:
         Second input array, also expected to have numeric data type.
     out ({None, usm_ndarray}, optional):
         Output array to populate.
-        Array have the correct shape and the expected data type.
+        Array must have the correct shape and the expected data type.
     order ("C","F","A","K", optional):
         Memory layout of the newly output array, if parameter `out` is `None`.
         Default: "K".
@@ -146,7 +146,7 @@ Args:
         Input array, expected to have numeric data type.
     out ({None, usm_ndarray}, optional):
         Output array to populate.
-        Array have the correct shape and the expected data type.
+        Array must have the correct shape and the expected data type.
     order ("C","F","A","K", optional):
         Memory layout of the newly output array, if parameter `out` is `None`.
         Default: "K".
@@ -172,7 +172,7 @@ Args:
         Input array, expected to have numeric data type.
     out ({None, usm_ndarray}, optional):
         Output array to populate.
-        Array have the correct shape and the expected data type.
+        Array must have the correct shape and the expected data type.
     order ("C","F","A","K", optional):
         Memory layout of the newly output array, if parameter `out` is `None`.
         Default: "K".
@@ -198,7 +198,7 @@ Args:
         Input array, expected to have numeric data type.
     out ({None, usm_ndarray}, optional):
         Output array to populate.
-        Array have the correct shape and the expected data type.
+        Array must have the correct shape and the expected data type.
     order ("C","F","A","K", optional):
         Memory layout of the newly output array, if parameter `out` is `None`.
         Default: "K".
@@ -230,7 +230,7 @@ Args:
         floating-point data type.
     out ({None, usm_ndarray}, optional):
         Output array to populate.
-        Array have the correct shape and the expected data type.
+        Array must have the correct shape and the expected data type.
     order ("C","F","A","K", optional):
         Memory layout of the newly output array, if parameter `out` is `None`.
         Default: "K".
@@ -256,7 +256,7 @@ Args:
         Input array, expected to have numeric data type.
     out ({None, usm_ndarray}, optional):
         Output array to populate.
-        Array have the correct shape and the expected data type.
+        Array must have the correct shape and the expected data type.
     order ("C","F","A","K", optional):
         Memory layout of the newly output array, if parameter `out` is `None`.
         Default: "K".
@@ -287,7 +287,7 @@ Args:
         type.
     out ({None, usm_ndarray}, optional):
         Output array to populate.
-        Array have the correct shape and the expected data type.
+        Array must have the correct shape and the expected data type.
     order ("C","F","A","K", optional):
         Memory layout of the newly output array, if parameter `out` is `None`.
         Default: "K".
@@ -321,7 +321,7 @@ Args:
         Each element must be greater than or equal to 0.
     out ({None, usm_ndarray}, optional):
         Output array to populate.
-        Array have the correct shape and the expected data type.
+        Array must have the correct shape and the expected data type.
     order ("C","F","A","K", optional):
         Memory layout of the newly output array, if parameter `out` is `None`.
         Default: "K".
@@ -351,7 +351,7 @@ Args:
         Input array, expected to have integer or boolean data type.
     out ({None, usm_ndarray}, optional):
         Output array to populate.
-        Array have the correct shape and the expected data type.
+        Array must have the correct shape and the expected data type.
     order ("C","F","A","K", optional):
         Memory layout of the newly output array, if parameter `out` is `None`.
         Default: "K".
@@ -385,7 +385,7 @@ Args:
         type.
     out ({None, usm_ndarray}, optional):
         Output array to populate.
-        Array have the correct shape and the expected data type.
+        Array must have the correct shape and the expected data type.
     order ("C","F","A","K", optional):
         Memory layout of the newly output array, if parameter `out` is `None`.
         Default: "K".
@@ -418,7 +418,7 @@ Args:
         Each element must be greater than or equal to 0.
     out ({None, usm_ndarray}, optional):
         Output array to populate.
-        Array have the correct shape and the expected data type.
+        Array must have the correct shape and the expected data type.
     order ("C","F","A","K", optional):
         Memory layout of the newly output array, if parameter `out` is `None`.
         Default: "K".
@@ -453,7 +453,7 @@ Args:
         type.
     out ({None, usm_ndarray}, optional):
         Output array to populate.
-        Array have the correct shape and the expected data type.
+        Array must have the correct shape and the expected data type.
     order ("C","F","A","K", optional):
         Memory layout of the newly output array, if parameter `out` is `None`.
         Default: "K".
@@ -484,7 +484,7 @@ Args:
         Input array, expected to have numeric data type.
     out ({None, usm_ndarray}, optional):
         Output array to populate.
-        Array have the correct shape and the expected data type.
+        Array must have the correct shape and the expected data type.
     order ("C","F","A","K", optional):
         Memory layout of the newly output array, if parameter `out` is `None`.
         Default: "K".
@@ -509,7 +509,7 @@ Args:
         Input array, expected to have numeric data type.
     out ({None, usm_ndarray}, optional):
         Output array to populate.
-        Array have the correct shape and the expected data type.
+        Array must have the correct shape and the expected data type.
     order ("C","F","A","K", optional):
         Memory layout of the newly output array, if parameter `out` is `None`.
         Default: "K".
@@ -534,7 +534,7 @@ Args:
         Input array, expected to have numeric data type.
     out ({None, usm_ndarray}, optional):
         Output array to populate.
-        Array have the correct shape and the expected data type.
+        Array must have the correct shape and the expected data type.
     order ("C","F","A","K", optional):
         Memory layout of the newly output array, if parameter `out` is `None`.
         Default: "K".
@@ -557,7 +557,7 @@ Args:
         Input array, expected to have numeric data type.
     out ({None, usm_ndarray}, optional):
         Output array to populate.
-        Array have the correct shape and the expected data type.
+        Array must have the correct shape and the expected data type.
     order ("C","F","A","K", optional):
         Memory layout of the newly output array, if parameter `out` is `None`.
         Default: "K".
@@ -585,7 +585,7 @@ Args:
         Second input array, also expected to have numeric data type.
     out ({None, usm_ndarray}, optional):
         Output array to populate.
-        Array have the correct shape and the expected data type.
+        Array must have the correct shape and the expected data type.
     order ("C","F","A","K", optional):
         Memory layout of the newly output array, if parameter `out` is `None`.
         Default: "K".
@@ -618,7 +618,7 @@ Args:
         Second input array, also expected to have numeric data type.
     out ({None, usm_ndarray}, optional):
         Output array to populate.
-        Array have the correct shape and the expected data type.
+        Array must have the correct shape and the expected data type.
     order ("C","F","A","K", optional):
         Memory layout of the newly output array, if parameter `out` is `None`.
         Default: "K".
@@ -643,7 +643,7 @@ Args:
         Input array, expected to have numeric data type.
     out ({None, usm_ndarray}, optional):
         Output array to populate.
-        Array have the correct shape and the expected data type.
+        Array must have the correct shape and the expected data type.
     order ("C","F","A","K", optional):
         Memory layout of the newly output array, if parameter `out` is `None`.
         Default: "K".
@@ -692,7 +692,7 @@ Args:
         Input array, expected to have numeric data type.
     out ({None, usm_ndarray}, optional):
         Output array to populate.
-        Array have the correct shape and the expected data type.
+        Array must have the correct shape and the expected data type.
     order ("C","F","A","K", optional):
         Memory layout of the newly output array, if parameter `out` is `None`.
         Default: "K".
@@ -746,7 +746,7 @@ Args:
         Second input array, also expected to have numeric data type.
     out ({None, usm_ndarray}, optional):
         Output array to populate.
-        Array have the correct shape and the expected data type.
+        Array must have the correct shape and the expected data type.
     order ("C","F","A","K", optional):
         Memory layout of the newly output array, if parameter `out` is `None`.
         Default: "K".
@@ -772,7 +772,7 @@ Args:
         Second input array, also expected to have numeric data type.
     out ({None, usm_ndarray}, optional):
         Output array to populate.
-        Array have the correct shape and the expected data type.
+        Array must have the correct shape and the expected data type.
     order ("C","F","A","K", optional):
         Memory layout of the newly output array, if parameter `out` is `None`.
         Default: "K".
@@ -801,7 +801,7 @@ Args:
         Input array, expected to have numeric data type.
     out ({None, usm_ndarray}, optional):
         Output array to populate.
-        Array have the correct shape and the expected data type.
+        Array must have the correct shape and the expected data type.
     order ("C","F","A","K", optional):
         Memory layout of the newly output array, if parameter `out` is `None`.
         Default: "K".
@@ -829,7 +829,7 @@ Args:
         Input array, expected to have numeric data type.
     out ({None, usm_ndarray}, optional):
         Output array to populate.
-        Array have the correct shape and the expected data type.
+        Array must have the correct shape and the expected data type.
     order ("C","F","A","K", optional):
         Memory layout of the newly output array, if parameter `out` is `None`.
         Default: "K".
@@ -855,7 +855,7 @@ Args:
         Input array, expected to have numeric data type.
     out ({None, usm_ndarray}, optional):
         Output array to populate.
-        Array have the correct shape and the expected data type.
+        Array must have the correct shape and the expected data type.
     order ("C","F","A","K", optional):
         Memory layout of the newly output array, if parameter `out` is `None`.
         Default: "K".
@@ -880,7 +880,7 @@ Args:
         Input array, expected to have numeric data type.
     out ({None, usm_ndarray}, optional):
         Output array to populate.
-        Array have the correct shape and the expected data type.
+        Array must have the correct shape and the expected data type.
     order ("C","F","A","K", optional):
         Memory layout of the newly output array, if parameter `out` is `None`.
         Default: "K".
@@ -908,7 +908,7 @@ Args:
         Second input array, also expected to have numeric data type.
     out ({None, usm_ndarray}, optional):
         Output array to populate.
-        Array have the correct shape and the expected data type.
+        Array must have the correct shape and the expected data type.
     order ("C","F","A","K", optional):
         Memory layout of the newly output array, if parameter `out` is `None`.
         Default: "K".
@@ -934,7 +934,7 @@ Args:
         Second input array, also expected to have numeric data type.
     out ({None, usm_ndarray}, optional):
         Output array to populate.
-        Array have the correct shape and the expected data type.
+        Array must have the correct shape and the expected data type.
     order ("C","F","A","K", optional):
         Memory layout of the newly output array, if parameter `out` is `None`.
         Default: "K".
@@ -1007,7 +1007,7 @@ Args:
         Input array, expected to have numeric data type.
     out ({None, usm_ndarray}, optional):
         Output array to populate.
-        Array have the correct shape and the expected data type.
+        Array must have the correct shape and the expected data type.
     order ("C","F","A","K", optional):
         Memory layout of the newly output array, if parameter `out` is `None`.
         Default: "K".
@@ -1033,7 +1033,7 @@ Args:
         Input array, expected to have numeric data type.
     out ({None, usm_ndarray}, optional):
         Output array to populate.
-        Array have the correct shape and the expected data type.
+        Array must have the correct shape and the expected data type.
     order ("C","F","A","K", optional):
         Memory layout of the newly output array, if parameter `out` is `None`.
         Default: "K".
@@ -1062,7 +1062,7 @@ Args:
         Second input array, also expected to have real-valued data type.
     out ({None, usm_ndarray}, optional):
         Output array to populate.
-        Array have the correct shape and the expected data type.
+        Array must have the correct shape and the expected data type.
     order ("C","F","A","K", optional):
         Memory layout of the newly output array, if parameter `out` is `None`.
         Default: "K".
@@ -1090,7 +1090,7 @@ Args:
         Second input array.
     out ({None, usm_ndarray}, optional):
         Output array to populate.
-        Array have the correct shape and the expected data type.
+        Array must have the correct shape and the expected data type.
     order ("C","F","A","K", optional):
         Memory layout of the newly output array, if parameter `out` is `None`.
         Default: "K".
@@ -1144,7 +1144,7 @@ Args:
         Second input array.
     out ({None, usm_ndarray}, optional):
         Output array to populate.
-        Array have the correct shape and the expected data type.
+        Array must have the correct shape and the expected data type.
     order ("C","F","A","K", optional):
         Memory layout of the newly output array, if parameter `out` is `None`.
         Default: "K".
@@ -1173,7 +1173,7 @@ Args:
         Second input array.
     out ({None, usm_ndarray}, optional):
         Output array to populate.
-        Array have the correct shape and the expected data type.
+        Array must have the correct shape and the expected data type.
     order ("C","F","A","K", optional):
         Memory layout of the newly output array, if parameter `out` is `None`.
         Default: "K".
@@ -1202,7 +1202,7 @@ Args:
         Second input array, also expected to have numeric data type.
     out ({None, usm_ndarray}, optional):
         Output array to populate.
-        Array have the correct shape and the expected data type.
+        Array must have the correct shape and the expected data type.
     order ("C","F","A","K", optional):
         Memory layout of the newly output array, if parameter `out` is `None`.
         Default: "K".
@@ -1232,7 +1232,7 @@ Args:
         Second input array, also expected to have numeric data type.
     out ({None, usm_ndarray}, optional):
         Output array to populate.
-        Array have the correct shape and the expected data type.
+        Array must have the correct shape and the expected data type.
     order ("C","F","A","K", optional):
         Memory layout of the newly output array, if parameter `out` is `None`.
         Default: "K".
@@ -1262,7 +1262,7 @@ Args:
         Second input array, also expected to have numeric data type.
     out ({None, usm_ndarray}, optional):
         Output array to populate.
-        Array have the correct shape and the expected data type.
+        Array must have the correct shape and the expected data type.
     order ("C","F","A","K", optional):
         Memory layout of the newly output array, if parameter `out` is `None`.
         Default: "K".
@@ -1320,7 +1320,7 @@ Args:
         Second input array, also expected to have numeric data type.
     out ({None, usm_ndarray}, optional):
         Output array to populate.
-        Array have the correct shape and the expected data type.
+        Array must have the correct shape and the expected data type.
     order ("C","F","A","K", optional):
         Memory layout of the newly output array, if parameter `out` is `None`.
         Default: "K".
@@ -1393,7 +1393,7 @@ Args:
         Input array, expected to have numeric data type.
     out ({None, usm_ndarray}, optional):
         Output array to populate.
-        Array have the correct shape and the expected data type.
+        Array must have the correct shape and the expected data type.
     order ("C","F","A","K", optional):
         Memory layout of the newly output array, if parameter `out` is `None`.
         Default: "K".
@@ -1418,7 +1418,7 @@ Args:
         Input array, expected to have numeric data type.
     out ({None, usm_ndarray}, optional):
         Output array to populate.
-        Array have the correct shape and the expected data type.
+        Array must have the correct shape and the expected data type.
     order ("C","F","A","K", optional):
         Memory layout of the newly output array, if parameter `out` is `None`.
         Default: "K".
@@ -1451,7 +1451,7 @@ Args:
         Second input array, also expected to have a real-valued data type.
     out ({None, usm_ndarray}, optional):
         Output array to populate.
-        Array have the correct shape and the expected data type.
+        Array must have the correct shape and the expected data type.
     order ("C","F","A","K", optional):
         Memory layout of the newly output array, if parameter `out` is `None`.
         Default: "K".
@@ -1480,7 +1480,7 @@ Args:
         Input array, expected to have numeric data type.
     out ({None, usm_ndarray}, optional):
         Output array to populate.
-        Array have the correct shape and the expected data type.
+        Array must have the correct shape and the expected data type.
     order ("C","F","A","K", optional):
         Memory layout of the newly output array, if parameter `out` is `None`.
         Default: "K".
@@ -1509,7 +1509,7 @@ Args:
         Input array, expected to have a numeric data type.
     out ({None, usm_ndarray}, optional):
         Output array to populate.
-        Array have the correct shape and the expected data type.
+        Array must have the correct shape and the expected data type.
     order ("C","F","A","K", optional):
         Memory layout of the newly output array, if parameter `out` is `None`.
         Default: "K".
@@ -1535,7 +1535,7 @@ Args:
         Input array, expected to have a numeric data type.
     out ({None, usm_ndarray}, optional):
         Output array to populate.
-        Array have the correct shape and the expected data type.
+        Array must have the correct shape and the expected data type.
     order ("C","F","A","K", optional):
         Memory layout of the newly output array, if parameter `out` is `None`.
         Default: "K".
@@ -1560,7 +1560,7 @@ Args:
         Input array, expected to have numeric data type.
     out ({None, usm_ndarray}, optional):
         Output array to populate.
-        Array have the correct shape and the expected data type.
+        Array must have the correct shape and the expected data type.
     order ("C","F","A","K", optional):
         Memory layout of the newly output array, if parameter `out` is `None`.
         Default: "K".
@@ -1583,7 +1583,7 @@ Args:
         Input array, expected to have numeric data type.
     out ({None, usm_ndarray}, optional):
         Output array to populate.
-        Array have the correct shape and the expected data type.
+        Array must have the correct shape and the expected data type.
     order ("C","F","A","K", optional):
         Memory layout of the newly output array, if parameter `out` is `None`.
         Default: "K".
@@ -1607,7 +1607,7 @@ Args:
         Input array, expected to have numeric data type.
     out ({None, usm_ndarray}, optional):
         Output array to populate.
-        Array have the correct shape and the expected data type.
+        Array must have the correct shape and the expected data type.
     order ("C","F","A","K", optional):
         Memory layout of the newly output array, if parameter `out` is `None`.
         Default: "K".
@@ -1633,7 +1633,7 @@ Args:
         Input array, expected to have numeric data type.
     out ({None, usm_ndarray}, optional):
         Output array to populate.
-        Array have the correct shape and the expected data type.
+        Array must have the correct shape and the expected data type.
     order ("C","F","A","K", optional):
         Memory layout of the newly output array, if parameter `out` is `None`.
         Default: "K".
@@ -1662,7 +1662,7 @@ Args:
         Second input array, also expected to have numeric data type.
     out ({None, usm_ndarray}, optional):
         Output array to populate.
-        Array have the correct shape and the expected data type.
+        Array must have the correct shape and the expected data type.
     order ("C","F","A","K", optional):
         Memory layout of the newly output array, if parameter `out` is `None`.
         Default: "K".
@@ -1692,7 +1692,7 @@ Args:
         Input array, expected to have numeric data type.
     out ({None, usm_ndarray}, optional):
         Output array to populate.
-        Array have the correct shape and the expected data type.
+        Array must have the correct shape and the expected data type.
     order ("C","F","A","K", optional):
         Memory layout of the newly output array, if parameter `out` is `None`.
         Default: "K".
@@ -1715,7 +1715,7 @@ Args:
         Input array, expected to have numeric data type.
     out ({None, usm_ndarray}, optional):
         Output array to populate.
-        Array have the correct shape and the expected data type.
+        Array must have the correct shape and the expected data type.
     order ("C","F","A","K", optional):
         Memory layout of the newly output array, if parameter `out` is `None`.
         Default: "K".
@@ -1743,7 +1743,7 @@ Args:
         Input array, expected to have numeric data type.
     out ({None, usm_ndarray}, optional):
         Output array to populate.
-        Array have the correct shape and the expected data type.
+        Array must have the correct shape and the expected data type.
     order ("C","F","A","K", optional):
         Memory layout of the newly output array, if parameter `out` is `None`.
         Default: "K".
@@ -1771,7 +1771,7 @@ Args:
         Second input array, also expected to have numeric data type.
     out ({None, usm_ndarray}, optional):
         Output array to populate.
-        Array have the correct shape and the expected data type.
+        Array must have the correct shape and the expected data type.
     order ("C","F","A","K", optional):
         Memory layout of the newly output array, if parameter `out` is `None`.
         Default: "K".

--- a/dpctl/tensor/_elementwise_funcs.py
+++ b/dpctl/tensor/_elementwise_funcs.py
@@ -1069,7 +1069,7 @@ log10 = UnaryElementwiseFunc(
 _logaddexp_docstring_ = """
 logaddexp(x1, x2, out=None, order='K')
 
-Calculates the natural logarithm of the sum of exponentiations for each element
+Calculates the natural logarithm of the sum of exponentials for each element
 `x1_i` of the input array `x1` with the respective element `x2_i` of the input
 array `x2`.
 
@@ -1091,7 +1091,7 @@ Args:
         Default: "K".
 Returns:
     usm_ndarray:
-        An array containing the result of element-wise division. The data type
+        An array containing the element-wise results. The data type
         of the returned array is determined by the Type Promotion Rules.
 """
 

--- a/dpctl/tensor/_elementwise_funcs.py
+++ b/dpctl/tensor/_elementwise_funcs.py
@@ -59,7 +59,7 @@ Computes inverse cosine for each element `x_i` for input array `x`.
 
 Args:
     x (usm_ndarray):
-        Input array, expected to have numeric data type.
+        Input array, expected to have a floating-point data type.
     out ({None, usm_ndarray}, optional):
         Output array to populate.
         Array must have the correct shape and the expected data type.
@@ -85,7 +85,7 @@ Computes inverse hyperbolic cosine for each element `x_i` for input array `x`.
 
 Args:
     x (usm_ndarray):
-        Input array, expected to have numeric data type.
+        Input array, expected to have a floating-point data type.
     out ({None, usm_ndarray}, optional):
         Output array to populate.
         Array must have the correct shape and the expected data type.
@@ -143,7 +143,7 @@ Computes inverse sine for each element `x_i` for input array `x`.
 
 Args:
     x (usm_ndarray):
-        Input array, expected to have numeric data type.
+        Input array, expected to have a floating-point data type.
     out ({None, usm_ndarray}, optional):
         Output array to populate.
         Array must have the correct shape and the expected data type.
@@ -169,7 +169,7 @@ Computes inverse hyperbolic sine for each element `x_i` for input array `x`.
 
 Args:
     x (usm_ndarray):
-        Input array, expected to have numeric data type.
+        Input array, expected to have a floating-point data type.
     out ({None, usm_ndarray}, optional):
         Output array to populate.
         Array must have the correct shape and the expected data type.
@@ -195,7 +195,7 @@ Computes inverse tangent for each element `x_i` for input array `x`.
 
 Args:
     x (usm_ndarray):
-        Input array, expected to have numeric data type.
+        Input array, expected to have a floating-point data type.
     out ({None, usm_ndarray}, optional):
         Output array to populate.
         Array must have the correct shape and the expected data type.
@@ -253,7 +253,7 @@ Computes hyperbolic inverse tangent for each element `x_i` for input array `x`.
 
 Args:
     x (usm_ndarray):
-        Input array, expected to have numeric data type.
+        Input array, expected to have a floating-point data type.
     out ({None, usm_ndarray}, optional):
         Output array to populate.
         Array must have the correct shape and the expected data type.
@@ -531,7 +531,7 @@ Computes cosine for each element `x_i` for input array `x`.
 
 Args:
     x (usm_ndarray):
-        Input array, expected to have numeric data type.
+        Input array, expected to have a floating-point data type.
     out ({None, usm_ndarray}, optional):
         Output array to populate.
         Array must have the correct shape and the expected data type.
@@ -554,7 +554,7 @@ Computes hyperbolic cosine for each element `x_i` for input array `x`.
 
 Args:
     x (usm_ndarray):
-        Input array, expected to have numeric data type.
+        Input array, expected to have a floating-point data type.
     out ({None, usm_ndarray}, optional):
         Output array to populate.
         Array must have the correct shape and the expected data type.
@@ -1557,7 +1557,7 @@ Computes sine for each element `x_i` of input array `x`.
 
 Args:
     x (usm_ndarray):
-        Input array, expected to have numeric data type.
+        Input array, expected to have a floating-point data type.
     out ({None, usm_ndarray}, optional):
         Output array to populate.
         Array must have the correct shape and the expected data type.
@@ -1580,7 +1580,7 @@ Computes hyperbolic sine for each element `x_i` for input array `x`.
 
 Args:
     x (usm_ndarray):
-        Input array, expected to have numeric data type.
+        Input array, expected to have a floating-point data type.
     out ({None, usm_ndarray}, optional):
         Output array to populate.
         Array must have the correct shape and the expected data type.
@@ -1689,7 +1689,7 @@ Computes tangent for each element `x_i` for input array `x`.
 
 Args:
     x (usm_ndarray):
-        Input array, expected to have numeric data type.
+        Input array, expected to have a floating-point data type.
     out ({None, usm_ndarray}, optional):
         Output array to populate.
         Array must have the correct shape and the expected data type.
@@ -1712,7 +1712,7 @@ Computes hyperbolic tangent for each element `x_i` for input array `x`.
 
 Args:
     x (usm_ndarray):
-        Input array, expected to have numeric data type.
+        Input array, expected to have a floating-point data type.
     out ({None, usm_ndarray}, optional):
         Output array to populate.
         Array must have the correct shape and the expected data type.

--- a/dpctl/tensor/_elementwise_funcs.py
+++ b/dpctl/tensor/_elementwise_funcs.py
@@ -1631,7 +1631,8 @@ sinh = UnaryElementwiseFunc(
 _square_docstring_ = """
 square(x, out=None, order='K')
 
-Computes `x_i**2` (or `x_i*x_i`) for each element `x_i` of input array `x`.
+Squares each element `x_i` of input array `x`.
+
 Args:
     x (usm_ndarray):
         Input array, expected to have numeric data type.
@@ -1643,9 +1644,8 @@ Args:
         Default: "K".
 Returns:
     usm_ndarray:
-        An array containing the square `x`.
-        The data type of the returned array is determined by
-        the Type Promotion Rules.
+        An array containing the element-wise squares of `x`. The data type of
+        the returned array is determined by the Type Promotion Rules.
 """
 
 square = UnaryElementwiseFunc(
@@ -1656,11 +1656,11 @@ square = UnaryElementwiseFunc(
 _sqrt_docstring_ = """
 sqrt(x, out=None, order='K')
 
-Computes positive square-root for each element `x_i` for input array `x`.
+Computes the positive square-root for each element `x_i` of input array `x`.
 
 Args:
     x (usm_ndarray):
-        Input array, expected to have numeric data type.
+        Input array, expected to have a floating-point data type.
     out ({None, usm_ndarray}, optional):
         Output array to populate.
         Array must have the correct shape and the expected data type.
@@ -1669,9 +1669,9 @@ Args:
         Default: "K".
 Returns:
     usm_narray:
-        An array containing the element-wise positive square-root.
-        The data type of the returned array is determined by
-        the Type Promotion Rules.
+        An array containing the element-wise positive square-roots of `x`. The
+        data type of the returned array is determined by the Type Promotion
+        Rules.
 """
 
 sqrt = UnaryElementwiseFunc(
@@ -1791,14 +1791,16 @@ trunc = UnaryElementwiseFunc(
 _hypot_docstring_ = """
 hypot(x1, x2, out=None, order='K')
 
-Calculates the ratio for each element `x1_i` of the input array `x1` with
-the respective element `x2_i` of the input array `x2`.
+Calculates the hypotenuse for a right triangle with "legs" `x1_i` and `x2_i` of
+input arrays `x1` and `x2`.
 
 Args:
     x1 (usm_ndarray):
-        First input array, expected to have numeric data type.
+        First input array, expected to have a real-valued floating-point data
+        type.
     x2 (usm_ndarray):
-        Second input array, also expected to have numeric data type.
+        Second input array, also expected to have a real-valued floating-point
+        data type.
     out ({None, usm_ndarray}, optional):
         Output array to populate.
         Array must have the correct shape and the expected data type.
@@ -1807,8 +1809,8 @@ Args:
         Default: "K".
 Returns:
     usm_narray:
-        An array containing the element-wise truncated value of input array.
-        The returned array has the same data type as `x`.
+        An array containing the element-wise hypotenuse. The data type
+        of the returned array is determined by the Type Promotion Rules.
 """
 
 hypot = BinaryElementwiseFunc(

--- a/dpctl/tensor/_elementwise_funcs.py
+++ b/dpctl/tensor/_elementwise_funcs.py
@@ -829,11 +829,11 @@ imag = UnaryElementwiseFunc(
 _isfinite_docstring_ = """
 isfinite(x, out=None, order='K')
 
-Checks if each element of input array is a finite number.
+Test if each element of input array is a finite number.
 
 Args:
     x (usm_ndarray):
-        Input array, expected to have numeric data type.
+        Input array.
     out ({None, usm_ndarray}, optional):
         Output array to populate.
         Array must have the correct shape and the expected data type.
@@ -855,11 +855,11 @@ isfinite = UnaryElementwiseFunc(
 _isinf_docstring_ = """
 isinf(x, out=None, order='K')
 
-Checks if each element of input array is an infinity.
+Test if each element of input array is an infinity.
 
 Args:
     x (usm_ndarray):
-        Input array, expected to have numeric data type.
+        Input array.
     out ({None, usm_ndarray}, optional):
         Output array to populate.
         Array must have the correct shape and the expected data type.
@@ -880,11 +880,11 @@ isinf = UnaryElementwiseFunc(
 _isnan_docstring_ = """
 isnan(x, out=None, order='K')
 
-Checks if each element of an input array is a NaN.
+Test if each element of an input array is a NaN.
 
 Args:
     x (usm_ndarray):
-        Input array, expected to have numeric data type.
+        Input array.
     out ({None, usm_ndarray}, optional):
         Output array to populate.
         Array must have the correct shape and the expected data type.

--- a/dpctl/tensor/_elementwise_funcs.py
+++ b/dpctl/tensor/_elementwise_funcs.py
@@ -113,9 +113,9 @@ the respective element `x2_i` of the input array `x2`.
 
 Args:
     x1 (usm_ndarray):
-        First input array, expected to have numeric data type.
+        First input array.
     x2 (usm_ndarray):
-        Second input array, also expected to have numeric data type.
+        Second input array.
     out ({None, usm_ndarray}, optional):
         Output array to populate.
         Array must have the correct shape and the expected data type.

--- a/dpctl/tensor/_elementwise_funcs.py
+++ b/dpctl/tensor/_elementwise_funcs.py
@@ -1102,8 +1102,8 @@ logaddexp = BinaryElementwiseFunc(
 _logical_and_docstring_ = """
 logical_and(x1, x2, out=None, order='K')
 
-Computes the logical AND for each element `x1_i` of the input array `x1`
-with the respective element `x2_i` of the input array `x2`.
+Computes the logical AND for each element `x1_i` of the input array `x1` with
+the respective element `x2_i` of the input array `x2`.
 
 Args:
     x1 (usm_ndarray):
@@ -1130,7 +1130,9 @@ logical_and = BinaryElementwiseFunc(
 # U24: ==== LOGICAL_NOT (x)
 _logical_not_docstring = """
 logical_not(x, out=None, order='K')
+
 Computes the logical NOT for each element `x_i` of input array `x`.
+
 Args:
     x (usm_ndarray):
         Input array.
@@ -1214,14 +1216,14 @@ logical_xor = BinaryElementwiseFunc(
 _maximum_docstring_ = """
 maximum(x1, x2, out=None, order='K')
 
-Compares two input arrays `x1` and `x2` and returns
-a new array containing the element-wise maxima.
+Compares two input arrays `x1` and `x2` and returns a new array containing the
+element-wise maxima.
 
 Args:
     x1 (usm_ndarray):
-        First input array, expected to have numeric data type.
+        First input array.
     x2 (usm_ndarray):
-        Second input array, also expected to have numeric data type.
+        Second input array.
     out ({None, usm_ndarray}, optional):
         Output array to populate.
         Array must have the correct shape and the expected data type.
@@ -1244,14 +1246,14 @@ maximum = BinaryElementwiseFunc(
 _minimum_docstring_ = """
 minimum(x1, x2, out=None, order='K')
 
-Compares two input arrays `x1` and `x2` and returns
-a new array containing the element-wise minima.
+Compares two input arrays `x1` and `x2` and returns a new array containing the
+element-wise minima.
 
 Args:
     x1 (usm_ndarray):
-        First input array, expected to have numeric data type.
+        First input array.
     x2 (usm_ndarray):
-        Second input array, also expected to have numeric data type.
+        Second input array.
     out ({None, usm_ndarray}, optional):
         Output array to populate.
         Array must have the correct shape and the expected data type.
@@ -1274,8 +1276,8 @@ minimum = BinaryElementwiseFunc(
 _multiply_docstring_ = """
 multiply(x1, x2, out=None, order='K')
 
-Calculates the product for each element `x1_i` of the input array `x1`
-with the respective element `x2_i` of the input array `x2`.
+Calculates the product for each element `x1_i` of the input array `x1` with the
+respective element `x2_i` of the input array `x2`.
 
 Args:
     x1 (usm_ndarray):
@@ -1306,9 +1308,10 @@ _negative_docstring_ = """
 negative(x, out=None, order='K')
 
 Computes the numerical negative for each element `x_i` of input array `x`.
+
 Args:
     x (usm_ndarray):
-        Input array, expected to have numeric data type.
+        Input array, expected to have a numeric data type.
     out (usm_ndarray):
         Output array to populate. Array must have the correct
         shape and the expected data type.
@@ -1363,7 +1366,7 @@ positive(x, out=None, order='K')
 Computes the numerical positive for each element `x_i` of input array `x`.
 Args:
     x (usm_ndarray):
-        Input array, expected to have numeric data type.
+        Input array, expected to have a numeric data type.
     out (usm_ndarray):
         Output array to populate. Array must have the correct
         shape and the expected data type.
@@ -1372,7 +1375,7 @@ Args:
         Default: "K".
 Return:
     usm_ndarray:
-        An array containing the values of `x`.
+        An array containing the positive of `x`.
 """
 
 positive = UnaryElementwiseFunc(
@@ -1702,7 +1705,6 @@ subtract = BinaryElementwiseFunc(
     binary_inplace_fn=ti._subtract_inplace,
     acceptance_fn=_acceptance_fn_subtract,
 )
-
 
 # U34: ==== TAN         (x)
 _tan_docstring = """

--- a/dpctl/tensor/_elementwise_funcs.py
+++ b/dpctl/tensor/_elementwise_funcs.py
@@ -491,7 +491,7 @@ Args:
         Default: "K".
 Returns:
     usm_ndarray:
-        An array containing the element-wise ceiling results.
+        An array containing the element-wise ceiling.
 """
 
 ceil = UnaryElementwiseFunc(
@@ -702,7 +702,7 @@ Args:
         Default: "K".
 Returns:
     usm_ndarray:
-        An array containing the element-wise floor results.
+        An array containing the element-wise floor.
 """
 
 floor = UnaryElementwiseFunc(
@@ -1507,7 +1507,7 @@ integer to `x_i`.
 
 Args:
     x (usm_ndarray):
-        Input array, expected to have a numeric data type.
+        Input array, expected to have a real-valued data type.
     out ({None, usm_ndarray}, optional):
         Output array to populate.
         Array must have the correct shape and the expected data type.
@@ -1516,7 +1516,7 @@ Args:
         Default: "K".
 Returns:
     usm_ndarray:
-        An array containing the element-wise rounded results.
+        An array containing the element-wise rounded values.
 """
 
 round = UnaryElementwiseFunc(
@@ -1770,7 +1770,7 @@ signed number `x` is discarded.
 
 Args:
     x (usm_ndarray):
-        Input array, expected to have numeric data type.
+        Input array, expected to have a real-valued data type.
     out ({None, usm_ndarray}, optional):
         Output array to populate.
         Array must have the correct shape and the expected data type.

--- a/dpctl/tensor/_elementwise_funcs.py
+++ b/dpctl/tensor/_elementwise_funcs.py
@@ -40,7 +40,7 @@ Args:
         Memory layout of the newly output array, if parameter `out` is `None`.
         Default: "K".
 Returns:
-    usm_narray:
+    usm_ndarray:
         An array containing the element-wise absolute values.
         For complex input, the absolute value is its magnitude.
         If `x` has a real-valued data type, the returned array has the
@@ -67,7 +67,7 @@ Args:
         Memory layout of the newly output array, if parameter `out` is `None`.
         Default: "K".
 Returns:
-    usm_narray:
+    usm_ndarray:
         An array containing the element-wise inverse cosine, in radians
         and in the closed interval `[-pi/2, pi/2]`. The data type
         of the returned array is determined by the Type Promotion Rules.
@@ -93,7 +93,7 @@ Args:
         Memory layout of the newly output array, if parameter `out` is `None`.
         Default: "K".
 Returns:
-    usm_narray:
+    usm_ndarray:
         An array containing the element-wise inverse hyperbolic cosine.
         The data type of the returned array is determined by
         the Type Promotion Rules.
@@ -123,7 +123,7 @@ Args:
         Memory layout of the newly output array, if parameter `out` is `None`.
         Default: "K".
 Returns:
-    usm_narray:
+    usm_ndarray:
         An array containing the element-wise sums. The data type of the
         returned array is determined by the Type Promotion Rules.
 """
@@ -151,7 +151,7 @@ Args:
         Memory layout of the newly output array, if parameter `out` is `None`.
         Default: "K".
 Returns:
-    usm_narray:
+    usm_ndarray:
         An array containing the element-wise inverse sine, in radians
         and in the closed interval `[-pi/2, pi/2]`. The data type
         of the returned array is determined by the Type Promotion Rules.
@@ -177,7 +177,7 @@ Args:
         Memory layout of the newly output array, if parameter `out` is `None`.
         Default: "K".
 Returns:
-    usm_narray:
+    usm_ndarray:
         An array containing the element-wise inverse hyperbolic sine.
         The data type of the returned array is determined by
         the Type Promotion Rules.
@@ -203,7 +203,7 @@ Args:
         Memory layout of the newly output array, if parameter `out` is `None`.
         Default: "K".
 Returns:
-    usm_narray:
+    usm_ndarray:
         An array containing the element-wise inverse tangent, in radians
         and in the closed interval `[-pi/2, pi/2]`. The data type
         of the returned array is determined by the Type Promotion Rules.
@@ -235,7 +235,7 @@ Args:
         Memory layout of the newly output array, if parameter `out` is `None`.
         Default: "K".
 Returns:
-    usm_narray:
+    usm_ndarray:
         An array containing the inverse tangent of the quotient `x1`/`x2`.
         The returned array must have a real-valued floating-point data type
         determined by Type Promotion Rules.
@@ -261,7 +261,7 @@ Args:
         Memory layout of the newly output array, if parameter `out` is `None`.
         Default: "K".
 Returns:
-    usm_narray:
+    usm_ndarray:
         An array containing the element-wise hyperbolic inverse tangent.
         The data type of the returned array is determined by
         the Type Promotion Rules.
@@ -292,7 +292,7 @@ Args:
         Memory layout of the newly output array, if parameter `out` is `None`.
         Default: "K".
 Returns:
-    usm_narray:
+    usm_ndarray:
         An array containing the element-wise results. The data type
         of the returned array is determined by the Type Promotion Rules.
 """
@@ -326,7 +326,7 @@ Args:
         Memory layout of the newly output array, if parameter `out` is `None`.
         Default: "K".
 Returns:
-    usm_narray:
+    usm_ndarray:
         An array containing the element-wise results. The data type
         of the returned array is determined by the Type Promotion Rules.
 """
@@ -356,7 +356,7 @@ Args:
         Memory layout of the newly output array, if parameter `out` is `None`.
         Default: "K".
 Returns:
-    usm_narray:
+    usm_ndarray:
         An array containing the element-wise results.
         The data type of the returned array is same as the data type of the
         input array.
@@ -390,7 +390,7 @@ Args:
         Memory layout of the newly output array, if parameter `out` is `None`.
         Default: "K".
 Returns:
-    usm_narray:
+    usm_ndarray:
         An array containing the element-wise results. The data type
         of the returned array is determined by the Type Promotion Rules.
 """
@@ -423,7 +423,7 @@ Args:
         Memory layout of the newly output array, if parameter `out` is `None`.
         Default: "K".
 Returns:
-    usm_narray:
+    usm_ndarray:
         An array containing the element-wise results. The data type
         of the returned array is determined by the Type Promotion Rules.
 """
@@ -458,7 +458,7 @@ Args:
         Memory layout of the newly output array, if parameter `out` is `None`.
         Default: "K".
 Returns:
-    usm_narray:
+    usm_ndarray:
         An array containing the element-wise results. The data type
         of the returned array is determined by the Type Promotion Rules.
 """
@@ -490,7 +490,7 @@ Args:
         Memory layout of the newly output array, if parameter `out` is `None`.
         Default: "K".
 Returns:
-    usm_narray:
+    usm_ndarray:
         An array containing the element-wise ceiling results.
 """
 
@@ -514,7 +514,7 @@ Args:
         Memory layout of the newly output array, if parameter `out` is `None`.
         Default: "K".
 Returns:
-    usm_narray:
+    usm_ndarray:
         An array containing the element-wise conjugate values.
 """
 
@@ -538,7 +538,7 @@ Args:
         Memory layout of the newly output array, if parameter `out` is `None`.
         Default: "K".
 Returns:
-    usm_narray:
+    usm_ndarray:
         An array containing the element-wise cosine. The data type
         of the returned array is determined by the Type Promotion Rules.
 """
@@ -561,7 +561,7 @@ Args:
         Memory layout of the newly output array, if parameter `out` is `None`.
         Default: "K".
 Returns:
-    usm_narray:
+    usm_ndarray:
         An array containing the element-wise hyperbolic cosine. The data type
         of the returned array is determined by the Type Promotion Rules.
 """
@@ -589,7 +589,7 @@ Args:
         Memory layout of the newly output array, if parameter `out` is `None`.
         Default: "K".
 Returns:
-    usm_narray:
+    usm_ndarray:
         An array containing the result of element-wise division. The data type
         of the returned array is determined by the Type Promotion Rules.
 """
@@ -622,7 +622,7 @@ Args:
         Memory layout of the newly output array, if parameter `out` is `None`.
         Default: "K".
 Returns:
-    usm_narray:
+    usm_ndarray:
         An array containing the result of element-wise equality comparison.
         The returned array has a data type of `bool`.
 """
@@ -647,7 +647,7 @@ Args:
         Memory layout of the newly output array, if parameter `out` is `None`.
         Default: "K".
 Returns:
-    usm_narray:
+    usm_ndarray:
         An array containing the element-wise exponential of x.
         The data type of the returned array is determined by
         the Type Promotion Rules.
@@ -701,7 +701,7 @@ Args:
         Memory layout of the newly output array, if parameter `out` is `None`.
         Default: "K".
 Returns:
-    usm_narray:
+    usm_ndarray:
         An array containing the element-wise floor results.
 """
 
@@ -724,7 +724,7 @@ Args:
         Second input array, also expected to have a real-valued or boolean data
         type.
 Returns:
-    usm_narray:
+    usm_ndarray:
         An array containing the result of element-wise floor of division.
         The data type of the returned array is determined by the Type
         Promotion Rules.
@@ -757,7 +757,7 @@ Args:
         Memory layout of the newly output array, if parameter `out` is `None`.
         Default: "K".
 Returns:
-    usm_narray:
+    usm_ndarray:
         An array containing the result of element-wise greater-than comparison.
         The returned array has a data type of `bool`.
 """
@@ -785,7 +785,7 @@ Args:
         Memory layout of the newly output array, if parameter `out` is `None`.
         Default: "K".
 Returns:
-    usm_narray:
+    usm_ndarray:
         An array containing the result of element-wise greater-than or equal-to
         comparison.
         The returned array has a data type of `bool`.
@@ -814,7 +814,7 @@ Args:
         Memory layout of the newly output array, if parameter `out` is `None`.
         Default: "K".
 Returns:
-    usm_narray:
+    usm_ndarray:
         An array containing the element-wise imaginary component of input.
         If the input is a real-valued data type, the returned array has
         the same data type. If the input is a complex floating-point
@@ -842,7 +842,7 @@ Args:
         Memory layout of the newly output array, if parameter `out` is `None`.
         Default: "K".
 Returns:
-    usm_narray:
+    usm_ndarray:
         An array which is True where `x` is not positive infinity,
         negative infinity, or NaN, False otherwise.
         The data type of the returned array is `bool`.
@@ -868,7 +868,7 @@ Args:
         Memory layout of the newly output array, if parameter `out` is `None`.
         Default: "K".
 Returns:
-    usm_narray:
+    usm_ndarray:
         An array which is True where `x` is positive or negative infinity,
         False otherwise. The data type of the returned array is `bool`.
 """
@@ -893,7 +893,7 @@ Args:
         Memory layout of the newly output array, if parameter `out` is `None`.
         Default: "K".
 Returns:
-    usm_narray:
+    usm_ndarray:
         An array which is True where x is NaN, False otherwise.
         The data type of the returned array is `bool`.
 """
@@ -921,7 +921,7 @@ Args:
         Memory layout of the newly output array, if parameter `out` is `None`.
         Default: "K".
 Returns:
-    usm_narray:
+    usm_ndarray:
         An array containing the result of element-wise less-than comparison.
         The returned array has a data type of `bool`.
 """
@@ -949,7 +949,7 @@ Args:
         Memory layout of the newly output array, if parameter `out` is `None`.
         Default: "K".
 Returns:
-    usm_narray:
+    usm_ndarray:
         An array containing the result of element-wise less-than or equal-to
         comparison. The returned array has a data type of `bool`.
 """
@@ -1029,7 +1029,7 @@ Args:
         Memory layout of the newly output array, if parameter `out` is `None`.
         Default: "K".
 Returns:
-    usm_narray:
+    usm_ndarray:
         An array containing the element-wise base-2 logarithm of `x`.
         The data type of the returned array is determined by the
         Type Promotion Rules.
@@ -1055,7 +1055,7 @@ Args:
         Memory layout of the newly output array, if parameter `out` is `None`.
         Default: "K".
 Returns:
-    usm_narray:
+    usm_ndarray:
         An array containing the element-wise base-10 logarithm of `x`.
         The data type of the returned array is determined by the
         Type Promotion Rules.
@@ -1090,7 +1090,7 @@ Args:
         Memory layout of the newly output array, if parameter `out` is `None`.
         Default: "K".
 Returns:
-    usm_narray:
+    usm_ndarray:
         An array containing the result of element-wise division. The data type
         of the returned array is determined by the Type Promotion Rules.
 """
@@ -1118,7 +1118,7 @@ Args:
         Memory layout of the newly output array, if parameter `out` is `None`.
         Default: "K".
 Returns:
-    usm_narray:
+    usm_ndarray:
         An array containing the element-wise logical AND results.
 """
 logical_and = BinaryElementwiseFunc(
@@ -1174,7 +1174,7 @@ Args:
         Memory layout of the newly output array, if parameter `out` is `None`.
         Default: "K".
 Returns:
-    usm_narray:
+    usm_ndarray:
         An array containing the element-wise logical OR results.
 """
 logical_or = BinaryElementwiseFunc(
@@ -1203,7 +1203,7 @@ Args:
         Memory layout of the newly output array, if parameter `out` is `None`.
         Default: "K".
 Returns:
-    usm_narray:
+    usm_ndarray:
         An array containing the element-wise logical XOR results.
 """
 logical_xor = BinaryElementwiseFunc(
@@ -1232,7 +1232,7 @@ Args:
         Memory layout of the newly output array, if parameter `out` is `None`.
         Default: "K".
 Returns:
-    usm_narray:
+    usm_ndarray:
         An array containing the element-wise maxima. The data type of
         the returned array is determined by the Type Promotion Rules.
 """
@@ -1262,7 +1262,7 @@ Args:
         Memory layout of the newly output array, if parameter `out` is `None`.
         Default: "K".
 Returns:
-    usm_narray:
+    usm_ndarray:
         An array containing the element-wise minima. The data type of
         the returned array is determined by the Type Promotion Rules.
 """
@@ -1292,7 +1292,7 @@ Args:
         Memory layout of the newly output array, if parameter `out` is `None`.
         Default: "K".
 Returns:
-    usm_narray:
+    usm_ndarray:
         An array containing the element-wise products. The data type of
         the returned array is determined by the Type Promotion Rules.
 """
@@ -1351,7 +1351,7 @@ Args:
         Memory layout of the newly output array, if parameter `out` is `None`.
         Default: "K".
 Returns:
-    usm_narray:
+    usm_ndarray:
         An array containing the result of element-wise inequality comparison.
         The returned array has a data type of `bool`.
 """
@@ -1425,7 +1425,7 @@ Args:
         Memory layout of the newly output array, if parameter `out` is `None`.
         Default: "K".
 Returns:
-    usm_narray:
+    usm_ndarray:
         An array containing the element-wise projection.
 """
 
@@ -1449,7 +1449,7 @@ Args:
         Memory layout of the newly output array, if parameter `out` is `None`.
         Default: "K".
 Returns:
-    usm_narray:
+    usm_ndarray:
         An array containing the element-wise real component of input.
         If the input is a real-valued data type, the returned array has
         the same data type. If the input is a complex floating-point
@@ -1515,7 +1515,7 @@ Args:
         Memory layout of the newly output array, if parameter `out` is `None`.
         Default: "K".
 Returns:
-    usm_narray:
+    usm_ndarray:
         An array containing the element-wise rounded results.
 """
 
@@ -1543,7 +1543,7 @@ Args:
         Memory layout of the newly output array, if parameter `out` is `None`.
         Default: "K".
 Returns:
-    usm_narray:
+    usm_ndarray:
         An array containing the element-wise result of the signum function. The
         data type of the returned array is determined by the Type Promotion
         Rules.
@@ -1570,7 +1570,7 @@ Args:
         Memory layout of the newly output array, if parameter `out` is `None`.
         Default: "K".
 Returns:
-    usm_narray:
+    usm_ndarray:
         An array containing the element-wise signbit results. The returned array
         must have a data type of `bool`.
 """
@@ -1595,7 +1595,7 @@ Args:
         Memory layout of the newly output array, if parameter `out` is `None`.
         Default: "K".
 Returns:
-    usm_narray:
+    usm_ndarray:
         An array containing the element-wise sine. The data type of the
         returned array is determined by the Type Promotion Rules.
 """
@@ -1618,7 +1618,7 @@ Args:
         Memory layout of the newly output array, if parameter `out` is `None`.
         Default: "K".
 Returns:
-    usm_narray:
+    usm_ndarray:
         An array containing the element-wise hyperbolic sine. The data type
         of the returned array is determined by the Type Promotion Rules.
 """
@@ -1668,7 +1668,7 @@ Args:
         Memory layout of the newly output array, if parameter `out` is `None`.
         Default: "K".
 Returns:
-    usm_narray:
+    usm_ndarray:
         An array containing the element-wise positive square-roots of `x`. The
         data type of the returned array is determined by the Type Promotion
         Rules.
@@ -1697,7 +1697,7 @@ Args:
         Memory layout of the newly output array, if parameter `out` is `None`.
         Default: "K".
 Returns:
-    usm_narray:
+    usm_ndarray:
         An array containing the element-wise differences. The data type
         of the returned array is determined by the Type Promotion Rules.
 """
@@ -1726,7 +1726,7 @@ Args:
         Memory layout of the newly output array, if parameter `out` is `None`.
         Default: "K".
 Returns:
-    usm_narray:
+    usm_ndarray:
         An array containing the element-wise tangent. The data type
         of the returned array is determined by the Type Promotion Rules.
 """
@@ -1749,7 +1749,7 @@ Args:
         Memory layout of the newly output array, if parameter `out` is `None`.
         Default: "K".
 Returns:
-    usm_narray:
+    usm_ndarray:
         An array containing the element-wise hyperbolic tangent. The data type
         of the returned array is determined by the Type Promotion Rules.
 """
@@ -1778,7 +1778,7 @@ Args:
         Memory layout of the newly output array, if parameter `out` is `None`.
         Default: "K".
 Returns:
-    usm_narray:
+    usm_ndarray:
         An array containing the result of element-wise division. The data type
         of the returned array is determined by the Type Promotion Rules.
 """
@@ -1808,7 +1808,7 @@ Args:
         Memory layout of the newly output array, if parameter `out` is `None`.
         Default: "K".
 Returns:
-    usm_narray:
+    usm_ndarray:
         An array containing the element-wise hypotenuse. The data type
         of the returned array is determined by the Type Promotion Rules.
 """
@@ -1834,7 +1834,7 @@ Args:
         Memory layout of the newly output array, if parameter `out` is `None`.
         Default: "K".
 Returns:
-    usm_narray:
+    usm_ndarray:
         An array containing the element-wise positive cube-root.
         The data type of the returned array is determined by
         the Type Promotion Rules.
@@ -1861,7 +1861,7 @@ Args:
         Memory layout of the newly output array, if parameter `out` is `None`.
         Default: "K".
 Returns:
-    usm_narray:
+    usm_ndarray:
         An array containing the element-wise base-2 exponentials.
         The data type of the returned array is determined by
         the Type Promotion Rules.
@@ -1892,7 +1892,7 @@ Args:
         Memory layout of the newly output array, if parameter `out` is `None`.
         Default: "K".
 Returns:
-    usm_narray:
+    usm_ndarray:
         An array containing the element-wise results. The data type
         of the returned array is determined by the Type Promotion Rules.
 """
@@ -1920,7 +1920,7 @@ Args:
         Memory layout of the newly output array, if parameter `out` is `None`.
         Default: "K".
 Returns:
-    usm_narray:
+    usm_ndarray:
         An array containing the element-wise reciprocal square-root.
         The returned array has a floating-point data type determined by
         the Type Promotion Rules.

--- a/dpctl/tensor/_elementwise_funcs.py
+++ b/dpctl/tensor/_elementwise_funcs.py
@@ -477,11 +477,12 @@ _ceil_docstring = """
 ceil(x, out=None, order='K')
 
 Returns the ceiling for each element `x_i` for input array `x`.
-The ceil of the scalar `x` is the smallest integer `i`, such that `i >= x`.
+
+The ceil of `x_i` is the smallest integer `n`, such that `n >= x_i`.
 
 Args:
     x (usm_ndarray):
-        Input array, expected to have numeric data type.
+        Input array, expected to have a real-valued data type.
     out ({None, usm_ndarray}, optional):
         Output array to populate.
         Array must have the correct shape and the expected data type.
@@ -490,8 +491,7 @@ Args:
         Default: "K".
 Returns:
     usm_narray:
-        An array containing the element-wise ceiling of input array.
-        The returned array has the same data type as `x`.
+        An array containing the element-wise ceiling results.
 """
 
 ceil = UnaryElementwiseFunc(
@@ -684,11 +684,12 @@ _floor_docstring = """
 floor(x, out=None, order='K')
 
 Returns the floor for each element `x_i` for input array `x`.
-The floor of the scalar `x` is the largest integer `i`, such that `i <= x`.
+
+The floor of `x_i` is the largest integer `n`, such that `n <= x_i`.
 
 Args:
     x (usm_ndarray):
-        Input array, expected to have numeric data type.
+        Input array, expected to have a real-valued data type.
     out ({None, usm_ndarray}, optional):
         Output array to populate.
         Array must have the correct shape and the expected data type.
@@ -697,8 +698,7 @@ Args:
         Default: "K".
 Returns:
     usm_narray:
-        An array containing the element-wise floor of input array.
-        The returned array has the same data type as `x`.
+        An array containing the element-wise floor results.
 """
 
 floor = UnaryElementwiseFunc(
@@ -1473,9 +1473,12 @@ round(x, out=None, order='K')
 Rounds each element `x_i` of the input array `x` to
 the nearest integer-valued number.
 
+When two integers are equally close to `x_i`, the result is the nearest even
+integer to `x_i`.
+
 Args:
     x (usm_ndarray):
-        Input array, expected to have numeric data type.
+        Input array, expected to have a numeric data type.
     out ({None, usm_ndarray}, optional):
         Output array to populate.
         Array must have the correct shape and the expected data type.
@@ -1484,8 +1487,7 @@ Args:
         Default: "K".
 Returns:
     usm_narray:
-        An array containing the element-wise rounded value. The data type
-        of the returned array is determined by the Type Promotion Rules.
+        An array containing the element-wise rounded results.
 """
 
 round = UnaryElementwiseFunc(
@@ -1732,9 +1734,10 @@ _trunc_docstring = """
 trunc(x, out=None, order='K')
 
 Returns the truncated value for each element `x_i` for input array `x`.
+
 The truncated value of the scalar `x` is the nearest integer i which is
- closer to zero than `x` is. In short, the fractional part of the
- signed number `x` is discarded.
+closer to zero than `x` is. In short, the fractional part of the
+signed number `x` is discarded.
 
 Args:
     x (usm_ndarray):

--- a/dpctl/tensor/_elementwise_funcs.py
+++ b/dpctl/tensor/_elementwise_funcs.py
@@ -94,9 +94,9 @@ Args:
         Default: "K".
 Returns:
     usm_ndarray:
-        An array containing the element-wise inverse hyperbolic cosine.
-        The data type of the returned array is determined by
-        the Type Promotion Rules.
+        An array containing the element-wise inverse hyperbolic cosine, in
+        radians and in the half-closed interval `[0, inf)`. The data type
+        of the returned array is determined by the Type Promotion Rules.
 """
 
 acosh = UnaryElementwiseFunc(

--- a/dpctl/tensor/_elementwise_funcs.py
+++ b/dpctl/tensor/_elementwise_funcs.py
@@ -506,7 +506,7 @@ Computes conjugate of each element `x_i` for input array `x`.
 
 Args:
     x (usm_ndarray):
-        Input array, expected to have numeric data type.
+        Input array, expected to have a numeric data type.
     out ({None, usm_ndarray}, optional):
         Output array to populate.
         Array must have the correct shape and the expected data type.
@@ -516,7 +516,6 @@ Args:
 Returns:
     usm_narray:
         An array containing the element-wise conjugate values.
-        The returned array has the same data type as `x`.
 """
 
 conj = UnaryElementwiseFunc(
@@ -798,7 +797,7 @@ Computes imaginary part of each element `x_i` for input array `x`.
 
 Args:
     x (usm_ndarray):
-        Input array, expected to have numeric data type.
+        Input array.
     out ({None, usm_ndarray}, optional):
         Output array to populate.
         Array must have the correct shape and the expected data type.
@@ -809,7 +808,7 @@ Returns:
     usm_narray:
         An array containing the element-wise imaginary component of input.
         If the input is a real-valued data type, the returned array has
-        the same datat type. If the input is a complex floating-point
+        the same data type. If the input is a complex floating-point
         data type, the returned array has a floating-point data type
         with the same floating-point precision as complex input.
 """
@@ -1390,7 +1389,7 @@ Computes projection of each element `x_i` for input array `x`.
 
 Args:
     x (usm_ndarray):
-        Input array, expected to have numeric data type.
+        Input array, expected to have a complex data type.
     out ({None, usm_ndarray}, optional):
         Output array to populate.
         Array must have the correct shape and the expected data type.
@@ -1400,7 +1399,6 @@ Args:
 Returns:
     usm_narray:
         An array containing the element-wise projection.
-        The returned array has the same data type as `x`.
 """
 
 proj = UnaryElementwiseFunc(
@@ -1415,7 +1413,7 @@ Computes real part of each element `x_i` for input array `x`.
 
 Args:
     x (usm_ndarray):
-        Input array, expected to have numeric data type.
+        Input array.
     out ({None, usm_ndarray}, optional):
         Output array to populate.
         Array must have the correct shape and the expected data type.
@@ -1426,7 +1424,7 @@ Returns:
     usm_narray:
         An array containing the element-wise real component of input.
         If the input is a real-valued data type, the returned array has
-        the same datat type. If the input is a complex floating-point
+        the same data type. If the input is a complex floating-point
         data type, the returned array has a floating-point data type
         with the same floating-point precision as complex input.
 """

--- a/dpctl/tensor/_elementwise_funcs.py
+++ b/dpctl/tensor/_elementwise_funcs.py
@@ -635,11 +635,11 @@ equal = BinaryElementwiseFunc(
 _exp_docstring = """
 exp(x, out=None, order='K')
 
-Computes exponential for each element `x_i` of input array `x`.
+Computes the exponential for each element `x_i` of input array `x`.
 
 Args:
     x (usm_ndarray):
-        Input array, expected to have numeric data type.
+        Input array, expected to have a floating-point data type.
     out ({None, usm_ndarray}, optional):
         Output array to populate.
         Array must have the correct shape and the expected data type.
@@ -658,10 +658,14 @@ exp = UnaryElementwiseFunc("exp", ti._exp_result_type, ti._exp, _exp_docstring)
 # U14: ==== EXPM1         (x)
 _expm1_docstring = """
 expm1(x, out=None, order='K')
-Computes an approximation of exp(x)-1 element-wise.
+
+Computes the exponential minus 1 for each element `x_i` of input array `x`.
+
+This function calculates `exp(x) - 1.0` more accurately for small values of `x`.
+
 Args:
     x (usm_ndarray):
-        Input array, expected to have numeric data type.
+        Input array, expected to have a floating-point data type.
     out (usm_ndarray):
         Output array to populate. Array must have the correct
         shape and the expected data type.
@@ -670,7 +674,7 @@ Args:
         Default: "K".
 Return:
     usm_ndarray:
-        An array containing the element-wise exp(x)-1 values.
+        An array containing the element-wise `exp(x) - 1` results.
         The data type of the returned array is determined by the Type
         Promotion Rules.
 """
@@ -959,10 +963,12 @@ less_equal = BinaryElementwiseFunc(
 # U20: ==== LOG         (x)
 _log_docstring = """
 log(x, out=None, order='K')
-Computes the natural logarithm element-wise.
+
+Computes the natural logarithm for each element `x_i` of input array `x`.
+
 Args:
     x (usm_ndarray):
-        Input array, expected to have numeric data type.
+        Input array, expected to have a floating-point data type.
     out (usm_ndarray):
         Output array to populate. Array must have the correct
         shape and the expected data type.
@@ -981,10 +987,15 @@ log = UnaryElementwiseFunc("log", ti._log_result_type, ti._log, _log_docstring)
 # U21: ==== LOG1P       (x)
 _log1p_docstring = """
 log1p(x, out=None, order='K')
-Computes an approximation of log(1+x) element-wise.
+
+Computes the natural logarithm of (1 + `x`) for each element `x_i` of input
+array `x`.
+
+This function calculates `log(1 + x)` more accurately for small values of `x`.
+
 Args:
     x (usm_ndarray):
-        Input array, expected to have numeric data type.
+        Input array, expected to have a floating-point data type.
     out (usm_ndarray):
         Output array to populate. Array must have the correct
         shape and the expected data type.
@@ -993,7 +1004,7 @@ Args:
         Default: "K".
 Return:
     usm_ndarray:
-        An array containing the element-wise log(1+x) values. The data type
+        An array containing the element-wise `log(1 + x)` results. The data type
         of the returned array is determined by the Type Promotion Rules.
 """
 
@@ -1009,7 +1020,7 @@ Computes the base-2 logarithm for each element `x_i` of input array `x`.
 
 Args:
     x (usm_ndarray):
-        Input array, expected to have numeric data type.
+        Input array, expected to have a floating-point data type.
     out ({None, usm_ndarray}, optional):
         Output array to populate.
         Array must have the correct shape and the expected data type.
@@ -1018,7 +1029,7 @@ Args:
         Default: "K".
 Returns:
     usm_narray:
-        An array containing the base-2 logarithm of `x`.
+        An array containing the element-wise base-2 logarithm of `x`.
         The data type of the returned array is determined by the
         Type Promotion Rules.
 """
@@ -1035,7 +1046,7 @@ Computes the base-10 logarithm for each element `x_i` of input array `x`.
 
 Args:
     x (usm_ndarray):
-        Input array, expected to have numeric data type.
+        Input array, expected to have a floating-point data type.
     out ({None, usm_ndarray}, optional):
         Output array to populate.
         Array must have the correct shape and the expected data type.
@@ -1044,7 +1055,7 @@ Args:
         Default: "K".
 Returns:
     usm_narray:
-        An array containing the base-1- logarithm of `x`.
+        An array containing the element-wise base-10 logarithm of `x`.
         The data type of the returned array is determined by the
         Type Promotion Rules.
 """
@@ -1057,14 +1068,20 @@ log10 = UnaryElementwiseFunc(
 _logaddexp_docstring_ = """
 logaddexp(x1, x2, out=None, order='K')
 
-Calculates the ratio for each element `x1_i` of the input array `x1` with
-the respective element `x2_i` of the input array `x2`.
+Calculates the natural logarithm of the sum of exponentiations for each element
+`x1_i` of the input array `x1` with the respective element `x2_i` of the input
+array `x2`.
+
+This function calculates `log(exp(x1) + exp(x2))` more accurately for small
+values of `x`.
 
 Args:
     x1 (usm_ndarray):
-        First input array, expected to have a real-valued data type.
+        First input array, expected to have a real-valued floating-point data
+        type.
     x2 (usm_ndarray):
-        Second input array, also expected to have real-valued data type.
+        Second input array, also expected to have a real-valued floating-point
+        data type.
     out ({None, usm_ndarray}, optional):
         Output array to populate.
         Array must have the correct shape and the expected data type.

--- a/dpctl/tensor/_elementwise_funcs.py
+++ b/dpctl/tensor/_elementwise_funcs.py
@@ -719,12 +719,13 @@ integer-value number that is not greater than the division result.
 
 Args:
     x1 (usm_ndarray):
-        First input array, expected to have numeric data type.
+        First input array, expected to have a real-valued or boolean data type.
     x2 (usm_ndarray):
-        Second input array, also expected to have numeric data type.
+        Second input array, also expected to have a real-valued or boolean data
+        type.
 Returns:
     usm_narray:
-        an array containing the result of element-wise floor division.
+        An array containing the result of element-wise floor of division.
         The data type of the returned array is determined by the Type
         Promotion Rules.
 """
@@ -1281,9 +1282,9 @@ respective element `x2_i` of the input array `x2`.
 
 Args:
     x1 (usm_ndarray):
-        First input array, expected to have numeric data type.
+        First input array.
     x2 (usm_ndarray):
-        Second input array, also expected to have numeric data type.
+        Second input array.
     out ({None, usm_ndarray}, optional):
         Output array to populate.
         Array must have the correct shape and the expected data type.
@@ -1351,7 +1352,7 @@ Args:
         Default: "K".
 Returns:
     usm_narray:
-        an array containing the result of element-wise inequality comparison.
+        An array containing the result of element-wise inequality comparison.
         The returned array has a data type of `bool`.
 """
 
@@ -1396,8 +1397,9 @@ Args:
         Second input array, also expected to have a numeric data type.
 Returns:
     usm_ndarray:
-        an array containing the element-wise result. The data type of
-        the returned array is determined by the Type Promotion Rules.
+        An array containing the bases in `x1` raised to the exponents in `x2`
+        element-wise. The data type of the returned array is determined by the
+        Type Promotion Rules.
 """
 pow = BinaryElementwiseFunc(
     "pow",
@@ -1481,8 +1483,9 @@ Args:
         Default: "K".
 Returns:
     usm_ndarray:
-        an array containing the element-wise remainders. The data type of
-        the returned array is determined by the Type Promotion Rules.
+        An array containing the element-wise remainders. Each remainder has the
+        same sign as respective element `x2_i`. The data type of the returned
+        array is determined by the Type Promotion Rules.
 """
 remainder = BinaryElementwiseFunc(
     "remainder",
@@ -1541,8 +1544,9 @@ Args:
         Default: "K".
 Returns:
     usm_narray:
-        An array containing the element-wise results. The data type of the
-        returned array is determined by the Type Promotion Rules.
+        An array containing the element-wise result of the signum function. The
+        data type of the returned array is determined by the Type Promotion
+        Rules.
 """
 
 sign = UnaryElementwiseFunc(
@@ -1558,7 +1562,7 @@ input array `x` is set.
 
 Args:
     x (usm_ndarray):
-        Input array, expected to have a numeric data type.
+        Input array, expected to have a real-valued floating-point data type.
     out ({None, usm_ndarray}, optional):
         Output array to populate.
         Array must have the correct shape and the expected data type.
@@ -1567,7 +1571,7 @@ Args:
         Default: "K".
 Returns:
     usm_narray:
-        An array containing the element-wise results. The returned array
+        An array containing the element-wise signbit results. The returned array
         must have a data type of `bool`.
 """
 
@@ -1683,9 +1687,9 @@ array `x1` and the respective element `x2_i` of the input array `x2`.
 
 Args:
     x1 (usm_ndarray):
-        First input array, expected to have numeric data type.
+        First input array, expected to have a numeric data type.
     x2 (usm_ndarray):
-        Second input array, also expected to have numeric data type.
+        Second input array, also expected to have a numeric data type.
     out ({None, usm_ndarray}, optional):
         Output array to populate.
         Array must have the correct shape and the expected data type.

--- a/dpctl/tensor/_elementwise_funcs.py
+++ b/dpctl/tensor/_elementwise_funcs.py
@@ -32,7 +32,7 @@ Calculates the absolute value for each element `x_i` of input array `x`.
 
 Args:
     x (usm_ndarray):
-        Input array, expected to have numeric data type.
+        Input array.
     out ({None, usm_ndarray}, optional):
         Output array to populate.
         Array must have the correct shape and the expected data type.

--- a/dpctl/tensor/_elementwise_funcs.py
+++ b/dpctl/tensor/_elementwise_funcs.py
@@ -579,9 +579,9 @@ the respective element `x2_i` of the input array `x2`.
 
 Args:
     x1 (usm_ndarray):
-        First input array, expected to have numeric data type.
+        First input array, expected to have a floating-point data type.
     x2 (usm_ndarray):
-        Second input array, also expected to have numeric data type.
+        Second input array, also expected to have a floating-point data type.
     out ({None, usm_ndarray}, optional):
         Output array to populate.
         Array must have the correct shape and the expected data type.
@@ -612,9 +612,9 @@ with the respective element `x2_i` of the input array `x2`.
 
 Args:
     x1 (usm_ndarray):
-        First input array, expected to have numeric data type.
+        First input array.
     x2 (usm_ndarray):
-        Second input array, also expected to have numeric data type.
+        Second input array.
     out ({None, usm_ndarray}, optional):
         Output array to populate.
         Array must have the correct shape and the expected data type.
@@ -736,13 +736,15 @@ floor_divide = BinaryElementwiseFunc(
 # B11: ==== GREATER       (x1, x2)
 _greater_docstring_ = """
 greater(x1, x2, out=None, order='K')
+
 Computes the greater-than test results for each element `x1_i` of
 the input array `x1` with the respective element `x2_i` of the input array `x2`.
+
 Args:
     x1 (usm_ndarray):
-        First input array, expected to have numeric data type.
+        First input array.
     x2 (usm_ndarray):
-        Second input array, also expected to have numeric data type.
+        Second input array.
     out ({None, usm_ndarray}, optional):
         Output array to populate.
         Array must have the correct shape and the expected data type.
@@ -762,13 +764,15 @@ greater = BinaryElementwiseFunc(
 # B12: ==== GREATER_EQUAL (x1, x2)
 _greater_equal_docstring_ = """
 greater_equal(x1, x2, out=None, order='K')
+
 Computes the greater-than or equal-to test results for each element `x1_i` of
 the input array `x1` with the respective element `x2_i` of the input array `x2`.
+
 Args:
     x1 (usm_ndarray):
-        First input array, expected to have numeric data type.
+        First input array.
     x2 (usm_ndarray):
-        Second input array, also expected to have numeric data type.
+        Second input array.
     out ({None, usm_ndarray}, optional):
         Output array to populate.
         Array must have the correct shape and the expected data type.
@@ -902,9 +906,9 @@ the input array `x1` with the respective element `x2_i` of the input array `x2`.
 
 Args:
     x1 (usm_ndarray):
-        First input array, expected to have numeric data type.
+        First input array.
     x2 (usm_ndarray):
-        Second input array, also expected to have numeric data type.
+        Second input array.
     out ({None, usm_ndarray}, optional):
         Output array to populate.
         Array must have the correct shape and the expected data type.
@@ -924,13 +928,15 @@ less = BinaryElementwiseFunc(
 # B14: ==== LESS_EQUAL  (x1, x2)
 _less_equal_docstring_ = """
 less_equal(x1, x2, out=None, order='K')
+
 Computes the less-than or equal-to test results for each element `x1_i` of
 the input array `x1` with the respective element `x2_i` of the input array `x2`.
+
 Args:
     x1 (usm_ndarray):
-        First input array, expected to have numeric data type.
+        First input array.
     x2 (usm_ndarray):
-        Second input array, also expected to have numeric data type.
+        Second input array.
     out ({None, usm_ndarray}, optional):
         Output array to populate.
         Array must have the correct shape and the expected data type.
@@ -1314,9 +1320,9 @@ input array `x1` with the respective element `x2_i` of the input array `x2`.
 
 Args:
     x1 (usm_ndarray):
-        First input array, expected to have numeric data type.
+        First input array.
     x2 (usm_ndarray):
-        Second input array, also expected to have numeric data type.
+        Second input array.
     out ({None, usm_ndarray}, optional):
         Output array to populate.
         Array must have the correct shape and the expected data type.


### PR DESCRIPTION
This pull request makes a number of changes to the docstrings of element-wise functions, with a focus on guaranteeing that the information in the docstrings is correct and removing typos.

Each function, when referencing expected data types of inputs, now refers to the types which will not be cast. For example, `dpt.divide` arguments now state that they expect floating-point data, as otherwise, the data will be copied and cast.

- [X] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
