### PR TITLE
Type promotion for `indices` arrays and casting `vals` in integer indexing

### DIFF
--- a/dpctl/tensor/_copy_utils.py
+++ b/dpctl/tensor/_copy_utils.py
@@ -813,8 +813,7 @@ def _take_multi_index(ary, inds, p):
     ind0 = inds[0]
     ary_sh = ary.shape
     p_end = p + len(inds)
-    inds_sz = ind0.size
-    if 0 in ary_sh[p:p_end] and inds_sz != 0:
+    if 0 in ary_sh[p:p_end] and ind0.size != 0:
         raise IndexError("cannot take non-empty indices from an empty axis")
     res_shape = ary_sh[:p] + ind0.shape + ary_sh[p_end:]
     res = dpt.empty(
@@ -949,8 +948,7 @@ def _put_multi_index(ary, inds, p, vals):
     ind0 = inds[0]
     ary_sh = ary.shape
     p_end = p + len(inds)
-    inds_sz = ind0.size
-    if 0 in ary_sh[p:p_end] and inds_sz != 0:
+    if 0 in ary_sh[p:p_end] and ind0.size != 0:
         raise IndexError(
             "cannot put into non-empty indices along an empty axis"
         )

--- a/dpctl/tensor/_copy_utils.py
+++ b/dpctl/tensor/_copy_utils.py
@@ -814,7 +814,7 @@ def _take_multi_index(ary, inds, p):
     ary_sh = ary.shape
     p_end = p + len(inds)
     inds_sz = ind0.size
-    if 0 in ary_sh[p : p_end + 1] and inds_sz != 0:
+    if 0 in ary_sh[p:p_end] and inds_sz != 0:
         raise IndexError("cannot take non-empty indices from an empty axis")
     res_shape = ary_sh[:p] + ind0.shape + ary_sh[p_end:]
     res = dpt.empty(
@@ -950,8 +950,10 @@ def _put_multi_index(ary, inds, p, vals):
     ary_sh = ary.shape
     p_end = p + len(inds)
     inds_sz = ind0.size
-    if 0 in ary_sh[p : p_end + 1] and inds_sz != 0:
-        raise IndexError("cannot put into non-empty indices from an empty axis")
+    if 0 in ary_sh[p:p_end] and inds_sz != 0:
+        raise IndexError(
+            "cannot put into non-empty indices along an empty axis"
+        )
     expected_vals_shape = ary_sh[:p] + ind0.shape + ary_sh[p_end:]
     if vals.dtype == ary.dtype:
         rhs = vals

--- a/dpctl/tensor/libtensor/source/integer_advanced_indexing.cpp
+++ b/dpctl/tensor/libtensor/source/integer_advanced_indexing.cpp
@@ -414,6 +414,10 @@ usm_ndarray_take(const dpctl::tensor::usm_ndarray &src,
         ind_offsets.push_back(py::ssize_t(0));
     }
 
+    if (ind_nelems == 0) {
+        return std::make_pair(sycl::event{}, sycl::event{});
+    }
+
     char **packed_ind_ptrs = sycl::malloc_device<char *>(k, exec_q);
 
     if (packed_ind_ptrs == nullptr) {
@@ -715,6 +719,10 @@ usm_ndarray_put(const dpctl::tensor::usm_ndarray &dst,
 
         ind_ptrs.push_back(ind_data);
         ind_offsets.push_back(py::ssize_t(0));
+    }
+
+    if (ind_nelems == 0) {
+        return std::make_pair(sycl::event{}, sycl::event{});
     }
 
     char **packed_ind_ptrs = sycl::malloc_device<char *>(k, exec_q);


### PR DESCRIPTION
This pull request proposes resolutions to #1360, #1382, and #1482 by changing the behavior of advanced indexing and indexing functions.

- `x[i_0, i_1, ...]` now promotes arrays `i_0 ... i_N` to an appropriate integer data type, and only raises where such a data type cannot be found
- `x[indices] = vals` now casts `vals` to the data type of `x` regardless of type. This aligns with `place`/boolean indexing.
- `dpt.put` now warns the user about race conditions when indices are not unique

Additionally, this PR implements changes to `take`, `put`, and generalized advanced integer indexing which handle cases where empty axes are being indexed.

- [X] Have you provided a meaningful PR description?
- [X] Have you added a test, reproducer or referred to an issue with a reproducer?
- [X] Have you tested your changes locally for CPU and GPU devices?
- [X] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
