### PR TITLE
Adds page for linear algebra functions to `dpctl.tensor` documentation

### DIFF
--- a/docs/doc_sources/reference_guides/dpctl/tensor.linear_algebra.rst
+++ b/docs/doc_sources/reference_guides/dpctl/tensor.linear_algebra.rst
@@ -1,0 +1,14 @@
+.. _dpctl_tensor_linear_algebra:
+
+Linear algebra functions
+==================
+
+.. currentmodule:: dpctl.tensor
+
+.. autosummary::
+    :toctree: generated
+
+    matmul
+    matrix_transpose
+    tensordot
+    vecdot

--- a/docs/doc_sources/reference_guides/dpctl/tensor.rst
+++ b/docs/doc_sources/reference_guides/dpctl/tensor.rst
@@ -23,6 +23,7 @@ This module contains:
 * :ref:`elementwise functions <dpctl_api_elementwise_functions>`
 * :ref:`indexing functions <dpctl_tensor_indexing_functions>`
 * :ref:`introspection functions <dpctl_tensor_inspection>`
+* :ref:`linear algebra functions <dpctl_tensor_linear_algebra>`
 * :ref:`searching functions <dpctl_tensor_searching_functions>`
 * :ref:`set functions <dpctl_tensor_set_functions>`
 * :ref:`sorting functions <dpctl_tensor_sorting_functions>`
@@ -40,6 +41,7 @@ This module contains:
     tensor.elementwise_functions
     tensor.indexing_functions
     tensor.inspection
+    tensor.linear_algebra
     tensor.manipulation_functions
     tensor.searching_functions
     tensor.set_functions


### PR DESCRIPTION
This PR adds a documentation page for linear algebra functions `matmul`, `matrix_transpose`, `tensordot`, and `vecdot`, which were previously undocumented in the base branch for dpctl documentation revamp.

Opening as a PR to not interfere with possible ongoing work in the branch.

- [X] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [X] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
