### PR TITLE
Renamed argument of DPCTLPlatform_Hash to match doxygen doc string

### DIFF
--- a/libsyclinterface/include/dpctl_sycl_platform_interface.h
+++ b/libsyclinterface/include/dpctl_sycl_platform_interface.h
@@ -176,6 +176,6 @@ DPCTLPlatform_GetDefaultContext(__dpctl_keep const DPCTLSyclPlatformRef PRef);
  * @ingroup PlatformInterface
  */
 DPCTL_API
-size_t DPCTLPlatform_Hash(__dpctl_keep DPCTLSyclPlatformRef CtxRef);
+size_t DPCTLPlatform_Hash(__dpctl_keep DPCTLSyclPlatformRef PRef);
 
 DPCTL_C_EXTERN_C_END


### PR DESCRIPTION
Inspecting documentation building log noticed mismatch between doxygen doc-string and actual declaration.

This PR fixes the mismatch.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
