### PR TITLE
Boolean reductions allocate int32 temporary as USM-device

### DIFF
--- a/dpctl/tensor/_utility_functions.py
+++ b/dpctl/tensor/_utility_functions.py
@@ -36,10 +36,13 @@ def _boolean_reduction(x, axis, keepdims, func):
     res_usm_type = x.usm_type
 
     wait_list = []
+    # always allocate the temporary as
+    # int32 and usm-device  to ensure that atomic updates
+    # are supported
     res_tmp = dpt.empty(
         res_shape,
         dtype=dpt.int32,
-        usm_type=res_usm_type,
+        usm_type="device",
         sycl_queue=exec_q,
     )
     hev0, ev0 = func(


### PR DESCRIPTION
Closes gh-1563

Allocating the temporary as USM-device ensures that atomic updates are always possible.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
