### PR TITLE
Remove 'template' from call to `get_kernel` method of kernel bundle in sorting

### DIFF
--- a/dpctl/tensor/libtensor/include/kernels/sorting/sort.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/sorting/sort.hpp
@@ -418,7 +418,7 @@ sort_over_work_group_contig_impl(sycl::queue &q,
     auto kb = sycl::get_kernel_bundle<sycl::bundle_state::executable>(
         ctx, {dev}, {kernel_id});
 
-    auto krn = kb.template get_kernel(kernel_id);
+    auto krn = kb.get_kernel(kernel_id);
 
     const std::uint32_t max_sg_size = krn.template get_info<
         sycl::info::kernel_device_specific::max_sub_group_size>(dev);


### PR DESCRIPTION
This PR removes an unnecessary templating of the `get_kernel` method of the kernel bundle in `sort.hpp`.

As no template parameter was given, this not only did not do anything, but was causing nightly builds to fail.

- [X] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [X] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
