### PR TITLE
Replaced windows-latest with windows-2019 to fix windows builds

### DIFF
--- a/.github/workflows/conda-package.yml
+++ b/.github/workflows/conda-package.yml
@@ -72,7 +72,7 @@ jobs:
           path: ${{ env.WHEELS_OUTPUT_FOLDER }}${{ env.PACKAGE_NAME }}-*.whl
 
   build_windows:
-    runs-on: windows-latest
+    runs-on: windows-2019
 
     strategy:
       matrix:
@@ -217,7 +217,7 @@ jobs:
       matrix:
         python: ['3.9', '3.10', '3.11']
         experimental: [false]
-        runner: [windows-latest]
+        runner: [windows-2019]
     continue-on-error: ${{ matrix.experimental }}
     env:
       workdir: '${{ github.workspace }}'
@@ -372,7 +372,7 @@ jobs:
   upload_windows:
     needs: test_windows
     if: ${{github.ref == 'refs/heads/master' || (startsWith(github.ref, 'refs/heads/release') == true) || github.event_name == 'push' && contains(github.ref, 'refs/tags/')}}
-    runs-on: windows-latest
+    runs-on: windows-2019
     strategy:
       matrix:
         python: ['3.9', '3.10', '3.11']


### PR DESCRIPTION
Based on experimentation with mkl_fft, switching from using "windows-latest" image to "windows-2019" fixes MS compiler use for Python packages.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
