### PR TITLE
Fix logic when built docs are published to gh-pages

### DIFF
--- a/.github/workflows/generate-docs.yml
+++ b/.github/workflows/generate-docs.yml
@@ -86,7 +86,7 @@ jobs:
           popd
           git reset --hard
       - name: Publish docs
-        if: ${{ github.event.pull_request && !github.event.pull_request.head.repo.fork && github.ref == 'refs/heads/master' && github.event.action != 'closed' }}
+        if: ${{ !github.event.pull_request && github.ref == 'refs/heads/master' }}
         shell: bash -l {0}
         run: |
           git remote add tokened_docs https://IntelPython:${{ secrets.GITHUB_TOKEN }}@github.com/IntelPython/dpctl.git


### PR DESCRIPTION
gh-1377 has made changes to condition of executing "Publish Docs" step which resulted in that condition always evaluating to False, and documentation changes were not uploaded for 8 months since the merge of that PR.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
