### PR TITLE
Fix for gh 1738

### DIFF
--- a/dpctl/tensor/_set_functions.py
+++ b/dpctl/tensor/_set_functions.py
@@ -425,8 +425,7 @@ def unique_inverse(x):
     )
     _manager.add_event_pair(ht_ev, sub_ev)
 
-    inv_dt = dpt.int64 if x.size > dpt.iinfo(dpt.int32).max else dpt.int32
-    inv = dpt.empty_like(x, dtype=inv_dt, order="C")
+    inv = dpt.empty_like(x, dtype=ind_dt, order="C")
     ht_ev, ssl_ev = _searchsorted_left(
         hay=unique_vals,
         needles=x,
@@ -608,8 +607,7 @@ def unique_all(x: dpt.usm_ndarray) -> UniqueAllResult:
     )
     _manager.add_event_pair(ht_ev, sub_ev)
 
-    inv_dt = dpt.int64 if x.size > dpt.iinfo(dpt.int32).max else dpt.int32
-    inv = dpt.empty_like(x, dtype=inv_dt, order="C")
+    inv = dpt.empty_like(x, dtype=ind_dt, order="C")
     ht_ev, ssl_ev = _searchsorted_left(
         hay=unique_vals,
         needles=x,

--- a/dpctl/tests/test_usm_ndarray_unique.py
+++ b/dpctl/tests/test_usm_ndarray_unique.py
@@ -321,3 +321,25 @@ def test_set_functions_compute_follows_data():
     assert ind.sycl_queue == q
     assert inv_ind.sycl_queue == q
     assert uc.sycl_queue == q
+
+
+def test_gh_1738():
+    get_queue_or_skip()
+
+    ones = dpt.ones(10, dtype="i8")
+    iota = dpt.arange(10, dtype="i8")
+
+    assert ones.device == iota.device
+
+    dpt_info = dpt.__array_namespace_info__()
+    ind_dt = dpt_info.default_dtypes(device=ones.device)["indexing"]
+
+    dt = dpt.unique_inverse(ones).inverse_indices.dtype
+    assert dt == ind_dt
+    dt = dpt.unique_all(ones).inverse_indices.dtype
+    assert dt == ind_dt
+
+    dt = dpt.unique_inverse(iota).inverse_indices.dtype
+    assert dt == ind_dt
+    dt = dpt.unique_all(iota).inverse_indices.dtype
+    assert dt == ind_dt


### PR DESCRIPTION
Resolves gh-1738

Changes `unique_all` and `unique_inverse` to always return `inverse_indices` data field as array with default indexing data type.

A test added to verify this behavior.

- [x] Have you provided a meaningful PR description?
- [x] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [x] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
