### PR TITLE
Expanded intel_device_info output

### DIFF
--- a/dpctl/tests/test_utils.py
+++ b/dpctl/tests/test_utils.py
@@ -141,6 +141,9 @@ def test_intel_device_info():
         "gpu_subslices_per_slice",
         "gpu_eu_count_per_subslice",
         "max_mem_bandwidth",
+        "free_memory",
+        "memory_clock_rate",
+        "memory_bus_width",
     ]
     for descriptor_name in descr.keys():
         test = descriptor_name in allowed_names

--- a/dpctl/utils/__init__.py
+++ b/dpctl/utils/__init__.py
@@ -72,6 +72,10 @@ def intel_device_info(dev, /):
 
     Descriptors other than the PCI identifier are supported only
     for :class:`.SyclDevices` with Level-Zero backend.
+
+    .. note::
+        Environment variable ``ZES_ENABLE_SYSMAN`` may need to be set
+        to ``1`` for the ``"free_memory"`` key to be reported.
     """
     if not isinstance(dev, SyclDevice):
         raise TypeError(f"Expected dpctl.SyclDevice, got {type(dev)}")

--- a/dpctl/utils/__init__.py
+++ b/dpctl/utils/__init__.py
@@ -27,6 +27,7 @@ from ._compute_follows_data import (
 )
 from ._device_queries import (
     intel_device_info_device_id,
+    intel_device_info_free_memory,
     intel_device_info_gpu_eu_count,
     intel_device_info_gpu_eu_count_per_subslice,
     intel_device_info_gpu_eu_simd_width,
@@ -34,6 +35,8 @@ from ._device_queries import (
     intel_device_info_gpu_slices,
     intel_device_info_gpu_subslices_per_slice,
     intel_device_info_max_mem_bandwidth,
+    intel_device_info_memory_bus_width,
+    intel_device_info_memory_clock_rate,
 )
 from ._onetrace_context import onetrace_enabled
 
@@ -62,6 +65,8 @@ def intel_device_info(dev, /):
         Number of EUs in subslice
     max_mem_bandwidth:
         Maximum memory bandwidth in bytes/second
+    free_memory:
+        Global memory available on the device in units of bytes
 
     Unsupported descriptors are omitted from the dictionary.
 
@@ -97,6 +102,15 @@ def intel_device_info(dev, /):
         bw = intel_device_info_max_mem_bandwidth(dev)
         if bw:
             res["max_mem_bandwidth"] = bw
+        fm = intel_device_info_free_memory(dev)
+        if fm:
+            res["free_memory"] = fm
+        mcr = intel_device_info_memory_clock_rate(dev)
+        if mcr:
+            res["memory_clock_rate"] = mcr
+        mbw = intel_device_info_memory_bus_width(dev)
+        if mbw:
+            res["memory_bus_width"] = mbw
         return res
     return dict()
 

--- a/dpctl/utils/src/device_queries.cpp
+++ b/dpctl/utils/src/device_queries.cpp
@@ -168,7 +168,7 @@ PYBIND11_MODULE(_device_queries, m)
           py::arg("device"));
 
     m.def("intel_device_info_free_memory", &py_intel_free_memory,
-          "Returns the memory avialble on the device in units of bytes.",
+          "Returns the memory available on the device in units of bytes.",
           py::arg("device"));
 
     m.def("intel_device_info_memory_clock_rate", &py_intel_memory_clock_rate,

--- a/dpctl/utils/src/device_queries.cpp
+++ b/dpctl/utils/src/device_queries.cpp
@@ -100,6 +100,36 @@ std::uint64_t py_intel_max_mem_bandwidth(const sycl::device &d)
     return bandwidth_unavailable;
 }
 
+std::uint64_t py_intel_free_memory(const sycl::device &d)
+{
+    static constexpr std::uint64_t free_memory_unavailable = 0;
+
+    if (d.has(sycl::aspect::ext_intel_free_memory)) {
+        return d.get_info<sycl::ext::intel::info::device::free_memory>();
+    }
+    return free_memory_unavailable;
+}
+
+std::uint32_t py_intel_memory_clock_rate(const sycl::device &d)
+{
+    static constexpr std::uint32_t rate_unavailable = 0;
+
+    if (d.has(sycl::aspect::ext_intel_memory_clock_rate)) {
+        return d.get_info<sycl::ext::intel::info::device::memory_clock_rate>();
+    }
+    return rate_unavailable;
+}
+
+std::uint32_t py_intel_memory_bus_width(const sycl::device &d)
+{
+    static constexpr std::uint32_t width_unavailable = 0;
+
+    if (d.has(sycl::aspect::ext_intel_memory_bus_width)) {
+        return d.get_info<sycl::ext::intel::info::device::memory_bus_width>();
+    }
+    return width_unavailable;
+}
+
 }; // namespace
 
 PYBIND11_MODULE(_device_queries, m)
@@ -135,5 +165,17 @@ PYBIND11_MODULE(_device_queries, m)
 
     m.def("intel_device_info_max_mem_bandwidth", &py_intel_max_mem_bandwidth,
           "Returns the maximum memory bandwidth in units of bytes/second.",
+          py::arg("device"));
+
+    m.def("intel_device_info_free_memory", &py_intel_free_memory,
+          "Returns the memory avialble on the device in units of bytes.",
+          py::arg("device"));
+
+    m.def("intel_device_info_memory_clock_rate", &py_intel_memory_clock_rate,
+          "Returns the maximum clock rate of device's global memory in MHz.",
+          py::arg("device"));
+
+    m.def("intel_device_info_memory_bus_width", &py_intel_memory_bus_width,
+          "Returns the maximum bus width between device and memory in bits.",
           py::arg("device"));
 }


### PR DESCRIPTION
Added `"free_memory"` for Free Global Memory on the device in bytes, `"memory_clock_rate"` for Maximum Memory Clock Rate in MHz, and `"memory_bus_width"` for bus width in bits.

Additions come from https://github.com/intel/llvm/blob/sycl/sycl/doc/extensions/supported/sycl_ext_intel_device_info.md

- [x] Have you provided a meaningful PR description?
- [x] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
