### PR TITLE
No copying of indexers in functor constructors

### DIFF
--- a/dpctl/tensor/libtensor/include/kernels/accumulators.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/accumulators.hpp
@@ -107,8 +107,8 @@ inclusive_scan_base_step(sycl::queue &exec_q,
                          outputT *output,
                          const size_t s0,
                          const size_t s1,
-                         IndexerT indexer,
-                         TransformerT transformer,
+                         const IndexerT &indexer,
+                         const TransformerT &transformer,
                          size_t &n_groups,
                          const std::vector<sycl::event> &depends = {})
 {
@@ -234,8 +234,8 @@ sycl::event inclusive_scan_iter(sycl::queue &exec_q,
                                 outputT *output,
                                 const size_t s0,
                                 const size_t s1,
-                                IndexerT indexer,
-                                TransformerT transformer,
+                                const IndexerT &indexer,
+                                const TransformerT &transformer,
                                 std::vector<sycl::event> &host_tasks,
                                 const std::vector<sycl::event> &depends = {})
 {

--- a/dpctl/tensor/libtensor/include/kernels/clip.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/clip.hpp
@@ -235,14 +235,14 @@ private:
     const T *min_p = nullptr;
     const T *max_p = nullptr;
     T *dst_p = nullptr;
-    IndexerT indexer;
+    const IndexerT indexer;
 
 public:
     ClipStridedFunctor(const T *x_p_,
                        const T *min_p_,
                        const T *max_p_,
                        T *dst_p_,
-                       IndexerT indexer_)
+                       const IndexerT &indexer_)
         : x_p(x_p_), min_p(min_p_), max_p(max_p_), dst_p(dst_p_),
           indexer(indexer_)
     {
@@ -298,7 +298,7 @@ sycl::event clip_strided_impl(sycl::queue &q,
     sycl::event clip_ev = q.submit([&](sycl::handler &cgh) {
         cgh.depends_on(depends);
 
-        FourOffsets_StridedIndexer indexer{
+        const FourOffsets_StridedIndexer indexer{
             nd, x_offset, min_offset, max_offset, dst_offset, shape_strides};
 
         cgh.parallel_for<clip_strided_kernel<T, FourOffsets_StridedIndexer>>(

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/common.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/common.hpp
@@ -249,12 +249,12 @@ struct UnaryStridedFunctor
 private:
     const argT *inp_ = nullptr;
     resT *res_ = nullptr;
-    IndexerT inp_out_indexer_;
+    const IndexerT inp_out_indexer_;
 
 public:
     UnaryStridedFunctor(const argT *inp_p,
                         resT *res_p,
-                        IndexerT inp_out_indexer)
+                        const IndexerT &inp_out_indexer)
         : inp_(inp_p), res_(res_p), inp_out_indexer_(inp_out_indexer)
     {
     }
@@ -356,7 +356,7 @@ unary_strided_impl(sycl::queue &exec_q,
         using IndexerT =
             typename dpctl::tensor::offset_utils::TwoOffsets_StridedIndexer;
 
-        IndexerT indexer{nd, arg_offset, res_offset, shape_and_strides};
+        const IndexerT indexer{nd, arg_offset, res_offset, shape_and_strides};
 
         const argTy *arg_tp = reinterpret_cast<const argTy *>(arg_p);
         resTy *res_tp = reinterpret_cast<resTy *>(res_p);
@@ -516,13 +516,13 @@ private:
     const argT1 *in1 = nullptr;
     const argT2 *in2 = nullptr;
     resT *out = nullptr;
-    ThreeOffsets_IndexerT three_offsets_indexer_;
+    const ThreeOffsets_IndexerT three_offsets_indexer_;
 
 public:
     BinaryStridedFunctor(const argT1 *inp1_tp,
                          const argT2 *inp2_tp,
                          resT *res_tp,
-                         ThreeOffsets_IndexerT inps_res_indexer)
+                         const ThreeOffsets_IndexerT &inps_res_indexer)
         : in1(inp1_tp), in2(inp2_tp), out(res_tp),
           three_offsets_indexer_(inps_res_indexer)
     {
@@ -848,8 +848,8 @@ binary_strided_impl(sycl::queue &exec_q,
         using IndexerT =
             typename dpctl::tensor::offset_utils::ThreeOffsets_StridedIndexer;
 
-        IndexerT indexer{nd, arg1_offset, arg2_offset, res_offset,
-                         shape_and_strides};
+        const IndexerT indexer{nd, arg1_offset, arg2_offset, res_offset,
+                               shape_and_strides};
 
         const argTy1 *arg1_tp = reinterpret_cast<const argTy1 *>(arg1_p);
         const argTy2 *arg2_tp = reinterpret_cast<const argTy2 *>(arg2_p);

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/common_inplace.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/common_inplace.hpp
@@ -177,12 +177,12 @@ struct BinaryInplaceStridedFunctor
 private:
     const argT *rhs = nullptr;
     resT *lhs = nullptr;
-    TwoOffsets_IndexerT two_offsets_indexer_;
+    const TwoOffsets_IndexerT two_offsets_indexer_;
 
 public:
     BinaryInplaceStridedFunctor(const argT *rhs_tp,
                                 resT *lhs_tp,
-                                TwoOffsets_IndexerT inp_res_indexer)
+                                const TwoOffsets_IndexerT &inp_res_indexer)
         : rhs(rhs_tp), lhs(lhs_tp), two_offsets_indexer_(inp_res_indexer)
     {
     }
@@ -375,7 +375,7 @@ binary_inplace_strided_impl(sycl::queue &exec_q,
         using IndexerT =
             typename dpctl::tensor::offset_utils::TwoOffsets_StridedIndexer;
 
-        IndexerT indexer{nd, rhs_offset, lhs_offset, shape_and_strides};
+        const IndexerT indexer{nd, rhs_offset, lhs_offset, shape_and_strides};
 
         const argTy *arg_tp = reinterpret_cast<const argTy *>(rhs_p);
         resTy *res_tp = reinterpret_cast<resTy *>(lhs_p);

--- a/dpctl/tensor/libtensor/include/kernels/integer_advanced_indexing.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/integer_advanced_indexing.hpp
@@ -101,9 +101,9 @@ private:
     int k_ = 0;
     size_t ind_nelems_ = 0;
     const ssize_t *axes_shape_and_strides_ = nullptr;
-    OrthogStrider orthog_strider;
-    IndicesStrider ind_strider;
-    AxesStrider axes_strider;
+    const OrthogStrider orthog_strider;
+    const IndicesStrider ind_strider;
+    const AxesStrider axes_strider;
 
 public:
     TakeFunctor(const char *src_cp,
@@ -112,9 +112,9 @@ public:
                 int k,
                 size_t ind_nelems,
                 const ssize_t *axes_shape_and_strides,
-                OrthogStrider orthog_strider_,
-                IndicesStrider ind_strider_,
-                AxesStrider axes_strider_)
+                const OrthogStrider &orthog_strider_,
+                const IndicesStrider &ind_strider_,
+                const AxesStrider &axes_strider_)
         : src_(src_cp), dst_(dst_cp), ind_(ind_cp), k_(k),
           ind_nelems_(ind_nelems),
           axes_shape_and_strides_(axes_shape_and_strides),
@@ -136,7 +136,7 @@ public:
         ssize_t src_offset = orthog_offsets.get_first_offset();
         ssize_t dst_offset = orthog_offsets.get_second_offset();
 
-        ProjectorT proj{};
+        const ProjectorT proj{};
         for (int axis_idx = 0; axis_idx < k_; ++axis_idx) {
             indT *ind_data = reinterpret_cast<indT *>(ind_[axis_idx]);
 
@@ -194,12 +194,12 @@ sycl::event take_impl(sycl::queue &q,
     sycl::event take_ev = q.submit([&](sycl::handler &cgh) {
         cgh.depends_on(depends);
 
-        TwoOffsets_StridedIndexer orthog_indexer{nd, src_offset, dst_offset,
-                                                 orthog_shape_and_strides};
-        NthStrideOffset indices_indexer{ind_nd, ind_offsets,
-                                        ind_shape_and_strides};
-        StridedIndexer axes_indexer{ind_nd, 0,
-                                    axes_shape_and_strides + (2 * k)};
+        const TwoOffsets_StridedIndexer orthog_indexer{
+            nd, src_offset, dst_offset, orthog_shape_and_strides};
+        const NthStrideOffset indices_indexer{ind_nd, ind_offsets,
+                                              ind_shape_and_strides};
+        const StridedIndexer axes_indexer{ind_nd, 0,
+                                          axes_shape_and_strides + (2 * k)};
 
         const size_t gws = orthog_nelems * ind_nelems;
 
@@ -231,9 +231,9 @@ private:
     int k_ = 0;
     size_t ind_nelems_ = 0;
     const ssize_t *axes_shape_and_strides_ = nullptr;
-    OrthogStrider orthog_strider;
-    IndicesStrider ind_strider;
-    AxesStrider axes_strider;
+    const OrthogStrider orthog_strider;
+    const IndicesStrider ind_strider;
+    const AxesStrider axes_strider;
 
 public:
     PutFunctor(char *dst_cp,
@@ -242,9 +242,9 @@ public:
                int k,
                size_t ind_nelems,
                const ssize_t *axes_shape_and_strides,
-               OrthogStrider orthog_strider_,
-               IndicesStrider ind_strider_,
-               AxesStrider axes_strider_)
+               const OrthogStrider &orthog_strider_,
+               const IndicesStrider &ind_strider_,
+               const AxesStrider &axes_strider_)
         : dst_(dst_cp), val_(val_cp), ind_(ind_cp), k_(k),
           ind_nelems_(ind_nelems),
           axes_shape_and_strides_(axes_shape_and_strides),
@@ -266,7 +266,7 @@ public:
         ssize_t dst_offset = orthog_offsets.get_first_offset();
         ssize_t val_offset = orthog_offsets.get_second_offset();
 
-        ProjectorT proj{};
+        const ProjectorT proj{};
         for (int axis_idx = 0; axis_idx < k_; ++axis_idx) {
             indT *ind_data = reinterpret_cast<indT *>(ind_[axis_idx]);
 
@@ -324,12 +324,12 @@ sycl::event put_impl(sycl::queue &q,
     sycl::event put_ev = q.submit([&](sycl::handler &cgh) {
         cgh.depends_on(depends);
 
-        TwoOffsets_StridedIndexer orthog_indexer{nd, dst_offset, val_offset,
-                                                 orthog_shape_and_strides};
-        NthStrideOffset indices_indexer{ind_nd, ind_offsets,
-                                        ind_shape_and_strides};
-        StridedIndexer axes_indexer{ind_nd, 0,
-                                    axes_shape_and_strides + (2 * k)};
+        const TwoOffsets_StridedIndexer orthog_indexer{
+            nd, dst_offset, val_offset, orthog_shape_and_strides};
+        const NthStrideOffset indices_indexer{ind_nd, ind_offsets,
+                                              ind_shape_and_strides};
+        const StridedIndexer axes_indexer{ind_nd, 0,
+                                          axes_shape_and_strides + (2 * k)};
 
         const size_t gws = orthog_nelems * ind_nelems;
 

--- a/dpctl/tensor/libtensor/include/kernels/repeat.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/repeat.hpp
@@ -66,10 +66,10 @@ private:
     const repT *reps = nullptr;
     const repT *cumsum = nullptr;
     size_t src_axis_nelems = 1;
-    OrthogIndexer orthog_strider;
-    SrcAxisIndexer src_axis_strider;
-    DstAxisIndexer dst_axis_strider;
-    RepIndexer reps_strider;
+    const OrthogIndexer orthog_strider;
+    const SrcAxisIndexer src_axis_strider;
+    const DstAxisIndexer dst_axis_strider;
+    const RepIndexer reps_strider;
 
 public:
     RepeatSequenceFunctor(const T *src_,
@@ -77,10 +77,10 @@ public:
                           const repT *reps_,
                           const repT *cumsum_,
                           size_t src_axis_nelems_,
-                          OrthogIndexer orthog_strider_,
-                          SrcAxisIndexer src_axis_strider_,
-                          DstAxisIndexer dst_axis_strider_,
-                          RepIndexer reps_strider_)
+                          const OrthogIndexer &orthog_strider_,
+                          const SrcAxisIndexer &src_axis_strider_,
+                          const DstAxisIndexer &dst_axis_strider_,
+                          const RepIndexer &reps_strider_)
         : src(src_), dst(dst_), reps(reps_), cumsum(cumsum_),
           src_axis_nelems(src_axis_nelems_), orthog_strider(orthog_strider_),
           src_axis_strider(src_axis_strider_),
@@ -157,14 +157,16 @@ repeat_by_sequence_impl(sycl::queue &q,
         T *dst_tp = reinterpret_cast<T *>(dst_cp);
 
         // orthog ndim indexer
-        TwoOffsets_StridedIndexer orthog_indexer{
+        const TwoOffsets_StridedIndexer orthog_indexer{
             orthog_nd, src_offset, dst_offset,
             orthog_src_dst_shape_and_strides};
         // indexers along repeated axis
-        Strided1DIndexer src_axis_indexer{0, src_axis_shape, src_axis_stride};
-        Strided1DIndexer dst_axis_indexer{0, dst_axis_shape, dst_axis_stride};
+        const Strided1DIndexer src_axis_indexer{0, src_axis_shape,
+                                                src_axis_stride};
+        const Strided1DIndexer dst_axis_indexer{0, dst_axis_shape,
+                                                dst_axis_stride};
         // indexer along reps array
-        Strided1DIndexer reps_indexer{0, reps_shape, reps_stride};
+        const Strided1DIndexer reps_indexer{0, reps_shape, reps_stride};
 
         const size_t gws = orthog_nelems * src_axis_nelems;
 
@@ -230,12 +232,12 @@ sycl::event repeat_by_sequence_1d_impl(sycl::queue &q,
         T *dst_tp = reinterpret_cast<T *>(dst_cp);
 
         // orthog ndim indexer
-        TwoZeroOffsets_Indexer orthog_indexer{};
+        constexpr TwoZeroOffsets_Indexer orthog_indexer{};
         // indexers along repeated axis
-        StridedIndexer src_indexer{src_nd, 0, src_shape_strides};
-        Strided1DIndexer dst_indexer{0, dst_shape, dst_stride};
+        const StridedIndexer src_indexer{src_nd, 0, src_shape_strides};
+        const Strided1DIndexer dst_indexer{0, dst_shape, dst_stride};
         // indexer along reps array
-        Strided1DIndexer reps_indexer{0, reps_shape, reps_stride};
+        const Strided1DIndexer reps_indexer{0, reps_shape, reps_stride};
 
         const size_t gws = src_nelems;
 
@@ -278,18 +280,18 @@ private:
     T *dst = nullptr;
     const ssize_t reps = 1;
     size_t dst_axis_nelems = 0;
-    OrthogIndexer orthog_strider;
-    SrcAxisIndexer src_axis_strider;
-    DstAxisIndexer dst_axis_strider;
+    const OrthogIndexer orthog_strider;
+    const SrcAxisIndexer src_axis_strider;
+    const DstAxisIndexer dst_axis_strider;
 
 public:
     RepeatScalarFunctor(const T *src_,
                         T *dst_,
                         const ssize_t reps_,
                         size_t dst_axis_nelems_,
-                        OrthogIndexer orthog_strider_,
-                        SrcAxisIndexer src_axis_strider_,
-                        DstAxisIndexer dst_axis_strider_)
+                        const OrthogIndexer &orthog_strider_,
+                        const SrcAxisIndexer &src_axis_strider_,
+                        const DstAxisIndexer &dst_axis_strider_)
         : src(src_), dst(dst_), reps(reps_), dst_axis_nelems(dst_axis_nelems_),
           orthog_strider(orthog_strider_), src_axis_strider(src_axis_strider_),
           dst_axis_strider(dst_axis_strider_)
@@ -353,11 +355,13 @@ sycl::event repeat_by_scalar_impl(sycl::queue &q,
         T *dst_tp = reinterpret_cast<T *>(dst_cp);
 
         // orthog ndim indexer
-        TwoOffsets_StridedIndexer orthog_indexer{
+        const TwoOffsets_StridedIndexer orthog_indexer{
             orthog_nd, src_offset, dst_offset, orthog_shape_and_strides};
         // indexers along repeated axis
-        Strided1DIndexer src_axis_indexer{0, src_axis_shape, src_axis_stride};
-        Strided1DIndexer dst_axis_indexer{0, dst_axis_shape, dst_axis_stride};
+        const Strided1DIndexer src_axis_indexer{0, src_axis_shape,
+                                                src_axis_stride};
+        const Strided1DIndexer dst_axis_indexer{0, dst_axis_shape,
+                                                dst_axis_stride};
 
         const size_t gws = orthog_nelems * dst_axis_nelems;
 
@@ -413,10 +417,10 @@ sycl::event repeat_by_scalar_1d_impl(sycl::queue &q,
         T *dst_tp = reinterpret_cast<T *>(dst_cp);
 
         // orthog ndim indexer
-        TwoZeroOffsets_Indexer orthog_indexer{};
+        constexpr TwoZeroOffsets_Indexer orthog_indexer{};
         // indexers along repeated axis
-        StridedIndexer src_indexer(src_nd, 0, src_shape_strides);
-        Strided1DIndexer dst_indexer{0, dst_shape, dst_stride};
+        const StridedIndexer src_indexer(src_nd, 0, src_shape_strides);
+        const Strided1DIndexer dst_indexer{0, dst_shape, dst_stride};
 
         const size_t gws = dst_nelems;
 

--- a/dpctl/tensor/libtensor/include/kernels/where.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/where.hpp
@@ -224,14 +224,14 @@ private:
     const T *x2_p = nullptr;
     T *dst_p = nullptr;
     const condT *cond_p = nullptr;
-    IndexerT indexer;
+    const IndexerT indexer;
 
 public:
     WhereStridedFunctor(const condT *cond_p_,
                         const T *x1_p_,
                         const T *x2_p_,
                         T *dst_p_,
-                        IndexerT indexer_)
+                        const IndexerT &indexer_)
         : x1_p(x1_p_), x2_p(x2_p_), dst_p(dst_p_), cond_p(cond_p_),
           indexer(indexer_)
     {
@@ -290,7 +290,7 @@ sycl::event where_strided_impl(sycl::queue &q,
     sycl::event where_ev = q.submit([&](sycl::handler &cgh) {
         cgh.depends_on(depends);
 
-        FourOffsets_StridedIndexer indexer{
+        const FourOffsets_StridedIndexer indexer{
             nd, cond_offset, x1_offset, x2_offset, dst_offset, shape_strides};
 
         cgh.parallel_for<


### PR DESCRIPTION
No copying of indexers in functor constructors

Used `const`/`constexpr` qualifiers for indexers created, as appropriate. 
Private members indexers in functor structs now use `const` qualifier.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [x] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
