### PR TITLE
Changes test_func_order tests for some unary functions

### DIFF
--- a/dpctl/tests/elementwise/test_abs.py
+++ b/dpctl/tests/elementwise/test_abs.py
@@ -84,18 +84,19 @@ def test_abs_order(dtype):
     skip_if_dtype_not_supported(dtype, q)
 
     arg_dt = np.dtype(dtype)
+    exp_dt = np.abs(np.ones(tuple(), dtype=arg_dt)).dtype
     input_shape = (10, 10, 10, 10)
     X = dpt.empty(input_shape, dtype=arg_dt, sycl_queue=q)
     X[..., 0::2] = 1
     X[..., 1::2] = 0
 
-    for ord in ["C", "F", "A", "K"]:
-        for perms in itertools.permutations(range(4)):
-            U = dpt.permute_dims(X[:, ::-1, ::-1, :], perms)
+    for perms in itertools.permutations(range(4)):
+        U = dpt.permute_dims(X[:, ::-1, ::-1, :], perms)
+        expected_Y = np.ones(U.shape, dtype=exp_dt)
+        expected_Y[..., 1::2] = 0
+        expected_Y = np.transpose(expected_Y, perms)
+        for ord in ["C", "F", "A", "K"]:
             Y = dpt.abs(U, order=ord)
-            expected_Y = np.ones(Y.shape, dtype=Y.dtype)
-            expected_Y[..., 1::2] = 0
-            expected_Y = np.transpose(expected_Y, perms)
             assert np.allclose(dpt.asnumpy(Y), expected_Y)
 
 

--- a/dpctl/tests/elementwise/test_complex.py
+++ b/dpctl/tests/elementwise/test_complex.py
@@ -120,7 +120,7 @@ def test_complex_order(np_call, dpt_call, dtype):
         expected_Y = np_call(dpt.asnumpy(U))
         for ord in ["C", "F", "A", "K"]:
             Y = dpt_call(U, order=ord)
-            assert np.allclose(dpt.asnumpy(Y), expected_Y)
+            assert_allclose(dpt.asnumpy(Y), expected_Y)
 
 
 @pytest.mark.parametrize("dtype", ["c8", "c16"])

--- a/dpctl/tests/elementwise/test_exp2.py
+++ b/dpctl/tests/elementwise/test_exp2.py
@@ -103,11 +103,11 @@ def test_exp2_order(dtype):
     X[..., 0::2] = 1 / 4
     X[..., 1::2] = 1 / 2
 
-    for ord in ["C", "F", "A", "K"]:
-        for perms in itertools.permutations(range(4)):
-            U = dpt.permute_dims(X[:, ::-1, ::-1, :], perms)
+    for perms in itertools.permutations(range(4)):
+        U = dpt.permute_dims(X[:, ::-1, ::-1, :], perms)
+        expected_Y = np.exp2(dpt.asnumpy(U))
+        for ord in ["C", "F", "A", "K"]:
             Y = dpt.exp2(U, order=ord)
-            expected_Y = np.exp2(dpt.asnumpy(U))
             tol = 8 * max(
                 dpt.finfo(Y.dtype).resolution,
                 np.finfo(expected_Y.dtype).resolution,

--- a/dpctl/tests/elementwise/test_expm1.py
+++ b/dpctl/tests/elementwise/test_expm1.py
@@ -103,11 +103,11 @@ def test_expm1_order(dtype):
     X[..., 0::2] = 1 / 50
     X[..., 1::2] = 1 / 25
 
-    for ord in ["C", "F", "A", "K"]:
-        for perms in itertools.permutations(range(4)):
-            U = dpt.permute_dims(X[:, ::-1, ::-1, :], perms)
+    for perms in itertools.permutations(range(4)):
+        U = dpt.permute_dims(X[:, ::-1, ::-1, :], perms)
+        expected_Y = np.expm1(dpt.asnumpy(U))
+        for ord in ["C", "F", "A", "K"]:
             Y = dpt.expm1(U, order=ord)
-            expected_Y = np.expm1(dpt.asnumpy(U))
             tol = 8 * max(
                 dpt.finfo(Y.dtype).resolution,
                 np.finfo(expected_Y.dtype).resolution,

--- a/dpctl/tests/elementwise/test_isfinite.py
+++ b/dpctl/tests/elementwise/test_isfinite.py
@@ -18,6 +18,7 @@ import itertools
 
 import numpy as np
 import pytest
+from numpy.testing import assert_allclose
 
 import dpctl.tensor as dpt
 from dpctl.tests.helper import get_queue_or_skip, skip_if_dtype_not_supported
@@ -90,9 +91,9 @@ def test_isfinite_order(dtype):
     input_shape = (10, 10, 10, 10)
     X = dpt.ones(input_shape, dtype=arg_dt, sycl_queue=q)
 
-    for ord in ["C", "F", "A", "K"]:
-        for perms in itertools.permutations(range(4)):
-            U = dpt.permute_dims(X[::2, ::-1, ::-1, ::5], perms)
+    for perms in itertools.permutations(range(4)):
+        U = dpt.permute_dims(X[::2, ::-1, ::-1, ::5], perms)
+        expected_Y = np.full(U.shape, fill_value=True, dtype=dpt.bool)
+        for ord in ["C", "F", "A", "K"]:
             Y = dpt.isfinite(U, order=ord)
-            expected_Y = np.full(Y.shape, True, dtype=Y.dtype)
-            assert np.allclose(dpt.asnumpy(Y), expected_Y)
+            assert_allclose(dpt.asnumpy(Y), expected_Y)

--- a/dpctl/tests/elementwise/test_isinf.py
+++ b/dpctl/tests/elementwise/test_isinf.py
@@ -18,6 +18,7 @@ import itertools
 
 import numpy as np
 import pytest
+from numpy.testing import assert_allclose
 
 import dpctl.tensor as dpt
 from dpctl.tests.helper import get_queue_or_skip, skip_if_dtype_not_supported
@@ -84,9 +85,9 @@ def test_isinf_order(dtype):
     input_shape = (10, 10, 10, 10)
     X = dpt.ones(input_shape, dtype=arg_dt, sycl_queue=q)
 
-    for ord in ["C", "F", "A", "K"]:
-        for perms in itertools.permutations(range(4)):
-            U = dpt.permute_dims(X[::2, ::-1, ::-1, ::5], perms)
+    for perms in itertools.permutations(range(4)):
+        U = dpt.permute_dims(X[::2, ::-1, ::-1, ::5], perms)
+        expected_Y = np.full(U.shape, fill_value=False, dtype=dpt.bool)
+        for ord in ["C", "F", "A", "K"]:
             Y = dpt.isinf(U, order=ord)
-            expected_Y = np.full(Y.shape, False, dtype=Y.dtype)
-            assert np.allclose(dpt.asnumpy(Y), expected_Y)
+            assert_allclose(dpt.asnumpy(Y), expected_Y)

--- a/dpctl/tests/elementwise/test_isnan.py
+++ b/dpctl/tests/elementwise/test_isnan.py
@@ -90,9 +90,9 @@ def test_isnan_order(dtype):
     input_shape = (10, 10, 10, 10)
     X = dpt.ones(input_shape, dtype=arg_dt, sycl_queue=q)
 
-    for ord in ["C", "F", "A", "K"]:
-        for perms in itertools.permutations(range(4)):
-            U = dpt.permute_dims(X[::2, ::-1, ::-1, ::5], perms)
+    for perms in itertools.permutations(range(4)):
+        U = dpt.permute_dims(X[::2, ::-1, ::-1, ::5], perms)
+        expected_Y = np.full(U.shape, fill_value=False, dtype=dpt.bool)
+        for ord in ["C", "F", "A", "K"]:
             Y = dpt.isnan(U, order=ord)
-            expected_Y = np.full(Y.shape, False, dtype=Y.dtype)
             assert np.allclose(dpt.asnumpy(Y), expected_Y)

--- a/dpctl/tests/elementwise/test_log.py
+++ b/dpctl/tests/elementwise/test_log.py
@@ -103,11 +103,11 @@ def test_log_order(dtype):
     X[..., 0::2] = 4 * dpt.e
     X[..., 1::2] = 10 * dpt.e
 
-    for ord in ["C", "F", "A", "K"]:
-        for perms in itertools.permutations(range(4)):
-            U = dpt.permute_dims(X[:, ::-1, ::-1, :], perms)
+    for perms in itertools.permutations(range(4)):
+        U = dpt.permute_dims(X[:, ::-1, ::-1, :], perms)
+        expected_Y = np.log(dpt.asnumpy(U))
+        for ord in ["C", "F", "A", "K"]:
             Y = dpt.log(U, order=ord)
-            expected_Y = np.log(dpt.asnumpy(U))
             tol = 8 * max(
                 dpt.finfo(Y.dtype).resolution,
                 np.finfo(expected_Y.dtype).resolution,

--- a/dpctl/tests/elementwise/test_log10.py
+++ b/dpctl/tests/elementwise/test_log10.py
@@ -107,11 +107,11 @@ def test_log_order(dtype):
     X[..., 0::2] = 4 * dpt.e
     X[..., 1::2] = 10 * dpt.e
 
-    for ord in ["C", "F", "A", "K"]:
-        for perms in itertools.permutations(range(4)):
-            U = dpt.permute_dims(X[:, ::-1, ::-1, :], perms)
+    for perms in itertools.permutations(range(4)):
+        U = dpt.permute_dims(X[:, ::-1, ::-1, :], perms)
+        expected_Y = np.log10(dpt.asnumpy(U))
+        for ord in ["C", "F", "A", "K"]:
             Y = dpt.log10(U, order=ord)
-            expected_Y = np.log10(dpt.asnumpy(U))
             tol = 8 * max(
                 dpt.finfo(Y.dtype).resolution,
                 np.finfo(expected_Y.dtype).resolution,

--- a/dpctl/tests/elementwise/test_log1p.py
+++ b/dpctl/tests/elementwise/test_log1p.py
@@ -103,11 +103,11 @@ def test_log1p_order(dtype):
     X[..., 0::2] = dpt.e / 1000
     X[..., 1::2] = dpt.e / 100
 
-    for ord in ["C", "F", "A", "K"]:
-        for perms in itertools.permutations(range(4)):
-            U = dpt.permute_dims(X[:, ::-1, ::-1, :], perms)
+    for perms in itertools.permutations(range(4)):
+        U = dpt.permute_dims(X[:, ::-1, ::-1, :], perms)
+        expected_Y = np.log1p(dpt.asnumpy(U))
+        for ord in ["C", "F", "A", "K"]:
             Y = dpt.log1p(U, order=ord)
-            expected_Y = np.log1p(dpt.asnumpy(U))
             tol = 8 * max(
                 dpt.finfo(Y.dtype).resolution,
                 np.finfo(expected_Y.dtype).resolution,

--- a/dpctl/tests/elementwise/test_log2.py
+++ b/dpctl/tests/elementwise/test_log2.py
@@ -103,11 +103,11 @@ def test_log_order(dtype):
     X[..., 0::2] = 4 * dpt.e
     X[..., 1::2] = 10 * dpt.e
 
-    for ord in ["C", "F", "A", "K"]:
-        for perms in itertools.permutations(range(4)):
-            U = dpt.permute_dims(X[:, ::-1, ::-1, :], perms)
+    for perms in itertools.permutations(range(4)):
+        U = dpt.permute_dims(X[:, ::-1, ::-1, :], perms)
+        expected_Y = np.log2(dpt.asnumpy(U))
+        for ord in ["C", "F", "A", "K"]:
             Y = dpt.log2(U, order=ord)
-            expected_Y = np.log2(dpt.asnumpy(U))
             tol = 8 * max(
                 dpt.finfo(Y.dtype).resolution,
                 np.finfo(expected_Y.dtype).resolution,

--- a/dpctl/tests/elementwise/test_negative.py
+++ b/dpctl/tests/elementwise/test_negative.py
@@ -76,11 +76,11 @@ def test_negative_order(dtype):
     X[..., 0::2] = 1
     X[..., 1::2] = 0
 
-    for ord in ["C", "F", "A", "K"]:
-        for perms in itertools.permutations(range(4)):
-            U = dpt.permute_dims(X[:, ::-1, ::-1, :], perms)
+    for perms in itertools.permutations(range(4)):
+        U = dpt.permute_dims(X[:, ::-1, ::-1, :], perms)
+        expected_Y = np.negative(np.ones(U.shape, dtype=U.dtype))
+        expected_Y[..., 1::2] = 0
+        expected_Y = np.transpose(expected_Y, perms)
+        for ord in ["C", "F", "A", "K"]:
             Y = dpt.negative(U, order=ord)
-            expected_Y = np.negative(np.ones(Y.shape, dtype=Y.dtype))
-            expected_Y[..., 1::2] = 0
-            expected_Y = np.transpose(expected_Y, perms)
             assert np.allclose(dpt.asnumpy(Y), expected_Y)

--- a/dpctl/tests/elementwise/test_positive.py
+++ b/dpctl/tests/elementwise/test_positive.py
@@ -69,11 +69,11 @@ def test_positive_order(dtype):
     X[..., 0::2] = 1
     X[..., 1::2] = 0
 
-    for ord in ["C", "F", "A", "K"]:
-        for perms in itertools.permutations(range(4)):
-            U = dpt.permute_dims(X[:, ::-1, ::-1, :], perms)
+    for perms in itertools.permutations(range(4)):
+        U = dpt.permute_dims(X[:, ::-1, ::-1, :], perms)
+        expected_Y = np.ones(U.shape, dtype=U.dtype)
+        expected_Y[..., 1::2] = 0
+        expected_Y = np.transpose(expected_Y, perms)
+        for ord in ["C", "F", "A", "K"]:
             Y = dpt.positive(U, order=ord)
-            expected_Y = np.ones(Y.shape, dtype=Y.dtype)
-            expected_Y[..., 1::2] = 0
-            expected_Y = np.transpose(expected_Y, perms)
             assert np.allclose(dpt.asnumpy(Y), expected_Y)

--- a/dpctl/tests/elementwise/test_sign.py
+++ b/dpctl/tests/elementwise/test_sign.py
@@ -64,18 +64,19 @@ def test_sign_order(dtype):
     skip_if_dtype_not_supported(dtype, q)
 
     arg_dt = np.dtype(dtype)
+    expected_dt = np.sign(np.ones(tuple(), dtype=arg_dt)).dtype
     input_shape = (10, 10, 10, 10)
     X = dpt.empty(input_shape, dtype=arg_dt, sycl_queue=q)
     X[..., 0::2] = 1
     X[..., 1::2] = 0
 
-    for ord in ["C", "F", "A", "K"]:
-        for perms in itertools.permutations(range(4)):
-            U = dpt.permute_dims(X[:, ::-1, ::-1, :], perms)
+    for perms in itertools.permutations(range(4)):
+        U = dpt.permute_dims(X[:, ::-1, ::-1, :], perms)
+        expected_Y = np.ones(U.shape, dtype=expected_dt)
+        expected_Y[..., 1::2] = 0
+        expected_Y = np.transpose(expected_Y, perms)
+        for ord in ["C", "F", "A", "K"]:
             Y = dpt.sign(U, order=ord)
-            expected_Y = np.ones(Y.shape, dtype=Y.dtype)
-            expected_Y[..., 1::2] = 0
-            expected_Y = np.transpose(expected_Y, perms)
             assert np.allclose(dpt.asnumpy(Y), expected_Y)
 
 

--- a/dpctl/tests/elementwise/test_sqrt.py
+++ b/dpctl/tests/elementwise/test_sqrt.py
@@ -110,11 +110,11 @@ def test_sqrt_order(dtype):
     X[..., 0::2] = 16.0
     X[..., 1::2] = 23.0
 
-    for ord in ["C", "F", "A", "K"]:
-        for perms in itertools.permutations(range(4)):
-            U = dpt.permute_dims(X[:, ::-1, ::-1, :], perms)
+    for perms in itertools.permutations(range(4)):
+        U = dpt.permute_dims(X[:, ::-1, ::-1, :], perms)
+        expected_Y = np.sqrt(dpt.asnumpy(U))
+        for ord in ["C", "F", "A", "K"]:
             Y = dpt.sqrt(U, order=ord)
-            expected_Y = np.sqrt(dpt.asnumpy(U))
             tol = 8 * max(
                 dpt.finfo(Y.dtype).resolution,
                 np.finfo(expected_Y.dtype).resolution,

--- a/dpctl/tests/elementwise/test_square.py
+++ b/dpctl/tests/elementwise/test_square.py
@@ -69,13 +69,13 @@ def test_square_order(dtype):
     X[..., 0::2] = 2
     X[..., 1::2] = 0
 
-    for ord in ["C", "F", "A", "K"]:
-        for perms in itertools.permutations(range(4)):
-            U = dpt.permute_dims(X[:, ::-1, ::-1, :], perms)
+    for perms in itertools.permutations(range(4)):
+        U = dpt.permute_dims(X[:, ::-1, ::-1, :], perms)
+        expected_Y = np.full(U.shape, 4, dtype=U.dtype)
+        expected_Y[..., 1::2] = 0
+        expected_Y = np.transpose(expected_Y, perms)
+        for ord in ["C", "F", "A", "K"]:
             Y = dpt.square(U, order=ord)
-            expected_Y = np.full(Y.shape, 4, dtype=Y.dtype)
-            expected_Y[..., 1::2] = 0
-            expected_Y = np.transpose(expected_Y, perms)
             assert np.allclose(dpt.asnumpy(Y), expected_Y)
 
 


### PR DESCRIPTION
The change is to iterate over permutations first, doing some work that does not depend on the order, and then iterate over orders.

This should save doing some computations 4 times (once for each order), now only done once.

The change shaves 4 seconds off of execution of entire test suite on CPU device (from 5 minutes 6 seconds to 5 minutes and 2 seconds).

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [x] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
