### PR TITLE
Use DPC++ 2024.1.0 to collect coverage

### DIFF
--- a/.github/workflows/generate-coverage.yaml
+++ b/.github/workflows/generate-coverage.yaml
@@ -17,7 +17,7 @@ jobs:
       ONEAPI_ROOT: /opt/intel/oneapi
       GTEST_ROOT: /home/runner/work/googletest-1.13.0/install
       # Use oneAPI compiler 2023 to work around an issue
-      USE_2023: 1
+      USE_2023: 0
 
     steps:
       - name: Cancel Previous Runs


### PR DESCRIPTION
Use DPC++ 2024.1.0 to collect coverage. 

Use of 2023.2.0 was a work-around.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
