### PR TITLE
Restore using -fno-sycl-footer option for coverage collection

### DIFF
--- a/libsyclinterface/cmake/modules/SetupCoverage.cmake
+++ b/libsyclinterface/cmake/modules/SetupCoverage.cmake
@@ -25,7 +25,7 @@ function(setup_coverage_generation)
     string(CONCAT PROFILE_FLAGS
         "-fprofile-instr-generate "
         "-fcoverage-mapping "
-#        "-fno-sycl-use-footer "
+        "-fno-sycl-use-footer "
 #        "-save-temps=obj "
     )
 


### PR DESCRIPTION
As pointed out by @diptorupd "dpctl.lcov" file no longer contains data for `libsyclinterface`'s ".cpp" files.

Restoring this option recovers those locally.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [x] If this PR is a work in progress, are you opening the PR as a draft?
