### PR TITLE
Fixes `_from_input_shape_strides` not validating order in all paths

### DIFF
--- a/dpctl/tensor/_stride_utils.pxi
+++ b/dpctl/tensor/_stride_utils.pxi
@@ -72,6 +72,9 @@ cdef int _from_input_shape_strides(
     cdef Py_ssize_t* shape_arr
     cdef Py_ssize_t* strides_arr
 
+    if (int(order) not in [ord('C'), ord('F'), ord('c'), ord('f')]):
+        return ERROR_INCORRECT_ORDER
+
     # 0-d array
     if (nd == 0):
         contig[0] = (USM_ARRAY_C_CONTIGUOUS | USM_ARRAY_F_CONTIGUOUS)
@@ -109,10 +112,6 @@ cdef int _from_input_shape_strides(
     nelems[0] = elem_count
     if (strides is None):
         # no need to allocate and populate strides
-        if (int(order) not in [ord('C'), ord('F'), ord('c'), ord('f')]):
-            PyMem_Free(shape_ptr[0]);
-            shape_ptr[0] = <Py_ssize_t *>(<size_t>0)
-            return ERROR_INCORRECT_ORDER
         if order == <char> ord('C') or order == <char> ord('c'):
             contig[0] = USM_ARRAY_C_CONTIGUOUS
         else:

--- a/dpctl/tests/test_usm_ndarray_ctor.py
+++ b/dpctl/tests/test_usm_ndarray_ctor.py
@@ -485,6 +485,10 @@ def test_ctor_invalid_order():
     get_queue_or_skip()
     with pytest.raises(ValueError):
         dpt.usm_ndarray((5, 5, 3), order="Z")
+    with pytest.raises(ValueError):
+        dpt.usm_ndarray((10), strides=(1,), order="Z")
+    with pytest.raises(ValueError):
+        dpt.usm_ndarray((), order="Z")
 
 
 def test_ctor_buffer_kwarg():


### PR DESCRIPTION
Moves `order` validation to the start of `_from_input_shape_strides` to guarantee it's valid even if unused.

Closes #1724 

- [X] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [X] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
