### PR TITLE
Correction to `dpctl.tensor.tile` for scalar input and empty repetitions

### DIFF
--- a/dpctl/tensor/_manipulation_functions.py
+++ b/dpctl/tensor/_manipulation_functions.py
@@ -964,18 +964,6 @@ def tile(x, repetitions):
                 f"Expected tuple or integer type, got {type(repetitions)}."
             )
 
-    # case of scalar
-    if x.size == 1:
-        if not repetitions:
-            # handle empty tuple
-            repetitions = (1,)
-        return dpt.full(
-            repetitions,
-            x,
-            dtype=x.dtype,
-            usm_type=x.usm_type,
-            sycl_queue=x.sycl_queue,
-        )
     rep_dims = len(repetitions)
     x_dims = x.ndim
     if rep_dims < x_dims:

--- a/dpctl/tests/test_usm_ndarray_manipulation.py
+++ b/dpctl/tests/test_usm_ndarray_manipulation.py
@@ -1378,20 +1378,24 @@ def test_tile_size_1():
 
     reps = 5
     # test for 0d array
-    x = dpt.asarray(2, dtype="i4")
-    res = dpt.tile(x, reps)
+    x1 = dpt.asarray(2, dtype="i4")
+    res = dpt.tile(x1, reps)
     assert dpt.all(res == dpt.full(reps, 2, dtype="i4"))
 
     # test for 1d array with single element
-    x = dpt.asarray([2], dtype="i4")
-    res = dpt.tile(x, reps)
+    x2 = dpt.asarray([2], dtype="i4")
+    res = dpt.tile(x2, reps)
     assert dpt.all(res == dpt.full(reps, 2, dtype="i4"))
 
-    # test empty reps returns copy of input
     reps = ()
-    res = dpt.tile(x, reps)
-    assert x.shape == res.shape
-    assert x == res
+    # test for gh-1627 behavior
+    res = dpt.tile(x1, reps)
+    assert x1.shape == res.shape
+    assert x1 == res
+
+    res = dpt.tile(x2, reps)
+    assert x2.shape == res.shape
+    assert x2 == res
 
 
 def test_tile_prepends_axes():


### PR DESCRIPTION
This PR fixes a bug in `tile` where if the input is 0D and `repetitions` is empty, instead of a copying a scalar input and returning a scalar, a 1D array of size 1 would be returned instead.

Per the [array API spec](https://data-apis.org/array-api/latest/API_specification/generated/array_api.tile.html) and Numpy, this is incorrect behavior.

Resolves #1627 

- [X] Have you provided a meaningful PR description?
- [X] Have you added a test, reproducer or referred to an issue with a reproducer?
- [X] Have you tested your changes locally for CPU and GPU devices?
- [X] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
