### PR TITLE
`order` of output array for binary elementwise funcs, `clip`, and `matmul` defaults to C-contiguous

### DIFF
--- a/dpctl/tensor/_clip.py
+++ b/dpctl/tensor/_clip.py
@@ -791,17 +791,17 @@ def clip(x, /, min=None, max=None, out=None, order="K"):
 
         if order == "K":
             if (
-                x.flags.f_contiguous
-                and a_min.flags.f_contiguous
-                and a_max.flags.f_contiguous
-            ):
-                order = "F"
-            elif (
                 x.flags.c_contiguous
                 and a_min.flags.c_contiguous
                 and a_max.flags.c_contiguous
             ):
                 order = "C"
+            elif (
+                x.flags.f_contiguous
+                and a_min.flags.f_contiguous
+                and a_max.flags.f_contiguous
+            ):
+                order = "F"
         if order == "K":
             buf1 = _empty_like_orderK(a_min, buf1_dt)
         else:

--- a/dpctl/tensor/_elementwise_common.py
+++ b/dpctl/tensor/_elementwise_common.py
@@ -858,10 +858,10 @@ class BinaryElementwiseFunc:
             return out
 
         if order == "K":
-            if src1.flags.f_contiguous and src2.flags.f_contiguous:
-                order = "F"
-            elif src1.flags.c_contiguous and src2.flags.c_contiguous:
+            if src1.flags.c_contiguous and src2.flags.c_contiguous:
                 order = "C"
+            elif src1.flags.f_contiguous and src2.flags.f_contiguous:
+                order = "F"
         if order == "K":
             buf1 = _empty_like_orderK(src1, buf1_dt)
         else:

--- a/dpctl/tensor/_linear_algebra_functions.py
+++ b/dpctl/tensor/_linear_algebra_functions.py
@@ -942,10 +942,10 @@ def matmul(x1, x2, out=None, dtype=None, order="K"):
         return out
 
     if order == "K":
-        if x1.flags.f_contiguous and x2.flags.f_contiguous:
-            order = "F"
-        elif x1.flags.c_contiguous and x2.flags.c_contiguous:
+        if x1.flags.c_contiguous and x2.flags.c_contiguous:
             order = "C"
+        elif x1.flags.f_contiguous and x2.flags.f_contiguous:
+            order = "F"
     if order == "K":
         buf1 = _empty_like_orderK(x1, buf1_dt)
     else:


### PR DESCRIPTION
This PR proposes a change to `clip`, `matmul`, and the `BinaryElementwiseFunc` class which makes `C` the default contiguity of outputs when `order="K"` and the input arrays must be cast.

This fixes a minor discrepancy where when multiple input arrays are both C- and F-contiguous and need to be cast, the output defaulted to F-contiguous instead of C-contiguous, creating unusual edge cases where type promotion (and therefore the selected device) became relevant to the output array's order, which should not be the case.

For example
```
In [1]: import dpctl.tensor as dpt, dpctl, numpy as np

In [2]: x1 = dpt.ones((10, 1), dtype="i4", device="cpu")

In [3]: x2 = dpt.ones((1, 5), dtype="f4", device="cpu")

In [4]: r = dpt.multiply(x1, x2)

In [5]: r.flags
Out[5]:
  C_CONTIGUOUS : False
  F_CONTIGUOUS : True
  WRITABLE : True
```
The selected device's type promotion graph contains `float64`, leading to F-contiguous outputs.

after this change:
```
In [1]: import dpctl.tensor as dpt, dpctl, numpy as np

In [2]: x1 = dpt.ones((10, 1), dtype="i4", device="cpu")
x
In [3]: x2 = dpt.ones((1, 5), dtype="f4", device="cpu")

In [4]: r = dpt.multiply(x1, x2)

In [5]: r.flags
Out[5]:
  C_CONTIGUOUS : True
  F_CONTIGUOUS : False
  WRITABLE : True
```

- [X] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [X] Have you tested your changes locally for CPU and GPU devices?
- [X] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [X] If this PR is a work in progress, are you opening the PR as a draft?
