### PR TITLE
Fix RuntimeError when running strided gemm on CUDA devices 

### DIFF
--- a/dpctl/tensor/libtensor/include/kernels/linalg_functions/gemm.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/linalg_functions/gemm.hpp
@@ -1272,10 +1272,13 @@ sycl::event _gemm_batch_nm_impl(sycl::queue &exec_q,
     const std::uint32_t max_sg_size = krn.template get_info<
         sycl::info::kernel_device_specific::max_sub_group_size>(dev);
 
+    const size_t k_wg_sz = krn.template get_info<
+        sycl::info::kernel_device_specific::work_group_size>(dev);
+
     // Limit work-group size
     constexpr size_t wg_sz_limit(2048);
-    const size_t max_wg_sz = std::min<size_t>(
-        dev.get_info<sycl::info::device::max_work_group_size>(), wg_sz_limit);
+    const size_t max_wg_sz = std::min(wg_sz_limit, k_wg_sz);
+
     const std::uint32_t max_subgroups_per_wg =
         static_cast<std::uint32_t>(max_wg_sz / max_sg_size);
 


### PR DESCRIPTION
Use kernel device-specific descriptor to determine maximal work-group size for this kernel.

This resolves

```
RuntimeError: Exceeded the number of registers available on the hardware.
        The number registers per work-group cannot exceed 65536 for this kernel on this device.
        The kernel uses 108 registers per work-item for a total of 1024 work-items per work-group.
 -54 (PI_ERROR_INVALID_WORK_GROUP_SIZE)
```

when running example:

```python
import dpctl.tensor as dpt
m1 = dpt.ones((1000, 1000), dtype="i4", device="cuda")
m2 = dpt.ones((1000, 1003), dtype="i4", device="cuda")
r = dpt.matmul(m1[:, :900], m2[:900, :])
```

- [x] Have you provided a meaningful PR description?
- [x] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [x] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
