### PR TITLE
Fix for typo in changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.16.1] - Apr. XX, 2024
 
 This is a bug-fix release, which also provides a change needed by ``numba_dpex`` project to support dispatching kernels
-consuming instances of ``sycl::kernel_accessor`` template type.
+consuming instances of ``sycl::local_accessor`` template type.
 
 ### Changed
 


### PR DESCRIPTION
Fixed typo in changelog introduced in recent gh-1613 and pointed out by @diptorupd 

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
