### PR TITLE
Replace "-c intel" in docs and readme file

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,11 +64,10 @@ guide](https://www.intel.com/content/www/us/en/developer/articles/guide/installa
 
 ## Conda
 
-To install `dpctl` from the Intel(R) channel on Anaconda
-cloud, use the following command:
+To install `dpctl` from the Intel(R) conda channel, use the following command:
 
 ```bash
-conda install dpctl -c intel
+conda install dpctl -c https://software.repos.intel.com/python/conda/
 ```
 
 ## Pip

--- a/docs/doc_sources/beginners_guides/installation.rst
+++ b/docs/doc_sources/beginners_guides/installation.rst
@@ -25,19 +25,19 @@ ecosystem.
 .. _conda_docs: https://docs.conda.io/projects/conda/en/stable/
 
 Released versions of the package can be installed from the Intel channel, as
-indicated by ``--channel intel`` option:
+indicated by ``--channel`` option:
 
 .. code-block:: bash
     :caption: Getting latest released version of ``dpctl`` using conda
 
-    conda create --name dpctl_env --channel intel dpctl
+    conda create --name dpctl_env --channel https://software.repos.intel.com/python/conda/ dpctl
 
 Development builds of ``dpctl`` can be accessed from the ``dppy/label/dev`` channel:
 
 .. code-block:: bash
     :caption: Getting latest development version
 
-    conda create -n dpctl_nightly -c dppy/label/dev -c intel dpctl
+    conda create -n dpctl_nightly -c dppy/label/dev -c https://software.repos.intel.com/python/conda/ dpctl
 
 .. note::
     If :py:mod:`dpctl` is not available for the Python version of interest,


### PR DESCRIPTION
Replace "-c intel" with "-c https://software.repos.intel.com/python/conda/" in docs and readme file.

The PyPI channel for intel packages still seems to function.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
