### PR TITLE
Disable vectorized `bitwise_invert` for boolean inputs

### DIFF
--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/bitwise_invert.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/bitwise_invert.hpp
@@ -58,7 +58,7 @@ template <typename argT, typename resT> struct BitwiseInvertFunctor
 
     using is_constant = typename std::false_type;
     // constexpr resT constant_value = resT{};
-    using supports_vec = typename std::true_type;
+    using supports_vec = typename std::false_type;
     using supports_sg_loadstore = typename std::true_type;
     ;
 
@@ -66,21 +66,6 @@ template <typename argT, typename resT> struct BitwiseInvertFunctor
     {
         if constexpr (std::is_same_v<argT, bool>) {
             return !in;
-        }
-        else {
-            return ~in;
-        }
-    }
-
-    template <int vec_sz>
-    sycl::vec<resT, vec_sz> operator()(const sycl::vec<argT, vec_sz> &in) const
-    {
-        if constexpr (std::is_same_v<argT, bool>) {
-            auto res_vec = !in;
-
-            using deducedT = typename std::remove_cv_t<
-                std::remove_reference_t<decltype(res_vec)>>::element_type;
-            return vec_cast<resT, deducedT, vec_sz>(res_vec);
         }
         else {
             return ~in;

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/bitwise_invert.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/bitwise_invert.hpp
@@ -58,9 +58,8 @@ template <typename argT, typename resT> struct BitwiseInvertFunctor
 
     using is_constant = typename std::false_type;
     // constexpr resT constant_value = resT{};
-    using supports_vec = typename std::false_type;
+    using supports_vec = typename std::negation<std::is_same<argT, bool>>;
     using supports_sg_loadstore = typename std::true_type;
-    ;
 
     resT operator()(const argT &in) const
     {
@@ -70,6 +69,12 @@ template <typename argT, typename resT> struct BitwiseInvertFunctor
         else {
             return ~in;
         }
+    }
+
+    template <int vec_sz>
+    sycl::vec<resT, vec_sz> operator()(const sycl::vec<argT, vec_sz> &in) const
+    {
+        return ~in;
     }
 };
 

--- a/dpctl/tests/elementwise/test_bitwise_invert.py
+++ b/dpctl/tests/elementwise/test_bitwise_invert.py
@@ -117,3 +117,13 @@ def test_bitwise_invert_order():
     ar1 = dpt.zeros((40, 40), dtype="i4", order="C")[:20, ::-2].mT
     r4 = dpt.bitwise_invert(ar1, order="K")
     assert r4.strides == (-1, 20)
+
+
+def test_bitwise_invert_large_boolean():
+    get_queue_or_skip()
+
+    x = dpt.tril(dpt.ones((32, 32), dtype="?"), k=-1)
+    res = dpt.astype(dpt.bitwise_invert(x), "i4")
+
+    assert dpt.all(res >= 0)
+    assert dpt.all(res <= 1)


### PR DESCRIPTION
This PR proposes removing the `sycl::vec` overload of `bitwise_invert` for boolean inputs to fix unexpected behaviors.

Vectorized `bitwise_invert` on boolean inputs would corrupt the data in a subtle way. When casting this data to an integer data type, 255 would always be the result of casting `true`.
This is likely related to `operator!` on `sycl::vec` returning -1 for `true` and expecting the output type to be a signed integer type.

- [X] Have you provided a meaningful PR description?
- [X] Have you added a test, reproducer or referred to an issue with a reproducer?
- [X] Have you tested your changes locally for CPU and GPU devices?
- [X] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
