### PR TITLE
Try/catch wrap a call to deallocate in silent usm_host_allocator class to be used by std::vector for array metadata transfers 

### DIFF
--- a/.github/workflows/os-llvm-sycl-build.yml
+++ b/.github/workflows/os-llvm-sycl-build.yml
@@ -13,11 +13,11 @@ jobs:
 
     env:
       DOWNLOAD_URL_PREFIX: https://github.com/intel/llvm/releases/download
-      DRIVER_PATH: 2023-WW27
-      OCLCPUEXP_FN: oclcpuexp-2023.16.6.0.28_rel.tar.gz
-      TBB_URL: https://github.com/oneapi-src/oneTBB/releases/download/v2021.9.0/
-      TBB_INSTALL_DIR: oneapi-tbb-2021.9.0
-      TBB_FN: oneapi-tbb-2021.9.0-lin.tgz
+      DRIVER_PATH: 2024-WW25
+      OCLCPUEXP_FN: oclcpuexp-2024.18.6.0.02_rel.tar.gz
+      TBB_URL: https://github.com/oneapi-src/oneTBB/releases/download/v2021.12.0/
+      TBB_INSTALL_DIR: oneapi-tbb-2021.12.0
+      TBB_FN: oneapi-tbb-2021.12.0-lin.tgz
 
     steps:
       - name: Cancel Previous Runs

--- a/.github/workflows/os-llvm-sycl-build.yml
+++ b/.github/workflows/os-llvm-sycl-build.yml
@@ -159,6 +159,4 @@ jobs:
           SYCL_CACHE_PERSISTENT: 1
         run: |
           source set_allvars.sh
-          # Skip the test that checks if there is only one hard
-          # copy of DPCTLSyclInterface library
-          python -m pytest -v dpctl/tests --no-sycl-interface-test
+          python -m pytest -sv dpctl/tests

--- a/dpctl/tensor/libtensor/source/integer_advanced_indexing.cpp
+++ b/dpctl/tensor/libtensor/source/integer_advanced_indexing.cpp
@@ -35,6 +35,7 @@
 #include "dpctl4pybind11.hpp"
 #include "kernels/integer_advanced_indexing.hpp"
 #include "utils/memory_overlap.hpp"
+#include "utils/offset_utils.hpp"
 #include "utils/output_validation.hpp"
 #include "utils/type_dispatch.hpp"
 #include "utils/type_utils.hpp"
@@ -91,7 +92,7 @@ _populate_kernel_params(sycl::queue &exec_q,
 {
 
     using usm_host_allocator_T =
-        sycl::usm_allocator<char *, sycl::usm::alloc::host>;
+        dpctl::tensor::offset_utils::usm_host_allocator<char *>;
     using ptrT = std::vector<char *, usm_host_allocator_T>;
 
     usm_host_allocator_T ptr_allocator(exec_q);
@@ -99,7 +100,7 @@ _populate_kernel_params(sycl::queue &exec_q,
         std::make_shared<ptrT>(k, ptr_allocator);
 
     using usm_host_allocatorT =
-        sycl::usm_allocator<py::ssize_t, sycl::usm::alloc::host>;
+        dpctl::tensor::offset_utils::usm_host_allocator<py::ssize_t>;
     using shT = std::vector<py::ssize_t, usm_host_allocatorT>;
 
     usm_host_allocatorT sz_allocator(exec_q);

--- a/dpctl/tensor/libtensor/source/triul_ctor.cpp
+++ b/dpctl/tensor/libtensor/source/triul_ctor.cpp
@@ -32,6 +32,7 @@
 #include "kernels/constructors.hpp"
 #include "simplify_iteration_space.hpp"
 #include "utils/memory_overlap.hpp"
+#include "utils/offset_utils.hpp"
 #include "utils/output_validation.hpp"
 #include "utils/type_dispatch.hpp"
 
@@ -150,7 +151,7 @@ usm_ndarray_triul(sycl::queue &exec_q,
     nd += 2;
 
     using usm_host_allocatorT =
-        sycl::usm_allocator<py::ssize_t, sycl::usm::alloc::host>;
+        dpctl::tensor::offset_utils::usm_host_allocator<py::ssize_t>;
     using usmshT = std::vector<py::ssize_t, usm_host_allocatorT>;
 
     usm_host_allocatorT allocator(exec_q);

--- a/dpctl/tests/test_usm_ndarray_print.py
+++ b/dpctl/tests/test_usm_ndarray_print.py
@@ -283,7 +283,6 @@ class TestPrintFns(TestPrint):
         x = dpt.arange(4, dtype="i4", sycl_queue=q)
         x.sycl_queue.wait()
         r = repr(x)
-        print(r)
         assert r == "usm_ndarray([0, 1, 2, 3], dtype=int32)"
 
         dpt.set_print_options(linewidth=1)


### PR DESCRIPTION
Introduced class `template <typename T> dpctl::tensor::offset_utils::usm_host_allocator` deriving from `sycl::usm_allocator<T, sycl::alloc::kind::host>` that wraps the call to ``base::deallocate`` in try/catch to prevent crashes due to seemingly benign exceptions thrown by call to `sycl::free` by CPU device runtime which are under investigation.

In case such an exception is caught, a message is printed to `std::cerr`, but the exception is otherwise ignored.

Run pytest with `-s` for testing with nightly sycl bundle to be able to see such message printed.

Also remove use of `--no-sycl-interface-test` option, since DPCTLSyclInterface library is no longer so-versioned.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
