### PR TITLE
Add a note for description of `axis` in accumulation functions

### DIFF
--- a/dpctl/tensor/_accumulation.py
+++ b/dpctl/tensor/_accumulation.py
@@ -271,6 +271,9 @@ def cumulative_sum(
         axis (Optional[int, Tuple[int, ...]]):
             axis along which cumulative sum must be computed.
             If `None`, the sum is computed over the entire array.
+            If `x` is a one-dimensional array, providing an `axis` is optional;
+            however, if `x` has more than one dimension, providing an `axis`
+            is required.
             Default: `None`.
         dtype (Optional[dtype]):
             data type of the returned array. If `None`, the default data
@@ -342,6 +345,9 @@ def cumulative_prod(
         axis (Optional[int, Tuple[int, ...]]):
             axis along which cumulative product must be computed.
             If `None`, the product is computed over the entire array.
+            If `x` is a one-dimensional array, providing an `axis` is optional;
+            however, if `x` has more than one dimension, providing an `axis`
+            is required.
             Default: `None`.
         dtype (Optional[dtype]):
             data type of the returned array. If `None`, the default data
@@ -414,6 +420,9 @@ def cumulative_logsumexp(
         axis (Optional[int, Tuple[int, ...]]):
             axis along which cumulative logsumexp must be computed.
             If `None`, the logsumexp is computed over the entire array.
+            If `x` is a one-dimensional array, providing an `axis` is optional;
+            however, if `x` has more than one dimension, providing an `axis`
+            is required.
             Default: `None`.
         dtype (Optional[dtype]):
             data type of the returned array. If `None`, the default data


### PR DESCRIPTION
The PR proposes to add a note for description of `axis` in accumulation functions as per Python array API for `cumulative_sum` documentation.
Without the note in the description it might not be clear that `axis` keyword is required (rather than optional) in some use cases.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
