### PR TITLE
Use Ubuntu 22.04 for `conda package` workflow

### DIFF
--- a/.github/workflows/conda-package.yml
+++ b/.github/workflows/conda-package.yml
@@ -18,7 +18,7 @@ env:
 
 jobs:
   build_linux:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     strategy:
       matrix:
@@ -129,7 +129,7 @@ jobs:
       matrix:
         python: ['3.9', '3.10', '3.11']
         experimental: [false]
-        runner: [ubuntu-20.04]
+        runner: [ubuntu-22.04]
     continue-on-error: ${{ matrix.experimental }}
 
     steps:
@@ -347,7 +347,7 @@ jobs:
   upload_linux:
     needs: test_linux
     if: ${{github.ref == 'refs/heads/master' || (startsWith(github.ref, 'refs/heads/release') == true) || github.event_name == 'push' && contains(github.ref, 'refs/tags/')}}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         python: ['3.9', '3.10', '3.11']
@@ -428,7 +428,7 @@ jobs:
       matrix:
         python: ['3.10']
         experimental: [false]
-        runner: [ubuntu-20.04]
+        runner: [ubuntu-22.04]
     continue-on-error: ${{ matrix.experimental }}
     env:
       EXAMPLES_ENV_NAME: examples
@@ -584,7 +584,7 @@ jobs:
       matrix:
         python: ['3.10']
         experimental: [false]
-        runner: [ubuntu-20.04]
+        runner: [ubuntu-22.04]
     continue-on-error: ${{ matrix.experimental }}
     steps:
       - name: Construct channels line


### PR DESCRIPTION
Ubuntu 20.04 will soon not be supported by oneAPI.

- [ ] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
