### PR TITLE
Initialize `UAR_BYTE_` and `UAR_UBYTE_` in `dpctl_capi`

### DIFF
--- a/dpctl/apis/include/dpctl4pybind11.hpp
+++ b/dpctl/apis/include/dpctl4pybind11.hpp
@@ -331,6 +331,8 @@ private:
         this->USM_ARRAY_F_CONTIGUOUS_ = USM_ARRAY_F_CONTIGUOUS;
         this->USM_ARRAY_WRITABLE_ = USM_ARRAY_WRITABLE;
         this->UAR_BOOL_ = UAR_BOOL;
+        this->UAR_BYTE_ = UAR_BYTE;
+        this->UAR_UBYTE_ = UAR_UBYTE;
         this->UAR_SHORT_ = UAR_SHORT;
         this->UAR_USHORT_ = UAR_USHORT;
         this->UAR_INT_ = UAR_INT;


### PR DESCRIPTION
This PR fixes two uninitialized typenums in `dpctl_capi` for `UAR_BYTE_` and `UAR_UBYTE_`.

It was noticed during extension writing that these variables are initialized to -1 and never set to the proper values.

- [X] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [X] Have you tested your changes locally for CPU and GPU devices?
- [X] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
