### PR TITLE
Implement manipulation of flattened SO files

### DIFF
--- a/.github/workflows/os-llvm-sycl-build.yml
+++ b/.github/workflows/os-llvm-sycl-build.yml
@@ -164,4 +164,6 @@ jobs:
           SYCL_CACHE_PERSISTENT: 1
         run: |
           source set_allvars.sh
-          python -m pytest -v dpctl/tests
+          # Skip the test that checks if there is only one hard
+          # copy of DPCTLSyclInterface library
+          python -m pytest -v dpctl/tests -k "not test_syclinterface"

--- a/.github/workflows/os-llvm-sycl-build.yml
+++ b/.github/workflows/os-llvm-sycl-build.yml
@@ -166,4 +166,4 @@ jobs:
           source set_allvars.sh
           # Skip the test that checks if there is only one hard
           # copy of DPCTLSyclInterface library
-          python -m pytest -v dpctl/tests -k "not test_syclinterface"
+          python -m pytest -v dpctl/tests --no-sycl-interface-test

--- a/conda-recipe/build.sh
+++ b/conda-recipe/build.sh
@@ -26,9 +26,31 @@ CMAKE_ARGS="${CMAKE_ARGS} -DDPCTL_LEVEL_ZERO_INCLUDE_DIR=${PREFIX}/include/level
 
 # -wnx flags mean: --wheel --no-isolation --skip-dependency-check
 ${PYTHON} -m build -w -n -x
+
+pushd dist
+${PYTHON} -m wheel unpack -d dpctl_wheel dpctl*.whl
+export lib_name=libDPCTLSyclInterface
+export so_full_path=$(find dpctl_wheel -regextype posix-extended -regex "^.*${lib_name}\.so")
+export sox_full_path=$(find dpctl_wheel -regextype posix-extended -regex "^.*${lib_name}\.so\.[0-9]*$")
+export soxxx_full_path=$(find dpctl_wheel -regextype posix-extended -regex "^.*${lib_name}\.so\.[0-9]*\.[0-9]*$")
+
+rm -rf ${so_full_path} ${soxxx_full_path}
+
+export so_name=$(basename ${so_full_path})
+export sox_name=$(basename ${sox_full_path})
+export soxxx_name=$(basename ${soxxx_full_path})
+export wheel_path=$(dirname $(dirname ${so_full_path}))
+
+# deal with hard copies
+${PYTHON} -m wheel pack ${wheel_path}
+
+rm -rf dpctl_wheel
+popd
+
 ${PYTHON} -m wheel tags --remove --build "$GIT_DESCRIBE_NUMBER" \
     --platform-tag "manylinux_${GLIBC_MAJOR}_${GLIBC_MINOR}_x86_64" \
     dist/dpctl*.whl
+
 ${PYTHON} -m pip install dist/dpctl*.whl \
     --no-build-isolation \
     --no-deps \
@@ -37,11 +59,14 @@ ${PYTHON} -m pip install dist/dpctl*.whl \
     --prefix "${PREFIX}" \
     -vv
 
+export libdir=$(find $PREFIX -name 'libDPCTLSyclInterface*' -exec dirname \{\} \;)
+
 # Recover symbolic links
 # libDPCTLSyclInterface.so.0 -> libDPCTLSyclInterface.so.0.17
 # libDPCTLSyclInterface.so -> libDPCTLSyclInterface.so.0
-find $PREFIX | grep libDPCTLSyclInterface | sort -r | \
-awk '{if ($0=="") ln=""; else if (ln=="") ln = $0; else system("rm " $0 ";\tln -s " ln " " $0); ln = $0 }'
+mv ${libdir}/${sox_name} ${libdir}/${soxxx_name}
+ln -s ${libdir}/${soxxx_name} ${libdir}/${sox_name}
+ln -s ${libdir}/${sox_name} ${libdir}/${so_name}
 
 # Copy wheel package
 if [[ -v WHEELS_OUTPUT_FOLDER ]]; then

--- a/dpctl/tests/conftest.py
+++ b/dpctl/tests/conftest.py
@@ -55,6 +55,12 @@ def pytest_addoption(parser):
         default=False,
         help="run broken complex tests",
     )
+    parser.addoption(
+        "--no-sycl-interface-test",
+        action="store_true",
+        default=False,
+        help="skip test_syclinterface",
+    )
 
 
 def pytest_collection_modifyitems(config, items):

--- a/dpctl/tests/test_service.py
+++ b/dpctl/tests/test_service.py
@@ -151,13 +151,21 @@ def test_dev_utils():
             device.parent_device
 
 
-def test_syclinterface():
+@pytest.fixture
+def should_skip_syclinterface(request):
+    return request.config.getoption("--no-sycl-interface-test")
+
+
+def test_syclinterface(should_skip_syclinterface):
     install_dir = os.path.dirname(os.path.abspath(dpctl.__file__))
     paths = glob.glob(os.path.join(install_dir, "*DPCTLSyclInterface*"))
     if "linux" in sys.platform:
-        assert len(paths) > 1 and any(
-            [os.path.islink(fn) for fn in paths]
-        ), "All library instances are hard links"
+        if should_skip_syclinterface:
+            pass
+        else:
+            assert len(paths) > 1 and any(
+                [os.path.islink(fn) for fn in paths]
+            ), "All library instances are hard links"
     elif sys.platform in ["win32", "cygwin"]:
         exts = []
         for fn in paths:

--- a/scripts/gen_coverage.py
+++ b/scripts/gen_coverage.py
@@ -102,6 +102,7 @@ def run(
             "dpctl",
             "-vv",
             "--ignore=dpctl/tensor/libtensor/tests",
+            "--no-sycl-interface-test",
         ],
         cwd=setup_dir,
         shell=False,


### PR DESCRIPTION
This PR modifies `build.sh` to post-process the wheel and remove duplicate shared objects produced by Python packaging that follows symbolic links.

Symbolic links are restored for conda after wheel is installed.

The check ``test_service.py::test_syclinterface`` was modified to ignore presence of duplicate copies of the library shared objects if `--no-sycl-interface-test` option was specified to pytest.


The option is used in 
- coverage collection script `scripts/get_coverage.py`
- in workflow which builds `dpctl` with nighly sycl bundle of intel/llvm.


-------


- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
