### PR TITLE
Removed use of std::move in DPCTLDeviceMgr_GetCachedContext

### DIFF
--- a/libsyclinterface/source/dpctl_sycl_device_manager.cpp
+++ b/libsyclinterface/source/dpctl_sycl_device_manager.cpp
@@ -185,11 +185,11 @@ DPCTLDeviceMgr_GetCachedContext(__dpctl_keep const DPCTLSyclDeviceRef DRef)
         return nullptr;
     }
 
-    auto entry = cache.find(*Device);
+    const auto &entry = cache.find(*Device);
     if (entry != cache.end()) {
         context *ContextPtr = nullptr;
         try {
-            ContextPtr = new context(std::move(entry->second));
+            ContextPtr = new context(entry->second);
             CRef = wrap<context>(ContextPtr);
         } catch (std::exception const &e) {
             error_handler(e, __FILE__, __func__, __LINE__);


### PR DESCRIPTION
Use of `std::move` destroys the context saved in the cache, negating existence of this cache, but also setting the code up for possible silent failures.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
