### PR TITLE
Add missing include to fix build break

### DIFF
--- a/libsyclinterface/source/dpctl_sycl_device_manager.cpp
+++ b/libsyclinterface/source/dpctl_sycl_device_manager.cpp
@@ -32,6 +32,7 @@
 #include <Config/dpctl_config.h> /* Config */
 #include <iomanip>
 #include <iostream>
+#include <sstream>
 #include <sycl/sycl.hpp> /* SYCL headers   */
 #include <unordered_map>
 #include <utility>


### PR DESCRIPTION
"libsyclinterface/source/dpctl_sycl_queue_manager.cpp" used `std::stringstream` but was not including `sstream` header. 

This caused build break in internal CI with forthcoming compiler.


- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
