### PR TITLE
Implements `out` keyword for `where` and reductions and `order` keyword for `where`

### DIFF
--- a/dpctl/tensor/_reduction.py
+++ b/dpctl/tensor/_reduction.py
@@ -192,8 +192,8 @@ def sum(x, /, *, axis=None, dtype=None, keepdims=False, out=None):
         axis (Optional[int, Tuple[int, ...]]):
             axis or axes along which sums must be computed. If a tuple
             of unique integers, sums are computed over multiple axes.
-            If `None`, the sum is computed over the entire array.
-            Default: `None`.
+            If ``None``, the sum is computed over the entire array.
+            Default: ``None``.
         dtype (Optional[dtype]):
             data type of the returned array. If ``None``, the default data
             type is inferred from the "kind" of the input array data type.

--- a/dpctl/tensor/_reduction.py
+++ b/dpctl/tensor/_reduction.py
@@ -443,6 +443,8 @@ def _comparison_over_axis(x, axis, keepdims, out, _reduction_fn):
         axis = tuple(range(nd))
     if not isinstance(axis, (tuple, list)):
         axis = (axis,)
+    if any([x.shape[i] == 0 for i in axis]):
+        raise ValueError("reduction cannot be performed over zero-size axes")
     axis = normalize_axis_tuple(axis, nd, "axis")
     red_nd = len(axis)
     perm = [i for i in range(nd) if i not in axis] + list(axis)
@@ -489,14 +491,6 @@ def _comparison_over_axis(x, axis, keepdims, out, _reduction_fn):
         out = dpt.empty(
             res_shape, dtype=res_dt, usm_type=res_usm_type, sycl_queue=exec_q
         )
-
-    if x.size == 0:
-        if any([x.shape[i] == 0 for i in axis]):
-            raise ValueError(
-                "reduction cannot be performed over zero-size axes"
-            )
-        else:
-            return out
 
     host_tasks_list = []
     if red_nd == 0:
@@ -615,6 +609,8 @@ def _search_over_axis(x, axis, keepdims, out, _reduction_fn):
             f"`axis` argument expected `int` or `None`, got {type(axis)}"
         )
     axis = normalize_axis_tuple(axis, nd, "axis")
+    if any([x.shape[i] == 0 for i in axis]):
+        raise ValueError("reduction cannot be performed over zero-size axes")
     red_nd = len(axis)
     perm = [i for i in range(nd) if i not in axis] + list(axis)
     x_tmp = dpt.permute_dims(x, perm)
@@ -660,14 +656,6 @@ def _search_over_axis(x, axis, keepdims, out, _reduction_fn):
         out = dpt.empty(
             res_shape, dtype=res_dt, usm_type=res_usm_type, sycl_queue=exec_q
         )
-
-    if x.size == 0:
-        if any([x.shape[i] == 0 for i in axis]):
-            raise ValueError(
-                "reduction cannot be performed over zero-size axes"
-            )
-        else:
-            return out
 
     if red_nd == 0:
         ht_e_fill, _ = ti._full_usm_ndarray(

--- a/dpctl/tensor/_search_functions.py
+++ b/dpctl/tensor/_search_functions.py
@@ -150,13 +150,16 @@ def where(condition, x1, x2, /, *, order="K", out=None):
             )
 
         if ti._array_overlap(condition, out):
-            out = dpt.empty_like(out)
+            if not ti._same_logical_tensors(condition, out):
+                out = dpt.empty_like(out)
 
         if ti._array_overlap(x1, out):
-            out = dpt.empty_like(out)
+            if not ti._same_logical_tensors(x1, out):
+                out = dpt.empty_like(out)
 
         if ti._array_overlap(x2, out):
-            out = dpt.empty_like(out)
+            if not ti._same_logical_tensors(x2, out):
+                out = dpt.empty_like(out)
 
     if order == "A":
         order = (

--- a/dpctl/tensor/_search_functions.py
+++ b/dpctl/tensor/_search_functions.py
@@ -40,37 +40,35 @@ def _where_result_type(dt1, dt2, dev):
         return None
 
 
-def where(condition, x1, x2):
-    """where(condition, x1, x2)
-
+def where(condition, x1, x2, /, *, order="K"):
+    """
     Returns :class:`dpctl.tensor.usm_ndarray` with elements chosen
-    from `x1` or `x2` depending on `condition`.
+    from ``x1`` or ``x2`` depending on ``condition``.
 
     Args:
-        condition (usm_ndarray): When True yields from `x1`,
-            and otherwise yields from `x2`.
-            Must be compatible with `x1` and `x2` according
+        condition (usm_ndarray): When ``True`` yields from ``x1``,
+            and otherwise yields from ``x2``.
+            Must be compatible with ``x1`` and ``x2`` according
             to broadcasting rules.
         x1 (usm_ndarray): Array from which values are chosen when
-            `condition` is True.
-            Must be compatible with `condition` and `x2` according
+            ``condition`` is ``True``.
+            Must be compatible with ``condition`` and ``x2`` according
             to broadcasting rules.
         x2 (usm_ndarray): Array from which values are chosen when
-            `condition` is not True.
-            Must be compatible with `condition` and `x2` according
+            ``condition`` is not ``True``.
+            Must be compatible with ``condition`` and ``x2`` according
             to broadcasting rules.
+        order (``"K"``, ``"C"``, ``"F"``, ``"A"``, optional):
+            Memory layout of the new output array.
+            Default: ``"K"``.
 
     Returns:
         usm_ndarray:
-            An array with elements from `x1` where `condition` is True,
-            and elements from `x2` elsewhere.
+            An array with elements from ``x1`` where ``condition`` is ``True``,
+            and elements from ``x2`` elsewhere.
 
     The data type of the returned array is determined by applying
-    the Type Promotion Rules to `x1` and `x2`.
-
-    The memory layout of the returned array is
-    F-contiguous (column-major) when all inputs are F-contiguous,
-    and C-contiguous (row-major) otherwise.
+    the Type Promotion Rules to ``x1`` and ``x2``.
     """
     if not isinstance(condition, dpt.usm_ndarray):
         raise TypeError(
@@ -84,6 +82,8 @@ def where(condition, x1, x2):
         raise TypeError(
             "Expecting dpctl.tensor.usm_ndarray type, " f"got {type(x2)}"
         )
+    if order not in ["K", "C", "F", "A"]:
+        order = "K"
     exec_q = dpctl.utils.get_execution_queue(
         (
             condition.sycl_queue,
@@ -114,15 +114,41 @@ def where(condition, x1, x2):
 
     res_shape = _broadcast_shapes(condition, x1, x2)
 
-    if condition.size == 0:
-        return dpt.empty(
-            res_shape, dtype=dst_dtype, usm_type=dst_usm_type, sycl_queue=exec_q
+    if order == "A":
+        order = (
+            "F"
+            if all(
+                arr.flags.f_contiguous
+                for arr in (
+                    condition,
+                    x1,
+                    x2,
+                )
+            )
+            else "C"
         )
+
+    if condition.size == 0:
+        if order == "K":
+            return _empty_like_triple_orderK(
+                condition, x1, x2, dst_dtype, res_shape, dst_usm_type, exec_q
+            )
+        else:
+            return dpt.empty(
+                res_shape,
+                dtype=dst_dtype,
+                order=order,
+                usm_type=dst_usm_type,
+                sycl_queue=exec_q,
+            )
 
     deps = []
     wait_list = []
     if x1_dtype != dst_dtype:
-        _x1 = _empty_like_orderK(x1, dst_dtype)
+        if order == "K":
+            _x1 = _empty_like_orderK(x1, dst_dtype)
+        else:
+            _x1 = dpt.empty_like(x1, dtype=dst_dtype, order=order)
         ht_copy1_ev, copy1_ev = ti._copy_usm_ndarray_into_usm_ndarray(
             src=x1, dst=_x1, sycl_queue=exec_q
         )
@@ -131,7 +157,10 @@ def where(condition, x1, x2):
         wait_list.append(ht_copy1_ev)
 
     if x2_dtype != dst_dtype:
-        _x2 = _empty_like_orderK(x2, dst_dtype)
+        if order == "K":
+            _x2 = _empty_like_orderK(x2, dst_dtype)
+        else:
+            _x2 = dpt.empty_like(x2, dtype=dst_dtype, order=order)
         ht_copy2_ev, copy2_ev = ti._copy_usm_ndarray_into_usm_ndarray(
             src=x2, dst=_x2, sycl_queue=exec_q
         )
@@ -139,9 +168,18 @@ def where(condition, x1, x2):
         deps.append(copy2_ev)
         wait_list.append(ht_copy2_ev)
 
-    dst = _empty_like_triple_orderK(
-        condition, x1, x2, dst_dtype, res_shape, dst_usm_type, exec_q
-    )
+    if order == "K":
+        dst = _empty_like_triple_orderK(
+            condition, x1, x2, dst_dtype, res_shape, dst_usm_type, exec_q
+        )
+    else:
+        dst = dpt.empty(
+            res_shape,
+            dtype=dst_dtype,
+            order=order,
+            usm_type=dst_usm_type,
+            sycl_queue=exec_q,
+        )
 
     condition = dpt.broadcast_to(condition, res_shape)
     x1 = dpt.broadcast_to(x1, res_shape)

--- a/dpctl/tensor/_search_functions.py
+++ b/dpctl/tensor/_search_functions.py
@@ -18,6 +18,7 @@ import dpctl
 import dpctl.tensor as dpt
 import dpctl.tensor._tensor_impl as ti
 from dpctl.tensor._manipulation_functions import _broadcast_shapes
+from dpctl.utils import ExecutionPlacementError
 
 from ._copy_utils import _empty_like_orderK, _empty_like_triple_orderK
 from ._type_utils import _all_data_types, _can_cast
@@ -40,7 +41,7 @@ def _where_result_type(dt1, dt2, dev):
         return None
 
 
-def where(condition, x1, x2, /, *, order="K"):
+def where(condition, x1, x2, /, *, order="K", out=None):
     """
     Returns :class:`dpctl.tensor.usm_ndarray` with elements chosen
     from ``x1`` or ``x2`` depending on ``condition``.
@@ -59,8 +60,14 @@ def where(condition, x1, x2, /, *, order="K"):
             Must be compatible with ``condition`` and ``x2`` according
             to broadcasting rules.
         order (``"K"``, ``"C"``, ``"F"``, ``"A"``, optional):
-            Memory layout of the new output array.
+            Memory layout of the new output arra,
+            if parameter ``out`` is ``None``.
             Default: ``"K"``.
+        out (Optional[usm_ndarray]):
+            the array into which the result is written.
+            The data type of `out` must match the expected shape and the
+            expected data type of the result.
+            If ``None`` then a new array is returned. Default: ``None``.
 
     Returns:
         usm_ndarray:
@@ -93,7 +100,7 @@ def where(condition, x1, x2, /, *, order="K"):
     )
     if exec_q is None:
         raise dpctl.utils.ExecutionPlacementError
-    dst_usm_type = dpctl.utils.get_coerced_usm_type(
+    out_usm_type = dpctl.utils.get_coerced_usm_type(
         (
             condition.usm_type,
             x1.usm_type,
@@ -103,8 +110,8 @@ def where(condition, x1, x2, /, *, order="K"):
 
     x1_dtype = x1.dtype
     x2_dtype = x2.dtype
-    dst_dtype = _where_result_type(x1_dtype, x2_dtype, exec_q.sycl_device)
-    if dst_dtype is None:
+    out_dtype = _where_result_type(x1_dtype, x2_dtype, exec_q.sycl_device)
+    if out_dtype is None:
         raise TypeError(
             "function 'where' does not support input "
             f"types ({x1_dtype}, {x2_dtype}), "
@@ -113,6 +120,43 @@ def where(condition, x1, x2, /, *, order="K"):
         )
 
     res_shape = _broadcast_shapes(condition, x1, x2)
+
+    orig_out = out
+    if out is not None:
+        if not isinstance(out, dpt.usm_ndarray):
+            raise TypeError(
+                "output array must be of usm_ndarray type, got " f"{type(out)}"
+            )
+
+        if not out.flags.writable:
+            raise ValueError("provided `out` array is read-only")
+
+        if out.shape != res_shape:
+            raise ValueError(
+                "The shape of input and output arrays are "
+                f"inconsistent. Expected output shape is {res_shape}, "
+                f"got {out.shape}"
+            )
+
+        if out_dtype != out.dtype:
+            raise ValueError(
+                f"Output array of type {out_dtype} is needed, "
+                f"got {out.dtype}"
+            )
+
+        if dpctl.utils.get_execution_queue((exec_q, out.sycl_queue)) is None:
+            raise ExecutionPlacementError(
+                "Input and output allocation queues are not compatible"
+            )
+
+        if ti._array_overlap(condition, out):
+            out = dpt.empty_like(out)
+
+        if ti._array_overlap(x1, out):
+            out = dpt.empty_like(out)
+
+        if ti._array_overlap(x2, out):
+            out = dpt.empty_like(out)
 
     if order == "A":
         order = (
@@ -129,26 +173,35 @@ def where(condition, x1, x2, /, *, order="K"):
         )
 
     if condition.size == 0:
-        if order == "K":
-            return _empty_like_triple_orderK(
-                condition, x1, x2, dst_dtype, res_shape, dst_usm_type, exec_q
-            )
+        if out is not None:
+            return out
         else:
-            return dpt.empty(
-                res_shape,
-                dtype=dst_dtype,
-                order=order,
-                usm_type=dst_usm_type,
-                sycl_queue=exec_q,
-            )
+            if order == "K":
+                return _empty_like_triple_orderK(
+                    condition,
+                    x1,
+                    x2,
+                    out_dtype,
+                    res_shape,
+                    out_usm_type,
+                    exec_q,
+                )
+            else:
+                return dpt.empty(
+                    res_shape,
+                    dtype=out_dtype,
+                    order=order,
+                    usm_type=out_usm_type,
+                    sycl_queue=exec_q,
+                )
 
     deps = []
     wait_list = []
-    if x1_dtype != dst_dtype:
+    if x1_dtype != out_dtype:
         if order == "K":
-            _x1 = _empty_like_orderK(x1, dst_dtype)
+            _x1 = _empty_like_orderK(x1, out_dtype)
         else:
-            _x1 = dpt.empty_like(x1, dtype=dst_dtype, order=order)
+            _x1 = dpt.empty_like(x1, dtype=out_dtype, order=order)
         ht_copy1_ev, copy1_ev = ti._copy_usm_ndarray_into_usm_ndarray(
             src=x1, dst=_x1, sycl_queue=exec_q
         )
@@ -156,11 +209,11 @@ def where(condition, x1, x2, /, *, order="K"):
         deps.append(copy1_ev)
         wait_list.append(ht_copy1_ev)
 
-    if x2_dtype != dst_dtype:
+    if x2_dtype != out_dtype:
         if order == "K":
-            _x2 = _empty_like_orderK(x2, dst_dtype)
+            _x2 = _empty_like_orderK(x2, out_dtype)
         else:
-            _x2 = dpt.empty_like(x2, dtype=dst_dtype, order=order)
+            _x2 = dpt.empty_like(x2, dtype=out_dtype, order=order)
         ht_copy2_ev, copy2_ev = ti._copy_usm_ndarray_into_usm_ndarray(
             src=x2, dst=_x2, sycl_queue=exec_q
         )
@@ -168,32 +221,43 @@ def where(condition, x1, x2, /, *, order="K"):
         deps.append(copy2_ev)
         wait_list.append(ht_copy2_ev)
 
-    if order == "K":
-        dst = _empty_like_triple_orderK(
-            condition, x1, x2, dst_dtype, res_shape, dst_usm_type, exec_q
-        )
-    else:
-        dst = dpt.empty(
-            res_shape,
-            dtype=dst_dtype,
-            order=order,
-            usm_type=dst_usm_type,
-            sycl_queue=exec_q,
-        )
+    if out is None:
+        if order == "K":
+            out = _empty_like_triple_orderK(
+                condition, x1, x2, out_dtype, res_shape, out_usm_type, exec_q
+            )
+        else:
+            out = dpt.empty(
+                res_shape,
+                dtype=out_dtype,
+                order=order,
+                usm_type=out_usm_type,
+                sycl_queue=exec_q,
+            )
 
     condition = dpt.broadcast_to(condition, res_shape)
     x1 = dpt.broadcast_to(x1, res_shape)
     x2 = dpt.broadcast_to(x2, res_shape)
 
-    hev, _ = ti._where(
+    hev, where_ev = ti._where(
         condition=condition,
         x1=x1,
         x2=x2,
-        dst=dst,
+        dst=out,
         sycl_queue=exec_q,
         depends=deps,
     )
+    if not (orig_out is None or orig_out is out):
+        # Copy the out data from temporary buffer to original memory
+        ht_copy_out_ev, _ = ti._copy_usm_ndarray_into_usm_ndarray(
+            src=out,
+            dst=orig_out,
+            sycl_queue=exec_q,
+            depends=[where_ev],
+        )
+        ht_copy_out_ev.wait()
+        out = orig_out
     dpctl.SyclEvent.wait_for(wait_list)
     hev.wait()
 
-    return dst
+    return out

--- a/dpctl/tensor/libtensor/source/where.cpp
+++ b/dpctl/tensor/libtensor/source/where.cpp
@@ -114,7 +114,12 @@ py_where(const dpctl::tensor::usm_ndarray &condition,
     }
 
     auto const &overlap = dpctl::tensor::overlap::MemoryOverlap();
-    if (overlap(dst, condition) || overlap(dst, x1) || overlap(dst, x2)) {
+    auto const &same_logical_tensors =
+        dpctl::tensor::overlap::SameLogicalTensors();
+    if ((overlap(dst, condition) && !same_logical_tensors(dst, condition)) ||
+        (overlap(dst, x1) && !same_logical_tensors(dst, x1)) ||
+        (overlap(dst, x2) && !same_logical_tensors(dst, x2)))
+    {
         throw py::value_error("Destination array overlaps with input.");
     }
 

--- a/dpctl/tests/test_usm_ndarray_reductions.py
+++ b/dpctl/tests/test_usm_ndarray_reductions.py
@@ -537,8 +537,9 @@ def test_numeric_reduction_out_kwarg():
     x = dpt.ones((n1, n2, n3), dtype="i4")
     out = dpt.zeros((2 * n1, 3 * n2), dtype="f4")
     res = dpt.sum(x, axis=-1, dtype="f4", out=out[::-2, 1::3])
-    assert dpt.allclose(out[::-2, 0::3], dpt.zeros_like(res))
-    assert dpt.allclose(out[::-2, 2::3], dpt.zeros_like(res))
+    zero_res = dpt.zeros_like(res)
+    assert dpt.allclose(out[::-2, 0::3], zero_res)
+    assert dpt.allclose(out[::-2, 2::3], zero_res)
     assert dpt.allclose(out[::-2, 1::3], res)
     assert dpt.allclose(out[::-2, 1::3], dpt.full_like(res, 5, dtype="f4"))
 

--- a/dpctl/tests/test_usm_ndarray_search_functions.py
+++ b/dpctl/tests/test_usm_ndarray_search_functions.py
@@ -386,31 +386,47 @@ def test_where_order():
         ar1 = dpt.zeros(test_sh, dtype=dt1, order="C")
         ar2 = dpt.ones(test_sh, dtype=dt2, order="C")
         condition = dpt.zeros(test_sh, dtype="?", order="C")
-        res = dpt.where(condition, ar1, ar2)
-        assert res.flags.c_contiguous
+        res1 = dpt.where(condition, ar1, ar2, order="C")
+        assert res1.flags.c_contiguous
+        res2 = dpt.where(condition, ar1, ar2, order="F")
+        assert res2.flags.f_contiguous
+        res3 = dpt.where(condition, ar1, ar2, order="A")
+        assert res3.flags.c_contiguous
+        res4 = dpt.where(condition, ar1, ar2, order="K")
+        assert res4.flags.c_contiguous
 
         ar1 = dpt.ones(test_sh, dtype=dt1, order="F")
         ar2 = dpt.ones(test_sh, dtype=dt2, order="F")
         condition = dpt.zeros(test_sh, dtype="?", order="F")
-        res = dpt.where(condition, ar1, ar2)
-        assert res.flags.f_contiguous
+        res1 = dpt.where(condition, ar1, ar2, order="C")
+        assert res1.flags.c_contiguous
+        res2 = dpt.where(condition, ar1, ar2, order="F")
+        assert res2.flags.f_contiguous
+        res3 = dpt.where(condition, ar1, ar2, order="A")
+        assert res2.flags.f_contiguous
+        res4 = dpt.where(condition, ar1, ar2, order="K")
+        assert res4.flags.f_contiguous
 
         ar1 = dpt.ones(test_sh2, dtype=dt1, order="C")[:20, ::-2]
         ar2 = dpt.ones(test_sh2, dtype=dt2, order="C")[:20, ::-2]
         condition = dpt.zeros(test_sh2, dtype="?", order="C")[:20, ::-2]
-        res = dpt.where(condition, ar1, ar2)
-        assert res.strides == (n, -1)
+        res1 = dpt.where(condition, ar1, ar2, order="K")
+        assert res1.strides == (n, -1)
+        res2 = dpt.where(condition, ar1, ar2, order="C")
+        assert res2.strides == (n, 1)
 
         ar1 = dpt.ones(test_sh2, dtype=dt1, order="C")[:20, ::-2].mT
         ar2 = dpt.ones(test_sh2, dtype=dt2, order="C")[:20, ::-2].mT
         condition = dpt.zeros(test_sh2, dtype="?", order="C")[:20, ::-2].mT
-        res = dpt.where(condition, ar1, ar2)
-        assert res.strides == (-1, n)
+        res1 = dpt.where(condition, ar1, ar2, order="K")
+        assert res1.strides == (-1, n)
+        res2 = dpt.where(condition, ar1, ar2, order="C")
+        assert res2.strides == (n, 1)
 
         ar1 = dpt.ones(n, dtype=dt1, order="C")
         ar2 = dpt.broadcast_to(dpt.ones(n, dtype=dt2, order="C"), test_sh)
         condition = dpt.zeros(n, dtype="?", order="C")
-        res = dpt.where(condition, ar1, ar2)
+        res = dpt.where(condition, ar1, ar2, order="K")
         assert res.strides == (20, 1)
 
 

--- a/dpctl/tests/test_usm_ndarray_search_functions.py
+++ b/dpctl/tests/test_usm_ndarray_search_functions.py
@@ -466,12 +466,14 @@ def test_where_out():
     assert dpt.all(res[:, 3, :] == ar1[:, 3, :])
 
     condition = dpt.tile(
-        dpt.reshape(dpt.asarray([True, False], dtype="?"), (1, 2, 1)),
+        dpt.reshape(dpt.asarray([1, 0], dtype="i4"), (1, 2, 1)),
         (n1, 2, n3),
     )
-    res = dpt.where(condition, condition, condition[:, ::-1, :], out=condition)
+    res = dpt.where(
+        condition[:, ::-1, :], condition[:, ::-1, :], condition, out=condition
+    )
     assert dpt.all(res == condition)
-    assert dpt.all(condition)
+    assert dpt.all(condition == 1)
 
     condition = dpt.tile(
         dpt.reshape(dpt.asarray([True, False], dtype="?"), (1, 2, 1)),
@@ -479,10 +481,10 @@ def test_where_out():
     )
     ar1 = dpt.full((n1, n2, n3), 7, dtype="i4")
     ar2 = dpt.full_like(ar1, -5)
-    res = dpt.where(condition, ar1, ar2, out=ar2)
-    assert dpt.all(ar2 == res)
-    assert dpt.all(ar2[:, ::2, :] == 7)
-    assert dpt.all(ar2[:, 1::2, :] == -5)
+    res = dpt.where(condition, ar1, ar2, out=ar2[:, ::-1, :])
+    assert dpt.all(ar2[:, ::-1, :] == res)
+    assert dpt.all(ar2[:, ::2, :] == -5)
+    assert dpt.all(ar2[:, 1::2, :] == 7)
 
     condition = dpt.tile(
         dpt.reshape(dpt.asarray([True, False], dtype="?"), (1, 2, 1)),
@@ -490,10 +492,10 @@ def test_where_out():
     )
     ar1 = dpt.full((n1, n2, n3), 7, dtype="i4")
     ar2 = dpt.full_like(ar1, -5)
-    res = dpt.where(condition, ar1, ar2, out=ar1)
-    assert dpt.all(ar1 == res)
-    assert dpt.all(ar1[:, ::2, :] == 7)
-    assert dpt.all(ar1[:, 1::2, :] == -5)
+    res = dpt.where(condition, ar1, ar2, out=ar1[:, ::-1, :])
+    assert dpt.all(ar1[:, ::-1, :] == res)
+    assert dpt.all(ar1[:, ::2, :] == -5)
+    assert dpt.all(ar1[:, 1::2, :] == 7)
 
 
 def test_where_out_arg_validation():


### PR DESCRIPTION
This pull request proposes building on the set of functions supporting the `out` keyword in dpctl. Specifically, this pull request implements this keyword in all reductions (e.g., `sum`, `max`, `argmax`) and `where`. This paves the way for statistical functions to support the keyword, and may make some function calls more efficient.

This pull request also implements the `order` keyword in `where`, now defaulting to `order="K"` behavior rather than `order="A"`.

- [X] Have you provided a meaningful PR description?
- [X] Have you added a test, reproducer or referred to an issue with a reproducer?
- [X] Have you tested your changes locally for CPU and GPU devices?
- [X] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
