### PR TITLE
Use bootstrap channel for Windows build too

### DIFF
--- a/.github/workflows/conda-package.yml
+++ b/.github/workflows/conda-package.yml
@@ -109,7 +109,7 @@ jobs:
       - name: Build conda package
         env:
           OVERRIDE_INTEL_IPO: 1   # IPO requires more resources that GH actions VM provides
-        run: conda build --no-test --python ${{ matrix.python }} -c ${{ env.INTEL_CHANNEL }} -c conda-forge --override-channels conda-recipe
+        run: conda build --no-test --python ${{ matrix.python }} -c dppy/label/bootstrap -c ${{ env.INTEL_CHANNEL }} -c conda-forge --override-channels conda-recipe
       - name: Upload artifact
         uses: actions/upload-artifact@v4.3.4
         with:


### PR DESCRIPTION
This change should enable Windows build to have the same NumPy pinning as Linux, that is `>=1.23,<2.0a0` instead of `>=1.26,<2.0a0`, by ensuring that NumPy 1.23 from bootstrap channels gets installed into build environment.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
