### PR TITLE
Docstring of expand_dims to reflect that axis can be a tuple

### DIFF
--- a/dpctl/tensor/_manipulation_functions.py
+++ b/dpctl/tensor/_manipulation_functions.py
@@ -127,8 +127,10 @@ def expand_dims(X, axis):
     of size one at the position specified by axis.
 
     Args:
-        x (usm_ndarray): input array
-        axis (int):  axis position (zero-based). If `x` has rank
+        x (usm_ndarray):
+            input array
+        axis (Union[int, Tuple[int]]):
+            axis position in the expanded axes (zero-based). If `x` has rank
             (i.e, number of dimensions) `N`, a valid `axis` must reside
             in the closed-interval `[-N-1, N]`. If provided a negative
             `axis`, the `axis` position at which to insert a singleton


### PR DESCRIPTION
`tensor.expand_dims` docstring change only.

Documentation string now reflects that `axis` keyword argument is allowed to be a tuple of integers. 

See https://github.com/data-apis/array-api/issues/760

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
