### PR TITLE
Dpctl support for numpy 2.0 in runtime

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,23 +2,23 @@
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
 -   repo: https://github.com/PyCQA/bandit
-    rev: '1.7.4'
+    rev: '1.7.9'
     hooks:
     -   id: bandit
         pass_filenames: false
         args: ["-r", "dpctl", "-lll"]
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.3.0
+    rev: v4.6.0
     hooks:
     -   id: end-of-file-fixer
     -   id: trailing-whitespace
 -   repo: https://github.com/psf/black
-    rev: 22.12.0
+    rev: 24.4.2
     hooks:
     -   id: black
         exclude: "versioneer.py|dpctl/_version.py"
 -   repo: https://github.com/pycqa/isort
-    rev: 5.12.0
+    rev: 5.13.2
     hooks:
     -   id: isort
         name: isort (python)
@@ -29,7 +29,7 @@ repos:
         name: isort (pyi)
         types: [pyi]
 -   repo: https://github.com/pycqa/flake8
-    rev: 5.0.4
+    rev: 7.1.0
     hooks:
     -   id: flake8
 -   repo: https://github.com/pocc/pre-commit-hooks

--- a/dpctl/tensor/_accumulation.py
+++ b/dpctl/tensor/_accumulation.py
@@ -14,8 +14,6 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-from numpy.core.numeric import normalize_axis_index
-
 import dpctl
 import dpctl.tensor as dpt
 import dpctl.tensor._tensor_accumulation_impl as tai
@@ -26,6 +24,8 @@ from dpctl.tensor._type_utils import (
     _to_device_supported_dtype,
 )
 from dpctl.utils import ExecutionPlacementError, SequentialOrderManager
+
+from ._numpy_helper import normalize_axis_index
 
 
 def _accumulate_common(

--- a/dpctl/tensor/_copy_utils.py
+++ b/dpctl/tensor/_copy_utils.py
@@ -17,7 +17,6 @@ import builtins
 import operator
 
 import numpy as np
-from numpy.core.numeric import normalize_axis_index
 
 import dpctl
 import dpctl.memory as dpm
@@ -27,6 +26,8 @@ import dpctl.utils
 from dpctl.tensor._data_types import _get_dtype
 from dpctl.tensor._device import normalize_queue_device
 from dpctl.tensor._type_utils import _dtype_supported_by_device_impl
+
+from ._numpy_helper import normalize_axis_index
 
 __doc__ = (
     "Implementation module for copy- and cast- operations on "
@@ -382,9 +383,11 @@ def _empty_like_orderK(X, dt, usm_type=None, dev=None):
     if min(st) < 0:
         st_sorted = [st[i] for i in perm]
         sl = tuple(
-            slice(None, None, -1)
-            if st_sorted[i] < 0
-            else slice(None, None, None)
+            (
+                slice(None, None, -1)
+                if st_sorted[i] < 0
+                else slice(None, None, None)
+            )
             for i in range(X.ndim)
         )
         R = R[sl]
@@ -435,9 +438,11 @@ def _empty_like_pair_orderK(X1, X2, dt, res_shape, usm_type, dev):
     R = dpt.empty(sh_sorted, dtype=dt, usm_type=usm_type, device=dev, order="C")
     if max(min(st1_sorted), min(st2_sorted)) < 0:
         sl = tuple(
-            slice(None, None, -1)
-            if (st1_sorted[i] < 0 and st2_sorted[i] < 0)
-            else slice(None, None, None)
+            (
+                slice(None, None, -1)
+                if (st1_sorted[i] < 0 and st2_sorted[i] < 0)
+                else slice(None, None, None)
+            )
             for i in range(nd1)
         )
         R = R[sl]
@@ -503,9 +508,15 @@ def _empty_like_triple_orderK(X1, X2, X3, dt, res_shape, usm_type, dev):
     R = dpt.empty(sh_sorted, dtype=dt, usm_type=usm_type, device=dev, order="C")
     if max(min(st1_sorted), min(st2_sorted), min(st3_sorted)) < 0:
         sl = tuple(
-            slice(None, None, -1)
-            if (st1_sorted[i] < 0 and st2_sorted[i] < 0 and st3_sorted[i] < 0)
-            else slice(None, None, None)
+            (
+                slice(None, None, -1)
+                if (
+                    st1_sorted[i] < 0
+                    and st2_sorted[i] < 0
+                    and st3_sorted[i] < 0
+                )
+                else slice(None, None, None)
+            )
             for i in range(nd1)
         )
         R = R[sl]
@@ -826,9 +837,9 @@ def _take_multi_index(ary, inds, p):
             )
         inds = tuple(
             map(
-                lambda ind: ind
-                if ind.dtype == ind_dt
-                else dpt.astype(ind, ind_dt),
+                lambda ind: (
+                    ind if ind.dtype == ind_dt else dpt.astype(ind, ind_dt)
+                ),
                 inds,
             )
         )
@@ -975,9 +986,9 @@ def _put_multi_index(ary, inds, p, vals):
             )
         inds = tuple(
             map(
-                lambda ind: ind
-                if ind.dtype == ind_dt
-                else dpt.astype(ind, ind_dt),
+                lambda ind: (
+                    ind if ind.dtype == ind_dt else dpt.astype(ind, ind_dt)
+                ),
                 inds,
             )
         )

--- a/dpctl/tensor/_indexing_functions.py
+++ b/dpctl/tensor/_indexing_functions.py
@@ -16,14 +16,13 @@
 
 import operator
 
-from numpy.core.numeric import normalize_axis_index
-
 import dpctl
 import dpctl.tensor as dpt
 import dpctl.tensor._tensor_impl as ti
 import dpctl.utils
 
 from ._copy_utils import _extract_impl, _nonzero_impl
+from ._numpy_helper import normalize_axis_index
 
 
 def _get_indexing_mode(name):

--- a/dpctl/tensor/_linear_algebra_functions.py
+++ b/dpctl/tensor/_linear_algebra_functions.py
@@ -16,8 +16,6 @@
 
 import operator
 
-from numpy.core.numeric import normalize_axis_index, normalize_axis_tuple
-
 import dpctl
 import dpctl.tensor as dpt
 import dpctl.tensor._tensor_elementwise_impl as tei
@@ -32,9 +30,11 @@ from dpctl.tensor._type_utils import (
 )
 from dpctl.utils import ExecutionPlacementError, SequentialOrderManager
 
+from ._numpy_helper import normalize_axis_index, normalize_axis_tuple
+
 
 def matrix_transpose(x):
-    """matrix_transpose(x)
+    r"""matrix_transpose(x)
 
     Transposes the innermost two dimensions of `x`, where `x` is a
     2-dimensional matrix or a stack of 2-dimensional matrices.
@@ -65,7 +65,7 @@ def matrix_transpose(x):
 
 
 def tensordot(x1, x2, axes=2):
-    """tensordot(x1, x2, axes=2)
+    r"""tensordot(x1, x2, axes=2)
 
     Returns a tensor contraction of `x1` and `x2` over specific axes.
 
@@ -308,7 +308,7 @@ def tensordot(x1, x2, axes=2):
 
 
 def vecdot(x1, x2, axis=-1):
-    """vecdot(x1, x2, axis=-1)
+    r"""vecdot(x1, x2, axis=-1)
 
     Computes the (vector) dot product of two arrays.
 
@@ -574,7 +574,7 @@ def vecdot(x1, x2, axis=-1):
 
 
 def matmul(x1, x2, out=None, dtype=None, order="K"):
-    """matmul(x1, x2, out=None, order="K")
+    r"""matmul(x1, x2, out=None, order="K")
 
     Computes the matrix product. Implements the same semantics
     as the built-in operator `@`.
@@ -721,7 +721,8 @@ def matmul(x1, x2, out=None, dtype=None, order="K"):
                 buf1_dt = res_dt
             else:
                 raise ValueError(
-                    f"`matmul` input `x1` cannot be cast from {x1_dtype} to "
+                    r"`matmul` input `x1` cannot be cast from "
+                    f"{x1_dtype} to "
                     f"requested type {res_dt} according to the casting rule "
                     "''same_kind''."
                 )
@@ -730,7 +731,8 @@ def matmul(x1, x2, out=None, dtype=None, order="K"):
                 buf2_dt = res_dt
             else:
                 raise ValueError(
-                    f"`matmul` input `x2` cannot be cast from {x2_dtype} to "
+                    r"`matmul` input `x2` cannot be cast from "
+                    f"{x2_dtype} to "
                     f"requested type {res_dt} according to the casting rule "
                     "''same_kind''."
                 )
@@ -762,7 +764,7 @@ def matmul(x1, x2, out=None, dtype=None, order="K"):
 
         if res_dt != out.dtype:
             raise ValueError(
-                f"Output array of type {res_dt} is needed," f"got {out.dtype}"
+                f"Output array of type {res_dt} is needed, got {out.dtype}"
             )
 
         if dpctl.utils.get_execution_queue((exec_q, out.sycl_queue)) is None:

--- a/dpctl/tensor/_manipulation_functions.py
+++ b/dpctl/tensor/_manipulation_functions.py
@@ -19,7 +19,6 @@ import itertools
 import operator
 
 import numpy as np
-from numpy.core.numeric import normalize_axis_index, normalize_axis_tuple
 
 import dpctl
 import dpctl.tensor as dpt
@@ -27,6 +26,7 @@ import dpctl.tensor._tensor_impl as ti
 import dpctl.utils as dputils
 
 from ._copy_utils import _broadcast_strides
+from ._numpy_helper import normalize_axis_index, normalize_axis_tuple
 from ._type_utils import _supported_dtype, _to_device_supported_dtype
 
 __doc__ = (

--- a/dpctl/tensor/_numpy_helper.py
+++ b/dpctl/tensor/_numpy_helper.py
@@ -1,0 +1,32 @@
+#                       Data Parallel Control (dpctl)
+#
+#  Copyright 2020-2024 Intel Corporation
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import numpy as np
+
+_npver = np.lib.NumpyVersion(np.__version__)
+
+if _npver < "1.25.0":
+    from numpy import AxisError
+else:
+    from numpy.exceptions import AxisError
+
+if _npver >= "2.0.0":
+    from numpy._core.numeric import normalize_axis_index, normalize_axis_tuple
+else:
+    from numpy.core.numeric import normalize_axis_index, normalize_axis_tuple
+
+
+__all__ = ["AxisError", "normalize_axis_index", "normalize_axis_tuple"]

--- a/dpctl/tensor/_reduction.py
+++ b/dpctl/tensor/_reduction.py
@@ -14,14 +14,13 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-from numpy.core.numeric import normalize_axis_tuple
-
 import dpctl
 import dpctl.tensor as dpt
 import dpctl.tensor._tensor_impl as ti
 import dpctl.tensor._tensor_reductions_impl as tri
 from dpctl.utils import ExecutionPlacementError, SequentialOrderManager
 
+from ._numpy_helper import normalize_axis_tuple
 from ._type_utils import (
     _default_accumulation_dtype,
     _default_accumulation_dtype_fp_types,
@@ -617,7 +616,9 @@ def _search_over_axis(x, axis, keepdims, out, _reduction_fn):
             axis = (axis,)
         else:
             raise TypeError(
-                f"`axis` argument expected `int` or `None`, got {type(axis)}"
+                f"'axis' argument expected to have type 'int' "
+                r"or be `None`, "
+                f"got type {type(axis)}"
             )
         axis = normalize_axis_tuple(axis, nd, "axis")
         perm = [i for i in range(nd) if i not in axis] + list(axis)

--- a/dpctl/tensor/_sorting.py
+++ b/dpctl/tensor/_sorting.py
@@ -14,12 +14,11 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-from numpy.core.numeric import normalize_axis_index
-
 import dpctl.tensor as dpt
 import dpctl.tensor._tensor_impl as ti
 import dpctl.utils as du
 
+from ._numpy_helper import normalize_axis_index
 from ._tensor_sorting_impl import (
     _argsort_ascending,
     _argsort_descending,

--- a/dpctl/tensor/_statistical_functions.py
+++ b/dpctl/tensor/_statistical_functions.py
@@ -14,13 +14,13 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-from numpy.core.numeric import normalize_axis_tuple
-
 import dpctl.tensor as dpt
 import dpctl.tensor._tensor_elementwise_impl as tei
 import dpctl.tensor._tensor_impl as ti
 import dpctl.tensor._tensor_reductions_impl as tri
 import dpctl.utils as du
+
+from ._numpy_helper import normalize_axis_tuple
 
 
 def _var_impl(x, axis, correction, keepdims):

--- a/dpctl/tensor/_utility_functions.py
+++ b/dpctl/tensor/_utility_functions.py
@@ -1,9 +1,25 @@
-from numpy.core.numeric import normalize_axis_tuple
+#                       Data Parallel Control (dpctl)
+#
+#  Copyright 2020-2024 Intel Corporation
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
 
 import dpctl.tensor as dpt
 import dpctl.tensor._tensor_impl as ti
 import dpctl.tensor._tensor_reductions_impl as tri
 import dpctl.utils as du
+
+from ._numpy_helper import normalize_axis_tuple
 
 
 def _boolean_reduction(x, axis, keepdims, func):

--- a/dpctl/tests/elementwise/test_log1p.py
+++ b/dpctl/tests/elementwise/test_log1p.py
@@ -164,4 +164,6 @@ def test_log1p_special_cases():
 
     tol = dpt.finfo(X.dtype).resolution
     with np.errstate(invalid="ignore"):
-        assert_allclose(dpt.asnumpy(dpt.log1p(X)), res, atol=tol, rtol=tol)
+        dpt_res = dpt.asnumpy(dpt.log1p(X))
+        assert_allclose(np.real(dpt_res), np.real(res), atol=tol, rtol=tol)
+        assert_allclose(np.imag(dpt_res), np.imag(res), atol=tol, rtol=tol)

--- a/dpctl/tests/test_usm_ndarray_manipulation.py
+++ b/dpctl/tests/test_usm_ndarray_manipulation.py
@@ -21,6 +21,7 @@ from numpy.testing import assert_, assert_array_equal, assert_raises_regex
 
 import dpctl
 import dpctl.tensor as dpt
+from dpctl.tensor._numpy_helper import AxisError
 from dpctl.tests.helper import get_queue_or_skip
 from dpctl.utils import ExecutionPlacementError
 
@@ -59,7 +60,7 @@ def test_permute_dims_0d_1d():
     assert_array_equal(dpt.asnumpy(Y_1d), dpt.asnumpy(X_1d))
 
     pytest.raises(ValueError, dpt.permute_dims, X_1d, ())
-    pytest.raises(np.AxisError, dpt.permute_dims, X_1d, (1))
+    pytest.raises(AxisError, dpt.permute_dims, X_1d, (1))
     pytest.raises(ValueError, dpt.permute_dims, X_1d, (1, 0))
     pytest.raises(
         ValueError, dpt.permute_dims, dpt.reshape(X_1d, (2, 3)), (1, 1)
@@ -105,8 +106,8 @@ def test_expand_dims_0d():
     Ynp = np.expand_dims(Xnp, axis=-1)
     assert_array_equal(Ynp, dpt.asnumpy(Y))
 
-    pytest.raises(np.AxisError, dpt.expand_dims, X, axis=1)
-    pytest.raises(np.AxisError, dpt.expand_dims, X, axis=-2)
+    pytest.raises(AxisError, dpt.expand_dims, X, axis=1)
+    pytest.raises(AxisError, dpt.expand_dims, X, axis=-2)
 
 
 @pytest.mark.parametrize("shapes", [(3,), (3, 3), (3, 3, 3)])
@@ -123,8 +124,8 @@ def test_expand_dims_1d_3d(shapes):
         Ynp = np.expand_dims(Xnp, axis=axis)
         assert_array_equal(Ynp, dpt.asnumpy(Y))
 
-    pytest.raises(np.AxisError, dpt.expand_dims, X, axis=shape_len + 1)
-    pytest.raises(np.AxisError, dpt.expand_dims, X, axis=-shape_len - 2)
+    pytest.raises(AxisError, dpt.expand_dims, X, axis=shape_len + 1)
+    pytest.raises(AxisError, dpt.expand_dims, X, axis=-shape_len - 2)
 
 
 @pytest.mark.parametrize(
@@ -145,9 +146,9 @@ def test_expand_dims_incorrect_tuple():
         X = dpt.empty((3, 3, 3), dtype="i4")
     except dpctl.SyclDeviceCreationError:
         pytest.skip("No SYCL devices available")
-    with pytest.raises(np.AxisError):
+    with pytest.raises(AxisError):
         dpt.expand_dims(X, axis=(0, -6))
-    with pytest.raises(np.AxisError):
+    with pytest.raises(AxisError):
         dpt.expand_dims(X, axis=(0, 5))
 
     with pytest.raises(ValueError):
@@ -181,10 +182,10 @@ def test_squeeze_0d():
     Ynp = Xnp.squeeze(-1)
     assert_array_equal(Ynp, dpt.asnumpy(Y))
 
-    pytest.raises(np.AxisError, dpt.squeeze, X, 1)
-    pytest.raises(np.AxisError, dpt.squeeze, X, -2)
-    pytest.raises(np.AxisError, dpt.squeeze, X, (1))
-    pytest.raises(np.AxisError, dpt.squeeze, X, (-2))
+    pytest.raises(AxisError, dpt.squeeze, X, 1)
+    pytest.raises(AxisError, dpt.squeeze, X, -2)
+    pytest.raises(AxisError, dpt.squeeze, X, (1))
+    pytest.raises(AxisError, dpt.squeeze, X, (-2))
     pytest.raises(ValueError, dpt.squeeze, X, (0, 0))
 
 
@@ -446,10 +447,10 @@ def test_flip_axis_incorrect():
     X_np = np.ones((4, 4))
     X = dpt.asarray(X_np, sycl_queue=q)
 
-    pytest.raises(np.AxisError, dpt.flip, dpt.asarray(np.ones(4)), axis=1)
-    pytest.raises(np.AxisError, dpt.flip, X, axis=2)
-    pytest.raises(np.AxisError, dpt.flip, X, axis=-3)
-    pytest.raises(np.AxisError, dpt.flip, X, axis=(0, 3))
+    pytest.raises(AxisError, dpt.flip, dpt.asarray(np.ones(4)), axis=1)
+    pytest.raises(AxisError, dpt.flip, X, axis=2)
+    pytest.raises(AxisError, dpt.flip, X, axis=-3)
+    pytest.raises(AxisError, dpt.flip, X, axis=(0, 3))
 
 
 def test_flip_0d():
@@ -461,9 +462,9 @@ def test_flip_0d():
     Y = dpt.flip(X)
     assert_array_equal(Ynp, dpt.asnumpy(Y))
 
-    pytest.raises(np.AxisError, dpt.flip, X, axis=0)
-    pytest.raises(np.AxisError, dpt.flip, X, axis=1)
-    pytest.raises(np.AxisError, dpt.flip, X, axis=-1)
+    pytest.raises(AxisError, dpt.flip, X, axis=0)
+    pytest.raises(AxisError, dpt.flip, X, axis=1)
+    pytest.raises(AxisError, dpt.flip, X, axis=-1)
 
 
 def test_flip_1d():
@@ -588,9 +589,9 @@ def test_roll_empty():
     Y = dpt.roll(X, 1)
     Ynp = np.roll(Xnp, 1)
     assert_array_equal(Ynp, dpt.asnumpy(Y))
-    with pytest.raises(np.AxisError):
+    with pytest.raises(AxisError):
         dpt.roll(X, 1, axis=0)
-    with pytest.raises(np.AxisError):
+    with pytest.raises(AxisError):
         dpt.roll(X, 1, axis=1)
 
 
@@ -1086,13 +1087,13 @@ def test_moveaxis_errors():
         pytest.skip("No SYCL devices available")
     x = dpt.reshape(x_flat, (1, 2, 3))
     assert_raises_regex(
-        np.AxisError, "source.*out of bounds", dpt.moveaxis, x, 3, 0
+        AxisError, "source.*out of bounds", dpt.moveaxis, x, 3, 0
     )
     assert_raises_regex(
-        np.AxisError, "source.*out of bounds", dpt.moveaxis, x, -4, 0
+        AxisError, "source.*out of bounds", dpt.moveaxis, x, -4, 0
     )
     assert_raises_regex(
-        np.AxisError, "destination.*out of bounds", dpt.moveaxis, x, 0, 5
+        AxisError, "destination.*out of bounds", dpt.moveaxis, x, 0, 5
     )
     assert_raises_regex(
         ValueError, "repeated axis in `source`", dpt.moveaxis, x, [0, 0], [0, 1]

--- a/dpctl/tests/test_usm_ndarray_utility_functions.py
+++ b/dpctl/tests/test_usm_ndarray_utility_functions.py
@@ -2,10 +2,10 @@ from random import randrange
 
 import numpy as np
 import pytest
-from numpy import AxisError
 from numpy.testing import assert_array_equal, assert_equal
 
 import dpctl.tensor as dpt
+from dpctl.tensor._numpy_helper import AxisError
 from dpctl.tests.helper import get_queue_or_skip, skip_if_dtype_not_supported
 
 _all_dtypes = [


### PR DESCRIPTION
Changes that allow `dpctl`  pass tests with NumPy 2.0 in the runtime environment

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [x] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
