### PR TITLE
x.__dlpack_device__() returns ID of the parent device

### DIFF
--- a/dpctl/_sycl_platform.pyx
+++ b/dpctl/_sycl_platform.pyx
@@ -267,14 +267,20 @@ cdef class SyclPlatform(_SyclPlatform):
         """Returns the default platform context for this platform
 
         Returns:
-            SyclContext: The default context for the platform.
+            SyclContext
+                The default context for the platform.
+        Raises:
+            SyclContextCreationError
+                If default_context is not supported
         """
         cdef DPCTLSyclContextRef CRef = (
             DPCTLPlatform_GetDefaultContext(self._platform_ref)
         )
 
         if (CRef == NULL):
-            raise RuntimeError("Getting default error ran into a problem")
+            raise SyclContextCreationError(
+                "Getting default_context ran into a problem"
+            )
         else:
             return SyclContext._create(CRef)
 

--- a/dpctl/tensor/_dlpack.pxd
+++ b/dpctl/tensor/_dlpack.pxd
@@ -18,6 +18,7 @@
 # cython: language_level=3
 # cython: linetrace=True
 
+from .._sycl_device cimport SyclDevice
 from ._usmarray cimport usm_ndarray
 
 
@@ -31,6 +32,8 @@ cpdef object to_dlpack_capsule(usm_ndarray array) except +
 cpdef usm_ndarray from_dlpack_capsule(object dltensor) except +
 
 cpdef from_dlpack(array)
+
+cdef int get_parent_device_ordinal_id(SyclDevice dev) except *
 
 cdef class DLPackCreationError(Exception):
     """

--- a/dpctl/tensor/_usmarray.pyx
+++ b/dpctl/tensor/_usmarray.pyx
@@ -954,10 +954,10 @@ cdef class usm_ndarray:
             DLPackCreationError: when array is allocation on a partitioned
                 SYCL device
         """
-        cdef int dev_id = (<c_dpctl.SyclDevice>self.sycl_device).get_overall_ordinal()
+        cdef int dev_id = c_dlpack.get_parent_device_ordinal_id(<c_dpctl.SyclDevice>self.sycl_device)
         if dev_id < 0:
             raise c_dlpack.DLPackCreationError(
-                "DLPack protocol is only supported for non-partitioned devices"
+                "Could not determine id of the device where array was allocated."
             )
         else:
             return (

--- a/dpctl/tests/test_usm_ndarray_dlpack.py
+++ b/dpctl/tests/test_usm_ndarray_dlpack.py
@@ -222,9 +222,13 @@ def test_dlpack_from_subdevice():
         pytest.skip("Default device can not be partitioned")
     assert isinstance(sdevs, list) and len(sdevs) > 0
     try:
-        q = dpctl.SyclQueue(sdevs[0].sycl_platform.default_context, sdevs[0])
+        ctx = sdevs[0].sycl_platform.default_context
+    except dpctl.SyclContextCreationError:
+        pytest.skip("Platform's default_context is not available")
+    try:
+        q = dpctl.SyclQueue(ctx, sdevs[0])
     except dpctl.SyclQueueCreationError:
-        pytest.skip("Default device can not be partitioned")
+        pytest.skip("Queue could not be created")
 
     ar = dpt.arange(n, dtype=dpt.int32, sycl_queue=q)
     ar2 = dpt.from_dlpack(ar)

--- a/libsyclinterface/source/dpctl_sycl_platform_interface.cpp
+++ b/libsyclinterface/source/dpctl_sycl_platform_interface.cpp
@@ -225,8 +225,17 @@ DPCTLPlatform_GetDefaultContext(__dpctl_keep const DPCTLSyclPlatformRef PRef)
 {
     auto P = unwrap<platform>(PRef);
     if (P) {
-        const auto &default_ctx = P->ext_oneapi_get_default_context();
-        return wrap<context>(new context(default_ctx));
+#ifdef SYCL_EXT_ONEAPI_DEFAULT_CONTEXT
+        try {
+            const auto &default_ctx = P->ext_oneapi_get_default_context();
+            return wrap<context>(new context(default_ctx));
+        } catch (const std::exception &ex) {
+            error_handler(ex, __FILE__, __func__, __LINE__);
+            return nullptr;
+        }
+#else
+        return nullptr;
+#endif
     }
     else {
         error_handler(


### PR DESCRIPTION
`x.__dlpack_device__()` returns ID of the parent device, if allocation device is not a root device.

It gives ID (position in `sycl::device::get_devices()`) for the root device that the array allocation device descends from for sub-devices, or ID of the allocation device is that device is a root device.

This allows sharing through DLPack of allocation on sub-devices, as long as default platform context for the platform the device is from was used in allocation.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [x] If this PR is a work in progress, are you opening the PR as a draft?
