### PR TITLE
Fix testing step of conda-package workflow

### DIFF
--- a/.github/workflows/conda-package.yml
+++ b/.github/workflows/conda-package.yml
@@ -180,7 +180,7 @@ jobs:
       - name: Install dpctl
         run: |
           export CHANNELS="-c $GITHUB_WORKSPACE/channel ${{ env.CHANNELS }}"
-          export TEST_DEPENDENCIES="pytest pytest-cov cython"
+          export TEST_DEPENDENCIES="pytest pytest-cov cython setuptools"
           export PACKAGE_VERSION=$(python -c "${VER_SCRIPT1} ${VER_SCRIPT2}")
           conda create -n ${{ env.TEST_ENV_NAME }} $PACKAGE_NAME=${PACKAGE_VERSION} ${TEST_DEPENDENCIES} python=${{ matrix.python }} ${CHANNELS}
           # Test installed packages
@@ -303,7 +303,7 @@ jobs:
           FOR /F "tokens=* USEBACKQ" %%F IN (`python -c "%SCRIPT%"`) DO (
              SET PACKAGE_VERSION=%%F
           )
-          SET TEST_DEPENDENCIES=pytest"<8" pytest-cov cython
+          SET TEST_DEPENDENCIES=pytest"<8" pytest-cov cython setuptools
           conda install -n ${{ env.TEST_ENV_NAME }} ${{ env.PACKAGE_NAME }}=%PACKAGE_VERSION% %TEST_DEPENDENCIES% python=${{ matrix.python }} -c ${{ env.workdir }}/channel ${{ env.CHANNELS }}
       - name: Report content of test environment
         shell: cmd /C CALL {0}


### PR DESCRIPTION
Add setuptools to list of packages to be installed into test environment in workflow.

This aligns it with test requirements section of meta.yaml. Setuptools is required by tests that check if an extension can be built using dpctl's headers.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
