### PR TITLE
Add `max dimensions` to array API capabilities

### DIFF
--- a/dpctl/tensor/_array_api.py
+++ b/dpctl/tensor/_array_api.py
@@ -59,8 +59,9 @@ class Info:
 
     def __init__(self):
         self._capabilities = {
-            "boolean_indexing": True,
-            "data_dependent_shapes": True,
+            "boolean indexing": True,
+            "data-dependent shapes": True,
+            "max dimensions": 64,
         }
         self._all_dtypes = {
             "bool": dpt.bool,
@@ -84,11 +85,20 @@ class Info:
 
         Returns a dictionary of ``dpctl``'s capabilities.
 
+        The dictionary contains the following keys:
+            ``"boolean indexing"``:
+                boolean indicating ``dpctl``'s support of boolean indexing.
+                Value: ``True``
+            ``"data-dependent shapes"``:
+                boolean indicating ``dpctl``'s support of data-dependent shapes.
+                Value: ``True``
+            ``max dimensions``:
+                integer indication the maximum array dimension supported by ``dpctl``.
+                Value: ``64``
+
         Returns:
             dict:
                 dictionary of ``dpctl``'s capabilities
-                - ``"boolean_indexing"``: bool
-                - ``data_dependent_shapes"``: bool
         """
         return self._capabilities.copy()
 

--- a/dpctl/tests/test_tensor_array_api_inspection.py
+++ b/dpctl/tests/test_tensor_array_api_inspection.py
@@ -79,8 +79,9 @@ def test_array_api_inspection_devices():
 
 def test_array_api_inspection_capabilities():
     capabilities = dpt.__array_namespace_info__().capabilities()
-    assert capabilities["boolean_indexing"]
-    assert capabilities["data_dependent_shapes"]
+    assert capabilities["boolean indexing"]
+    assert capabilities["data-dependent shapes"]
+    assert capabilities["max dimensions"] == 64
 
 
 def test_array_api_inspection_default_dtypes():


### PR DESCRIPTION
This PR adds ``max dimensions`` to the ``dpctl.tensor.__array_namespace_info__().capabilities()`` dictionary.

Also revises the other keys to this dictionary, which [did not align exactly with their inclusion in the specification](https://data-apis.org/array-api/draft/API_specification/generated/array_api.info.capabilities.html).

- [X] Have you provided a meaningful PR description?
- [X] Have you added a test, reproducer or referred to an issue with a reproducer?
- [X] Have you tested your changes locally for CPU and GPU devices?
- [X] Have you made sure that new changes do not introduce compiler warnings?
- [X] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
