### PR TITLE
Fix compiler version pinning in maintenance/0.17.x

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set required_compiler_version = "2024.0" %}
+{% set required_compiler_version = "2024.2.0" %}
 {% set runtime_lower_bound = required_compiler_version %}
 {% set runtime_upper_bound = "2024.3.0a0" %}
 


### PR DESCRIPTION
Fixed compiler version from "2024.0" to "2024.2.0"

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
