### PR TITLE
Remove pinning of compiler version for test_examples step

### DIFF
--- a/.github/workflows/conda-package.yml
+++ b/.github/workflows/conda-package.yml
@@ -415,7 +415,7 @@ jobs:
     runs-on:  ${{ matrix.runner }}
     strategy:
       matrix:
-        python: ['3.9']
+        python: ['3.10']
         experimental: [false]
         runner: [ubuntu-20.04]
     continue-on-error: ${{ matrix.experimental }}
@@ -468,7 +468,7 @@ jobs:
       - name: Install example requirements
         shell: bash -l {0}
         env:
-          DPCPP_CMPLR: dpcpp_linux-64">=2024.0.0,<2024.0.1"
+          DPCPP_CMPLR: dpcpp_linux-64">=2024.0"
         run: |
           CHANNELS="${{ env.CHANNELS }}"
           . $CONDA/etc/profile.d/conda.sh


### PR DESCRIPTION
Fix conda-packages workflow's step 'test_examples_linux' by removing pinning from above on compiler's version.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
