### PR TITLE
Removes malformed fast path for zero-size arrays in `repeat`

### DIFF
--- a/dpctl/tensor/_manipulation_functions.py
+++ b/dpctl/tensor/_manipulation_functions.py
@@ -838,9 +838,6 @@ def repeat(x, repeats, /, *, axis=None):
             f"got {type(repeats)}"
         )
 
-    if axis_size == 0:
-        return dpt.empty(x_shape, dtype=x.dtype, sycl_queue=exec_q)
-
     if scalar:
         res_axis_size = repeats * axis_size
         if axis is not None:

--- a/dpctl/tests/test_usm_ndarray_manipulation.py
+++ b/dpctl/tests/test_usm_ndarray_manipulation.py
@@ -1485,3 +1485,35 @@ def test_tile_arg_validation():
     x = dpt.empty(())
     with pytest.raises(TypeError):
         dpt.tile(x, dict())
+
+
+def test_repeat_0_size():
+    get_queue_or_skip()
+
+    x = dpt.ones((0, 10, 0), dtype="i4")
+    repetitions = 2
+    res = dpt.repeat(x, repetitions)
+    assert res.shape == (0,)
+    res = dpt.repeat(x, repetitions, axis=2)
+    assert res.shape == x.shape
+    res = dpt.repeat(x, repetitions, axis=1)
+    axis_sz = x.shape[1] * repetitions
+    assert res.shape == (0, 20, 0)
+
+    repetitions = dpt.asarray(2, dtype="i4")
+    res = dpt.repeat(x, repetitions)
+    assert res.shape == (0,)
+    res = dpt.repeat(x, repetitions, axis=2)
+    assert res.shape == x.shape
+    res = dpt.repeat(x, repetitions, axis=1)
+    assert res.shape == (0, 20, 0)
+
+    repetitions = dpt.arange(10, dtype="i4")
+    res = dpt.repeat(x, repetitions, axis=1)
+    axis_sz = dpt.sum(repetitions)
+    assert res.shape == (0, axis_sz, 0)
+
+    repetitions = (2,) * 10
+    res = dpt.repeat(x, repetitions, axis=1)
+    axis_sz = 2 * x.shape[1]
+    assert res.shape == (0, axis_sz, 0)


### PR DESCRIPTION
This PR fixes a small bug in `dpctl.tensor.repeat` caught by the array API tests where calling `repeat` with `axis=None` on a zero-size array would result in an array with the shape of the input, rather than `x.shape == (0,)` as expected.

To fix this, the malformed fast path for zero-size arrays has been removed, as it was unnecessary: all calls in repeat are already special-cased in the C++ backend to return empty events for zero-size inputs, so any savings for this path were minimal.

- [X] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [X] Have you tested your changes locally for CPU and GPU devices?
- [X] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
