### PR TITLE
Separate changes in pr 1763 from changes in pr 1760

### DIFF
--- a/dpctl/tensor/_type_utils.py
+++ b/dpctl/tensor/_type_utils.py
@@ -208,7 +208,7 @@ def _get_device_default_dtype(dt_kind, sycl_dev):
     elif dt_kind == "i":
         return dpt.dtype(ti.default_device_int_type(sycl_dev))
     elif dt_kind == "u":
-        return dpt.dtype(ti.default_device_int_type(sycl_dev).upper())
+        return dpt.dtype(ti.default_device_uint_type(sycl_dev))
     elif dt_kind == "f":
         return dpt.dtype(ti.default_device_fp_type(sycl_dev))
     elif dt_kind == "c":
@@ -790,7 +790,7 @@ def _default_accumulation_dtype(inp_dt, q):
         if inp_dt.itemsize > res_dt.itemsize:
             res_dt = inp_dt
     elif inp_kind in "u":
-        res_dt = dpt.dtype(ti.default_device_int_type(q).upper())
+        res_dt = dpt.dtype(ti.default_device_uint_type(q))
         res_ii = dpt.iinfo(res_dt)
         inp_ii = dpt.iinfo(inp_dt)
         if inp_ii.min >= res_ii.min and inp_ii.max <= res_ii.max:

--- a/dpctl/tensor/libtensor/source/device_support_queries.hpp
+++ b/dpctl/tensor/libtensor/source/device_support_queries.hpp
@@ -39,6 +39,7 @@ namespace py_internal
 
 extern std::string default_device_fp_type(const py::object &);
 extern std::string default_device_int_type(const py::object &);
+extern std::string default_device_uint_type(const py::object &);
 extern std::string default_device_bool_type(const py::object &);
 extern std::string default_device_complex_type(const py::object &);
 extern std::string default_device_index_type(const py::object &);

--- a/dpctl/tensor/libtensor/source/tensor_ctors.cpp
+++ b/dpctl/tensor/libtensor/source/tensor_ctors.cpp
@@ -331,7 +331,13 @@ PYBIND11_MODULE(_tensor_impl, m)
 
     m.def("default_device_int_type",
           dpctl::tensor::py_internal::default_device_int_type,
-          "Gives default integer type supported by device.", py::arg("dev"));
+          "Gives default signed integer type supported by device.",
+          py::arg("dev"));
+
+    m.def("default_device_uint_type",
+          dpctl::tensor::py_internal::default_device_uint_type,
+          "Gives default unsigned integer type supported by device.",
+          py::arg("dev"));
 
     m.def("default_device_bool_type",
           dpctl::tensor::py_internal::default_device_bool_type,

--- a/dpctl/tests/test_usm_ndarray_ctor.py
+++ b/dpctl/tests/test_usm_ndarray_ctor.py
@@ -1010,9 +1010,9 @@ def test_pyx_capi_check_constants():
     assert uint_typenum == dpt.dtype(np.uintc).num
 
     long_typenum = _pyx_capi_int(X, "UAR_LONG")
-    assert long_typenum == dpt.dtype(np.int_).num
+    assert long_typenum == dpt.dtype("l").num
     ulong_typenum = _pyx_capi_int(X, "UAR_ULONG")
-    assert ulong_typenum == dpt.dtype(np.uint).num
+    assert ulong_typenum == dpt.dtype("L").num
 
     longlong_typenum = _pyx_capi_int(X, "UAR_LONGLONG")
     assert longlong_typenum == dpt.dtype(np.longlong).num


### PR DESCRIPTION
This PR ports commits from gh-1763 to main branch. 

This would get changes to support developing `dpctl` on Windows with NumPy 2.0 in faster than gh-1760 gets merged.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
