### PR TITLE
Backport pull/1695 to maintenance/0.17.x 

### DIFF
--- a/conda-recipe/dpctl-post-link.sh
+++ b/conda-recipe/dpctl-post-link.sh
@@ -1,5 +1,19 @@
 #!/usr/bin/bash
 
+# Copyright 2020-2024 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 systemwide_icd=/etc/OpenCL/vendors/intel.icd
 local_vendors=$PREFIX/etc/OpenCL/vendors
 icd_fn=$local_vendors/intel-ocl-gpu.icd

--- a/conda-recipe/dpctl-pre-unlink.sh
+++ b/conda-recipe/dpctl-pre-unlink.sh
@@ -1,5 +1,19 @@
 #!/usr/bin/bash
 
+# Copyright 2020-2024 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 local_vendors=$PREFIX/etc/OpenCL/vendors
 icd_fn=$local_vendors/intel-ocl-gpu.icd
 


### PR DESCRIPTION
The gh-1695 added license headers for pre-unlink/post-link scripts

These shell scripts are included in the shipped conda package, and require a license header.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
