### PR TITLE
Update reduction data types for 2023.12 array API specification, update `__array_api_version__`

### DIFF
--- a/dpctl/tensor/_array_api.py
+++ b/dpctl/tensor/_array_api.py
@@ -49,7 +49,7 @@ def _isdtype_impl(dtype, kind):
         raise TypeError(f"Unsupported data type kind: {kind}")
 
 
-__array_api_version__ = "2022.12"
+__array_api_version__ = "2023.12"
 
 
 class Info:
@@ -80,6 +80,8 @@ class Info:
 
     def capabilities(self):
         """
+        capabilities()
+
         Returns a dictionary of `dpctl`'s capabilities.
 
         Returns:
@@ -92,12 +94,16 @@ class Info:
 
     def default_device(self):
         """
+        default_device()
+
         Returns the default SYCL device.
         """
         return dpctl.select_default_device()
 
-    def default_dtypes(self, device=None):
+    def default_dtypes(self, *, device=None):
         """
+        default_dtypes(*, device=None)
+
         Returns a dictionary of default data types for `device`.
 
         Args:
@@ -129,8 +135,10 @@ class Info:
             "indexing": dpt.dtype(default_device_index_type(device)),
         }
 
-    def dtypes(self, device=None, kind=None):
+    def dtypes(self, *, device=None, kind=None):
         """
+        dtypes(*, device=None, kind=None)
+
         Returns a dictionary of all Array API data types of a specified `kind`
         supported by `device`
 
@@ -193,13 +201,16 @@ class Info:
 
     def devices(self):
         """
+        devices()
+
         Returns a list of supported devices.
         """
         return dpctl.get_devices()
 
 
 def __array_namespace_info__():
-    """__array_namespace_info__()
+    """
+    __array_namespace_info__()
 
     Returns a namespace with Array API namespace inspection utilities.
 

--- a/dpctl/tensor/_type_utils.py
+++ b/dpctl/tensor/_type_utils.py
@@ -733,6 +733,49 @@ def isdtype(dtype, kind):
         raise TypeError(f"Unsupported data type kind: {kind}")
 
 
+def _default_accumulation_dtype(inp_dt, q):
+    """Gives default output data type for given input data
+    type `inp_dt` when accumulation is performed on queue `q`
+    """
+    inp_kind = inp_dt.kind
+    if inp_kind in "bi":
+        res_dt = dpt.dtype(ti.default_device_int_type(q))
+        if inp_dt.itemsize > res_dt.itemsize:
+            res_dt = inp_dt
+    elif inp_kind in "u":
+        res_dt = dpt.dtype(ti.default_device_int_type(q).upper())
+        res_ii = dpt.iinfo(res_dt)
+        inp_ii = dpt.iinfo(inp_dt)
+        if inp_ii.min >= res_ii.min and inp_ii.max <= res_ii.max:
+            pass
+        else:
+            res_dt = inp_dt
+    elif inp_kind in "fc":
+        res_dt = inp_dt
+
+    return res_dt
+
+
+def _default_accumulation_dtype_fp_types(inp_dt, q):
+    """Gives default output data type for given input data
+    type `inp_dt` when accumulation is performed on queue `q`
+    and the accumulation supports only floating-point data types
+    """
+    inp_kind = inp_dt.kind
+    if inp_kind in "biu":
+        res_dt = dpt.dtype(ti.default_device_fp_type(q))
+        can_cast_v = dpt.can_cast(inp_dt, res_dt)
+        if not can_cast_v:
+            _fp64 = q.sycl_device.has_aspect_fp64
+            res_dt = dpt.float64 if _fp64 else dpt.float32
+    elif inp_kind in "f":
+        res_dt = inp_dt
+    elif inp_kind in "c":
+        raise ValueError("function not defined for complex types")
+
+    return res_dt
+
+
 __all__ = [
     "_find_buf_dtype",
     "_find_buf_dtype2",
@@ -753,4 +796,6 @@ __all__ = [
     "WeakIntegralType",
     "WeakFloatingType",
     "WeakComplexType",
+    "_default_accumulation_dtype",
+    "_default_accumulation_dtype_fp_types",
 ]

--- a/dpctl/tests/test_tensor_array_api_inspection.py
+++ b/dpctl/tests/test_tensor_array_api_inspection.py
@@ -96,7 +96,7 @@ def test_array_api_inspection_default_dtypes():
 
     info = dpt.__array_namespace_info__()
     default_dts_nodev = info.default_dtypes()
-    default_dts_dev = info.default_dtypes(dev)
+    default_dts_dev = info.default_dtypes(device=dev)
 
     assert (
         int_dt == default_dts_nodev["integral"] == default_dts_dev["integral"]

--- a/dpctl/tests/test_usm_ndarray_indexing.py
+++ b/dpctl/tests/test_usm_ndarray_indexing.py
@@ -491,7 +491,7 @@ def test_mixed_index_getitem():
     x = dpt.reshape(dpt.arange(1000, dtype="i4"), (10, 10, 10))
     i1b = dpt.ones(10, dtype="?")
     info = x.__array_namespace__().__array_namespace_info__()
-    ind_dt = info.default_dtypes(x.device)["indexing"]
+    ind_dt = info.default_dtypes(device=x.device)["indexing"]
     i0 = dpt.asarray([0, 2, 3], dtype=ind_dt)[:, dpt.newaxis]
     i2 = dpt.asarray([3, 4, 7], dtype=ind_dt)[:, dpt.newaxis]
     y = x[i0, i1b, i2]
@@ -503,7 +503,7 @@ def test_mixed_index_setitem():
     x = dpt.reshape(dpt.arange(1000, dtype="i4"), (10, 10, 10))
     i1b = dpt.ones(10, dtype="?")
     info = x.__array_namespace__().__array_namespace_info__()
-    ind_dt = info.default_dtypes(x.device)["indexing"]
+    ind_dt = info.default_dtypes(device=x.device)["indexing"]
     i0 = dpt.asarray([0, 2, 3], dtype=ind_dt)[:, dpt.newaxis]
     i2 = dpt.asarray([3, 4, 7], dtype=ind_dt)[:, dpt.newaxis]
     v_shape = (3, int(dpt.sum(i1b, dtype="i8")))

--- a/dpctl/tests/test_usm_ndarray_reductions.py
+++ b/dpctl/tests/test_usm_ndarray_reductions.py
@@ -406,7 +406,7 @@ def test_logsumexp_complex():
     get_queue_or_skip()
 
     x = dpt.zeros(1, dtype="c8")
-    with pytest.raises(TypeError):
+    with pytest.raises(ValueError):
         dpt.logsumexp(x)
 
 
@@ -470,7 +470,7 @@ def test_hypot_complex():
     get_queue_or_skip()
 
     x = dpt.zeros(1, dtype="c8")
-    with pytest.raises(TypeError):
+    with pytest.raises(ValueError):
         dpt.reduce_hypot(x)
 
 

--- a/dpctl/tests/test_usm_ndarray_searchsorted.py
+++ b/dpctl/tests/test_usm_ndarray_searchsorted.py
@@ -12,7 +12,7 @@ def _check(hay_stack, needles, needles_np):
     assert hay_stack.ndim == 1
 
     info_ = dpt.__array_namespace_info__()
-    default_dts_dev = info_.default_dtypes(hay_stack.device)
+    default_dts_dev = info_.default_dtypes(device=hay_stack.device)
     index_dt = default_dts_dev["indexing"]
 
     p_left = dpt.searchsorted(hay_stack, needles, side="left")


### PR DESCRIPTION
This pull request updates reductions over floating point data to be performed in the input type by default as per the 2023.12 array API spec.

This pull request also changes `__array_api_version__` to 2023.12. As `cumulative_sum` is a requirement of the 2023.12 spec, this PR should be redirected to master after the base branch is merged.

- [X] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [X] Have you tested your changes locally for CPU and GPU devices?
- [X] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [X] If this PR is a work in progress, are you opening the PR as a draft?
