### PR TITLE
Avoid sycl::queue copying in libtensor

### DIFF
--- a/dpctl/tensor/libtensor/include/kernels/reductions.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/reductions.hpp
@@ -2383,7 +2383,7 @@ public:
 };
 
 typedef sycl::event (*search_strided_impl_fn_ptr)(
-    sycl::queue,
+    sycl::queue &,
     size_t,
     size_t,
     const char *,
@@ -2507,7 +2507,7 @@ template <typename argTy,
           typename ReductionOpT,
           typename IndexOpT>
 sycl::event search_over_group_temps_strided_impl(
-    sycl::queue exec_q,
+    sycl::queue &exec_q,
     size_t iter_nelems, // number of reductions    (num. of rows in a matrix
                         // when reducing over rows)
     size_t reduction_nelems, // size of each reduction  (length of rows, i.e.
@@ -2804,7 +2804,7 @@ sycl::event search_over_group_temps_strided_impl(
 }
 
 typedef sycl::event (*search_contig_impl_fn_ptr)(
-    sycl::queue,
+    sycl::queue &,
     size_t,
     size_t,
     const char *,
@@ -2819,7 +2819,7 @@ template <typename argTy,
           typename ReductionOpT,
           typename IndexOpT>
 sycl::event search_axis1_over_group_temps_contig_impl(
-    sycl::queue exec_q,
+    sycl::queue &exec_q,
     size_t iter_nelems, // number of reductions    (num. of rows in a matrix
                         // when reducing over rows)
     size_t reduction_nelems, // size of each reduction  (length of rows, i.e.
@@ -3098,7 +3098,7 @@ template <typename argTy,
           typename ReductionOpT,
           typename IndexOpT>
 sycl::event search_axis0_over_group_temps_contig_impl(
-    sycl::queue exec_q,
+    sycl::queue &exec_q,
     size_t iter_nelems, // number of reductions    (num. of rows in a matrix
                         // when reducing over rows)
     size_t reduction_nelems, // size of each reduction  (length of rows, i.e.

--- a/dpctl/tensor/libtensor/source/device_support_queries.cpp
+++ b/dpctl/tensor/libtensor/source/device_support_queries.cpp
@@ -82,7 +82,7 @@ sycl::device _extract_device(const py::object &arg)
 
     PyObject *source = arg.ptr();
     if (api.PySyclQueue_Check_(source)) {
-        sycl::queue q = py::cast<sycl::queue>(arg);
+        const sycl::queue &q = py::cast<sycl::queue>(arg);
         return q.get_device();
     }
     else if (api.PySyclDevice_Check_(source)) {
@@ -98,31 +98,31 @@ sycl::device _extract_device(const py::object &arg)
 
 std::string default_device_fp_type(const py::object &arg)
 {
-    sycl::device d = _extract_device(arg);
+    const sycl::device &d = _extract_device(arg);
     return _default_device_fp_type(d);
 }
 
 std::string default_device_int_type(const py::object &arg)
 {
-    sycl::device d = _extract_device(arg);
+    const sycl::device &d = _extract_device(arg);
     return _default_device_int_type(d);
 }
 
 std::string default_device_bool_type(const py::object &arg)
 {
-    sycl::device d = _extract_device(arg);
+    const sycl::device &d = _extract_device(arg);
     return _default_device_bool_type(d);
 }
 
 std::string default_device_complex_type(const py::object &arg)
 {
-    sycl::device d = _extract_device(arg);
+    const sycl::device &d = _extract_device(arg);
     return _default_device_complex_type(d);
 }
 
 std::string default_device_index_type(const py::object &arg)
 {
-    sycl::device d = _extract_device(arg);
+    const sycl::device &d = _extract_device(arg);
     return _default_device_index_type(d);
 }
 

--- a/dpctl/tensor/libtensor/source/elementwise_functions/elementwise_functions.hpp
+++ b/dpctl/tensor/libtensor/source/elementwise_functions/elementwise_functions.hpp
@@ -63,7 +63,7 @@ template <typename output_typesT,
 std::pair<sycl::event, sycl::event>
 py_unary_ufunc(const dpctl::tensor::usm_ndarray &src,
                const dpctl::tensor::usm_ndarray &dst,
-               sycl::queue q,
+               sycl::queue &q,
                const std::vector<sycl::event> &depends,
                //
                const output_typesT &output_type_vec,
@@ -301,7 +301,7 @@ std::pair<sycl::event, sycl::event> py_binary_ufunc(
     const dpctl::tensor::usm_ndarray &src1,
     const dpctl::tensor::usm_ndarray &src2,
     const dpctl::tensor::usm_ndarray &dst, // dst = op(src1, src2), elementwise
-    sycl::queue exec_q,
+    sycl::queue &exec_q,
     const std::vector<sycl::event> depends,
     //
     const output_typesT &output_type_table,
@@ -622,7 +622,7 @@ template <typename output_typesT,
 std::pair<sycl::event, sycl::event>
 py_binary_inplace_ufunc(const dpctl::tensor::usm_ndarray &lhs,
                         const dpctl::tensor::usm_ndarray &rhs,
-                        sycl::queue exec_q,
+                        sycl::queue &exec_q,
                         const std::vector<sycl::event> depends,
                         //
                         const output_typesT &output_type_table,


### PR DESCRIPTION
Changed signatures functions to take ``sycl::queue `` argument by reference, not by value.

Since ``sycl::queue`` contains a shared pointer inside, copying it involves operating atomic variable, and hence should be avoided if possible.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [x] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
