### PR TITLE
Implements `dpctl.tensor.count_nonzero` and `dpctl.tensor.diff`

### DIFF
--- a/docs/doc_sources/api_reference/dpctl/tensor.elementwise_functions.rst
+++ b/docs/doc_sources/api_reference/dpctl/tensor.elementwise_functions.rst
@@ -64,6 +64,7 @@ function values computed for every element of input array(s).
     minimum
     multiply
     negative
+    nextafter
     not_equal
     positive
     pow

--- a/docs/doc_sources/api_reference/dpctl/tensor.searching_functions.rst
+++ b/docs/doc_sources/api_reference/dpctl/tensor.searching_functions.rst
@@ -10,6 +10,7 @@ Searching functions
 
     argmax
     argmin
+    count_nonzero
     nonzero
     searchsorted
     where

--- a/docs/doc_sources/api_reference/dpctl/tensor.utility_functions.rst
+++ b/docs/doc_sources/api_reference/dpctl/tensor.utility_functions.rst
@@ -11,6 +11,7 @@ Utility functions
     all
     any
     allclose
+    diff
 
 Device object
 -------------

--- a/dpctl/tensor/__init__.py
+++ b/dpctl/tensor/__init__.py
@@ -94,7 +94,7 @@ from dpctl.tensor._reshape import reshape
 from dpctl.tensor._search_functions import where
 from dpctl.tensor._statistical_functions import mean, std, var
 from dpctl.tensor._usmarray import usm_ndarray
-from dpctl.tensor._utility_functions import all, any
+from dpctl.tensor._utility_functions import all, any, diff
 
 from ._accumulation import cumulative_logsumexp, cumulative_prod, cumulative_sum
 from ._array_api import __array_api_version__, __array_namespace_info__
@@ -373,4 +373,5 @@ __all__ = [
     "cumulative_prod",
     "cumulative_sum",
     "nextafter",
+    "diff",
 ]

--- a/dpctl/tensor/__init__.py
+++ b/dpctl/tensor/__init__.py
@@ -176,6 +176,7 @@ from ._elementwise_funcs import (
 from ._reduction import (
     argmax,
     argmin,
+    count_nonzero,
     logsumexp,
     max,
     min,
@@ -374,4 +375,5 @@ __all__ = [
     "cumulative_sum",
     "nextafter",
     "diff",
+    "count_nonzero",
 ]

--- a/dpctl/tensor/_reduction.py
+++ b/dpctl/tensor/_reduction.py
@@ -773,3 +773,15 @@ def argmin(x, /, *, axis=None, keepdims=False, out=None):
             default array index data type for the device of ``x``.
     """
     return _search_over_axis(x, axis, keepdims, out, tri._argmin_over_axis)
+
+
+def count_nonzero(x, /, *, axis=None, keepdims=False, out=None):
+    if x.dtype != dpt.bool:
+        x = dpt.astype(x, dpt.bool, copy=False)
+    return sum(
+        x,
+        axis=axis,
+        dtype=ti.default_device_index_type(x.sycl_device),
+        keepdims=keepdims,
+        out=None,
+    )

--- a/dpctl/tensor/_reduction.py
+++ b/dpctl/tensor/_reduction.py
@@ -776,6 +776,37 @@ def argmin(x, /, *, axis=None, keepdims=False, out=None):
 
 
 def count_nonzero(x, /, *, axis=None, keepdims=False, out=None):
+    """
+    Counts the number of elements in the input array ``x`` which are non-zero.
+
+    Args:
+        x (usm_ndarray):
+            input array.
+        axis (Optional[int, Tuple[int, ...]]):
+            axis or axes along which to count. If a tuple of unique integers,
+            the number of non-zero values are computed over multiple axes.
+            If ``None``, the number of non-zero values is computed over the
+            entire array.
+            Default: ``None``.
+        keepdims (Optional[bool]):
+            if ``True``, the reduced axes (dimensions) are included in the
+            result as singleton dimensions, so that the returned array remains
+            compatible with the input arrays according to Array Broadcasting
+            rules. Otherwise, if ``False``, the reduced axes are not included
+            in the returned array. Default: ``False``.
+        out (Optional[usm_ndarray]):
+            the array into which the result is written.
+            The data type of ``out`` must match the expected shape and data
+            type.
+            If ``None`` then a new array is returned. Default: ``None``.
+
+    Returns:
+        usm_ndarray:
+            an array containing the count of non-zero values. If the sum was
+            computed over the entire array, a zero-dimensional array is
+            returned. The returned array will have the default array index data
+            type.
+    """
     if x.dtype != dpt.bool:
         x = dpt.astype(x, dpt.bool, copy=False)
     return sum(

--- a/dpctl/tensor/_reduction.py
+++ b/dpctl/tensor/_reduction.py
@@ -814,5 +814,5 @@ def count_nonzero(x, /, *, axis=None, keepdims=False, out=None):
         axis=axis,
         dtype=ti.default_device_index_type(x.sycl_device),
         keepdims=keepdims,
-        out=None,
+        out=out,
     )

--- a/dpctl/tensor/_type_utils.py
+++ b/dpctl/tensor/_type_utils.py
@@ -450,6 +450,112 @@ def _resolve_weak_types_all_py_ints(o1_dtype, o2_dtype, dev):
         return o1_dtype, o2_dtype
 
 
+def _resolve_one_strong_two_weak_types(st_dtype, dtype1, dtype2, dev):
+    "Resolves weak data types per NEP-0050,"
+    "where the second and third arguments are"
+    "permitted to be weak types"
+    if _is_weak_dtype(st_dtype):
+        raise ValueError
+    if _is_weak_dtype(dtype1):
+        if _is_weak_dtype(dtype2):
+            kind_num1 = _weak_type_num_kind(dtype1)
+            kind_num2 = _weak_type_num_kind(dtype2)
+            st_kind_num = _strong_dtype_num_kind(st_dtype)
+
+            if kind_num1 > st_kind_num:
+                if isinstance(dtype1, WeakIntegralType):
+                    ret_dtype1 = dpt.dtype(ti.default_device_int_type(dev))
+                elif isinstance(dtype1, WeakComplexType):
+                    if st_dtype is dpt.float16 or st_dtype is dpt.float32:
+                        ret_dtype1 = dpt.complex64
+                    ret_dtype1 = _to_device_supported_dtype(dpt.complex128, dev)
+                else:
+                    ret_dtype1 = _to_device_supported_dtype(dpt.float64, dev)
+            else:
+                ret_dtype1 = st_dtype
+
+            if kind_num2 > st_kind_num:
+                if isinstance(dtype2, WeakIntegralType):
+                    ret_dtype2 = dpt.dtype(ti.default_device_int_type(dev))
+                elif isinstance(dtype2, WeakComplexType):
+                    if st_dtype is dpt.float16 or st_dtype is dpt.float32:
+                        ret_dtype2 = dpt.complex64
+                    ret_dtype2 = _to_device_supported_dtype(dpt.complex128, dev)
+                else:
+                    ret_dtype2 = _to_device_supported_dtype(dpt.float64, dev)
+            else:
+                ret_dtype2 = st_dtype
+
+            return ret_dtype1, ret_dtype2
+
+        max_dt_num_kind, max_dtype = max(
+            [
+                (_strong_dtype_num_kind(st_dtype), st_dtype),
+                (_strong_dtype_num_kind(dtype2), dtype2),
+            ]
+        )
+        dt1_kind_num = _weak_type_num_kind(dtype1)
+        if dt1_kind_num > max_dt_num_kind:
+            if isinstance(dtype1, WeakIntegralType):
+                return dpt.dtype(ti.default_device_int_type(dev)), dtype2
+            if isinstance(dtype1, WeakComplexType):
+                if max_dtype is dpt.float16 or max_dtype is dpt.float32:
+                    return dpt.complex64, dtype2
+                return (
+                    _to_device_supported_dtype(dpt.complex128, dev),
+                    dtype2,
+                )
+            return _to_device_supported_dtype(dpt.float64, dev), dtype2
+        else:
+            return max_dtype, dtype2
+    elif _is_weak_dtype(dtype2):
+        max_dt_num_kind, max_dtype = max(
+            [
+                (_strong_dtype_num_kind(st_dtype), st_dtype),
+                (_strong_dtype_num_kind(dtype1), dtype1),
+            ]
+        )
+        dt2_kind_num = _weak_type_num_kind(dtype2)
+        if dt2_kind_num > max_dt_num_kind:
+            if isinstance(dtype2, WeakIntegralType):
+                return dtype1, dpt.dtype(ti.default_device_int_type(dev))
+            if isinstance(dtype2, WeakComplexType):
+                if max_dtype is dpt.float16 or max_dtype is dpt.float32:
+                    return dtype1, dpt.complex64
+                return (
+                    dtype1,
+                    _to_device_supported_dtype(dpt.complex128, dev),
+                )
+            return dtype1, _to_device_supported_dtype(dpt.float64, dev)
+        else:
+            return dtype1, max_dtype
+    else:
+        # both are strong dtypes
+        # return unmodified
+        return dtype1, dtype2
+
+
+def _resolve_one_strong_one_weak_types(st_dtype, dtype, dev):
+    "Resolves one weak data type with one strong data type per NEP-0050"
+    if _is_weak_dtype(st_dtype):
+        raise ValueError
+    if _is_weak_dtype(dtype):
+        st_kind_num = _strong_dtype_num_kind(st_dtype)
+        kind_num = _weak_type_num_kind(dtype)
+        if kind_num > st_kind_num:
+            if isinstance(dtype, WeakIntegralType):
+                return dpt.dtype(ti.default_device_int_type(dev))
+            if isinstance(dtype, WeakComplexType):
+                if st_dtype is dpt.float16 or st_dtype is dpt.float32:
+                    return dpt.complex64
+                return _to_device_supported_dtype(dpt.complex128, dev)
+            return _to_device_supported_dtype(dpt.float64, dev)
+        else:
+            return st_dtype
+    else:
+        return dtype
+
+
 class finfo_object:
     """
     `numpy.finfo` subclass which returns Python floating-point scalars for
@@ -838,6 +944,8 @@ __all__ = [
     "_acceptance_fn_divide",
     "_acceptance_fn_negative",
     "_acceptance_fn_subtract",
+    "_resolve_one_strong_one_weak_types",
+    "_resolve_one_strong_two_weak_types",
     "_resolve_weak_types",
     "_resolve_weak_types_all_py_ints",
     "_weak_type_num_kind",

--- a/dpctl/tensor/_utility_functions.py
+++ b/dpctl/tensor/_utility_functions.py
@@ -465,7 +465,20 @@ def diff(x, /, *, axis=-1, n=1, prepend=None, append=None):
     )
 
     diff_op = dpt.not_equal if x.dtype == dpt.bool else dpt.subtract
-    for _ in range(n):
+    if n > 1:
+        arr_tmp0 = diff_op(arr[sl0], arr[sl1])
+        arr_tmp1 = diff_op(arr_tmp0[sl0], arr_tmp0[sl1])
+        n = n - 2
+        if n > 0:
+            sl3 = tuple(
+                slice(None) if i != axis else slice(None, -2)
+                for i in range(x_nd)
+            )
+            for _ in range(n):
+                arr_tmp0_sliced = arr_tmp0[sl3]
+                diff_op(arr_tmp1[sl0], arr_tmp1[sl1], out=arr_tmp0_sliced)
+                arr_tmp0, arr_tmp1 = arr_tmp1, arr_tmp0_sliced
+        arr = arr_tmp1
+    else:
         arr = diff_op(arr[sl0], arr[sl1])
-
     return arr

--- a/dpctl/tensor/_utility_functions.py
+++ b/dpctl/tensor/_utility_functions.py
@@ -20,10 +20,6 @@ import dpctl.tensor as dpt
 import dpctl.tensor._tensor_impl as ti
 import dpctl.tensor._tensor_reductions_impl as tri
 import dpctl.utils as du
-from dpctl.tensor._clip import (
-    _resolve_one_strong_one_weak_types,
-    _resolve_one_strong_two_weak_types,
-)
 from dpctl.tensor._elementwise_common import (
     _get_dtype,
     _get_queue_usm_type,
@@ -32,6 +28,10 @@ from dpctl.tensor._elementwise_common import (
 )
 
 from ._numpy_helper import normalize_axis_index, normalize_axis_tuple
+from ._type_utils import (
+    _resolve_one_strong_one_weak_types,
+    _resolve_one_strong_two_weak_types,
+)
 
 
 def _boolean_reduction(x, axis, keepdims, func):
@@ -159,6 +159,8 @@ def any(x, /, *, axis=None, keepdims=False):
 
 
 def _validate_diff_shape(sh1, sh2, axis):
+    """Utility for validating that two shapes `sh1` and `sh2`
+    are possible to concatenate along `axis`."""
     if not sh2:
         # scalars will always be accepted
         return True
@@ -173,6 +175,9 @@ def _validate_diff_shape(sh1, sh2, axis):
 
 
 def _concat_diff_input(arr, axis, prepend, append):
+    """Concatenates `arr`, `prepend` and, `append` along `axis`,
+    where `arr` is an array and `prepend` and `append` are
+    any mixture of arrays and scalars."""
     if prepend is not None and append is not None:
         q1, x_usm_type = arr.sycl_queue, arr.usm_type
         q2, prepend_usm_type = _get_queue_usm_type(prepend)

--- a/dpctl/tensor/_utility_functions.py
+++ b/dpctl/tensor/_utility_functions.py
@@ -260,7 +260,9 @@ def _concat_diff_input(arr, axis, prepend, append):
         arr_dtype = arr.dtype
         prepend_dtype = _get_dtype(prepend, sycl_dev)
         append_dtype = _get_dtype(append, sycl_dev)
-        if not all(_validate_dtype(o) for o in (prepend_dtype, append_dtype)):
+        if not builtins.all(
+            _validate_dtype(o) for o in (prepend_dtype, append_dtype)
+        ):
             raise ValueError("Operands have unsupported data types")
         prepend_dtype, append_dtype = _resolve_one_strong_two_weak_types(
             arr_dtype, prepend_dtype, append_dtype, sycl_dev

--- a/dpctl/tensor/_utility_functions.py
+++ b/dpctl/tensor/_utility_functions.py
@@ -280,7 +280,7 @@ def _concat_diff_input(arr, axis, prepend, append):
             a_append = append
         else:
             a_append = dpt.asarray(
-                prepend,
+                append,
                 dtype=append_dtype,
                 usm_type=coerced_usm_type,
                 sycl_queue=exec_q,

--- a/dpctl/tensor/_utility_functions.py
+++ b/dpctl/tensor/_utility_functions.py
@@ -14,12 +14,24 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
+import operator
+
 import dpctl.tensor as dpt
 import dpctl.tensor._tensor_impl as ti
 import dpctl.tensor._tensor_reductions_impl as tri
 import dpctl.utils as du
+from dpctl.tensor._clip import (
+    _resolve_one_strong_one_weak_types,
+    _resolve_one_strong_two_weak_types,
+)
+from dpctl.tensor._elementwise_common import (
+    _get_dtype,
+    _get_queue_usm_type,
+    _get_shape,
+    _validate_dtype,
+)
 
-from ._numpy_helper import normalize_axis_tuple
+from ._numpy_helper import normalize_axis_index, normalize_axis_tuple
 
 
 def _boolean_reduction(x, axis, keepdims, func):
@@ -144,3 +156,272 @@ def any(x, /, *, axis=None, keepdims=False):
             containing the results of the logical OR reduction.
     """
     return _boolean_reduction(x, axis, keepdims, tri._any)
+
+
+def _validate_diff_shape(sh1, sh2, axis):
+    if not sh2:
+        # scalars will always be accepted
+        return True
+    else:
+        sh1_ndim = len(sh1)
+        if sh1_ndim == len(sh2) and all(
+            sh1[i] == sh2[i] for i in range(sh1_ndim) if i != axis
+        ):
+            return True
+        else:
+            return False
+
+
+def _concat_diff_input(arr, axis, prepend, append):
+    if prepend is not None and append is not None:
+        q1, x_usm_type = arr.sycl_queue, arr.usm_type
+        q2, prepend_usm_type = _get_queue_usm_type(prepend)
+        q3, append_usm_type = _get_queue_usm_type(append)
+        if q2 is None and q3 is None:
+            exec_q = q1
+            coerced_usm_type = x_usm_type
+        elif q3 is None:
+            exec_q = du.get_execution_queue((q1, q2))
+            if exec_q is None:
+                raise du.ExecutionPlacementError(
+                    "Execution placement can not be unambiguously inferred "
+                    "from input arguments."
+                )
+            coerced_usm_type = du.get_coerced_usm_type(
+                (
+                    x_usm_type,
+                    prepend_usm_type,
+                )
+            )
+        elif q2 is None:
+            exec_q = du.get_execution_queue((q1, q3))
+            if exec_q is None:
+                raise du.ExecutionPlacementError(
+                    "Execution placement can not be unambiguously inferred "
+                    "from input arguments."
+                )
+            coerced_usm_type = du.get_coerced_usm_type(
+                (
+                    x_usm_type,
+                    append_usm_type,
+                )
+            )
+        else:
+            exec_q = du.get_execution_queue((q1, q2, q3))
+            if exec_q is None:
+                raise du.ExecutionPlacementError(
+                    "Execution placement can not be unambiguously inferred "
+                    "from input arguments."
+                )
+            coerced_usm_type = du.get_coerced_usm_type(
+                (
+                    x_usm_type,
+                    prepend_usm_type,
+                    append_usm_type,
+                )
+            )
+        du.validate_usm_type(coerced_usm_type, allow_none=False)
+        arr_shape = arr.shape
+        prepend_shape = _get_shape(prepend)
+        append_shape = _get_shape(append)
+        if not all(
+            isinstance(s, (tuple, list))
+            for s in (
+                prepend_shape,
+                append_shape,
+            )
+        ):
+            raise TypeError(
+                "Shape of arguments can not be inferred. "
+                "Arguments are expected to be "
+                "lists, tuples, or both"
+            )
+        valid_prepend_shape = _validate_diff_shape(
+            arr_shape, prepend_shape, axis
+        )
+        if not valid_prepend_shape:
+            raise ValueError(
+                f"`diff` argument `prepend` with shape {prepend_shape} is "
+                f"invalid for first input with shape {arr_shape}"
+            )
+        valid_append_shape = _validate_diff_shape(arr_shape, append_shape, axis)
+        if not valid_append_shape:
+            raise ValueError(
+                f"`diff` argument `append` with shape {append_shape} is invalid"
+                f" for first input with shape {arr_shape}"
+            )
+        sycl_dev = exec_q.sycl_device
+        arr_dtype = arr.dtype
+        prepend_dtype = _get_dtype(prepend, sycl_dev)
+        append_dtype = _get_dtype(append, sycl_dev)
+        if not all(_validate_dtype(o) for o in (prepend_dtype, append_dtype)):
+            raise ValueError("Operands have unsupported data types")
+        prepend_dtype, append_dtype = _resolve_one_strong_two_weak_types(
+            arr_dtype, prepend_dtype, append_dtype, sycl_dev
+        )
+        if isinstance(prepend, dpt.usm_ndarray):
+            a_prepend = prepend
+        else:
+            a_prepend = dpt.asarray(
+                prepend,
+                dtype=prepend_dtype,
+                usm_type=coerced_usm_type,
+                sycl_queue=exec_q,
+            )
+        if isinstance(append, dpt.usm_ndarray):
+            a_append = append
+        else:
+            a_append = dpt.asarray(
+                prepend,
+                dtype=append_dtype,
+                usm_type=coerced_usm_type,
+                sycl_queue=exec_q,
+            )
+        if not prepend_shape:
+            prepend_shape = arr_shape[:axis] + (1,) + arr_shape[axis + 1 :]
+            a_prepend = dpt.broadcast_to(a_prepend, arr_shape)
+        if not append_shape:
+            append_shape = arr_shape[:axis] + (1,) + arr_shape[axis + 1 :]
+            a_append = dpt.broadcast_to(a_append, arr_shape)
+        return dpt.concat((a_prepend, arr, a_append), axis=axis)
+    elif prepend is not None:
+        q1, x_usm_type = arr.sycl_queue, arr.usm_type
+        q2, prepend_usm_type = _get_queue_usm_type(prepend)
+        if q2 is None:
+            exec_q = q1
+            coerced_usm_type = x_usm_type
+        else:
+            exec_q = du.get_execution_queue((q1, q2))
+            if exec_q is None:
+                raise du.ExecutionPlacementError(
+                    "Execution placement can not be unambiguously inferred "
+                    "from input arguments."
+                )
+            coerced_usm_type = du.get_coerced_usm_type(
+                (
+                    x_usm_type,
+                    prepend_usm_type,
+                )
+            )
+        du.validate_usm_type(coerced_usm_type, allow_none=False)
+        arr_shape = arr.shape
+        prepend_shape = _get_shape(prepend)
+        if not isinstance(prepend_shape, (tuple, list)):
+            raise TypeError(
+                "Shape of argument can not be inferred. "
+                "Argument is expected to be a "
+                "list or tuple"
+            )
+        valid_prepend_shape = _validate_diff_shape(
+            arr_shape, prepend_shape, axis
+        )
+        if not valid_prepend_shape:
+            raise ValueError(
+                f"`diff` argument `prepend` with shape {prepend_shape} is "
+                f"invalid for first input with shape {arr_shape}"
+            )
+        sycl_dev = exec_q.sycl_device
+        arr_dtype = arr.dtype
+        prepend_dtype = _get_dtype(prepend, sycl_dev)
+        if not _validate_dtype(prepend_dtype):
+            raise ValueError("Operand has unsupported data type")
+        prepend_dtype = _resolve_one_strong_one_weak_types(
+            arr_dtype, prepend_dtype, sycl_dev
+        )
+        if isinstance(prepend, dpt.usm_ndarray):
+            a_prepend = prepend
+        else:
+            a_prepend = dpt.asarray(
+                prepend,
+                dtype=prepend_dtype,
+                usm_type=coerced_usm_type,
+                sycl_queue=exec_q,
+            )
+        if not prepend_shape:
+            prepend_shape = arr_shape[:axis] + (1,) + arr_shape[axis + 1 :]
+            a_prepend = dpt.broadcast_to(a_prepend, arr_shape)
+        return dpt.concat((a_prepend, arr), axis=axis)
+    elif append is not None:
+        q1, x_usm_type = arr.sycl_queue, arr.usm_type
+        q2, append_usm_type = _get_queue_usm_type(append)
+        if q2 is None:
+            exec_q = q1
+            coerced_usm_type = x_usm_type
+        else:
+            exec_q = du.get_execution_queue((q1, q2))
+            if exec_q is None:
+                raise du.ExecutionPlacementError(
+                    "Execution placement can not be unambiguously inferred "
+                    "from input arguments."
+                )
+            coerced_usm_type = du.get_coerced_usm_type(
+                (
+                    x_usm_type,
+                    append_usm_type,
+                )
+            )
+        du.validate_usm_type(coerced_usm_type, allow_none=False)
+        arr_shape = arr.shape
+        append_shape = _get_shape(append)
+        if not isinstance(append_shape, (tuple, list)):
+            raise TypeError(
+                "Shape of argument can not be inferred. "
+                "Argument is expected to be a "
+                "list or tuple"
+            )
+        valid_append_shape = _validate_diff_shape(arr_shape, append_shape, axis)
+        if not valid_append_shape:
+            raise ValueError(
+                f"`diff` argument `append` with shape {append_shape} is invalid"
+                f" for first input with shape {arr_shape}"
+            )
+        sycl_dev = exec_q.sycl_device
+        arr_dtype = arr.dtype
+        append_dtype = _get_dtype(append, sycl_dev)
+        if not _validate_dtype(append_dtype):
+            raise ValueError("Operand has unsupported data type")
+        append_dtype = _resolve_one_strong_one_weak_types(
+            arr_dtype, append_dtype, sycl_dev
+        )
+        if isinstance(append, dpt.usm_ndarray):
+            a_append = append
+        else:
+            a_append = dpt.asarray(
+                append,
+                dtype=append_dtype,
+                usm_type=coerced_usm_type,
+                sycl_queue=exec_q,
+            )
+        if not append_shape:
+            append_shape = arr_shape[:axis] + (1,) + arr_shape[axis + 1 :]
+            a_append = dpt.broadcast_to(a_append, arr_shape)
+        return dpt.concat((arr, a_append), axis=axis)
+    else:
+        arr1 = arr
+    return arr1
+
+
+def diff(x, /, *, axis=-1, n=1, prepend=None, append=None):
+
+    if not isinstance(x, dpt.usm_ndarray):
+        raise TypeError(
+            "Expecting dpctl.tensor.usm_ndarray type, " f"got {type(x)}"
+        )
+    x_nd = x.ndim
+    axis = normalize_axis_index(operator.index(axis), x_nd)
+    n = operator.index(n)
+
+    arr = _concat_diff_input(x, axis, prepend, append)
+
+    # form slices and recurse
+    sl0 = tuple(
+        slice(None) if i != axis else slice(1, None) for i in range(x_nd)
+    )
+    sl1 = tuple(
+        slice(None) if i != axis else slice(None, -1) for i in range(x_nd)
+    )
+
+    for _ in range(n):
+        arr = arr[sl0] - arr[sl1]
+
+    return arr

--- a/dpctl/tensor/_utility_functions.py
+++ b/dpctl/tensor/_utility_functions.py
@@ -407,6 +407,43 @@ def _concat_diff_input(arr, axis, prepend, append):
 
 
 def diff(x, /, *, axis=-1, n=1, prepend=None, append=None):
+    """
+    Calculates the `n`-th discrete forward difference of `x` along `axis`.
+
+    Args:
+        x (usm_ndarray):
+            input array.
+        axis (int):
+            axis along which to compute the difference. A valid axis must be on
+            the interval `[-N, N)`, where `N` is the rank (number of
+            dimensions) of `x`.
+            Default: `-1`
+        n (int):
+            number of times to recursively compute the difference.
+            Default: `1`.
+        prepend (Union[usm_ndarray, bool, int, float, complex]):
+            value or values to prepend to the specified axis before taking the
+            difference.
+            Must have the same shape as `x` except along `axis`, which can have
+            any shape.
+            Default: `None`.
+        append (Union[usm_ndarray, bool, int, float, complex]):
+            value or values to append to the specified axis before taking the
+            difference.
+            Must have the same shape as `x` except along `axis`, which can have
+            any shape.
+            Default: `None`.
+
+    Returns:
+        usm_ndarray:
+            an array containing the `n`-th differences. The array will have the
+            same shape as `x`, except along `axis`, which will have shape
+
+            - prepend.shape[axis] + x.shape[axis] + append.shape[axis] - n
+
+            The data type of the returned array is determined by the Type
+            Promotion Rules.
+    """
 
     if not isinstance(x, dpt.usm_ndarray):
         raise TypeError(
@@ -417,7 +454,8 @@ def diff(x, /, *, axis=-1, n=1, prepend=None, append=None):
     n = operator.index(n)
 
     arr = _concat_diff_input(x, axis, prepend, append)
-
+    if n == 0:
+        return arr
     # form slices and recurse
     sl0 = tuple(
         slice(None) if i != axis else slice(1, None) for i in range(x_nd)

--- a/dpctl/tensor/_utility_functions.py
+++ b/dpctl/tensor/_utility_functions.py
@@ -464,7 +464,8 @@ def diff(x, /, *, axis=-1, n=1, prepend=None, append=None):
         slice(None) if i != axis else slice(None, -1) for i in range(x_nd)
     )
 
+    diff_op = dpt.not_equal if x.dtype == dpt.bool else dpt.subtract
     for _ in range(n):
-        arr = arr[sl0] - arr[sl1]
+        arr = diff_op(arr[sl0], arr[sl1])
 
     return arr

--- a/dpctl/tensor/_utility_functions.py
+++ b/dpctl/tensor/_utility_functions.py
@@ -440,10 +440,8 @@ def diff(x, /, *, axis=-1, n=1, prepend=None, append=None):
     Returns:
         usm_ndarray:
             an array containing the `n`-th differences. The array will have the
-            same shape as `x`, except along `axis`, which will have shape
-
-            - prepend.shape[axis] + x.shape[axis] + append.shape[axis] - n
-
+            same shape as `x`, except along `axis`, which will have shape:
+                prepend.shape[axis] + x.shape[axis] + append.shape[axis] - n
             The data type of the returned array is determined by the Type
             Promotion Rules.
     """

--- a/dpctl/tensor/_utility_functions.py
+++ b/dpctl/tensor/_utility_functions.py
@@ -287,10 +287,10 @@ def _concat_diff_input(arr, axis, prepend, append):
             )
         if not prepend_shape:
             prepend_shape = arr_shape[:axis] + (1,) + arr_shape[axis + 1 :]
-            a_prepend = dpt.broadcast_to(a_prepend, arr_shape)
+            a_prepend = dpt.broadcast_to(a_prepend, prepend_shape)
         if not append_shape:
             append_shape = arr_shape[:axis] + (1,) + arr_shape[axis + 1 :]
-            a_append = dpt.broadcast_to(a_append, arr_shape)
+            a_append = dpt.broadcast_to(a_append, append_shape)
         return dpt.concat((a_prepend, arr, a_append), axis=axis)
     elif prepend is not None:
         q1, x_usm_type = arr.sycl_queue, arr.usm_type
@@ -347,7 +347,7 @@ def _concat_diff_input(arr, axis, prepend, append):
             )
         if not prepend_shape:
             prepend_shape = arr_shape[:axis] + (1,) + arr_shape[axis + 1 :]
-            a_prepend = dpt.broadcast_to(a_prepend, arr_shape)
+            a_prepend = dpt.broadcast_to(a_prepend, prepend_shape)
         return dpt.concat((a_prepend, arr), axis=axis)
     elif append is not None:
         q1, x_usm_type = arr.sycl_queue, arr.usm_type
@@ -402,7 +402,7 @@ def _concat_diff_input(arr, axis, prepend, append):
             )
         if not append_shape:
             append_shape = arr_shape[:axis] + (1,) + arr_shape[axis + 1 :]
-            a_append = dpt.broadcast_to(a_append, arr_shape)
+            a_append = dpt.broadcast_to(a_append, append_shape)
         return dpt.concat((arr, a_append), axis=axis)
     else:
         arr1 = arr

--- a/dpctl/tensor/_utility_functions.py
+++ b/dpctl/tensor/_utility_functions.py
@@ -14,6 +14,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
+import builtins
 import operator
 
 import dpctl.tensor as dpt
@@ -166,7 +167,7 @@ def _validate_diff_shape(sh1, sh2, axis):
         return True
     else:
         sh1_ndim = len(sh1)
-        if sh1_ndim == len(sh2) and all(
+        if sh1_ndim == len(sh2) and builtins.all(
             sh1[i] == sh2[i] for i in range(sh1_ndim) if i != axis
         ):
             return True
@@ -229,7 +230,7 @@ def _concat_diff_input(arr, axis, prepend, append):
         arr_shape = arr.shape
         prepend_shape = _get_shape(prepend)
         append_shape = _get_shape(append)
-        if not all(
+        if not builtins.all(
             isinstance(s, (tuple, list))
             for s in (
                 prepend_shape,

--- a/dpctl/tests/test_tensor_diff.py
+++ b/dpctl/tests/test_tensor_diff.py
@@ -1,0 +1,81 @@
+#                       Data Parallel Control (dpctl)
+#
+#  Copyright 2020-2024 Intel Corporation
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import pytest
+
+import dpctl.tensor as dpt
+from dpctl.tests.helper import get_queue_or_skip, skip_if_dtype_not_supported
+
+_all_dtypes = [
+    "?",
+    "i1",
+    "u1",
+    "i2",
+    "u2",
+    "i4",
+    "u4",
+    "i8",
+    "u8",
+    "f2",
+    "f4",
+    "f8",
+    "c8",
+    "c16",
+]
+
+
+@pytest.mark.parametrize("dt", _all_dtypes)
+def test_diff_basic(dt):
+    q = get_queue_or_skip()
+    skip_if_dtype_not_supported(dt, q)
+
+    x = dpt.asarray([9, 12, 7, 17, 10, 18, 15, 9, 8, 8], dtype=dt, sycl_queue=q)
+    res = dpt.diff(x)
+    op = dpt.not_equal if x.dtype is dpt.bool else dpt.subtract
+    expected_res = op(x[1:], x[:-1])
+    if dpt.dtype(dt).kind in "fc":
+        assert dpt.allclose(res, expected_res)
+    else:
+        assert dpt.all(res == expected_res)
+
+    res = dpt.diff(x, n=5)
+    expected_res = x
+    for _ in range(5):
+        expected_res = op(expected_res[1:], expected_res[:-1])
+    if dpt.dtype(dt).kind in "fc":
+        assert dpt.allclose(res, expected_res)
+    else:
+        assert dpt.all(res == expected_res)
+
+
+def test_diff_axis():
+    get_queue_or_skip()
+
+    x = dpt.tile(
+        dpt.asarray([9, 12, 7, 17, 10, 18, 15, 9, 8, 8], dtype="i4"), (3, 4, 1)
+    )
+    x[:, ::2, :] = 0
+    res = dpt.diff(x, n=1, axis=1)
+    expected_res = dpt.subtract(x[:, 1:, :], x[:, :-1, :])
+    assert dpt.all(res == expected_res)
+
+    res = dpt.diff(x, n=3, axis=1)
+    expected_res = x
+    for _ in range(3):
+        expected_res = dpt.subtract(
+            expected_res[:, 1:, :], expected_res[:, :-1, :]
+        )
+    assert dpt.all(res == expected_res)

--- a/dpctl/tests/test_tensor_diff.py
+++ b/dpctl/tests/test_tensor_diff.py
@@ -71,9 +71,9 @@ def test_diff_axis():
     x[:, ::2, :] = 0
 
     for n in [1, 2, 3]:
-        res = dpt.diff(x, n=3, axis=1)
+        res = dpt.diff(x, n=n, axis=1)
         expected_res = x
-        for _ in range(3):
+        for _ in range(n):
             expected_res = dpt.subtract(
                 expected_res[:, 1:, :], expected_res[:, :-1, :]
             )
@@ -90,10 +90,10 @@ def test_diff_prepend_append_type_promotion():
         ("i8", "c8", "u8"),
     ]
 
-    for _dts in dts:
-        x = dpt.ones(10, dtype=_dts[1])
-        prepend = dpt.full(1, 2, dtype=_dts[0])
-        append = dpt.full(1, 3, dtype=_dts[2])
+    for dt0, dt1, dt2 in dts:
+        x = dpt.ones(10, dtype=dt1)
+        prepend = dpt.full(1, 2, dtype=dt0)
+        append = dpt.full(1, 3, dtype=dt2)
 
         res = dpt.diff(x, prepend=prepend, append=append)
         assert res.dtype == _to_device_supported_dtype(

--- a/dpctl/tests/test_tensor_diff.py
+++ b/dpctl/tests/test_tensor_diff.py
@@ -247,8 +247,7 @@ def test_diff_wrong_append_prepend_shape():
 
     assert_raises_regex(
         ValueError,
-        "`diff` argument `prepend` with shape.*is invalid"
-        " for first input with shape.*",
+        ".*shape.*is invalid.*",
         dpt.diff,
         arr,
         prepend=arr_bad_sh,
@@ -257,8 +256,7 @@ def test_diff_wrong_append_prepend_shape():
 
     assert_raises_regex(
         ValueError,
-        "`diff` argument `append` with shape.*is invalid"
-        " for first input with shape.*",
+        ".*shape.*is invalid.*",
         dpt.diff,
         arr,
         prepend=arr,
@@ -267,8 +265,7 @@ def test_diff_wrong_append_prepend_shape():
 
     assert_raises_regex(
         ValueError,
-        "`diff` argument `prepend` with shape.*is invalid"
-        " for first input with shape.*",
+        ".*shape.*is invalid.*",
         dpt.diff,
         arr,
         prepend=arr_bad_sh,
@@ -276,8 +273,7 @@ def test_diff_wrong_append_prepend_shape():
 
     assert_raises_regex(
         ValueError,
-        "`diff` argument `append` with shape.*is invalid"
-        " for first input with shape.*",
+        ".*shape.*is invalid.*",
         dpt.diff,
         arr,
         append=arr_bad_sh,
@@ -293,53 +289,20 @@ def test_diff_compute_follows_data():
     ar2 = dpt.ones(1, dtype="i4", sycl_queue=q2)
     ar3 = dpt.ones(1, dtype="i4", sycl_queue=q3)
 
-    assert_raises_regex(
-        ExecutionPlacementError,
-        "Execution placement can not be unambiguously inferred from input "
-        "arguments",
-        dpt.diff,
-        ar1,
-        prepend=ar2,
-        append=ar3,
-    )
+    with pytest.raises(ExecutionPlacementError):
+        dpt.diff(ar1, prepend=ar2, append=ar3)
 
-    assert_raises_regex(
-        ExecutionPlacementError,
-        "Execution placement can not be unambiguously inferred from input "
-        "arguments",
-        dpt.diff,
-        ar1,
-        prepend=ar2,
-        append=0,
-    )
+    with pytest.raises(ExecutionPlacementError):
+        dpt.diff(ar1, prepend=ar2, append=0)
 
-    assert_raises_regex(
-        ExecutionPlacementError,
-        "Execution placement can not be unambiguously inferred from input "
-        "arguments",
-        dpt.diff,
-        ar1,
-        prepend=0,
-        append=ar2,
-    )
+    with pytest.raises(ExecutionPlacementError):
+        dpt.diff(ar1, prepend=0, append=ar2)
 
-    assert_raises_regex(
-        ExecutionPlacementError,
-        "Execution placement can not be unambiguously inferred from input "
-        "arguments",
-        dpt.diff,
-        ar1,
-        prepend=ar2,
-    )
+    with pytest.raises(ExecutionPlacementError):
+        dpt.diff(ar1, prepend=ar2)
 
-    assert_raises_regex(
-        ExecutionPlacementError,
-        "Execution placement can not be unambiguously inferred from input "
-        "arguments",
-        dpt.diff,
-        ar1,
-        append=ar2,
-    )
+    with pytest.raises(ExecutionPlacementError):
+        dpt.diff(ar1, append=ar2)
 
 
 def test_diff_input_validation():

--- a/dpctl/tests/test_tensor_diff.py
+++ b/dpctl/tests/test_tensor_diff.py
@@ -122,3 +122,22 @@ def test_diff_0d():
     x = dpt.ones(())
     with pytest.raises(ValueError):
         dpt.diff(x)
+
+
+def test_diff_empty_array():
+    get_queue_or_skip()
+
+    x = dpt.ones((3, 0, 5))
+    res = dpt.diff(x, axis=1)
+    assert res.shape == x.shape
+
+    res = dpt.diff(x, axis=0)
+    assert res.shape == (2, 0, 5)
+
+    append = dpt.ones((3, 2, 5))
+    res = dpt.diff(x, axis=1, append=append)
+    assert res.shape == (3, 1, 5)
+
+    prepend = dpt.ones((3, 2, 5))
+    res = dpt.diff(x, axis=1, prepend=prepend)
+    assert res.shape == (3, 1, 5)

--- a/dpctl/tests/test_tensor_diff.py
+++ b/dpctl/tests/test_tensor_diff.py
@@ -150,7 +150,8 @@ def test_diff_no_op():
     res = dpt.diff(x, n=0)
     assert dpt.all(x == res)
 
-    res = dpt.diff(dpt.reshape(x, (2, 5)), n=0, axis=0)
+    x = dpt.reshape(x, (2, 5))
+    res = dpt.diff(x, n=0, axis=0)
     assert dpt.all(x == res)
 
 

--- a/dpctl/tests/test_usm_ndarray_reductions.py
+++ b/dpctl/tests/test_usm_ndarray_reductions.py
@@ -682,9 +682,9 @@ def test_count_nonzero(dt):
     x = dpt.ones(10, dtype=dt, sycl_queue=q)
     res = dpt.count_nonzero(x)
     assert res == 10
-    assert x.dtype == expected_dt
+    assert res.dtype == expected_dt
 
     x[3:6] = 0
     res = dpt.count_nonzero(x)
     assert res == 7
-    assert x.dtype == expected_dt
+    assert res.dtype == expected_dt

--- a/dpctl/tests/test_usm_ndarray_reductions.py
+++ b/dpctl/tests/test_usm_ndarray_reductions.py
@@ -21,6 +21,7 @@ import pytest
 from numpy.testing import assert_allclose
 
 import dpctl.tensor as dpt
+from dpctl.tensor._tensor_impl import default_device_index_type
 from dpctl.tests.helper import get_queue_or_skip, skip_if_dtype_not_supported
 from dpctl.utils import ExecutionPlacementError
 
@@ -669,3 +670,21 @@ def test_reduction_out_kwarg_arg_validation():
             keepdims=True,
             out=dpt.empty_like(out_wrong_keepdims, dtype=ind_dt),
         )
+
+
+@pytest.mark.parametrize("dt", _all_dtypes)
+def test_count_nonzero(dt):
+    q = get_queue_or_skip()
+    skip_if_dtype_not_supported(dt, q)
+
+    expected_dt = default_device_index_type(q.sycl_device)
+
+    x = dpt.ones(10, dtype=dt, sycl_queue=q)
+    res = dpt.count_nonzero(x)
+    assert res == 10
+    assert x.dtype == expected_dt
+
+    x[3:6] = 0
+    res = dpt.count_nonzero(x)
+    assert res == 7
+    assert x.dtype == expected_dt


### PR DESCRIPTION
This PR proposes introducing two new functions to dpctl which will be coming to the array API specification's next version: `count_nonzero` and `diff`.

* `count_nonzero` casts an array to `bool` before calling `sum`. As dedicated kernels for `sum` of `bool` into any integer type, the summation won't require any additional copies.

* `diff` recursively takes the `n`-th forward difference along a given axis of an array. `prepend` and `append` arguments (which can be arrays or scalars) are concatenated to the input array. We diverge from the array API by permitting scalars for `prepend` and `append` as well as not constraining them to the same type as the input array

- [X] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [X] Have you tested your changes locally for CPU and GPU devices?
- [X] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [X] If this PR is a work in progress, are you opening the PR as a draft?
