### PR TITLE
Fix for crash reported in gh-1654

### DIFF
--- a/dpctl/tensor/libtensor/include/kernels/sorting/sort.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/sorting/sort.hpp
@@ -67,7 +67,7 @@ void merge_impl(const std::size_t offset,
     const std::size_t local_size_2 = local_end_2 - local_start_2;
 
     const auto r_item_1 = in_acc[end_1 - 1];
-    const auto l_item_2 = in_acc[start_2];
+    const auto l_item_2 = (start_2 < end_2) ? in_acc[start_2] : r_item_1;
 
     // Copy if the sequences are sorted with respect to each other or merge
     // otherwise


### PR DESCRIPTION
Closes gh-1654

The reason behind the crash was out of bound access to shared local memory accessor.

This also fixes a crash in `dpt.sort` on CUDA device for sorting of 256 elements of floating point numbers.

- [x] Have you provided a meaningful PR description?
- [x] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [x] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
