### PR TITLE
Fix logic to computing value of release Sphinx variable

### DIFF
--- a/docs/doc_sources/conf.py.in
+++ b/docs/doc_sources/conf.py.in
@@ -21,7 +21,7 @@ author = "Intel Corp."
 
 version = dpctl.__version__.strip(".dirty")
 # The full version, including alpha/beta/rc tags
-release, _ = dpctl.__version__.strip(".dirty").split("+")
+release = dpctl.__version__.strip(".dirty").split("+")[0]
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration


### PR DESCRIPTION
Presently the code was not ready to version to not have "+" separator in the version string. This change make the code more robust, and should fix the broken documentation build.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
