### PR TITLE
Improve performance of test_sort_complex_fp_nan

### DIFF
--- a/dpctl/tests/test_usm_ndarray_sorting.py
+++ b/dpctl/tests/test_usm_ndarray_sorting.py
@@ -275,9 +275,16 @@ def test_sort_complex_fp_nan(dtype):
 
     assert np.allclose(dpt.asnumpy(s), expected, equal_nan=True)
 
+    pairs = []
     for i, j in itertools.permutations(range(inp.shape[0]), 2):
-        r1 = dpt.asnumpy(dpt.sort(inp[dpt.asarray([i, j])]))
-        r2 = np.sort(dpt.asnumpy(inp[dpt.asarray([i, j])]))
+        pairs.append([i, j])
+    sub_arrs = inp[dpt.asarray(pairs)]
+    m1 = dpt.asnumpy(dpt.sort(sub_arrs, axis=1))
+    m2 = np.sort(dpt.asnumpy(sub_arrs), axis=1)
+    for k in range(len(pairs)):
+        i, j = pairs[k]
+        r1 = m1[k]
+        r2 = m2[k]
         assert np.array_equal(
             r1.view(np.int64), r2.view(np.int64)
         ), f"Failed for {i} and {j}"


### PR DESCRIPTION
This test used to perform numerous operations on very short vectors. The change replaced that with single row-wise operation on matrices.

Now:

```
(dev_dpctl) opavlyk@opavlyk-mobl:~/repos/dpctl$ SYCL_CACHE_PERSISTENT=1 ONEAPI_DEVICE_SELECTOR=opencl:gpu python -m pytest -v -s ~/repos/dpctl/dpctl/tests/test_usm_ndarray_sorting.py::test_sort_complex_fp_nan
=================================================================================== test session starts ====================================================================================
platform linux -- Python 3.12.3, pytest-8.2.0, pluggy-1.5.0 -- /home/opavlyk/mamba/envs/dev_dpctl/bin/python
cachedir: .pytest_cache
hypothesis profile 'default' -> database=DirectoryBasedExampleDatabase(PosixPath('/home/opavlyk/repos/dpctl/.hypothesis/examples'))
metadata: {'Python': '3.12.3', 'Platform': 'Linux-5.15.146.1-microsoft-standard-WSL2-x86_64-with-glibc2.39', 'Packages': {'pytest': '8.2.0', 'pluggy': '1.5.0'}, 'Plugins': {'json-report': '1.5.0', 'hypothesis': '6.102.4', 'cov': '5.0.0', 'metadata': '3.1.1'}}
rootdir: /home/opavlyk/repos/dpctl
configfile: pyproject.toml
plugins: json-report-1.5.0, hypothesis-6.102.4, cov-5.0.0, metadata-3.1.1
collected 2 items

dpctl/tests/test_usm_ndarray_sorting.py::test_sort_complex_fp_nan[c8] PASSED
dpctl/tests/test_usm_ndarray_sorting.py::test_sort_complex_fp_nan[c16] SKIPPED (Intel(R) Graphics [0x9a49] does not support double precision floating point types)

=============================================================================== 1 passed, 1 skipped in 0.34s ===============================================================================
```

This single test used to take 3.5 seconds to execute.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
