### PR TITLE
Add local_accessor kernel_arg_type

### DIFF
--- a/dpctl/_backend.pxd
+++ b/dpctl/_backend.pxd
@@ -67,7 +67,8 @@ cdef extern from "syclinterface/dpctl_sycl_enum_types.h":
         _UINT64_T           'DPCTL_UINT64_T',
         _FLOAT              'DPCTL_FLOAT32_T',
         _DOUBLE             'DPCTL_FLOAT64_T',
-        _VOID_PTR           'DPCTL_VOID_PTR'
+        _VOID_PTR           'DPCTL_VOID_PTR',
+        _LOCAL_ACCESSOR     'DPCTL_LOCAL_ACCESSOR'
 
     ctypedef enum _queue_property_type 'DPCTLQueuePropertyType':
         _DEFAULT_PROPERTY   'DPCTL_DEFAULT_PROPERTY'

--- a/dpctl/_sycl_queue.pyx
+++ b/dpctl/_sycl_queue.pyx
@@ -233,6 +233,15 @@ cdef class _kernel_arg_type:
             _arg_data_type._VOID_PTR
         )
 
+    @property
+    def dpctl_local_accessor(self):
+        cdef str p_name = "dpctl_local_accessor"
+        return kernel_arg_type_attribute(
+            self._name,
+            p_name,
+            _arg_data_type._LOCAL_ACCESSOR
+        )
+
 
 kernel_arg_type = _kernel_arg_type()
 

--- a/dpctl/tests/test_sycl_kernel_submit.py
+++ b/dpctl/tests/test_sycl_kernel_submit.py
@@ -274,3 +274,4 @@ def test_kernel_arg_type():
     _check_kernel_arg_type_instance(kernel_arg_type.dpctl_float32)
     _check_kernel_arg_type_instance(kernel_arg_type.dpctl_float64)
     _check_kernel_arg_type_instance(kernel_arg_type.dpctl_void_ptr)
+    _check_kernel_arg_type_instance(kernel_arg_type.dpctl_local_accessor)


### PR DESCRIPTION
Adds `_arg_data_type._LOCAL_ACCESSOR` to `_backend.pyx`, and `dpctl_local_accessor` to `dpctl._sycl_queue.kernel_arg_type`.

- [x] Have you provided a meaningful PR description?
- [x] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
