### PR TITLE
Enhance from_dlpack to support imported kDLCPU data to kDLOneAPI

### DIFF
--- a/dpctl/tensor/_usmarray.pyx
+++ b/dpctl/tensor/_usmarray.pyx
@@ -1242,7 +1242,7 @@ cdef class usm_ndarray:
                             _arr.flags["W"] = self.flags["W"]
                             return c_dlpack.numpy_to_dlpack_versioned_capsule(_arr, True)
                         else:
-                            raise NotImplementedError(
+                            raise BufferError(
                                 f"targeting `dl_device` {dl_device} with `__dlpack__` is not "
                                 "yet implemented"
                             )


### PR DESCRIPTION
This PR contributes to gh-1781 to support importing objects resident on other devices to oneAPI devices by copying via host.

```
In [1]: import dpctl.tensor as dpt, numpy as np

In [2]: x = dpt.ones((2, 3))

In [3]: x.device
Out[3]: Device(level_zero:gpu:0)

In [4]: y = dpt.from_dlpack(x, device=(1,0))

In [5]: type(y)
Out[5]: numpy.ndarray

In [6]: w1 = dpt.from_dlpack(y, device="opencl:gpu")

In [7]: w1.device
Out[7]: Device(opencl:gpu:0)

In [8]: w2 = dpt.from_dlpack(y, device="gpu")

In [9]: w2.device
Out[9]: Device(level_zero:gpu:0)

In [10]: w3 = dpt.from_dlpack(y, device="cpu")

In [11]: w3.device, type(w3)
Out[11]: (Device(opencl:cpu:0), dpctl.tensor._usmarray.usm_ndarray)
```

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
