### PR TITLE
Drop use of soversion for dpctl sycl interface

### DIFF
--- a/conda-recipe/build.sh
+++ b/conda-recipe/build.sh
@@ -27,26 +27,6 @@ CMAKE_ARGS="${CMAKE_ARGS} -DDPCTL_LEVEL_ZERO_INCLUDE_DIR=${PREFIX}/include/level
 # -wnx flags mean: --wheel --no-isolation --skip-dependency-check
 ${PYTHON} -m build -w -n -x
 
-pushd dist
-${PYTHON} -m wheel unpack -d dpctl_wheel dpctl*.whl
-export lib_name=libDPCTLSyclInterface
-export so_full_path=$(find dpctl_wheel -regextype posix-extended -regex "^.*${lib_name}\.so")
-export sox_full_path=$(find dpctl_wheel -regextype posix-extended -regex "^.*${lib_name}\.so\.[0-9]*$")
-export soxxx_full_path=$(find dpctl_wheel -regextype posix-extended -regex "^.*${lib_name}\.so\.[0-9]*\.[0-9]*$")
-
-rm -rf ${so_full_path} ${soxxx_full_path}
-
-export so_name=$(basename ${so_full_path})
-export sox_name=$(basename ${sox_full_path})
-export soxxx_name=$(basename ${soxxx_full_path})
-export wheel_path=$(dirname $(dirname ${so_full_path}))
-
-# deal with hard copies
-${PYTHON} -m wheel pack ${wheel_path}
-
-rm -rf dpctl_wheel
-popd
-
 ${PYTHON} -m wheel tags --remove --build "$GIT_DESCRIBE_NUMBER" \
     --platform-tag "manylinux_${GLIBC_MAJOR}_${GLIBC_MINOR}_x86_64" \
     dist/dpctl*.whl
@@ -58,15 +38,6 @@ ${PYTHON} -m pip install dist/dpctl*.whl \
     --no-index \
     --prefix "${PREFIX}" \
     -vv
-
-export libdir=$(find $PREFIX -name 'libDPCTLSyclInterface*' -exec dirname \{\} \;)
-
-# Recover symbolic links
-# libDPCTLSyclInterface.so.0 -> libDPCTLSyclInterface.so.0.17
-# libDPCTLSyclInterface.so -> libDPCTLSyclInterface.so.0
-mv ${libdir}/${sox_name} ${libdir}/${soxxx_name}
-ln -s ${libdir}/${soxxx_name} ${libdir}/${sox_name}
-ln -s ${libdir}/${sox_name} ${libdir}/${so_name}
 
 # Copy wheel package
 if [[ -d "${WHEELS_OUTPUT_FOLDER}" ]]; then

--- a/dpctl/tests/test_service.py
+++ b/dpctl/tests/test_service.py
@@ -163,9 +163,11 @@ def test_syclinterface(should_skip_syclinterface):
         if should_skip_syclinterface:
             pass
         else:
-            assert len(paths) > 1 and any(
-                [os.path.islink(fn) for fn in paths]
-            ), "All library instances are hard links"
+            len_p = len(paths)
+            n_symlinks = sum([int(os.path.islink(fn)) for fn in paths])
+            assert len_p == 1 + n_symlinks, (
+                "Multiple library instances are hard links",
+            )
     elif sys.platform in ["win32", "cygwin"]:
         exts = []
         for fn in paths:

--- a/libsyclinterface/CMakeLists.txt
+++ b/libsyclinterface/CMakeLists.txt
@@ -284,16 +284,19 @@ if(DPCTL_ENABLE_GLOG)
 endif()
 
 
-include(GetProjectVersion)
-# the get_version function is defined in the GetProjectVersion module and
-# defines: VERSION, SEMVER, MAJOR, MINOR, PATCH. These variables are populated
-# by parsing the output of git describe.
-get_version()
-set_target_properties(DPCTLSyclInterface
-    PROPERTIES
-        VERSION ${VERSION_MAJOR}.${VERSION_MINOR}
-        SOVERSION ${VERSION_MAJOR}
-)
+set(buld_so_version 0)
+if (build_so_version)
+    include(GetProjectVersion)
+    # the get_version function is defined in the GetProjectVersion module and
+    # defines: VERSION, SEMVER, MAJOR, MINOR, PATCH. These variables are populated
+    # by parsing the output of git describe.
+    get_version()
+    set_target_properties(DPCTLSyclInterface
+        PROPERTIES
+            VERSION ${VERSION_MAJOR}.${VERSION_MINOR}
+            SOVERSION ${VERSION_MAJOR}
+    )
+endif()
 
 if(DPCTL_ENABLE_L0_PROGRAM_CREATION)
     target_include_directories(DPCTLSyclInterface


### PR DESCRIPTION
Turns off SOVERSION-ing of libDPCTLSyclInterface

Library SOVersioning is used to allow libraries of different versions
to coexist in the same layout. Since libDPCTLSyclInterface library
is being installed into site-packages/dpctl, and since Python does
not support multiple versions of the same package installed, such a
situation where SOVersioning is required never arises.

SOVersioning causes creation of symbolic links which are not supported
by Python wheels (symbolic links are followed and 3 hard identical
copies of the library are bing created) and only cause wheel size
to be overinflated.

With all this said, it is better to not set VERSION/SOVERSION
target property.


- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
