### PR TITLE
Require numpy 2 at build time

### DIFF
--- a/.github/workflows/conda-package.yml
+++ b/.github/workflows/conda-package.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Build conda package
         run: |
           # use bootstrap channel to pull NumPy linked with OpenBLAS
-          CHANNELS="-c dppy/label/bootstrap -c ${{ env.INTEL_CHANNEL }} -c conda-forge --override-channels"
+          CHANNELS="-c conda-forge --override-channels"
           VERSIONS="--python ${{ matrix.python }} --numpy 2.0"
           TEST="--no-test"
           conda build \
@@ -109,7 +109,7 @@ jobs:
       - name: Build conda package
         env:
           OVERRIDE_INTEL_IPO: 1   # IPO requires more resources that GH actions VM provides
-        run: conda build --no-test --python ${{ matrix.python }} --numpy 2.0 -c dppy/label/bootstrap -c ${{ env.INTEL_CHANNEL }} -c conda-forge --override-channels conda-recipe
+        run: conda build --no-test --python ${{ matrix.python }} --numpy 2.0 -c conda-forge --override-channels conda-recipe
       - name: Upload artifact
         uses: actions/upload-artifact@v4.3.6
         with:

--- a/.github/workflows/conda-package.yml
+++ b/.github/workflows/conda-package.yml
@@ -22,7 +22,7 @@ jobs:
 
     strategy:
       matrix:
-        python: ['3.9', '3.10', '3.11']
+        python: ['3.9', '3.10', '3.11', '3.12']
     steps:
       - uses: actions/checkout@v4.1.7
         with:
@@ -54,7 +54,7 @@ jobs:
         run: |
           # use bootstrap channel to pull NumPy linked with OpenBLAS
           CHANNELS="-c dppy/label/bootstrap -c ${{ env.INTEL_CHANNEL }} -c conda-forge --override-channels"
-          VERSIONS="--python ${{ matrix.python }} --numpy 1.23"
+          VERSIONS="--python ${{ matrix.python }} --numpy 2.0"
           TEST="--no-test"
           conda build \
             $TEST \
@@ -77,7 +77,7 @@ jobs:
 
     strategy:
       matrix:
-        python: ['3.9', '3.10', '3.11']
+        python: ['3.9', '3.10', '3.11', '3.12']
     env:
       conda-bld: C:\Miniconda\conda-bld\win-64\
     steps:
@@ -109,7 +109,7 @@ jobs:
       - name: Build conda package
         env:
           OVERRIDE_INTEL_IPO: 1   # IPO requires more resources that GH actions VM provides
-        run: conda build --no-test --python ${{ matrix.python }} -c dppy/label/bootstrap -c ${{ env.INTEL_CHANNEL }} -c conda-forge --override-channels conda-recipe
+        run: conda build --no-test --python ${{ matrix.python }} --numpy 2.0 -c dppy/label/bootstrap -c ${{ env.INTEL_CHANNEL }} -c conda-forge --override-channels conda-recipe
       - name: Upload artifact
         uses: actions/upload-artifact@v4.3.6
         with:

--- a/.github/workflows/conda-package.yml
+++ b/.github/workflows/conda-package.yml
@@ -127,7 +127,7 @@ jobs:
 
     strategy:
       matrix:
-        python: ['3.9', '3.10', '3.11']
+        python: ['3.9', '3.10', '3.11', '3.12']
         experimental: [false]
         runner: [ubuntu-22.04]
     continue-on-error: ${{ matrix.experimental }}
@@ -220,7 +220,7 @@ jobs:
         shell: cmd /C CALL {0}
     strategy:
       matrix:
-        python: ['3.9', '3.10', '3.11']
+        python: ['3.9', '3.10', '3.11', '3.12']
         experimental: [false]
         runner: [windows-2019]
     continue-on-error: ${{ matrix.experimental }}
@@ -350,7 +350,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        python: ['3.9', '3.10', '3.11']
+        python: ['3.9', '3.10', '3.11', '3.12']
     steps:
       - name: Download conda artifact
         uses: actions/download-artifact@v4
@@ -386,7 +386,7 @@ jobs:
     runs-on: windows-2019
     strategy:
       matrix:
-        python: ['3.9', '3.10', '3.11']
+        python: ['3.9', '3.10', '3.11', '3.12']
     steps:
       - name: Download artifact
         uses: actions/download-artifact@v4
@@ -426,7 +426,7 @@ jobs:
     runs-on:  ${{ matrix.runner }}
     strategy:
       matrix:
-        python: ['3.10']
+        python: ['3.11']
         experimental: [false]
         runner: [ubuntu-22.04]
     continue-on-error: ${{ matrix.experimental }}

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -51,7 +51,7 @@ requirements:
         - python
         - {{ pin_compatible('dpcpp-cpp-rt', min_pin='x.x', max_pin='x') }}
         - {{ pin_compatible('intel-cmplr-lib-rt', min_pin='x.x', max_pin='x') }}
-        - {{ pin_compatible('numpy', min_pin='x.x', max_pin='x') }}
+        - numpy
         - {{ pin_compatible('level-zero', min_pin='x.x', max_pin='x') }} # [linux]
 
 test:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ requires = [
   "ninja>=1.11.1; platform_system!='Windows'",
   "cmake>=3.29.0",
   "cython>=3.0.10",
-  "numpy >=1.23",
+  "numpy>=2.0.0",
   # WARNING: check with doc how to upgrade
   "versioneer[toml]==0.29"
 ]


### PR DESCRIPTION
Change `pyproject.toml` to require `numpy>=2.0` for building `dpctl`.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [x] If this PR is a work in progress, are you opening the PR as a draft?
