### PR TITLE
Use Note in SyclTimer docstring

### DIFF
--- a/dpctl/_sycl_timer.py
+++ b/dpctl/_sycl_timer.py
@@ -74,9 +74,9 @@ class SyclTimer:
         exit of the context and uses profiling information from events
         associated with these submissions to perform the timing. Thus
         :class:`dpctl.SyclTimer` requires the queue with "enable_profiling"
-        property. In order to be able to collect the profiling information
-        the property, the `dt` method ensures that both submitted barriers
-        complete their execution and thus effectively synchronizes the queue.
+        property. In order to be able to collect the profiling information,
+        the `dt` property ensures that both submitted barriers complete their
+        execution and thus effectively synchronizes the queue.
 
     Args:
         host_timer (callable): A callable such that host_timer() returns current

--- a/dpctl/_sycl_timer.py
+++ b/dpctl/_sycl_timer.py
@@ -69,14 +69,14 @@ class SyclTimer:
             # retrieve elapsed times in milliseconds
             wall_dt, device_dt = timer.dt
 
-    Remark:
+    Note:
         The timer submits barriers to the queue at the entrance and the
         exit of the context and uses profiling information from events
         associated with these submissions to perform the timing. Thus
         :class:`dpctl.SyclTimer` requires the queue with "enable_profiling"
         property. In order to be able to collect the profiling information
-        the property `dt` ensures that both submitted barriers complete
-        their execution and thus effectively synchronizing the queue.
+        the property, the `dt` method ensures that both submitted barriers
+        complete their execution and thus effectively synchronizes the queue.
 
     Args:
         host_timer (callable): A callable such that host_timer() returns current


### PR DESCRIPTION
Use Note in `dpctl.SyclTimer` docstring.

Also fix grammar in the text of the note. 

The change in this PR only affects docstring of `dpctl.SyclTimer` class.

- [ ] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
