### PR TITLE
Backport changelong edits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ and complies with revision [2023.12](https://data-apis.org/array-api/2023.12/) o
 * Fixed bug in basic slicing of empty arrays: [gh-1680](https://github.com/IntelPython/dpctl/pull/1680)
 * Fixed bug in `tensor.bitwise_invert` for boolean input array: [gh-1681](https://github.com/IntelPython/dpctl/pull/1681)
 * Fixed bug in `tensor.repeat` on zero-size input arrays: [gh-1682](https://github.com/IntelPython/dpctl/pull/1682)
+* Fixed bug in `tensor.searchsorted` for 0d needle vector and strided hay: [gh-1694](https://github.com/IntelPython/dpctl/pull/1694)
 
 
 ## [0.16.1] - Apr. 10, 2024

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-## [0.17.0] - May. XX, 2024
+## [0.17.0] - May. 23, 2024
 
 This release features updated documentation web-page https://intelpython.github.io/dpctl/latest/index.html, adds cumulative reductions,
 and complies with revision [2023.12](https://data-apis.org/array-api/2023.12/) of Python Array API specification.


### PR DESCRIPTION
This PR backports two commits from maintenance/0.17.x that changed `CHANGELOG.md` to set the release date for 0.17, and to add an entry to changelog about fix gh-1694

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
