### PR TITLE
Pin compiler at build-time, and limit range for run-time

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.21...3.27 FATAL_ERROR)
 
 project(dpctl
-    VERSION 0.15
+    VERSION 0.17
     LANGUAGES CXX
     DESCRIPTION "Python interface for XPU programming"
 )

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -1,7 +1,6 @@
 {% set required_compiler_version = "2024.0" %}
-{% set excluded_compiler_version1 = "2024.0.1" %}
-{% set excluded_compiler_version2 = "2024.0.2" %}
-{% set excluded_compiler_version3 = "2024.0.3" %}
+{% set runtime_lower_bound = required_compiler_version %}
+{% set runtime_upper_bound = "2024.3.0a0" %}
 
 package:
     name: dpctl
@@ -19,8 +18,7 @@ build:
 requirements:
     build:
         - {{ compiler('cxx') }}
-        - {{ compiler('dpcpp') }} >={{ required_compiler_version }},!={{ excluded_compiler_version1 }},!={{ excluded_compiler_version2 }},!={{ excluded_compiler_version3 }}  # [win]
-        - {{ compiler('dpcpp') }} >={{ required_compiler_version }},!={{ excluded_compiler_version1 }},!={{ excluded_compiler_version2 }}  # [linux]
+        - {{ compiler('dpcpp') }} {{ required_compiler_version }}
         - sysroot_linux-64 >=2.28  # [linux]
     host:
         - setuptools
@@ -35,7 +33,7 @@ requirements:
     run:
         - python
         - {{ pin_compatible('numpy', min_pin='x.x', max_pin='x') }}
-        - dpcpp-cpp-rt >={{ required_compiler_version }}
+        - dpcpp-cpp-rt >={{ runtime_lower_bound }},<{{ runtime_upper_bound }}
         - level-zero  # [linux]
 
 test:


### PR DESCRIPTION
This change pins compile-time version of the compiler to 2024.2.0, and restricts the range of compiler runtime libraries accordingly for `dpctl=0.17.0`.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
