### PR TITLE
`extract` and `_extract_impl` now coerce USM type

### DIFF
--- a/dpctl/tensor/_copy_utils.py
+++ b/dpctl/tensor/_copy_utils.py
@@ -707,6 +707,9 @@ def _extract_impl(ary, ary_mask, axis=0):
         raise TypeError(
             f"Expecting type dpctl.tensor.usm_ndarray, got {type(ary_mask)}"
         )
+    dst_usm_type = dpctl.utils.get_coerced_usm_type(
+        (ary.usm_type, ary_mask.usm_type)
+    )
     exec_q = dpctl.utils.get_execution_queue(
         (ary.sycl_queue, ary_mask.sycl_queue)
     )
@@ -733,7 +736,7 @@ def _extract_impl(ary, ary_mask, axis=0):
     )
     dst_shape = ary.shape[:pp] + (mask_count,) + ary.shape[pp + mask_nd :]
     dst = dpt.empty(
-        dst_shape, dtype=ary.dtype, usm_type=ary.usm_type, device=ary.device
+        dst_shape, dtype=ary.dtype, usm_type=dst_usm_type, device=ary.device
     )
     if dst.size == 0:
         return dst


### PR DESCRIPTION
This PR changes `_extract_impl` in `_copy_utils` to coerce USM types to bring `extract` and boolean indexing in line with other operations in dpctl which take multiple arrays as input

Closes #1723 

- [X] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [X] Have you tested your changes locally for CPU and GPU devices?
- [X] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
