### PR TITLE
Fixes `dpctl.tensor.round` on CUDA devices

### DIFF
--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/round.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/round.hpp
@@ -81,7 +81,7 @@ template <typename argT, typename resT> struct RoundFunctor
 private:
     template <typename T> T round_func(const T &input) const
     {
-        return std::rint(input);
+        return sycl::rint(input);
     }
 };
 


### PR DESCRIPTION
When compiled for CUDA, `std::rint` would incorrectly round values halfway between two integers towards 0 (i.e., `1.5 -> 1.`). The array API specification requires that these values be rounded to the nearest even integer instead.

To resolve this, `std::rint` has been replaced with `sycl::rint`, which does not rely on the [current floating-point rounding mode](https://en.cppreference.com/w/cpp/numeric/math/rint) ([see SYCL specification](https://registry.khronos.org/SYCL/specs/sycl-2020/html/sycl-2020.html#_math_functions)).

[As was pointed out at the time of implementation](https://github.com/IntelPython/dpctl/pull/1299#issuecomment-1652072391) the floating-point rounding mode can vary between devices.

- [X] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [X] Have you tested your changes locally for CPU and GPU devices?
- [X] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
