### PR TITLE
Search for ur_adapter_opencl alongside pi_opencl

### DIFF
--- a/libsyclinterface/CMakeLists.txt
+++ b/libsyclinterface/CMakeLists.txt
@@ -61,7 +61,7 @@ if(DPCTL_ENABLE_L0_PROGRAM_CREATION)
     endif()
     if (UNIX)
         find_library(PI_LEVEL_ZERO_LIB
-            NAMES pi_level_zero
+            NAMES pi_level_zero ur_adapter_level_zero
             HINTS ${IntelSyclCompiler_LIBRARY_DIR}
         )
         find_program(READELF_PROG readelf)
@@ -81,7 +81,7 @@ endif()
 
 if (UNIX)
   find_library(PI_OPENCL_LIB
-      NAMES pi_opencl
+      NAMES pi_opencl ur_adapter_opencl
       HINTS ${IntelSyclCompiler_LIBRARY_DIR}
   )
   find_program(READELF_PROG readelf)


### PR DESCRIPTION
Search for `ur_adapter_opencl` and `ur_adapter_level_zero` alongside `pi_opencl` and `pi_level_zero` to accomodate building with both DPC++ 2024.2.0 and open source build of DPC++, a precursor for the forthcoming version of DPC++.

intel/llvm DPC++ has made switch to using unified runtimes, and the compiler nightly build artifacts no longer contain pi_level_zero.so and pi_opencl.so libraries that we used to infer the SO-versioned name of ze_loader and OpenCL loader libraries from.

This change adds ur_adapter_* names to find_library CMake commands.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
