### PR TITLE
Relax hard pinning for build time compiler

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -20,7 +20,7 @@ requirements:
     # TODO: keep in sync with /pyproject.toml
     build:
         - {{ compiler('cxx') }}
-        - {{ compiler('dpcpp') }} {{ required_compiler_version }}
+        - {{ compiler('dpcpp') }} >={{ required_compiler_version }}
         - sysroot_linux-64 >=2.28  # [linux]
     host:
         - python


### PR DESCRIPTION
This PR replaces hard pinning of compiler version in build environment to `>=`.

This allows internal CI to build with future version of compiler as well.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
