### PR TITLE
Propagate read-only flag from sycl_usm_array_interface in asarray

### DIFF
--- a/dpctl/tensor/_ctors.py
+++ b/dpctl/tensor/_ctors.py
@@ -203,7 +203,7 @@ def _usm_ndarray_from_suai(obj):
         strides=sua_iface.get("strides", None),
     )
     _data_field = sua_iface["data"]
-    if isinstance(_data_field, tuple) and len(_data_field) == 2:
+    if isinstance(_data_field, tuple) and len(_data_field) > 1:
         ro_field = _data_field[1]
     else:
         ro_field = False

--- a/dpctl/tensor/_ctors.py
+++ b/dpctl/tensor/_ctors.py
@@ -202,6 +202,13 @@ def _usm_ndarray_from_suai(obj):
         buffer=membuf,
         strides=sua_iface.get("strides", None),
     )
+    _data_field = sua_iface["data"]
+    if isinstance(_data_field, tuple) and len(_data_field) == 2:
+        ro_field = _data_field[1]
+    else:
+        ro_field = False
+    if ro_field:
+        ary.flags["W"] = False
     return ary
 
 

--- a/dpctl/tests/test_usm_ndarray_ctor.py
+++ b/dpctl/tests/test_usm_ndarray_ctor.py
@@ -2380,16 +2380,17 @@ class ObjWithSyclUsmArrayInterface:
         return _suai
 
 
-def test_asarray_writable_flag():
+@pytest.mark.parametrize("ro_flag", [True, False])
+def test_asarray_writable_flag(ro_flag):
     try:
         a = dpt.empty(8)
     except dpctl.SyclDeviceCreationError:
         pytest.skip("No SYCL devices available")
 
-    a.flags["W"] = False
+    a.flags["W"] = not ro_flag
     wrapped = ObjWithSyclUsmArrayInterface(a)
 
     b = dpt.asarray(wrapped)
 
-    assert not b.flags["W"]
+    assert b.flags["W"] == (not ro_flag)
     assert b._pointer == a._pointer


### PR DESCRIPTION
Change to `dpt.asarray` to take read-only flag value from ``__sycl_usm_array_interface__`` into account.

```IPython
In [1]: import dpctl, dpctl.utils as du, dpctl.tensor as dpt, dpnp

In [2]: x = dpt.linspace(100, 0, num=101, dtype="f8")

In [3]: x.flags["W"] = False

In [4]: y = dpnp.asarray(x)

In [5]: z = dpt.asarray(y)

In [6]: z.flags
Out[6]:
  C_CONTIGUOUS : True
  F_CONTIGUOUS : True
  WRITABLE : False
```

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
