### PR TITLE
Removed use of deprecated SYCL_DEVICE_FILTER

### DIFF
--- a/examples/python/device_selection.py
+++ b/examples/python/device_selection.py
@@ -25,8 +25,8 @@ def create_default_device():
     Create default SyclDevice using `sycl::default_selector`.
 
     Device created can be influenced by environment variable
-    SYCL_DEVICE_FILTER, which determines SYCL devices seen by the
-    SYCL runtime.
+    ONEAPI_DEVICE_SELECTOR, which determines SYCL devices seen by the
+    oneAPI DPC++ runtime.
     """
     d1 = dpctl.SyclDevice()
     d2 = dpctl.select_default_device()
@@ -40,8 +40,8 @@ def create_gpu_device():
     Create a GPU device.
 
     Device created can be influenced by environment variable
-    SYCL_DEVICE_FILTER, which determines SYCL devices seen by the
-    SYCL runtime.
+    ONEAPI_DEVICE_SELECTOR, which determines SYCL devices seen by the
+    oneAPI DPC++ runtime.
     """
     try:
         d1 = dpctl.SyclDevice("gpu")
@@ -60,8 +60,8 @@ def create_gpu_device_if_present():
     will be raised.
 
     Device created can be influenced by environment variable
-    SYCL_DEVICE_FILTER, which determines SYCL devices seen by the
-    SYCL runtime.
+    ONEAPI_DEVICE_SELECTOR, which determines SYCL devices seen by the
+    oneAPI DPC++ runtime.
     """
     d = dpctl.SyclDevice("gpu,cpu")
     print("Selected " + ("GPU" if d.is_gpu else "CPU") + " device")
@@ -72,8 +72,8 @@ def custom_select_device():
     Programmatically select among available devices.
 
     Device created can be influenced by environment variable
-    SYCL_DEVICE_FILTER, which determines SYCL devices seen by the
-    SYCL runtime.
+    ONEAPI_DEVICE_SELECTOR, which determines SYCL devices seen by the
+    oneAPI DPC++ runtime.
     """
     # select devices that support half-precision computation
     devs = [d for d in dpctl.get_devices() if d.has_aspect_fp16]

--- a/examples/python/lsplatform.py
+++ b/examples/python/lsplatform.py
@@ -24,7 +24,7 @@ def print_available_platforms():
     """
     Print information about SYCL platforms visible to runtime.
 
-    Environment variable `SYCL_DEVICE_FILTER` affects this list.
+    Environment variable `ONEAPI_DEVICE_SELECTOR` affects this list.
     """
     dpctl.lsplatform()
 
@@ -34,7 +34,7 @@ def list_available_platforms():
     Get a list of SyclPlatform instances corresponding to platforms
     visible to SYCL runtime.
 
-    Environment variable `SYCL_DEVICE_FILTER` affects this list.
+    Environment variable `ONEAPI_DEVICE_SELECTOR` affects this list.
     """
     for p in dpctl.get_platforms():
         print(p)


### PR DESCRIPTION
Replaced it with `ONEAPI_DEVICE_SELECTOR` environment variable.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
