### PR TITLE
Remove private method lookup in dpctl_capi

### DIFF
--- a/dpctl/apis/include/dpctl4pybind11.hpp
+++ b/dpctl/apis/include/dpctl4pybind11.hpp
@@ -181,7 +181,7 @@ public:
 
     static auto &get()
     {
-        static dpctl_capi api = lookup();
+        static dpctl_capi api{};
         return api;
     }
 
@@ -403,12 +403,6 @@ private:
     dpctl_capi(dpctl_capi const &) = default;
     dpctl_capi &operator=(dpctl_capi const &) = default;
     dpctl_capi &operator=(dpctl_capi &&) = default;
-
-    static dpctl_capi &lookup()
-    {
-        static dpctl_capi api;
-        return api;
-    }
 
 }; // struct dpctl_capi
 } // namespace detail


### PR DESCRIPTION
This PR removes private method `dpctl_capi::lookup`.

This removes one of static `dpctl_capi` instance from `dpctl_capi` definition. This leaves a single static instance created dynamically in get static method.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
