### PR TITLE
Fix bug in basic slicing of empty arrays

### DIFF
--- a/dpctl/tests/test_usm_ndarray_ctor.py
+++ b/dpctl/tests/test_usm_ndarray_ctor.py
@@ -452,6 +452,30 @@ def test_slicing_basic():
     assert np.array_equal(Xh, Xnp[Xnp[2] : Xnp[5]])
 
 
+def test_slicing_empty():
+    try:
+        X = dpt.usm_ndarray((0, 10), dtype="i4")
+    except dpctl.SyclDeviceCreationError:
+        pytest.skip("No SYCL devices available")
+    x = dpt.moveaxis(X, 1, 0)
+    # this used to raise ValueError
+    y = x[1]
+    assert y.ndim == 1
+    assert y.shape == (0,)
+    assert y.dtype == X.dtype
+    assert y.usm_type == X.usm_type
+    assert y.sycl_queue == X.sycl_queue
+    w = x[1:3]
+    assert w.ndim == 2
+    assert w.shape == (
+        2,
+        0,
+    )
+    assert w.dtype == X.dtype
+    assert w.usm_type == X.usm_type
+    assert w.sycl_queue == X.sycl_queue
+
+
 def test_ctor_invalid_shape():
     with pytest.raises(TypeError):
         dpt.usm_ndarray(dict())


### PR DESCRIPTION
Reproducer provided by @ndgrigorian:

```python
import dpctl.tensor as dpt
x = dpt.ones((0, 10))
y = dpt.moveaxis(x, 1, 0)
y[1] # raises ValueError
```

Now this returns empty 1d array like `y[0]` does.

A test is added for both integral basic indexing,
and for simple slice.

---

- [x] Have you provided a meaningful PR description?
- [x] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [x] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
