### PR TITLE
Need barrier after call to custom inclusive scan to avoid race condition

### DIFF
--- a/dpctl/tensor/libtensor/include/kernels/accumulators.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/accumulators.hpp
@@ -290,6 +290,9 @@ inclusive_scan_base_step(sycl::queue &exec_q,
             else {
                 wg_iscan_val = su_ns::custom_inclusive_scan_over_group(
                     it.get_group(), slm_iscan_tmp, local_iscan.back(), scan_op);
+                // ensure all finished reading from SLM, to avoid race condition
+                // with subsequent writes into SLM
+                it.barrier(sycl::access::fence_space::local_space);
             }
 
             slm_iscan_tmp[(lid + 1) % wg_size] = wg_iscan_val;


### PR DESCRIPTION
Need barrier after call to custom inclusive scan to avoid race condition with subsequent writes into SLM.

Added comments explaining why barriers are needed

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
