### PR TITLE
Add support for aspect::emulated

### DIFF
--- a/dpctl/_backend.pxd
+++ b/dpctl/_backend.pxd
@@ -95,6 +95,7 @@ cdef extern from "syclinterface/dpctl_sycl_enum_types.h":
         _usm_atomic_host_allocations        'usm_atomic_host_allocations',
         _usm_atomic_shared_allocations      'usm_atomic_shared_allocations',
         _host_debuggable                    'host_debuggable',
+        _emulated                           'emulated',
 
     ctypedef enum _partition_affinity_domain_type 'DPCTLPartitionAffinityDomainType':
         _not_applicable                     'not_applicable',

--- a/dpctl/_sycl_device.pyx
+++ b/dpctl/_sycl_device.pyx
@@ -771,6 +771,20 @@ cdef class SyclDevice(_SyclDevice):
         return DPCTLDevice_HasAspect(self._device_ref, AT)
 
     @property
+    def has_aspect_emulated(self):
+        """ Returns ``True`` if this device is somehow emulated, ``False``
+        otherwise. A device with this aspect is not intended for performance,
+        and instead will generally have another purpose such as emulation
+        or profiling.
+
+        Returns:
+            bool:
+                Indicates if device is somehow emulated.
+        """
+        cdef _aspect_type AT = _aspect_type._emulated
+        return DPCTLDevice_HasAspect(self._device_ref, AT)
+
+    @property
     def image_2d_max_width(self):
         """ Returns the maximum width of a 2D image or 1D image in pixels.
             The minimum value is 8192 if the SYCL device has

--- a/dpctl/tests/_device_attributes_checks.py
+++ b/dpctl/tests/_device_attributes_checks.py
@@ -245,6 +245,13 @@ def check_has_aspect_host_debuggable(device):
         pytest.fail("has_aspect_host_debuggable call failed")
 
 
+def check_has_aspect_emulated(device):
+    try:
+        device.has_aspect_emulated
+    except Exception:
+        pytest.fail("has_aspect_emulated call failed")
+
+
 def check_is_accelerator(device):
     try:
         device.is_accelerator
@@ -698,6 +705,7 @@ list_of_checks = [
     check_has_aspect_usm_atomic_host_allocations,
     check_has_aspect_usm_atomic_shared_allocations,
     check_has_aspect_host_debuggable,
+    check_has_aspect_emulated,
     check_max_read_image_args,
     check_max_write_image_args,
     check_image_2d_max_width,

--- a/dpctl/tests/test_sycl_device.py
+++ b/dpctl/tests/test_sycl_device.py
@@ -163,13 +163,12 @@ list_of_supported_aspects = [
     "atomic64",
     "usm_atomic_host_allocations",
     "usm_atomic_shared_allocations",
+    "emulated",
 ]
 
 # SYCL 2020 spec aspects not presently
 # supported in DPC++, and dpctl
-list_of_unsupported_aspects = [
-    "emulated",
-]
+list_of_unsupported_aspects = []
 
 
 @pytest.fixture(params=list_of_supported_aspects)
@@ -199,13 +198,13 @@ def test_supported_aspect(supported_aspect):
 
 def test_unsupported_aspect(unsupported_aspect):
     try:
-        dpctl.select_device_with_aspects(unsupported_aspect)
+        d = dpctl.SyclDevice()
+        has_it = hasattr(d, "has_aspect_" + unsupported_aspect)
+    except dpctl.SyclDeviceCreationError:
+        has_it = False
+    if has_it:
         raise AttributeError(
             f"The {unsupported_aspect} aspect is now supported in dpctl"
-        )
-    except AttributeError:
-        pytest.skip(
-            f"The {unsupported_aspect} aspect is not supported in dpctl"
         )
 
 

--- a/libsyclinterface/helper/source/dpctl_utils_helper.cpp
+++ b/libsyclinterface/helper/source/dpctl_utils_helper.cpp
@@ -326,6 +326,8 @@ aspect DPCTL_DPCTLAspectTypeToSyclAspect(DPCTLSyclAspectType AspectTy)
         return aspect::usm_atomic_shared_allocations;
     case DPCTLSyclAspectType::host_debuggable:
         return aspect::host_debuggable;
+    case DPCTLSyclAspectType::emulated:
+        return aspect::emulated;
     default:
         throw std::runtime_error("Unsupported aspect type");
     }
@@ -370,6 +372,8 @@ DPCTLSyclAspectType DPCTL_SyclAspectToDPCTLAspectType(aspect Aspect)
         return DPCTLSyclAspectType::usm_atomic_shared_allocations;
     case aspect::host_debuggable:
         return DPCTLSyclAspectType::host_debuggable;
+    case aspect::emulated:
+        return DPCTLSyclAspectType::emulated;
     default:
         throw std::runtime_error("Unsupported aspect type");
     }

--- a/libsyclinterface/helper/source/dpctl_utils_helper.cpp
+++ b/libsyclinterface/helper/source/dpctl_utils_helper.cpp
@@ -214,6 +214,9 @@ std::string DPCTL_AspectToStr(aspect aspectTy)
     case aspect::host_debuggable:
         ss << "host_debuggable";
         break;
+    case aspect::emulated:
+        ss << "emulated";
+        break;
     default:
         throw std::runtime_error("Unsupported aspect type");
     }
@@ -279,6 +282,9 @@ aspect DPCTL_StrToAspectType(const std::string &aspectTyStr)
     }
     else if (aspectTyStr == "host_debuggable") {
         aspectTy = aspect::host_debuggable;
+    }
+    else if (aspectTyStr == "emulated") {
+        aspectTy = aspect::emulated;
     }
     else {
         // \todo handle the error

--- a/libsyclinterface/include/syclinterface/dpctl_sycl_enum_types.h
+++ b/libsyclinterface/include/syclinterface/dpctl_sycl_enum_types.h
@@ -128,6 +128,7 @@ typedef enum
     usm_atomic_host_allocations,
     usm_atomic_shared_allocations,
     host_debuggable,
+    emulated
 } DPCTLSyclAspectType;
 
 /*!

--- a/libsyclinterface/tests/test_sycl_device_aspects.cpp
+++ b/libsyclinterface/tests/test_sycl_device_aspects.cpp
@@ -166,7 +166,7 @@ struct TestDPCTLSyclDeviceInterfaceAspects
         auto syclAspect = GetParam().second.second;
         try {
             hasAspect = D->has(syclAspect);
-        } catch (sycl::exception const &e) {
+        } catch (sycl::exception const &) {
         }
     }
 

--- a/libsyclinterface/tests/test_sycl_device_aspects.cpp
+++ b/libsyclinterface/tests/test_sycl_device_aspects.cpp
@@ -123,7 +123,8 @@ auto build_params()
                            sycl::aspect::usm_atomic_host_allocations),
             std::make_pair("usm_atomic_shared_allocations",
                            sycl::aspect::usm_atomic_shared_allocations),
-            std::make_pair("host_debuggable", sycl::aspect::host_debuggable));
+            std::make_pair("host_debuggable", sycl::aspect::host_debuggable),
+            std::make_pair("emulated", sycl::aspect::emulated));
 
     auto pairs =
         build_param_pairs<const char *, std::pair<const char *, sycl::aspect>,


### PR DESCRIPTION
Add `dpctl.SyclDevice.has_aspect_emulated` now that DPC++ supports it, see gh-292

- [x] Have you provided a meaningful PR description?
- [x] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
