### PR TITLE
Set release date of 0.16.1 in changelog document

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.16.1] - Apr. XX, 2024
+## [0.16.1] - Apr. 10, 2024
 
 This is a bug-fix release, which also provides a change needed by ``numba_dpex`` project to support dispatching kernels
 consuming instances of ``sycl::local_accessor`` template type.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.21...3.27 FATAL_ERROR)
 
 project(dpctl
-    VERSION 0.15
+    VERSION 0.16
     LANGUAGES CXX
     DESCRIPTION "Python interface for XPU programming"
 )


### PR DESCRIPTION
This PR proposes 2 changes:

* Change PROJECT version in CMakeLists.txt to 0.16
* Sets the date of 0.16.1 release to April 10, 2024

-----

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
