### PR TITLE
Improve coverage sycl interface

### DIFF
--- a/libsyclinterface/dbg_build.sh
+++ b/libsyclinterface/dbg_build.sh
@@ -7,6 +7,11 @@ pushd build || exit 1
 INSTALL_PREFIX=$(pwd)/../install
 rm -rf ${INSTALL_PREFIX}
 
+# With DPC++ 2024.0 adn newer set these to ensure that
+# cmake can find llvm-cov and other utilities
+LLVM_TOOLS_HOME=${CMPLR_ROOT}/bin/compiler
+PATH=$PATH:${CMPLR_ROOT}/bin/compiler
+
 cmake                                                       \
     -DCMAKE_BUILD_TYPE=Debug                                \
     -DCMAKE_C_COMPILER=icx                                  \
@@ -16,13 +21,19 @@ cmake                                                       \
     -DCMAKE_PREFIX_PATH=${INSTALL_PREFIX}                   \
     -DDPCTL_ENABLE_L0_PROGRAM_CREATION=ON                   \
     -DDPCTL_BUILD_CAPI_TESTS=ON                             \
+    -DDPCTL_GENERATE_COVERAGE=OFF                           \
     ..
 
-make V=1 -n -j 4 && make check && make install
+# build
+make V=1 -n -j 4
+# run ctest
+make check
+# install
+make install
 
 # Turn on to generate coverage report html files reconfigure with
 # -DDPCTL_GENERATE_COVERAGE=ON and then
-# make lcov-genhtml
+# make llvm-cov-report
 
 # For more verbose tests use:
 # cd tests

--- a/libsyclinterface/include/dpctl_sycl_queue_interface.h
+++ b/libsyclinterface/include/dpctl_sycl_queue_interface.h
@@ -171,6 +171,18 @@ DPCTL_API
 __dpctl_give DPCTLSyclDeviceRef
 DPCTLQueue_GetDevice(__dpctl_keep const DPCTLSyclQueueRef QRef);
 
+/*! @brief Structure to be used to specify dimensionality and type of
+ * local_accessor kernel type argument.
+ */
+typedef struct MDLocalAccessorTy
+{
+    size_t ndim;
+    DPCTLKernelArgType dpctl_type_id;
+    size_t dim0;
+    size_t dim1;
+    size_t dim2;
+} MDLocalAccessor;
+
 /*!
  * @brief Submits the kernel to the specified queue with the provided range
  * argument.

--- a/libsyclinterface/source/dpctl_sycl_queue_interface.cpp
+++ b/libsyclinterface/source/dpctl_sycl_queue_interface.cpp
@@ -121,15 +121,6 @@ typedef struct complex
     uint64_t imag;
 } complexNumber;
 
-typedef struct MDLocalAccessorTy
-{
-    size_t ndim;
-    DPCTLKernelArgType dpctl_type_id;
-    size_t dim0;
-    size_t dim1;
-    size_t dim2;
-} MDLocalAccessor;
-
 void set_dependent_events(handler &cgh,
                           __dpctl_keep const DPCTLSyclEventRef *DepEvents,
                           size_t NDepEvents)

--- a/libsyclinterface/tests/CMakeLists.txt
+++ b/libsyclinterface/tests/CMakeLists.txt
@@ -89,8 +89,35 @@ if(DPCTL_GENERATE_COVERAGE)
         ${CMAKE_DL_LIBS}
     )
     set(object_arg "-object;")
-    add_custom_target(llvm-cov
+    add_custom_target(run-c-api-tests
         COMMAND ${CMAKE_COMMAND} -E env DPCTL_VERBOSITY=warning ${CMAKE_CURRENT_BINARY_DIR}/dpctl_c_api_tests
+        WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+        COMMAND_EXPAND_LISTS
+        DEPENDS dpctl_c_api_tests
+    )
+    add_custom_target(llvm-cov-show
+        COMMAND ${LLVMProfdata_EXE}
+        merge
+        -sparse default.profraw
+        -o
+        dpctl.profdata
+        COMMAND ${LLVMCov_EXE}
+        export
+        -format=lcov
+        -ignore-filename-regex=/tmp/icpx*
+        -instr-profile=dpctl.profdata
+        "${object_arg}$<JOIN:$<TARGET_OBJECTS:DPCTLSyclInterface>,;${object_arg}>"
+        > dpctl.lcov
+        COMMAND ${LLVMCov_EXE}
+        show
+        -instr-profile=dpctl.profdata
+        "${object_arg}$<JOIN:$<TARGET_OBJECTS:DPCTLSyclInterface>,;${object_arg}>"
+        WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+        COMMAND_EXPAND_LISTS
+        DEPENDS run-c-api-tests
+    )
+
+    add_custom_target(llvm-cov-report
         COMMAND ${LLVMProfdata_EXE}
         merge
         -sparse default.profraw
@@ -109,11 +136,10 @@ if(DPCTL_GENERATE_COVERAGE)
         "${object_arg}$<JOIN:$<TARGET_OBJECTS:DPCTLSyclInterface>,;${object_arg}>"
         WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
         COMMAND_EXPAND_LISTS
-        DEPENDS dpctl_c_api_tests
+        DEPENDS run-c-api-tests
     )
 
     add_custom_target(lcov-genhtml
-        COMMAND ${CMAKE_COMMAND} -E env DPCTL_VERBOSITY=warning ${CMAKE_CURRENT_BINARY_DIR}/dpctl_c_api_tests
         COMMAND ${LLVMProfdata_EXE}
         merge
         -sparse default.profraw
@@ -132,7 +158,7 @@ if(DPCTL_GENERATE_COVERAGE)
         ${COVERAGE_OUTPUT_DIR}/dpctl-c-api-coverage
         WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
         COMMAND_EXPAND_LISTS
-        DEPENDS dpctl_c_api_tests
+        DEPENDS run-c-api-tests
     )
 else()
     target_link_libraries(dpctl_c_api_tests

--- a/libsyclinterface/tests/test_sycl_device_aspects.cpp
+++ b/libsyclinterface/tests/test_sycl_device_aspects.cpp
@@ -97,7 +97,7 @@ auto build_gtest_values(const std::array<std::pair<T1, T2>, N> &params)
 auto build_params()
 {
     constexpr auto param_1 = get_param_list<const char *>(
-        "opencl:gpu", "opencl:cpu", "level_zero:gpu", "host");
+        "opencl:gpu", "opencl:cpu", "level_zero:gpu");
 
     constexpr auto param_2 =
         get_param_list<std::pair<const char *, sycl::aspect>>(

--- a/libsyclinterface/tests/test_sycl_queue_interface.cpp
+++ b/libsyclinterface/tests/test_sycl_queue_interface.cpp
@@ -90,6 +90,34 @@ protected:
 
 } /* End of anonymous namespace */
 
+TEST(TestDPCTLSyclQueueInterface, CheckCreate)
+{
+    /* We are testing that we do not crash even when input is NULL. */
+    DPCTLSyclQueueRef QRef = nullptr;
+
+    EXPECT_NO_FATAL_FAILURE(
+        QRef = DPCTLQueue_Create(nullptr, nullptr, nullptr, 0));
+    ASSERT_TRUE(QRef == nullptr);
+}
+
+TEST(TestDPCTLSyclQueueInterface, CheckCreate2)
+{
+    /* We are testing that we do not crash even when input is NULL. */
+    DPCTLSyclQueueRef QRef = nullptr;
+    DPCTLSyclDeviceSelectorRef DSRef = nullptr;
+    DPCTLSyclDeviceRef DRef = nullptr;
+
+    EXPECT_NO_FATAL_FAILURE(DSRef = DPCTLDefaultSelector_Create());
+    EXPECT_NO_FATAL_FAILURE(DRef = DPCTLDevice_CreateFromSelector(DSRef));
+    EXPECT_NO_FATAL_FAILURE(DPCTLDeviceSelector_Delete(DSRef));
+
+    EXPECT_NO_FATAL_FAILURE(QRef =
+                                DPCTLQueue_Create(nullptr, DRef, nullptr, 0));
+    ASSERT_TRUE(QRef == nullptr);
+
+    EXPECT_NO_FATAL_FAILURE(DPCTLDevice_Delete(DRef));
+}
+
 TEST(TestDPCTLSyclQueueInterface, CheckCreateForDevice)
 {
     /* We are testing that we do not crash even when input is NULL. */

--- a/libsyclinterface/tests/test_sycl_queue_submit_local_accessor_arg.cpp
+++ b/libsyclinterface/tests/test_sycl_queue_submit_local_accessor_arg.cpp
@@ -44,15 +44,6 @@ constexpr size_t SIZE = 100;
 
 using namespace dpctl::syclinterface;
 
-typedef struct MDLocalAccessorTy
-{
-    size_t ndim;
-    DPCTLKernelArgType dpctl_type_id;
-    size_t dim0;
-    size_t dim1;
-    size_t dim2;
-} MDLocalAccessor;
-
 template <typename T>
 void submit_kernel(DPCTLSyclQueueRef QRef,
                    DPCTLSyclKernelBundleRef KBRef,

--- a/scripts/gen_coverage.py
+++ b/scripts/gen_coverage.py
@@ -82,7 +82,7 @@ def run(
         .strip("\n")
     )
     subprocess.check_call(
-        ["cmake", "--build", ".", "--target", "llvm-cov"],
+        ["cmake", "--build", ".", "--target", "llvm-cov-report"],
         cwd=cmake_build_dir,
     )
     env["LLVM_PROFILE_FILE"] = "dpctl_pytest.profraw"


### PR DESCRIPTION
This PR extends `test_sycl_queue_submit` to use 1D range, 2D range, 3D range and use dependent events.

- [x] Have you provided a meaningful PR description?
- [x] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
