### PR TITLE
Update docstring description of `axis` keyword in cumulative functions

### DIFF
--- a/dpctl/tensor/_accumulation.py
+++ b/dpctl/tensor/_accumulation.py
@@ -229,7 +229,7 @@ def cumulative_sum(
     Args:
         x (usm_ndarray):
             input array.
-        axis (Optional[int, Tuple[int, ...]]):
+        axis (Optional[int]):
             axis along which cumulative sum must be computed.
             If `None`, the sum is computed over the entire array.
             If `x` is a one-dimensional array, providing an `axis` is optional;
@@ -308,7 +308,7 @@ def cumulative_prod(
     Args:
         x (usm_ndarray):
             input array.
-        axis (Optional[int, Tuple[int, ...]]):
+        axis (Optional[int]):
             axis along which cumulative product must be computed.
             If `None`, the product is computed over the entire array.
             If `x` is a one-dimensional array, providing an `axis` is optional;
@@ -388,7 +388,7 @@ def cumulative_logsumexp(
     Args:
         x (usm_ndarray):
             input array.
-        axis (Optional[int, Tuple[int, ...]]):
+        axis (Optional[int]):
             axis along which cumulative logsumexp must be computed.
             If `None`, the logsumexp is computed over the entire array.
             If `x` is a one-dimensional array, providing an `axis` is optional;


### PR DESCRIPTION
The `axis` keyword in cumulative functions supported only as an integer. No support of a `axis` with tuple value is assumed.
The PR proposes to update the docstings description to reflect actual behavior.

- [ ] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
