### PR TITLE
Documentation: Add doc page for `dpctl.tensor._flags.Flags` class

### DIFF
--- a/docs/doc_sources/api_reference/dpctl/flags.rst
+++ b/docs/doc_sources/api_reference/dpctl/flags.rst
@@ -1,0 +1,24 @@
+.. _Flags_class:
+
+``Flags`` class
+===================
+
+Helper class for querying information about the memory layout of an array.
+
+    Note that dictionary-like access to some members is permitted:
+
+        "C", "C_CONTIGUOUS":
+            Equivalent to `c_contiguous`
+        "F", "F_CONTIGUOUS":
+            Equivalent to `f_contiguous`
+        "W", "WRITABLE":
+            Equivalent to `writable`
+        "FC":
+            Equivalent to `fc`
+        "FNC":
+            Equivalent to `fnc`
+        "FORC", "CONTIGUOUS":
+            Equivalent to `forc` and `contiguous`
+
+.. autoclass:: dpctl.tensor._flags.Flags
+    :members:

--- a/docs/doc_sources/api_reference/dpctl/flags.rst
+++ b/docs/doc_sources/api_reference/dpctl/flags.rst
@@ -3,7 +3,8 @@
 ``Flags`` class
 ===================
 
-Helper class for querying information about the memory layout of an array.
+.. autoclass:: dpctl.tensor._flags.Flags
+    :members:
 
     Note that dictionary-like access to some members is permitted:
 
@@ -19,6 +20,3 @@ Helper class for querying information about the memory layout of an array.
             Equivalent to `fnc`
         "FORC", "CONTIGUOUS":
             Equivalent to `forc` and `contiguous`
-
-.. autoclass:: dpctl.tensor._flags.Flags
-    :members:

--- a/docs/doc_sources/api_reference/dpctl/flags.rst
+++ b/docs/doc_sources/api_reference/dpctl/flags.rst
@@ -9,14 +9,14 @@
     Note that dictionary-like access to some members is permitted:
 
         "C", "C_CONTIGUOUS":
-            Equivalent to `c_contiguous`
+            Equivalent to ``c_contiguous``
         "F", "F_CONTIGUOUS":
-            Equivalent to `f_contiguous`
+            Equivalent to ``f_contiguous``
         "W", "WRITABLE":
-            Equivalent to `writable`
+            Equivalent to ``writable``
         "FC":
-            Equivalent to `fc`
+            Equivalent to ``fc``
         "FNC":
-            Equivalent to `fnc`
+            Equivalent to ``fnc``
         "FORC", "CONTIGUOUS":
-            Equivalent to `forc` and `contiguous`
+            Equivalent to ``forc`` and ``contiguous``

--- a/docs/doc_sources/api_reference/dpctl/tensor.usm_ndarray.rst
+++ b/docs/doc_sources/api_reference/dpctl/tensor.usm_ndarray.rst
@@ -23,3 +23,8 @@ Implementation of :py:class:`usm_ndarray` conforms to
 .. _dpctl_tensor_usm_ndarray_to_device_example:
 
 .. include:: examples/usm_ndarray.rst
+
+.. toctree::
+    :hidden:
+
+    flags

--- a/dpctl/tensor/_flags.pyx
+++ b/dpctl/tensor/_flags.pyx
@@ -34,8 +34,9 @@ cdef cpp_bool _check_bit(int flag, int mask):
 
 cdef class Flags:
     """
-    Helper class to represent memory layout flags of
-    :class:`dpctl.tensor.usm_ndarray`.
+    Helper class to query the flags of a :class:`dpctl.tensor.usm_ndarray`
+    instance, which describe how the instance interfaces with its underlying
+    memory.
     """
     cdef int flags_
     cdef usm_ndarray arr_

--- a/dpctl/tensor/_usmarray.pyx
+++ b/dpctl/tensor/_usmarray.pyx
@@ -681,7 +681,7 @@ cdef class usm_ndarray:
     @property
     def flags(self):
         """
-        Returns :class:`dpctl.tensor._flags` object.
+        Returns :class:`dpctl.tensor._flags.Flags` object.
         """
         return _flags.Flags(self, self.flags_)
 


### PR DESCRIPTION
This PR adds a new documentation page for the `Flags` helper class which also lists the values its `__getitem__` method will accept for dictionary-like access.

- [X] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
