### PR TITLE
Add usm memory constructor from existing allocation

### DIFF
--- a/dpctl/apis/include/dpctl4pybind11.hpp
+++ b/dpctl/apis/include/dpctl4pybind11.hpp
@@ -764,7 +764,7 @@ public:
             reinterpret_cast<DPCTLSyclQueueRef>(q_uptr.get());
 
         auto vacuous_destructor = []() {};
-        py::object mock_owner = py::capsule(vacuous_destructor);
+        py::capsule mock_owner(vacuous_destructor);
 
         // create memory object owned by mock_owner, it is a new reference
         PyObject *_memory =
@@ -773,14 +773,13 @@ public:
 
         using py_uptrT =
             std::unique_ptr<PyObject, decltype(ref_count_decrementer)>;
-        auto memory_uptr = py_uptrT(_memory, ref_count_decrementer);
 
         if (!_memory) {
             throw py::error_already_set();
         }
 
-        std::shared_ptr<void> *opaque_ptr = nullptr;
-        opaque_ptr = new std::shared_ptr<void>(shptr);
+        auto memory_uptr = py_uptrT(_memory, ref_count_decrementer);
+        std::shared_ptr<void> *opaque_ptr = new std::shared_ptr<void>(shptr);
 
         Py_MemoryObject *memobj = reinterpret_cast<Py_MemoryObject *>(_memory);
         // replace mock_owner capsule as the owner

--- a/dpctl/apis/include/dpctl4pybind11.hpp
+++ b/dpctl/apis/include/dpctl4pybind11.hpp
@@ -27,6 +27,7 @@
 
 #include "dpctl_capi.h"
 #include <complex>
+#include <exception>
 #include <memory>
 #include <pybind11/pybind11.h>
 #include <sycl/sycl.hpp>
@@ -746,6 +747,54 @@ public:
     {
         if (!m_ptr)
             throw py::error_already_set();
+    }
+
+    /*! @brief Create usm_memory object from shared pointer that manages
+     *  lifetime of the USM allocation.
+     */
+    usm_memory(void *usm_ptr,
+               size_t nbytes,
+               const sycl::queue &q,
+               std::shared_ptr<void> shptr)
+    {
+        auto const &api = ::dpctl::detail::dpctl_capi::get();
+        DPCTLSyclUSMRef usm_ref = reinterpret_cast<DPCTLSyclUSMRef>(usm_ptr);
+        auto q_uptr = std::make_unique<sycl::queue>(q);
+        DPCTLSyclQueueRef QRef =
+            reinterpret_cast<DPCTLSyclQueueRef>(q_uptr.get());
+
+        auto vacuous_destructor = []() {};
+        py::object mock_owner = py::capsule(vacuous_destructor);
+
+        // create memory object owned by mock_owner, it is a new reference
+        PyObject *_memory =
+            api.Memory_Make_(usm_ref, nbytes, QRef, mock_owner.ptr());
+        auto ref_count_decrementer = [](PyObject *o) noexcept { Py_DECREF(o); };
+
+        using py_uptrT =
+            std::unique_ptr<PyObject, decltype(ref_count_decrementer)>;
+        auto memory_uptr = py_uptrT(_memory, ref_count_decrementer);
+
+        if (!_memory) {
+            throw py::error_already_set();
+        }
+
+        std::shared_ptr<void> *opaque_ptr = nullptr;
+        opaque_ptr = new std::shared_ptr<void>(shptr);
+
+        Py_MemoryObject *memobj = reinterpret_cast<Py_MemoryObject *>(_memory);
+        // replace mock_owner capsule as the owner
+        memobj->refobj = Py_None;
+        // set opaque ptr field, usm_memory now knowns that USM is managed
+        // by smart pointer
+        memobj->_opaque_ptr = reinterpret_cast<void *>(opaque_ptr);
+
+        // _memory will delete created copies of sycl::queue, and
+        // std::shared_ptr and the deleter of the shared_ptr<void> is
+        // supposed to free the USM allocation
+        m_ptr = _memory;
+        q_uptr.release();
+        memory_uptr.release();
     }
 
     sycl::queue get_queue() const

--- a/examples/pybind11/external_usm_allocation/README.md
+++ b/examples/pybind11/external_usm_allocation/README.md
@@ -1,8 +1,10 @@
 # Exposing USM Allocations Made by the Native Code to dpctl
 
-This extension demonstrates how a Python object backed by
+This extension demonstrates how a Python object representing
 a native class, which allocates USM memory, can expose it
-to the `dpctl.memory` entities using `__sycl_usm_array_interface__`.
+to the `dpctl.memory` entities using `__sycl_usm_array_interface__`,
+and how to create `dpctl.memory` object from allocation made
+in native extension.
 
 
 ## Building
@@ -29,4 +31,10 @@ shared
 [1.0, 1.0, 0.0, 2.0, 2.0]
 [0.0, 0.0, 0.0, 3.0, -1.0]
 [0.0, 0.0, 0.0, -1.0, 5.0]
+
+========================================
+device
+64
+[0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0]
 ```

--- a/examples/pybind11/external_usm_allocation/example.py
+++ b/examples/pybind11/external_usm_allocation/example.py
@@ -50,3 +50,10 @@ print("")
 list_of_lists = matr.tolist()
 for row in list_of_lists:
     print(row)
+
+print("====" * 10)
+
+mbuf = eua.make_zeroed_device_memory(4 * 16, q)
+print(mbuf.get_usm_type())
+print(mbuf.nbytes)
+print(mbuf.copy_to_host())

--- a/examples/pybind11/external_usm_allocation/tests/test_direct.py
+++ b/examples/pybind11/external_usm_allocation/tests/test_direct.py
@@ -16,12 +16,22 @@
 
 # coding: utf-8
 
-from ._external_usm_alloc import DMatrix, make_zeroed_device_memory
+import external_usm_allocation as eua
 
-__all__ = ["DMatrix", "make_zeroed_device_memory"]
+import dpctl
+import dpctl.memory as dpm
+import dpctl.tensor as dpt
 
-__doc__ = """
-   Example of implementing C++ class with its own USM memory allocation logic
-and interfacing that allocation with `dpctl` by implementing
-`__sycl_usm_array_interface__`.
-"""
+
+def test_direct():
+    q = dpctl.SyclQueue()
+
+    nb = 2 * 30
+    mbuf = eua.make_zeroed_device_memory(nb, q)
+
+    assert isinstance(mbuf, dpm.MemoryUSMDevice)
+    assert mbuf.nbytes == 2 * 30
+    assert mbuf.sycl_queue == q
+
+    x = dpt.usm_ndarray(30, dtype="i2", buffer=mbuf)
+    assert dpt.all(x == dpt.zeros(30, dtype="i2", sycl_queue=q))


### PR DESCRIPTION
This PR add `dpctl::memory::usm_memory` constructor to create Python memory object from natively made allocation.

The signature is 

```cpp
usm_memory(void *usm_ptr, size_t nbytes, sycl::queue &q, std::shared_ptr<void> owner)
```

where `usm_ptr` is the pointer to USM-allocation, `nbytes` the size of allocation in bytes, `q` the queue associated with the Python memory object, and `owner` is the shared pointer whose destructor frees USM allocation via its custom deleter argument.

Example of using such constructor is added to `examples/pybind11/external_usm_allocation` extension.

- [x] Have you provided a meaningful PR description?
- [x] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [x] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
