### PR TITLE
Fix crash testing with sycl nightly runtime

### DIFF
--- a/.github/workflows/os-llvm-sycl-build.yml
+++ b/.github/workflows/os-llvm-sycl-build.yml
@@ -15,7 +15,6 @@ jobs:
       DOWNLOAD_URL_PREFIX: https://github.com/intel/llvm/releases/download
       DRIVER_PATH: 2023-WW27
       OCLCPUEXP_FN: oclcpuexp-2023.16.6.0.28_rel.tar.gz
-      FPGAEMU_FN: fpgaemu-2023.16.6.0.28_rel.tar.gz
       TBB_URL: https://github.com/oneapi-src/oneTBB/releases/download/v2021.9.0/
       TBB_INSTALL_DIR: oneapi-tbb-2021.9.0
       TBB_FN: oneapi-tbb-2021.9.0-lin.tgz
@@ -83,15 +82,12 @@ jobs:
               rm -rf ${ARTIFACT_NAME}.tar.gz
               wget ${DOWNLOAD_URL_PREFIX}/${DEPLOY_NIGHTLY_TAG}/${ARTIFACT_NAME}.tar.gz && echo ${DEPLOY_LLVM_TAG_SHA} > bundle_id.txt || rm -rf bundle_id.txt
               [ -f ${OCLCPUEXP_FN} ] || wget ${DOWNLOAD_URL_PREFIX}/${DRIVER_PATH}/${OCLCPUEXP_FN} || rm -rf bundle_id.txt
-              [ -f ${FPGAEMU_FN} ] || wget ${DOWNLOAD_URL_PREFIX}/${DRIVER_PATH}/${FPGAEMU_FN} || rm -rf bundle_id.txt
               [ -f ${TBB_FN} ] || wget ${TBB_URL}/${TBB_FN} || rm -rf bundle_id.txt
               rm -rf dpcpp_compiler
               mkdir -p dpcpp_compiler
               tar xf ${ARTIFACT_NAME}.tar.gz -C dpcpp_compiler
               mkdir -p oclcpuexp
-              mkdir -p fpgaemu
               [ -d oclcpuexp/x64 ] || tar xf ${OCLCPUEXP_FN} -C oclcpuexp
-              [ -d fpgaemu/x64 ] || tar xf ${FPGAEMU_FN} -C fpgaemu
               [ -d ${TBB_INSTALL_DIR}/lib ] || tar xf ${TBB_FN}
               cp oclcpuexp/x64/libOpenCL.so* dpcpp_compiler/lib/
           fi
@@ -110,7 +106,7 @@ jobs:
       - name: Install dpctl dependencies
         shell: bash -l {0}
         run: |
-          pip install numpy"<1.26.0" cython setuptools pytest scikit-build cmake ninja versioneer[toml]==0.29
+          pip install numpy cython setuptools pytest scikit-build cmake ninja versioneer[toml]==0.29
 
       - name: Checkout repo
         uses: actions/checkout@v4.1.7
@@ -126,10 +122,9 @@ jobs:
           export PATH=${SYCL_BUNDLE_FOLDER}/dpcpp_compiler/bin:${PATH}
           export LD_LIBRARY_PATH=${SYCL_BUNDLE_FOLDER}/dpcpp_compiler/lib:${LD_LIBRARY_PATH}
           export LD_LIBRARY_PATH=${SYCL_BUNDLE_FOLDER}/oclcpuexp/x64:${LD_LIBRARY_PATH}
-          export LD_LIBRARY_PATH=${SYCL_BUNDLE_FOLDER}/fpgaemu/x64:${LD_LIBRARY_PATH}
           export LD_LIBRARY_PATH=${SYCL_BUNDLE_FOLDER}/${TBB_INSTALL_DIR}/lib/intel64/gcc4.8:${LD_LIBRARY_PATH}
           export OCL_ICD_VENDORS=
-          export OCL_ICD_FILENAMES=libintelocl.so:libintelocl_emu.so
+          export OCL_ICD_FILENAMES=libintelocl.so
           EOF
           chmod +x set_allvars.sh
           cat set_allvars.sh

--- a/dpctl/tensor/libtensor/include/kernels/copy_and_cast.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/copy_and_cast.hpp
@@ -635,7 +635,7 @@ void copy_and_cast_from_host_impl(
 
     // perform explicit synchronization. Implicit synchronization would be
     // performed by sycl::buffer destructor.
-    copy_and_cast_from_host_ev.wait_and_throw();
+    copy_and_cast_from_host_ev.wait();
 
     return;
 }

--- a/dpctl/tensor/libtensor/source/copy_numpy_ndarray_into_usm_ndarray.cpp
+++ b/dpctl/tensor/libtensor/source/copy_numpy_ndarray_into_usm_ndarray.cpp
@@ -130,7 +130,7 @@ void copy_numpy_ndarray_into_usm_ndarray(
                               src_nelems * src_elem_size, depends);
 
             // wait for copy_ev to complete
-            copy_ev.wait_and_throw();
+            copy_ev.wait();
 
             return;
         }

--- a/libsyclinterface/source/dpctl_sycl_device_interface.cpp
+++ b/libsyclinterface/source/dpctl_sycl_device_interface.cpp
@@ -598,6 +598,16 @@ DPCTLDevice_CreateSubDevicesEqually(__dpctl_keep const DPCTLSyclDeviceRef DRef,
             return nullptr;
         }
         auto D = unwrap<device>(DRef);
+        const auto &supported_properties =
+            D->get_info<info::device::partition_properties>();
+        const auto &beg_it = supported_properties.begin();
+        const auto &end_it = supported_properties.end();
+        if (std::find(beg_it, end_it,
+                      info::partition_property::partition_equally) == end_it)
+        {
+            // device does not support partition equally
+            return nullptr;
+        }
         try {
             auto subDevices = D->create_sub_devices<
                 info::partition_property::partition_equally>(count);
@@ -631,6 +641,16 @@ DPCTLDevice_CreateSubDevicesByCounts(__dpctl_keep const DPCTLSyclDeviceRef DRef,
     }
     if (DRef) {
         auto D = unwrap<device>(DRef);
+        const auto &supported_properties =
+            D->get_info<info::device::partition_properties>();
+        const auto &beg_it = supported_properties.begin();
+        const auto &end_it = supported_properties.end();
+        if (std::find(beg_it, end_it,
+                      info::partition_property::partition_by_counts) == end_it)
+        {
+            // device does not support partition by counts
+            return nullptr;
+        }
         std::vector<std::remove_pointer<decltype(D)>::type> subDevices;
         try {
             subDevices = D->create_sub_devices<
@@ -661,9 +681,29 @@ __dpctl_give DPCTLDeviceVectorRef DPCTLDevice_CreateSubDevicesByAffinity(
     vecTy *Devices = nullptr;
     auto D = unwrap<device>(DRef);
     if (D) {
+        const auto &supported_properties =
+            D->get_info<info::device::partition_properties>();
+        const auto &beg_it = supported_properties.begin();
+        const auto &end_it = supported_properties.end();
+        if (std::find(beg_it, end_it,
+                      info::partition_property::partition_by_affinity_domain) ==
+            end_it)
+        {
+            // device does not support partition by affinity domain
+            return nullptr;
+        }
         try {
             auto domain = DPCTL_DPCTLPartitionAffinityDomainTypeToSycl(
                 PartitionAffinityDomainTy);
+            const auto &supported_affinity_domains =
+                D->get_info<info::device::partition_affinity_domains>();
+            const auto &beg_it = supported_affinity_domains.begin();
+            const auto &end_it = supported_affinity_domains.end();
+            if (std::find(beg_it, end_it, domain) == end_it) {
+                // device does not support partitioning by this particular
+                // affinity domain
+                return nullptr;
+            }
             auto subDevices = D->create_sub_devices<
                 info::partition_property::partition_by_affinity_domain>(domain);
             Devices = new vecTy();


### PR DESCRIPTION
This PR improves SYCLInterface functions `DPCTLDevice_CreateSubDevicesEqually`, `DPCTLDevice_CreateSubDevicesByCounts`, and `DPCTLDevice_CreateSubDevicesByAffinity`. 

These now check whether given device supports respective partition property before attempting it. If the input device does not support it, `nullptr` is returned without error logged. 

Furthermore, `DPCTLDevice_CreateSubDevicesByAffinity` checks whether the input device supports partitioning over request affinity domain, and returns `nullptr` without error logged if it does not.

This changes became necessary since nightly SYCL bundles are now built with assertions on, and runtime hits an assertion specifying `info::partition_affinity_domain::not_applicable` which is not meant to be used as an input.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [x] If this PR is a work in progress, are you opening the PR as a draft?
