### PR TITLE
Cmake incremental builds improvement

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.21...3.27 FATAL_ERROR)
 
 project(dpctl
-    VERSION 0.15
+    VERSION 0.17
     LANGUAGES CXX
     DESCRIPTION "Python interface for XPU programming"
 )
@@ -46,11 +46,6 @@ if(_dpctl_sycl_targets)
 endif()
 
 add_subdirectory(libsyclinterface)
-
-file(GLOB _dpctl_capi_headers dpctl/apis/include/*.h*)
-install(FILES ${_dpctl_capi_headers}
-    DESTINATION dpctl/include
-)
 
 # Define CMAKE_INSTALL_xxx: LIBDIR, INCLUDEDIR
 include(GNUInstallDirs)

--- a/dpctl/CMakeLists.txt
+++ b/dpctl/CMakeLists.txt
@@ -91,7 +91,7 @@ foreach(hf ${_syclinterface_h})
     add_custom_command(OUTPUT ${_target_header_file}
         COMMAND ${CMAKE_COMMAND} -E copy_if_different ${hf} ${_target_header_file}
         DEPENDS ${hf} _build_time_create_dpctl_include
-	VERBATIM
+	    VERBATIM
     )
 endforeach()
 
@@ -144,19 +144,19 @@ function(build_dpctl_ext _trgt _src _dest)
     Python_add_library(${_trgt} MODULE WITH_SOABI ${_generated_src})
     if (BUILD_DPCTL_EXT_SYCL)
         add_sycl_to_target(TARGET ${_trgt} SOURCES ${_generated_src})
-	if(_dpctl_sycl_targets)
-	    # make fat binary
+	    if(_dpctl_sycl_targets)
+	        # make fat binary
             target_compile_options(
                 ${_trgt}
                 PRIVATE
                 -fsycl-targets=${_dpctl_sycl_targets}
             )
-	    target_link_options(
-	        ${_trgt}
-	        PRIVATE
-	        -fsycl-targets=${_dpctl_sycl_targets}
-	    )
-	endif()
+            target_link_options(
+                ${_trgt}
+                PRIVATE
+                -fsycl-targets=${_dpctl_sycl_targets}
+            )
+        endif()
     endif()
     target_include_directories(${_trgt} PRIVATE ${NumPy_INCLUDE_DIR} ${DPCTL_INCLUDE_DIR})
     add_dependencies(${_trgt} _build_time_create_dpctl_include_copy ${_cythonize_trgt})
@@ -173,31 +173,31 @@ function(build_dpctl_ext _trgt _src _dest)
     set(_generated_api_h "${_generated_src_dir}/${_name_wle}_api.h")
     set(_copy_trgt "${_trgt}_copy_capi_include")
     add_custom_target(
-         ${_copy_trgt} ALL
-         COMMAND ${CMAKE_COMMAND}
-	     -DSOURCE_FILE=${_generated_public_h}
-	     -DDEST=${CMAKE_CURRENT_SOURCE_DIR}
-	     -P ${CMAKE_SOURCE_DIR}/dpctl/cmake/copy_existing.cmake
-         COMMAND ${CMAKE_COMMAND}
-	     -DSOURCE_FILE=${_generated_api_h}
-	     -DDEST=${CMAKE_CURRENT_SOURCE_DIR}
-	     -P ${CMAKE_SOURCE_DIR}/dpctl/cmake/copy_existing.cmake
-	 DEPENDS ${_trgt}
-	 VERBATIM
-         COMMENT "Copying Cython-generated headers to dpctl"
+        ${_copy_trgt} ALL
+        COMMAND ${CMAKE_COMMAND}
+	    -DSOURCE_FILE=${_generated_public_h}
+	    -DDEST=${CMAKE_CURRENT_SOURCE_DIR}
+	    -P ${CMAKE_SOURCE_DIR}/dpctl/cmake/copy_existing.cmake
+        COMMAND ${CMAKE_COMMAND}
+	    -DSOURCE_FILE=${_generated_api_h}
+	    -DDEST=${CMAKE_CURRENT_SOURCE_DIR}
+	    -P ${CMAKE_SOURCE_DIR}/dpctl/cmake/copy_existing.cmake
+	    DEPENDS ${_trgt}
+	    VERBATIM
+        COMMENT "Copying Cython-generated headers to dpctl"
     )
     if (DPCTL_GENERATE_COVERAGE)
-         set(_copy_cxx_trgt "${_trgt}_copy_cxx")
-         add_custom_target(
-             ${_copy_cxx_trgt} ALL
-             COMMAND ${CMAKE_COMMAND}
-	         -DSOURCE_FILE=${_generated_src}
-	         -DDEST=${CMAKE_CURRENT_SOURCE_DIR}
-	         -P ${CMAKE_SOURCE_DIR}/dpctl/cmake/copy_existing.cmake
-	     DEPENDS ${_trgt}
-	     VERBATIM
-             COMMENT "Copying Cython-generated source to dpctl"
-         )
+        set(_copy_cxx_trgt "${_trgt}_copy_cxx")
+        add_custom_target(
+            ${_copy_cxx_trgt} ALL
+            COMMAND ${CMAKE_COMMAND}
+	        -DSOURCE_FILE=${_generated_src}
+	        -DDEST=${CMAKE_CURRENT_SOURCE_DIR}
+	        -P ${CMAKE_SOURCE_DIR}/dpctl/cmake/copy_existing.cmake
+	        DEPENDS ${_trgt}
+	        VERBATIM
+            COMMENT "Copying Cython-generated source to dpctl"
+        )
     endif()
     install(TARGETS ${_trgt} LIBRARY DESTINATION ${_dest})
 endfunction()

--- a/libsyclinterface/CMakeLists.txt
+++ b/libsyclinterface/CMakeLists.txt
@@ -280,7 +280,7 @@ set_target_properties(DPCTLSyclInterface
 
 if (SKBUILD)
     set(_lib_destination dpctl)
-    set(_include_destination dpctl/include/syclinterface)
+    set(_include_destination ${CMAKE_INSTALL_PREFIX}/unused)
 else()
     set(_lib_destination ${CMAKE_INSTALL_PREFIX}/lib)
     set(_include_destination ${CMAKE_INSTALL_PREFIX}/include)


### PR DESCRIPTION
Avoid installing header files which are formed during building steps. 

During installation the files are not changed, but timestamps get updated prompting incremental cmake build to do full build instead.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [x] If this PR is a work in progress, are you opening the PR as a draft?
