### PR TITLE
`diff` raises an exception for negative values of `n`

### DIFF
--- a/dpctl/tensor/_utility_functions.py
+++ b/dpctl/tensor/_utility_functions.py
@@ -453,7 +453,8 @@ def diff(x, /, *, axis=-1, n=1, prepend=None, append=None):
     x_nd = x.ndim
     axis = normalize_axis_index(operator.index(axis), x_nd)
     n = operator.index(n)
-
+    if n < 0:
+        raise ValueError(f"`n` must be positive, got {n}")
     arr = _concat_diff_input(x, axis, prepend, append)
     if n == 0:
         return arr

--- a/dpctl/tests/test_tensor_diff.py
+++ b/dpctl/tests/test_tensor_diff.py
@@ -313,3 +313,17 @@ def test_diff_input_validation():
         dpt.diff,
         bad_in,
     )
+
+
+def test_diff_positive_order():
+    get_queue_or_skip()
+
+    x = dpt.ones(1, dtype="i4")
+    n = -1
+    assert_raises_regex(
+        ValueError,
+        ".*must be positive.*",
+        dpt.diff,
+        x,
+        n=n,
+    )


### PR DESCRIPTION
`diff` now raises an exception for negative `n` as is expected, rather than just defaulting to `n=1` case

Closes #1779 

- [X] Have you provided a meaningful PR description?
- [X] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [X] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
