### PR TITLE
Fix main script

### DIFF
--- a/dpctl/__main__.py
+++ b/dpctl/__main__.py
@@ -30,12 +30,12 @@ def _dpctl_dir() -> str:
 
 
 def get_include_dir() -> str:
-    "Prints include flags for dpctl and SyclInterface library"
+    "Prints include flags for dpctl and DPCTLSyclInterface library"
     return os.path.join(_dpctl_dir(), "include")
 
 
 def print_include_flags() -> None:
-    "Prints include flags for dpctl and SyclInterface library"
+    "Prints include flags for dpctl and DPCTLSyclInterface library"
     print("-I " + get_include_dir())
 
 
@@ -46,13 +46,13 @@ def get_tensor_include_dir() -> str:
 
 
 def print_tensor_include_flags() -> None:
-    "Prints include flags for dpctl and SyclInterface library"
+    "Prints include flags for dpctl and DPCTLSyclInterface library"
     libtensor_dir = get_tensor_include_dir()
     print("-I " + libtensor_dir)
 
 
 def print_cmake_dir() -> None:
-    "Prints directory with FindDpctl.cmake"
+    "Prints directory with dpctl-config.cmake"
     dpctl_dir = _dpctl_dir()
     cmake_dir = os.path.join(dpctl_dir, "resources", "cmake")
     print(cmake_dir)
@@ -64,13 +64,13 @@ def get_library_dir() -> str:
 
 
 def print_library() -> None:
-    "Prints linker flags for SyclInterface library"
+    "Prints linker flags for DPCTLSyclInterface library"
     dpctl_dir = get_library_dir()
     plt = platform.platform()
     ld_flags = "-L " + dpctl_dir
     if plt != "Windows":
         ld_flags = ld_flags + " -Wl,-rpath," + dpctl_dir
-    print(ld_flags + " -lSyclInterface")
+    print(ld_flags + " -lDPCTLSyclInterface")
 
 
 def _warn_if_any_set(args, li) -> None:

--- a/dpctl/tests/test_service.py
+++ b/dpctl/tests/test_service.py
@@ -205,7 +205,9 @@ def test_main_library():
     )
     assert res.returncode == 0
     assert res.stdout
-    assert res.stdout.decode("utf-8").startswith("-L")
+    output = res.stdout.decode("utf-8")
+    assert output.startswith("-L")
+    assert "DPCTLSyclInterface" in output
 
 
 def test_tensor_includes():


### PR DESCRIPTION
Output of `python -m dpctl --library` incorrectly output `-lSyclInterface`. It should have been `-lDPCTLSyclInterface`. 

This PR changes the output, adjusts docstrings to use correct library name and modifies test to assert that the expected library name occurs as a substring in the output.

This fix should be backported to 0.16.1

- [x] Have you provided a meaningful PR description?
- [x] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
