### PR TITLE
Avoid superfluous copy of dpctl_capi struct

### DIFF
--- a/dpctl/apis/include/dpctl4pybind11.hpp
+++ b/dpctl/apis/include/dpctl4pybind11.hpp
@@ -402,8 +402,9 @@ private:
 
     dpctl_capi(dpctl_capi const &) = default;
     dpctl_capi &operator=(dpctl_capi const &) = default;
+    dpctl_capi &operator=(dpctl_capi &&) = default;
 
-    static dpctl_capi lookup()
+    static dpctl_capi &lookup()
     {
         static dpctl_capi api;
         return api;


### PR DESCRIPTION
This PR eliminates superfluous copying of `dpctl_capi` instance, even if it is later eliminated by the compiler. 

The copying would necessary in `static dpctl_capi api = lookup()` line, since `lookup` returns `dpctl_capi` instance by value.
The change is to make it return a reference.

Since `dpctl_capi` is a singleton, this change only eliminates a single copy, so consider it a technical debt cleanup change.

The PR also adds a default move assignment operator for `dpctl_capi`.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [x] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
