### PR TITLE
Address sphinx errors

### DIFF
--- a/dpctl/_sycl_device.pyx
+++ b/dpctl/_sycl_device.pyx
@@ -503,6 +503,7 @@ cdef class SyclDevice(_SyclDevice):
 
         Indicates that the device supports the following atomic operations on
         64-bit values:
+
             - atomic::load
             - atomic::store
             - atomic::fetch_add

--- a/dpctl/memory/_memory.pyx
+++ b/dpctl/memory/_memory.pyx
@@ -83,6 +83,7 @@ class USMAllocationError(Exception):
     An exception raised when Universal Shared Memory (USM) allocation
     call returns a null pointer, signaling a failure to perform the allocation.
     Some common reasons for allocation failure are:
+
         * insufficient free memory to perform the allocation request
         * allocation size exceeds the maximum supported by targeted backend
     """

--- a/dpctl/tensor/_linear_algebra_functions.py
+++ b/dpctl/tensor/_linear_algebra_functions.py
@@ -81,10 +81,11 @@ def tensordot(x1, x2, axes=2):
             then the contraction is performed over last `N` axes of `x1` and
             the first `N` axis of `x2` in order. The size of each corresponding
             axis must match and must be non-negative.
-               * if `N` equals `0`, the result is the tensor outer product
-               * if `N` equals `1`, the result is the tensor dot product
-               * if `N` equals `2`, the result is the tensor double
-                 contraction (default).
+
+                * if `N` equals `0`, the result is the tensor outer product
+                * if `N` equals `1`, the result is the tensor dot product
+                * if `N` equals `2`, the result is the tensor double
+                  contraction (default).
             If `axes` is a tuple of two sequences `(x1_axes, x2_axes)`, the
             first sequence applies to `x1` and the second sequence applies
             to `x2`. Both sequences must have equal length, and each axis

--- a/dpctl/tensor/_print.py
+++ b/dpctl/tensor/_print.py
@@ -116,50 +116,61 @@ def set_print_options(
     Set options for printing :class:`dpctl.tensor.usm_ndarray` class.
 
     Args:
-        linewidth (int, optional): Number of characters printed per line.
+        linewidth (int, optional):
+            Number of characters printed per line.
             Raises `TypeError` if linewidth is not an integer.
             Default: `75`.
-        edgeitems (int, optional): Number of elements at the beginning and end
+        edgeitems (int, optional):
+            Number of elements at the beginning and end
             when the printed array is abbreviated.
             Raises `TypeError` if edgeitems is not an integer.
             Default: `3`.
-        threshold (int, optional): Number of elements that triggers array
-            abbreviation.
+        threshold (int, optional):
+            Number of elements that triggers array abbreviation.
             Raises `TypeError` if threshold is not an integer.
             Default: `1000`.
-        precision (int or None, optional): Number of digits printed for
-            floating point numbers.
+        precision (int or None, optional):
+            Number of digits printed for floating point numbers.
             Raises `TypeError` if precision is not an integer.
             Default: `8`.
-        floatmode (str, optional): Controls how floating point
-            numbers are interpreted.
-
-            `"fixed:`: Always prints exactly `precision` digits.
-            `"unique"`: Ignores precision, prints the number of
-                digits necessary to uniquely specify each number.
-            `"maxprec"`: Prints `precision` digits or fewer,
-                if fewer will uniquely represent a number.
-            `"maxprec_equal"`: Prints an equal number of digits
-                for each number. This number is `precision` digits or fewer,
-                if fewer will uniquely represent each number.
+        floatmode (str, optional):
+            Controls how floating point numbers are interpreted.
+                `"fixed:`:
+                    Always prints exactly `precision` digits.
+                `"unique"`:
+                    Ignores precision, prints the number of
+                    digits necessary to uniquely specify each number.
+                `"maxprec"`:
+                    Prints `precision` digits or fewer,
+                    if fewer will uniquely represent a number.
+                `"maxprec_equal"`:
+                    Prints an equal number of digits
+                    for each number. This number is `precision` digits
+                    or fewer, if fewer will uniquely represent each number.
             Raises `ValueError` if floatmode is not one of
             `fixed`, `unique`, `maxprec`, or `maxprec_equal`.
             Default: "maxprec_equal"
-        suppress (bool, optional): If `True,` numbers equal to zero
-            in the current precision will print as zero.
+        suppress (bool, optional):
+            If `True,` numbers equal to zero in the current precision
+            will print as zero.
             Default: `False`.
-        nanstr (str, optional): String used to represent nan.
+        nanstr (str, optional):
+            String used to represent nan.
             Raises `TypeError` if nanstr is not a string.
             Default: `"nan"`.
-        infstr (str, optional): String used to represent infinity.
+        infstr (str, optional):
+            String used to represent infinity.
             Raises `TypeError` if infstr is not a string.
             Default: `"inf"`.
-        sign (str, optional): Controls the sign of floating point
-            numbers.
-            `"-"`: Omit the sign of positive numbers.
-            `"+"`: Always print the sign of positive numbers.
-            `" "`: Always print a whitespace in place of the
-                sign of positive numbers.
+        sign (str, optional):
+            Controls the sign of floating point numbers.
+                `"-"`:
+                    Omit the sign of positive numbers.
+                `"+"`:
+                    Always print the sign of positive numbers.
+                `" "`:
+                    Always print a whitespace in place of the
+                    sign of positive numbers.
             Raises `ValueError` if sign is not one of
             `"-"`, `"+"`, or `" "`.
             Default: `"-"`.
@@ -287,60 +298,71 @@ def usm_ndarray_str(
     :class:`dpctl.tensor.usm_ndarray`.
 
     Args:
-        x (usm_ndarray): Input array.
-        line_width (int, optional): Number of characters printed per line.
+        x (usm_ndarray):
+            Input array.
+        line_width (int, optional):
+            Number of characters printed per line.
             Raises `TypeError` if line_width is not an integer.
             Default: `75`.
-        edgeitems (int, optional): Number of elements at the beginning and end
+        edgeitems (int, optional):
+            Number of elements at the beginning and end
             when the printed array is abbreviated.
             Raises `TypeError` if edgeitems is not an integer.
             Default: `3`.
-        threshold (int, optional): Number of elements that triggers array
-            abbreviation.
+        threshold (int, optional):
+            Number of elements that triggers array abbreviation.
             Raises `TypeError` if threshold is not an integer.
             Default: `1000`.
-        precision (int or None, optional): Number of digits printed for
-            floating point numbers.
+        precision (int or None, optional):
+            Number of digits printed for floating point numbers.
             Raises `TypeError` if precision is not an integer.
             Default: `8`.
-        floatmode (str, optional): Controls how floating point
-            numbers are interpreted.
-
-            `"fixed:`: Always prints exactly `precision` digits.
-            `"unique"`: Ignores precision, prints the number of
-                digits necessary to uniquely specify each number.
-            `"maxprec"`: Prints `precision` digits or fewer,
-                if fewer will uniquely represent a number.
-            `"maxprec_equal"`: Prints an equal number of digits
-                for each number. This number is `precision` digits or fewer,
-                if fewer will uniquely represent each number.
+        floatmode (str, optional):
+            Controls how floating point numbers are interpreted.
+                `"fixed:`:
+                    Always prints exactly `precision` digits.
+                `"unique"`:
+                    Ignores precision, prints the number of
+                    digits necessary to uniquely specify each number.
+                `"maxprec"`:
+                    Prints `precision` digits or fewer,
+                    if fewer will uniquely represent a number.
+                `"maxprec_equal"`:
+                    Prints an equal number of digits for each number.
+                    This number is `precision` digits or fewer,
+                    if fewer will uniquely represent each number.
             Raises `ValueError` if floatmode is not one of
             `fixed`, `unique`, `maxprec`, or `maxprec_equal`.
             Default: "maxprec_equal"
-        suppress (bool, optional): If `True,` numbers equal to zero
-            in the current precision will print as zero.
+        suppress (bool, optional):
+            If `True,` numbers equal to zero in the current precision
+            will print as zero.
             Default: `False`.
-        sign (str, optional): Controls the sign of floating point
-            numbers.
-            `"-"`: Omit the sign of positive numbers.
-            `"+"`: Always print the sign of positive numbers.
-            `" "`: Always print a whitespace in place of the
-                sign of positive numbers.
+        sign (str, optional):
+            Controls the sign of floating point numbers.
+                `"-"`:
+                    Omit the sign of positive numbers.
+                `"+"`:
+                    Always print the sign of positive numbers.
+                `" "`:
+                    Always print a whitespace in place of the
+                    sign of positive numbers.
             Raises `ValueError` if sign is not one of
             `"-"`, `"+"`, or `" "`.
             Default: `"-"`.
-        numpy (bool, optional): If `True,` then before other specified print
+        numpy (bool, optional):
+            If `True,` then before other specified print
             options are set, a dictionary of Numpy's print options
             will be used to initialize dpctl's print options.
             Default: "False"
-        separator (str, optional): String inserted between elements of
-            the array string.
+        separator (str, optional):
+            String inserted between elements of the array string.
             Default: " "
-        prefix (str, optional): String used to determine spacing to the left
-            of the array string.
+        prefix (str, optional):
+            String used to determine spacing to the left of the array string.
             Default: ""
-        suffix (str, optional): String that determines length of the last line
-            of the array string.
+        suffix (str, optional):
+            String that determines length of the last line of the array string.
             Default: ""
 
     Returns:

--- a/dpctl/tensor/_reduction.py
+++ b/dpctl/tensor/_reduction.py
@@ -194,6 +194,7 @@ def sum(x, axis=None, dtype=None, keepdims=False):
         dtype (Optional[dtype]):
             data type of the returned array. If `None`, the default data
             type is inferred from the "kind" of the input array data type.
+
                 * If `x` has a real-valued floating-point data type,
                   the returned array will have the default real-valued
                   floating-point data type for the device where input
@@ -220,6 +221,7 @@ def sum(x, axis=None, dtype=None, keepdims=False):
             compatible with the input arrays according to Array Broadcasting
             rules. Otherwise, if `False`, the reduced axes are not included in
             the returned array. Default: `False`.
+
     Returns:
         usm_ndarray:
             an array containing the sums. If the sum was computed over the
@@ -254,6 +256,7 @@ def prod(x, axis=None, dtype=None, keepdims=False):
         dtype (Optional[dtype]):
             data type of the returned array. If `None`, the default data
             type is inferred from the "kind" of the input array data type.
+
                 * If `x` has a real-valued floating-point data type,
                   the returned array will have the default real-valued
                   floating-point data type for the device where input
@@ -280,6 +283,7 @@ def prod(x, axis=None, dtype=None, keepdims=False):
             compatible with the input arrays according to Array Broadcasting
             rules. Otherwise, if `False`, the reduced axes are not included in
             the returned array. Default: `False`.
+
     Returns:
         usm_ndarray:
             an array containing the products. If the product was computed over
@@ -315,6 +319,7 @@ def logsumexp(x, axis=None, dtype=None, keepdims=False):
         dtype (Optional[dtype]):
             data type of the returned array. If `None`, the default data
             type is inferred from the "kind" of the input array data type.
+
                 * If `x` has a real-valued floating-point data type,
                   the returned array will have the default real-valued
                   floating-point data type for the device where input
@@ -333,6 +338,7 @@ def logsumexp(x, axis=None, dtype=None, keepdims=False):
             compatible with the input arrays according to Array Broadcasting
             rules. Otherwise, if `False`, the reduced axes are not included in
             the returned array. Default: `False`.
+
     Returns:
         usm_ndarray:
             an array containing the results. If the result was computed over
@@ -370,6 +376,7 @@ def reduce_hypot(x, axis=None, dtype=None, keepdims=False):
         dtype (Optional[dtype]):
             data type of the returned array. If `None`, the default data
             type is inferred from the "kind" of the input array data type.
+
                 * If `x` has a real-valued floating-point data type,
                   the returned array will have the default real-valued
                   floating-point data type for the device where input
@@ -388,6 +395,7 @@ def reduce_hypot(x, axis=None, dtype=None, keepdims=False):
             compatible with the input arrays according to Array Broadcasting
             rules. Otherwise, if `False`, the reduced axes are not included in
             the returned array. Default: `False`.
+
     Returns:
         usm_ndarray:
             an array containing the results. If the result was computed over

--- a/dpctl/tensor/_type_utils.py
+++ b/dpctl/tensor/_type_utils.py
@@ -629,7 +629,8 @@ def iinfo(dtype):
 
     Returns:
         iinfo_object:
-            An object with the following attributes
+            An object with the following attributes:
+
             * bits: int
                 number of bits occupied by the data type
             * max: int
@@ -658,7 +659,8 @@ def finfo(dtype):
 
     Returns:
         finfo_object:
-            an object have the following attributes
+            an object have the following attributes:
+
                 * bits: int
                     number of bits occupied by dtype.
                 * eps: float

--- a/dpctl/tensor/_usmarray.pyx
+++ b/dpctl/tensor/_usmarray.pyx
@@ -82,23 +82,23 @@ cdef class usm_ndarray:
             If ``dtype`` has the value ``None``, it is determined by default
             floating point type supported by target device.
             The supported types are
-               * ``bool``
-                     boolean type
-               * ``int8``, ``int16``, ``int32``, ``int64``,
-                     signed integer types
-               * ``uint8``, ``uint16``, ``uint32``, ``uint64``,
-                     unsigned integer types
-               * ``float16``
-                     half-precision floating type,
-                     supported if target device's property
-                     ``has_aspect_fp16`` is ``True``
-               * ``float32``, ``complex64``
-                     single-precision real and complex floating
-                     types
-               * ``float64``, ``complex128``
-                     double-precision real and complex floating
-                     types, supported if target device's property
-                     ``has_aspect_fp64`` is ``True``.
+
+                ``bool``:
+                    boolean type
+                ``int8``, ``int16``, ``int32``, ``int64``:
+                    signed integer types
+                ``uint8``, ``uint16``, ``uint32``, ``uint64``:
+                    unsigned integer types
+                ``float16``:
+                    half-precision floating type,
+                    supported if target device's property
+                    ``has_aspect_fp16`` is ``True``
+                ``float32``, ``complex64``:
+                    single-precision real and complex floating types
+                ``float64``, ``complex128``:
+                    double-precision real and complex floating
+                    types, supported if target device's property
+                    ``has_aspect_fp64`` is ``True``.
             Default: ``None``.
         strides (tuple, optional):
             Strides of the array to be created in elements.

--- a/dpctl/utils/_onetrace_context.py
+++ b/dpctl/utils/_onetrace_context.py
@@ -32,15 +32,20 @@ def onetrace_enabled():
     """Enable `onetrace` collection for kernels executed in this context.
 
     N.B.: Proper working of this utility assumes that Python interpreter
-    has been launched by `onetrace` tool from intel/pti-gpu project.
+    has been launched by `onetrace` or `unitrace` tool from project
+    `intel/pti-gpu <https://github.com/intel/pti-gpu>`_.
 
     :Example:
-        Launch the Python interpreter using `onetrace` tool: ::
+        Launch the Python interpreter using `onetrace` tool:
+
+        .. code-block:: bash
 
             $ onetrace --conditional-collection -v -t --demangle python app.py
 
         Now using the context manager in the Python sessions enables
-        data collection and its output for every offloaded kernel ::
+        data collection and its output for every offloaded kernel:
+
+        .. code-block:: python
 
             import dpctl.tensor as dpt
             from dpctl.utils import onetrace_enabled


### PR DESCRIPTION
Addressed indentation, and spacing errors tripping Sphinx, as guided by output of `sphinx-build` command.

The log of sphinx build should not contain non-blocking `ERROR statements in the build log/

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
