### PR TITLE
Fix for gh 1785

### DIFF
--- a/dpctl/tensor/_slicing.pxi
+++ b/dpctl/tensor/_slicing.pxi
@@ -81,7 +81,7 @@ cdef bint _is_boolean(object x) except *:
         return True
     if isinstance(x, bool):
         return True
-    if isinstance(x, int):
+    if isinstance(x, (int, float, complex)):
         return False
     if _is_buffer(x):
         mbuf = memoryview(x)
@@ -204,7 +204,11 @@ def _basic_slice_meta(ind, shape : tuple, strides : tuple, offset : int):
                     )
                 array_count += 1
             else:
-                raise TypeError
+                raise IndexError(
+                    "Only integers, slices (`:`), ellipsis (`...`), "
+                    "dpctl.tensor.newaxis (`None`) and integer and "
+                    "boolean arrays are valid indices."
+                )
         if ellipses_count > 1:
             raise IndexError(
                 "an index can only have a single ellipsis ('...')")
@@ -283,6 +287,8 @@ def _basic_slice_meta(ind, shape : tuple, strides : tuple, offset : int):
                 new_shape.extend(shape[k:k_new])
                 new_strides.extend(strides[k:k_new])
                 k = k_new
+            else:
+                raise IndexError
         new_shape.extend(shape[k:])
         new_strides.extend(strides[k:])
         new_shape_len += len(shape) - k
@@ -291,4 +297,8 @@ def _basic_slice_meta(ind, shape : tuple, strides : tuple, offset : int):
 #        assert len(new_advanced_ind) == array_count
         return (tuple(new_shape), tuple(new_strides), new_offset, tuple(new_advanced_ind), new_advanced_start_pos)
     else:
-        raise TypeError
+        raise IndexError(
+            "Only integers, slices (`:`), ellipsis (`...`), "
+            "dpctl.tensor.newaxis (`None`) and integer and "
+            "boolean arrays are valid indices."
+        )

--- a/dpctl/tests/test_usm_ndarray_ctor.py
+++ b/dpctl/tests/test_usm_ndarray_ctor.py
@@ -441,7 +441,7 @@ def test_slicing_basic():
     Xusm[:, -4]
     with pytest.raises(IndexError):
         Xusm[:, -128]
-    with pytest.raises(TypeError):
+    with pytest.raises(IndexError):
         Xusm[{1, 2, 3, 4, 5, 6, 7}]
     X = dpt.usm_ndarray(10, "u1")
     X.usm_data.copy_from_host(b"\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09")

--- a/dpctl/tests/test_usm_ndarray_ctor.py
+++ b/dpctl/tests/test_usm_ndarray_ctor.py
@@ -2416,3 +2416,25 @@ def test_asarray_writable_flag(ro_flag):
 
     assert b.flags["W"] == (not ro_flag)
     assert b._pointer == a._pointer
+
+
+def test_getitem_validation():
+    """Test based on gh-1785"""
+    try:
+        a = dpt.empty((2, 2, 2))
+    except dpctl.SyclDeviceCreationError:
+        pytest.skip("No SYCL devices available")
+    with pytest.raises(IndexError):
+        a[0.0]
+    with pytest.raises(IndexError):
+        a[1, 0.0, ...]
+    with pytest.raises(IndexError):
+        a[1, 0.0, dpt.newaxis, 1]
+    with pytest.raises(IndexError):
+        a[dpt.newaxis, ..., 0.0]
+    with pytest.raises(IndexError):
+        a[dpt.newaxis, ..., 0.0, dpt.newaxis]
+    with pytest.raises(IndexError):
+        a[..., 0.0, dpt.newaxis]
+    with pytest.raises(IndexError):
+        a[:, 0.0, dpt.newaxis]

--- a/dpctl/tests/test_usm_ndarray_indexing.py
+++ b/dpctl/tests/test_usm_ndarray_indexing.py
@@ -983,7 +983,7 @@ def test_take_arg_validation():
         dpt.take(dict(), ind0, axis=0)
     with pytest.raises(TypeError):
         dpt.take(x, dict(), axis=0)
-    with pytest.raises(TypeError):
+    with pytest.raises(IndexError):
         x[[]]
     with pytest.raises(IndexError):
         dpt.take(x, ind1, axis=0)
@@ -1016,7 +1016,7 @@ def test_put_arg_validation():
         dpt.put(dict(), ind0, val, axis=0)
     with pytest.raises(TypeError):
         dpt.put(x, dict(), val, axis=0)
-    with pytest.raises(TypeError):
+    with pytest.raises(IndexError):
         x[[]] = val
     with pytest.raises(IndexError):
         dpt.put(x, ind1, val, axis=0)


### PR DESCRIPTION
Resolves gh-1785

Treat `float` and `complex` types as non-booleans. They used to be treated so because `bool(key)` works for these types.

Changed exception raised for unrecognized key from `TypeError` to `IndexError`,

- [x] Have you provided a meaningful PR description?
- [x] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [x] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
