### PR TITLE
Update wheel tag with pep600

### DIFF
--- a/conda-recipe/build.sh
+++ b/conda-recipe/build.sh
@@ -17,7 +17,7 @@ echo "${PYTHON} setup.py install ${SKBUILD_ARGS}"
 
 if [ -n "${WHEELS_OUTPUT_FOLDER}" ]; then
     # Install packages and assemble wheel package from built bits
-    WHEELS_BUILD_ARGS="-p manylinux2014_x86_64 --build-number ${GIT_DESCRIBE_NUMBER}"
+    WHEELS_BUILD_ARGS="-p manylinux_2_28_x86_64 --build-number ${GIT_DESCRIBE_NUMBER}"
     ${PYTHON} setup.py install bdist_wheel ${WHEELS_BUILD_ARGS} ${SKBUILD_ARGS}
     cp dist/dpctl*.whl ${WHEELS_OUTPUT_FOLDER}
 else


### PR DESCRIPTION
This PR is designed to fix the problem described here: [SAT-6873](https://jira.devtools.intel.com/browse/SAT-6873). I did some experiments and found out that using pep600 wheel tag prevents the wheel from being installed on non-supported platforms

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
