### PR TITLE
Include utility for std::move

### DIFF
--- a/dpctl/memory/_opaque_smart_ptr.hpp
+++ b/dpctl/memory/_opaque_smart_ptr.hpp
@@ -34,6 +34,7 @@
 #include "syclinterface/dpctl_sycl_types.h"
 #include <memory>
 #include <sycl/sycl.hpp>
+#include <utility>
 
 #include <exception>
 #include <iostream>


### PR DESCRIPTION
Added missing `#include <utility>` for definition of `std::move`.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
