### PR TITLE
Improve exception raised by `broadcast_arrays` with no arguments

### DIFF
--- a/dpctl/tensor/_manipulation_functions.py
+++ b/dpctl/tensor/_manipulation_functions.py
@@ -265,6 +265,8 @@ def broadcast_arrays(*args):
             `device` and `usm_type` attributes as its corresponding input
             array.
     """
+    if len(args) == 0:
+        raise ValueError("`broadcast_arrays` requires at least one argument")
     for X in args:
         if not isinstance(X, dpt.usm_ndarray):
             raise TypeError(f"Expected usm_ndarray type, got {type(X)}.")

--- a/dpctl/tests/test_usm_ndarray_manipulation.py
+++ b/dpctl/tests/test_usm_ndarray_manipulation.py
@@ -435,6 +435,11 @@ def test_incompatible_shapes_raise_valueerror(shapes):
         assert_broadcast_arrays_raise(input_shapes[::-1])
 
 
+def test_broadcast_arrays_no_args():
+    with pytest.raises(ValueError):
+        dpt.broadcast_arrays()
+
+
 def test_flip_axis_incorrect():
     q = get_queue_or_skip()
 


### PR DESCRIPTION
This PR improves the message of the ValueError raised by `broadcast_arrays` when called with no arguments.

Closes #1718 

- [X] Have you provided a meaningful PR description?
- [X] Have you added a test, reproducer or referred to an issue with a reproducer?
- [X] Have you tested your changes locally for CPU and GPU devices?
- [X] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
