### PR TITLE
Reshape improvements

### DIFF
--- a/dpctl/tensor/_reshape.py
+++ b/dpctl/tensor/_reshape.py
@@ -177,6 +177,10 @@ def reshape(X, /, shape, *, order="C", copy=None):
             tuple(shape), dtype=X.dtype, buffer=flat_res, order=order
         )
     # can form a view
+    if (len(shape) == X.ndim) and all(
+        s1 == s2 for s1, s2 in zip(shape, X.shape)
+    ):
+        return X
     return dpt.usm_ndarray(
         shape,
         dtype=X.dtype,

--- a/dpctl/tests/test_usm_ndarray_ctor.py
+++ b/dpctl/tests/test_usm_ndarray_ctor.py
@@ -1471,6 +1471,16 @@ def test_reshape_orderF():
     assert np.array_equal(c_np, dpt.asnumpy(c))
 
 
+def test_reshape_noop():
+    """Per gh-1664"""
+    try:
+        a = dpt.ones((2, 1))
+    except dpctl.SyclDeviceCreationError:
+        pytest.skip("No SYCL devices available")
+    b = dpt.reshape(a, (2, 1))
+    assert b is a
+
+
 def test_reshape_zero_size():
     try:
         a = dpt.empty((0,))

--- a/dpctl/tests/test_usm_ndarray_ctor.py
+++ b/dpctl/tests/test_usm_ndarray_ctor.py
@@ -1454,6 +1454,23 @@ def test_reshape():
     assert A4.shape == requested_shape
 
 
+def test_reshape_orderF():
+    try:
+        a = dpt.arange(6 * 3 * 4, dtype="i4")
+    except dpctl.SyclDeviceCreationError:
+        pytest.skip("No SYCL devices available")
+    b = dpt.reshape(a, (6, 2, 6))
+    c = dpt.reshape(b, (9, 8), order="F")
+    assert c.flags.f_contiguous
+    assert c._pointer != b._pointer
+    assert b._pointer == a._pointer
+
+    a_np = np.arange(6 * 3 * 4, dtype="i4")
+    b_np = np.reshape(a_np, (6, 2, 6))
+    c_np = np.reshape(b_np, (9, 8), order="F")
+    assert np.array_equal(c_np, dpt.asnumpy(c))
+
+
 def test_reshape_zero_size():
     try:
         a = dpt.empty((0,))


### PR DESCRIPTION
Closes gh-1664.

Improves performance of `dpt.reshape(X, new_shape, order="F")` when copy is needed.

- [x] Have you provided a meaningful PR description?
- [x] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [x] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
