### PR TITLE
In pyproject change to numpy>=1.23

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ dependencies = [
   # TODO: do we have to set sycl runtime dependencies here
   # "dpcpp-cpp-rt>=0.59.0",
   # "intel-cmplr-lib-rt>=0.59.0"
-  "numpy>=1.24.0"
+  "numpy>=1.23.0"
 ]
 description = "A lightweight Python wrapper for a subset of SYCL."
 dynamic = ["version"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ requires = [
   "ninja>=1.11.1; platform_system!='Windows'",
   "cmake>=3.29.0",
   "cython>=3.0.10",
-  "numpy >=1.24",
+  "numpy >=1.23",
   # WARNING: check with doc how to upgrade
   "versioneer[toml]==0.29"
 ]


### PR DESCRIPTION
This is to align with current setup of public CI/CD.

Requirement "numpy >=1.24" was causing current build command which stipulates `conda build ... -numpy 1.23` to use latest NumPy from Intel channel (which is 1.26), and resulted in produced artifact with metainformation requiring ">=1.26,<2.0a0". 

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
