### PR TITLE
Edit docstrings for `tile` and `repeat`, fix "usm_narray" typos

### DIFF
--- a/dpctl/tensor/_elementwise_funcs.py
+++ b/dpctl/tensor/_elementwise_funcs.py
@@ -2160,7 +2160,7 @@ Args:
         Default: "K".
 
 Returns:
-    usm_narray:
+    usm_ndarray:
         An array containing the element-wise reciprocals.
         The returned array has a floating-point data type determined
         by the Type Promotion Rules.
@@ -2195,7 +2195,7 @@ Args:
         Default: "K".
 
 Returns:
-    usm_narray:
+    usm_ndarray:
         An array containing the element-wise phase angles.
         The returned array has a floating-point data type determined
         by the Type Promotion Rules.

--- a/dpctl/tensor/_indexing_functions.py
+++ b/dpctl/tensor/_indexing_functions.py
@@ -326,7 +326,7 @@ def nonzero(arr):
 
     Return the indices of non-zero elements.
 
-    Returns the tuple of usm_narrays, one for each dimension
+    Returns a tuple of usm_ndarrays, one for each dimension
     of `arr`, containing the indices of the non-zero elements
     in that dimension. The values of `arr` are always tested in
     row-major, C-style order.

--- a/dpctl/tensor/_manipulation_functions.py
+++ b/dpctl/tensor/_manipulation_functions.py
@@ -725,7 +725,7 @@ def repeat(x, repeats, /, *, axis=None):
         repeats (Union[int, Sequence[int, ...], usm_ndarray]):
             The number of repetitions for each element.
 
-            `repeats` must be broadcast compatible with `N` where `N` is
+            `repeats` must be broadcast-compatible with `N` where `N` is
             `prod(x.shape)` if `axis` is `None` and `x.shape[axis]`
             otherwise.
 

--- a/dpctl/tensor/_manipulation_functions.py
+++ b/dpctl/tensor/_manipulation_functions.py
@@ -937,21 +937,28 @@ def tile(x, repetitions, /):
     `repetitions`.
 
     For `N` = len(`repetitions`) and `M` = len(`x.shape`):
-    - if `M < N`, `x` will have `N - M` new axes prepended to its shape
-    - if `M > N`, `repetitions` will have `M - N` new axes 1 prepended to it
+
+        * If `M < N`, `x` will have `N - M` new axes prepended to its shape
+        * If `M > N`, `repetitions` will have `M - N` ones prepended to it
 
     Args:
         x (usm_ndarray): input array
 
         repetitions (Union[int, Tuple[int, ...]]):
-            The number of repetitions for each dimension.
+            The number of repetitions along each dimension of `x`.
 
     Returns:
-        usm_narray:
-            Array with tiled elements.
-            The returned array must have the same data type as `x`,
-            is created on the same device as `x` and has the same USM
-            allocation type as `x`.
+        usm_ndarray:
+            tiled output array.
+
+            The returned array will have rank `max(M, N)`. If `S` is
+            the shape of `x` after prepending dimensions and `R` is
+            `repetitions` after prepending ones, then the shape of
+            the result will be `S[i] * R[i]` for each dimension `i`.
+            
+            The returned array will have the same data type as `x`.
+            The returned array will be located on the same device as
+            `x` and have the same USM allocation type as `x`.
     """
     if not isinstance(x, dpt.usm_ndarray):
         raise TypeError(f"Expected usm_ndarray type, got {type(x)}.")

--- a/dpctl/tensor/_manipulation_functions.py
+++ b/dpctl/tensor/_manipulation_functions.py
@@ -95,7 +95,7 @@ def permute_dims(X, /, axes):
            `(0,1,...,N-1)` where `N` is the number of axes (dimensions)
            of `x`.
     Returns:
-        usm_narray:
+        usm_ndarray:
             An array with permuted axes.
             The returned array must has the same data type as `x`,
             is created on the same device as `x` and has the same USM allocation
@@ -646,7 +646,7 @@ def moveaxis(X, source, destination, /):
             in the half-open interval `[-N, N)`.
 
     Returns:
-        usm_narray:
+        usm_ndarray:
             Array with moved axes.
             The returned array must has the same data type as `x`,
             is created on the same device as `x` and has the same
@@ -693,7 +693,7 @@ def swapaxes(X, axis1, axis2):
             a valid `axis` must be in the half-open interval `[-N, N)`.
 
     Returns:
-        usm_narray:
+        usm_ndarray:
             Array with swapped axes.
             The returned array must has the same data type as `x`,
             is created on the same device as `x` and has the same USM

--- a/dpctl/tensor/_manipulation_functions.py
+++ b/dpctl/tensor/_manipulation_functions.py
@@ -717,31 +717,37 @@ def swapaxes(X, axis1, axis2):
 def repeat(x, repeats, /, *, axis=None):
     """repeat(x, repeats, axis=None)
 
-    Repeat elements of an array.
+    Repeat elements of an array on a per-element basis.
 
     Args:
         x (usm_ndarray): input array
 
         repeats (Union[int, Sequence[int, ...], usm_ndarray]):
             The number of repetitions for each element.
-            `repeats` is broadcast to fit the shape of the given axis.
+
+            `repeats` must be broadcast compatible with `N` where `N` is
+            `prod(x.shape)` if `axis` is `None` and `x.shape[axis]`
+            otherwise.
+
             If `repeats` is an array, it must have an integer data type.
-            Otherwise, `repeats` must be a Python integer, tuple, list, or
-            range.
+            Otherwise, `repeats` must be a Python integer or sequence of
+            Python integers (i.e., a tuple, list, or range).
 
         axis (Optional[int]):
             The axis along which to repeat values. If `axis` is `None`, the
-            function repeats elements of the flattened array.
-            Default: `None`.
+            function repeats elements of the flattened array. Default: `None`.
 
     Returns:
-        usm_narray:
-            Array with repeated elements.
-            The returned array must have the same data type as `x`, is created
-            on the same device as `x` and has the same USM allocation type as
-            `x`. If `axis` is `None`, the returned array is one-dimensional,
+        usm_ndarray:
+            output array with repeated elements.
+
+            If `axis` is `None`, the returned array is one-dimensional,
             otherwise, it has the same shape as `x`, except for the axis along
             which elements were repeated.
+
+            The returned array will have the same data type as `x`.
+            The returned array will be located on the same device as `x` and
+            have the same USM allocation type as `x`.
 
     Raises:
         AxisError: if `axis` value is invalid.
@@ -951,14 +957,14 @@ def tile(x, repetitions, /):
         usm_ndarray:
             tiled output array.
 
-            The returned array will have rank `max(M, N)`. If `S` is
-            the shape of `x` after prepending dimensions and `R` is
-            `repetitions` after prepending ones, then the shape of
-            the result will be `S[i] * R[i]` for each dimension `i`.
-            
+            The returned array will have rank `max(M, N)`. If `S` is the
+            shape of `x` after prepending dimensions and `R` is
+            `repetitions` after prepending ones, then the shape of the
+            result will be `S[i] * R[i]` for each dimension `i`.
+
             The returned array will have the same data type as `x`.
-            The returned array will be located on the same device as
-            `x` and have the same USM allocation type as `x`.
+            The returned array will be located on the same device as `x` and
+            have the same USM allocation type as `x`.
     """
     if not isinstance(x, dpt.usm_ndarray):
         raise TypeError(f"Expected usm_ndarray type, got {type(x)}.")

--- a/examples/cython/usm_memory/blackscholes/blackscholes.pyx
+++ b/examples/cython/usm_memory/blackscholes/blackscholes.pyx
@@ -135,7 +135,7 @@ def populate_params(
     """ populate_params(params, pl, ph, sl, sh, tl, th, rl, rh, vl, vh, seed)
 
     Args:
-        params: usm_narray
+        params: usm_ndarray
             Array of shape (n_opts, 5) to populate with price, strike, time to
             maturity, interest rate, volatility rate per option using uniform
             distribution with provided distribution parameters.


### PR DESCRIPTION
This PR changes docstrings for `tile` and `repeat` to better describe behaviors of these functions, and fixes minor typos throughout dpctl where "usm_narray" was used instead of "usm_ndarray"

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
