### PR TITLE
Replace sycl::free with sycl_free_noexcept

### DIFF
--- a/dpctl/tensor/libtensor/include/kernels/accumulators.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/accumulators.hpp
@@ -32,6 +32,7 @@
 
 #include "dpctl_tensor_types.hpp"
 #include "utils/offset_utils.hpp"
+#include "utils/sycl_alloc_utils.hpp"
 #include "utils/sycl_utils.hpp"
 #include "utils/type_dispatch_building.hpp"
 #include "utils/type_utils.hpp"
@@ -436,7 +437,8 @@ sycl::event inclusive_scan_iter_1d(sycl::queue &exec_q,
         sycl::event free_ev = exec_q.submit([&](sycl::handler &cgh) {
             cgh.depends_on(dependent_event);
             const auto &ctx = exec_q.get_context();
-            cgh.host_task([ctx, temp]() { sycl::free(temp, ctx); });
+            using dpctl::tensor::alloc_utils::sycl_free_noexcept;
+            cgh.host_task([ctx, temp]() { sycl_free_noexcept(temp, ctx); });
         });
         host_tasks.push_back(free_ev);
     }
@@ -765,7 +767,8 @@ sycl::event inclusive_scan_iter(sycl::queue &exec_q,
         sycl::event free_ev = exec_q.submit([&](sycl::handler &cgh) {
             cgh.depends_on(dependent_event);
             const auto &ctx = exec_q.get_context();
-            cgh.host_task([ctx, temp]() { sycl::free(temp, ctx); });
+            using dpctl::tensor::alloc_utils::sycl_free_noexcept;
+            cgh.host_task([ctx, temp]() { sycl_free_noexcept(temp, ctx); });
         });
         host_tasks.push_back(free_ev);
     }
@@ -917,7 +920,9 @@ size_t cumsum_val_contig_impl(sycl::queue &q,
     });
     copy_e.wait();
     size_t return_val = static_cast<size_t>(*last_elem_host_usm);
-    sycl::free(last_elem_host_usm, q);
+
+    using dpctl::tensor::alloc_utils::sycl_free_noexcept;
+    sycl_free_noexcept(last_elem_host_usm, q);
 
     return return_val;
 }
@@ -1026,7 +1031,9 @@ size_t cumsum_val_strided_impl(sycl::queue &q,
     });
     copy_e.wait();
     size_t return_val = static_cast<size_t>(*last_elem_host_usm);
-    sycl::free(last_elem_host_usm, q);
+
+    using dpctl::tensor::alloc_utils::sycl_free_noexcept;
+    sycl_free_noexcept(last_elem_host_usm, q);
 
     return return_val;
 }

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/common.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/common.hpp
@@ -31,6 +31,7 @@
 #include "kernels/alignment.hpp"
 #include "kernels/dpctl_tensor_types.hpp"
 #include "utils/offset_utils.hpp"
+#include "utils/sycl_alloc_utils.hpp"
 
 namespace dpctl
 {
@@ -947,7 +948,9 @@ sycl::event binary_contig_matrix_contig_row_broadcast_impl(
     sycl::event tmp_cleanup_ev = exec_q.submit([&](sycl::handler &cgh) {
         cgh.depends_on(comp_ev);
         const sycl::context &ctx = exec_q.get_context();
-        cgh.host_task([ctx, padded_vec]() { sycl::free(padded_vec, ctx); });
+        using dpctl::tensor::alloc_utils::sycl_free_noexcept;
+        cgh.host_task(
+            [ctx, padded_vec]() { sycl_free_noexcept(padded_vec, ctx); });
     });
     host_tasks.push_back(tmp_cleanup_ev);
 
@@ -1026,7 +1029,9 @@ sycl::event binary_contig_row_contig_matrix_broadcast_impl(
     sycl::event tmp_cleanup_ev = exec_q.submit([&](sycl::handler &cgh) {
         cgh.depends_on(comp_ev);
         const sycl::context &ctx = exec_q.get_context();
-        cgh.host_task([ctx, padded_vec]() { sycl::free(padded_vec, ctx); });
+        using dpctl::tensor::alloc_utils::sycl_free_noexcept;
+        cgh.host_task(
+            [ctx, padded_vec]() { sycl_free_noexcept(padded_vec, ctx); });
     });
     host_tasks.push_back(tmp_cleanup_ev);
 

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/common_inplace.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/common_inplace.hpp
@@ -30,6 +30,8 @@
 
 #include "kernels/alignment.hpp"
 #include "kernels/dpctl_tensor_types.hpp"
+#include "utils/offset_utils.hpp"
+#include "utils/sycl_alloc_utils.hpp"
 
 namespace dpctl
 {
@@ -458,7 +460,9 @@ sycl::event binary_inplace_row_matrix_broadcast_impl(
     sycl::event tmp_cleanup_ev = exec_q.submit([&](sycl::handler &cgh) {
         cgh.depends_on(comp_ev);
         const sycl::context &ctx = exec_q.get_context();
-        cgh.host_task([ctx, padded_vec]() { sycl::free(padded_vec, ctx); });
+        using dpctl::tensor::alloc_utils::sycl_free_noexcept;
+        cgh.host_task(
+            [ctx, padded_vec]() { sycl_free_noexcept(padded_vec, ctx); });
     });
     host_tasks.push_back(tmp_cleanup_ev);
 

--- a/dpctl/tensor/libtensor/include/kernels/linalg_functions/dot_product.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/linalg_functions/dot_product.hpp
@@ -35,6 +35,7 @@
 #include "kernels/dpctl_tensor_types.hpp"
 #include "kernels/reductions.hpp"
 #include "utils/offset_utils.hpp"
+#include "utils/sycl_alloc_utils.hpp"
 #include "utils/sycl_utils.hpp"
 #include "utils/type_utils.hpp"
 
@@ -1153,8 +1154,9 @@ sycl::event dot_product_tree_impl(sycl::queue &exec_q,
                 cgh.depends_on(final_reduction_ev);
                 const sycl::context &ctx = exec_q.get_context();
 
+                using dpctl::tensor::alloc_utils::sycl_free_noexcept;
                 cgh.host_task([ctx, partially_reduced_tmp] {
-                    sycl::free(partially_reduced_tmp, ctx);
+                    sycl_free_noexcept(partially_reduced_tmp, ctx);
                 });
             });
 
@@ -1403,8 +1405,9 @@ dot_product_contig_tree_impl(sycl::queue &exec_q,
                 cgh.depends_on(final_reduction_ev);
                 const sycl::context &ctx = exec_q.get_context();
 
+                using dpctl::tensor::alloc_utils::sycl_free_noexcept;
                 cgh.host_task([ctx, partially_reduced_tmp] {
-                    sycl::free(partially_reduced_tmp, ctx);
+                    sycl_free_noexcept(partially_reduced_tmp, ctx);
                 });
             });
 

--- a/dpctl/tensor/libtensor/include/kernels/linalg_functions/gemm.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/linalg_functions/gemm.hpp
@@ -35,6 +35,7 @@
 #include "kernels/dpctl_tensor_types.hpp"
 #include "kernels/reductions.hpp"
 #include "utils/offset_utils.hpp"
+#include "utils/sycl_alloc_utils.hpp"
 #include "utils/sycl_utils.hpp"
 #include "utils/type_utils.hpp"
 
@@ -2364,7 +2365,8 @@ gemm_batch_tree_k_impl(sycl::queue &exec_q,
                     cgh.depends_on(red_ev);
                     const sycl::context &ctx = exec_q.get_context();
 
-                    cgh.host_task([ctx, tmp] { sycl::free(tmp, ctx); });
+                    using dpctl::tensor::alloc_utils::sycl_free_noexcept;
+                    cgh.host_task([ctx, tmp] { sycl_free_noexcept(tmp, ctx); });
                 });
             return cleanup_host_task_event;
         }
@@ -2427,8 +2429,9 @@ gemm_batch_tree_k_impl(sycl::queue &exec_q,
                     cgh.depends_on(red_ev);
                     const sycl::context &ctx = exec_q.get_context();
 
+                    using dpctl::tensor::alloc_utils::sycl_free_noexcept;
                     cgh.host_task([ctx, partially_reduced_tmp] {
-                        sycl::free(partially_reduced_tmp, ctx);
+                        sycl_free_noexcept(partially_reduced_tmp, ctx);
                     });
                 });
 
@@ -2661,7 +2664,8 @@ gemm_batch_tree_nm_impl(sycl::queue &exec_q,
                     cgh.depends_on(red_ev);
                     const sycl::context &ctx = exec_q.get_context();
 
-                    cgh.host_task([ctx, tmp] { sycl::free(tmp, ctx); });
+                    using dpctl::tensor::alloc_utils::sycl_free_noexcept;
+                    cgh.host_task([ctx, tmp] { sycl_free_noexcept(tmp, ctx); });
                 });
             return cleanup_host_task_event;
         }
@@ -2728,8 +2732,9 @@ gemm_batch_tree_nm_impl(sycl::queue &exec_q,
                     cgh.depends_on(red_ev);
                     const sycl::context &ctx = exec_q.get_context();
 
+                    using dpctl::tensor::alloc_utils::sycl_free_noexcept;
                     cgh.host_task([ctx, partially_reduced_tmp] {
-                        sycl::free(partially_reduced_tmp, ctx);
+                        sycl_free_noexcept(partially_reduced_tmp, ctx);
                     });
                 });
 
@@ -3038,7 +3043,8 @@ gemm_batch_contig_tree_k_impl(sycl::queue &exec_q,
                     cgh.depends_on(red_ev);
                     const sycl::context &ctx = exec_q.get_context();
 
-                    cgh.host_task([ctx, tmp] { sycl::free(tmp, ctx); });
+                    using dpctl::tensor::alloc_utils::sycl_free_noexcept;
+                    cgh.host_task([ctx, tmp] { sycl_free_noexcept(tmp, ctx); });
                 });
             return cleanup_host_task_event;
         }
@@ -3097,8 +3103,9 @@ gemm_batch_contig_tree_k_impl(sycl::queue &exec_q,
                     cgh.depends_on(red_ev);
                     const sycl::context &ctx = exec_q.get_context();
 
+                    using dpctl::tensor::alloc_utils::sycl_free_noexcept;
                     cgh.host_task([ctx, partially_reduced_tmp] {
-                        sycl::free(partially_reduced_tmp, ctx);
+                        sycl_free_noexcept(partially_reduced_tmp, ctx);
                     });
                 });
 
@@ -3238,7 +3245,8 @@ gemm_batch_contig_tree_nm_impl(sycl::queue &exec_q,
                     cgh.depends_on(red_ev);
                     const sycl::context &ctx = exec_q.get_context();
 
-                    cgh.host_task([ctx, tmp] { sycl::free(tmp, ctx); });
+                    using dpctl::tensor::alloc_utils::sycl_free_noexcept;
+                    cgh.host_task([ctx, tmp] { sycl_free_noexcept(tmp, ctx); });
                 });
             return cleanup_host_task_event;
         }
@@ -3299,8 +3307,9 @@ gemm_batch_contig_tree_nm_impl(sycl::queue &exec_q,
                     cgh.depends_on(red_ev);
                     const sycl::context &ctx = exec_q.get_context();
 
+                    using dpctl::tensor::alloc_utils::sycl_free_noexcept;
                     cgh.host_task([ctx, partially_reduced_tmp] {
-                        sycl::free(partially_reduced_tmp, ctx);
+                        sycl_free_noexcept(partially_reduced_tmp, ctx);
                     });
                 });
 
@@ -3603,7 +3612,8 @@ sycl::event gemm_tree_k_impl(sycl::queue &exec_q,
                     cgh.depends_on(red_ev);
                     const sycl::context &ctx = exec_q.get_context();
 
-                    cgh.host_task([ctx, tmp] { sycl::free(tmp, ctx); });
+                    using dpctl::tensor::alloc_utils::sycl_free_noexcept;
+                    cgh.host_task([ctx, tmp] { sycl_free_noexcept(tmp, ctx); });
                 });
             return cleanup_host_task_event;
         }
@@ -3646,8 +3656,9 @@ sycl::event gemm_tree_k_impl(sycl::queue &exec_q,
                     cgh.depends_on(red_ev);
                     const sycl::context &ctx = exec_q.get_context();
 
+                    using dpctl::tensor::alloc_utils::sycl_free_noexcept;
                     cgh.host_task([ctx, partially_reduced_tmp] {
-                        sycl::free(partially_reduced_tmp, ctx);
+                        sycl_free_noexcept(partially_reduced_tmp, ctx);
                     });
                 });
 
@@ -3769,7 +3780,8 @@ sycl::event gemm_tree_nm_impl(sycl::queue &exec_q,
                     cgh.depends_on(red_ev);
                     const sycl::context &ctx = exec_q.get_context();
 
-                    cgh.host_task([ctx, tmp] { sycl::free(tmp, ctx); });
+                    using dpctl::tensor::alloc_utils::sycl_free_noexcept;
+                    cgh.host_task([ctx, tmp] { sycl_free_noexcept(tmp, ctx); });
                 });
             return cleanup_host_task_event;
         }
@@ -3812,8 +3824,9 @@ sycl::event gemm_tree_nm_impl(sycl::queue &exec_q,
                     cgh.depends_on(red_ev);
                     const sycl::context &ctx = exec_q.get_context();
 
+                    using dpctl::tensor::alloc_utils::sycl_free_noexcept;
                     cgh.host_task([ctx, partially_reduced_tmp] {
-                        sycl::free(partially_reduced_tmp, ctx);
+                        sycl_free_noexcept(partially_reduced_tmp, ctx);
                     });
                 });
 
@@ -4016,7 +4029,8 @@ sycl::event gemm_contig_tree_k_impl(sycl::queue &exec_q,
                     cgh.depends_on(red_ev);
                     const sycl::context &ctx = exec_q.get_context();
 
-                    cgh.host_task([ctx, tmp] { sycl::free(tmp, ctx); });
+                    using dpctl::tensor::alloc_utils::sycl_free_noexcept;
+                    cgh.host_task([ctx, tmp] { sycl_free_noexcept(tmp, ctx); });
                 });
             return cleanup_host_task_event;
         }
@@ -4058,8 +4072,9 @@ sycl::event gemm_contig_tree_k_impl(sycl::queue &exec_q,
                     cgh.depends_on(red_ev);
                     const sycl::context &ctx = exec_q.get_context();
 
+                    using dpctl::tensor::alloc_utils::sycl_free_noexcept;
                     cgh.host_task([ctx, partially_reduced_tmp] {
-                        sycl::free(partially_reduced_tmp, ctx);
+                        sycl_free_noexcept(partially_reduced_tmp, ctx);
                     });
                 });
 
@@ -4170,7 +4185,8 @@ sycl::event gemm_contig_tree_nm_impl(sycl::queue &exec_q,
                     cgh.depends_on(red_ev);
                     const sycl::context &ctx = exec_q.get_context();
 
-                    cgh.host_task([ctx, tmp] { sycl::free(tmp, ctx); });
+                    using dpctl::tensor::alloc_utils::sycl_free_noexcept;
+                    cgh.host_task([ctx, tmp] { sycl_free_noexcept(tmp, ctx); });
                 });
             return cleanup_host_task_event;
         }
@@ -4211,8 +4227,9 @@ sycl::event gemm_contig_tree_nm_impl(sycl::queue &exec_q,
                     cgh.depends_on(red_ev);
                     const sycl::context &ctx = exec_q.get_context();
 
+                    using dpctl::tensor::alloc_utils::sycl_free_noexcept;
                     cgh.host_task([ctx, partially_reduced_tmp] {
-                        sycl::free(partially_reduced_tmp, ctx);
+                        sycl_free_noexcept(partially_reduced_tmp, ctx);
                     });
                 });
 

--- a/dpctl/tensor/libtensor/include/kernels/reductions.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/reductions.hpp
@@ -34,6 +34,7 @@
 #include "dpctl_tensor_types.hpp"
 #include "utils/math_utils.hpp"
 #include "utils/offset_utils.hpp"
+#include "utils/sycl_alloc_utils.hpp"
 #include "utils/sycl_utils.hpp"
 #include "utils/type_dispatch_building.hpp"
 #include "utils/type_utils.hpp"
@@ -1374,8 +1375,9 @@ sycl::event reduction_over_group_temps_strided_impl(
                 cgh.depends_on(final_reduction_ev);
                 const sycl::context &ctx = exec_q.get_context();
 
+                using dpctl::tensor::alloc_utils::sycl_free_noexcept;
                 cgh.host_task([ctx, partially_reduced_tmp] {
-                    sycl::free(partially_reduced_tmp, ctx);
+                    sycl_free_noexcept(partially_reduced_tmp, ctx);
                 });
             });
 
@@ -1617,8 +1619,9 @@ sycl::event reduction_axis1_over_group_temps_contig_impl(
                 cgh.depends_on(final_reduction_ev);
                 const sycl::context &ctx = exec_q.get_context();
 
+                using dpctl::tensor::alloc_utils::sycl_free_noexcept;
                 cgh.host_task([ctx, partially_reduced_tmp] {
-                    sycl::free(partially_reduced_tmp, ctx);
+                    sycl_free_noexcept(partially_reduced_tmp, ctx);
                 });
             });
 
@@ -1861,8 +1864,9 @@ sycl::event reduction_axis0_over_group_temps_contig_impl(
                 cgh.depends_on(final_reduction_ev);
                 const sycl::context &ctx = exec_q.get_context();
 
+                using dpctl::tensor::alloc_utils::sycl_free_noexcept;
                 cgh.host_task([ctx, partially_reduced_tmp] {
-                    sycl::free(partially_reduced_tmp, ctx);
+                    sycl_free_noexcept(partially_reduced_tmp, ctx);
                 });
             });
 
@@ -2796,10 +2800,11 @@ sycl::event search_over_group_temps_strided_impl(
                 cgh.depends_on(final_reduction_ev);
                 sycl::context ctx = exec_q.get_context();
 
+                using dpctl::tensor::alloc_utils::sycl_free_noexcept;
                 cgh.host_task(
                     [ctx, partially_reduced_tmp, partially_reduced_vals_tmp] {
-                        sycl::free(partially_reduced_tmp, ctx);
-                        sycl::free(partially_reduced_vals_tmp, ctx);
+                        sycl_free_noexcept(partially_reduced_tmp, ctx);
+                        sycl_free_noexcept(partially_reduced_vals_tmp, ctx);
                     });
             });
 
@@ -3087,10 +3092,11 @@ sycl::event search_axis1_over_group_temps_contig_impl(
                 cgh.depends_on(final_reduction_ev);
                 sycl::context ctx = exec_q.get_context();
 
+                using dpctl::tensor::alloc_utils::sycl_free_noexcept;
                 cgh.host_task(
                     [ctx, partially_reduced_tmp, partially_reduced_vals_tmp] {
-                        sycl::free(partially_reduced_tmp, ctx);
-                        sycl::free(partially_reduced_vals_tmp, ctx);
+                        sycl_free_noexcept(partially_reduced_tmp, ctx);
+                        sycl_free_noexcept(partially_reduced_vals_tmp, ctx);
                     });
             });
 
@@ -3374,10 +3380,11 @@ sycl::event search_axis0_over_group_temps_contig_impl(
                 cgh.depends_on(final_reduction_ev);
                 sycl::context ctx = exec_q.get_context();
 
+                using dpctl::tensor::alloc_utils::sycl_free_noexcept;
                 cgh.host_task(
                     [ctx, partially_reduced_tmp, partially_reduced_vals_tmp] {
-                        sycl::free(partially_reduced_tmp, ctx);
-                        sycl::free(partially_reduced_vals_tmp, ctx);
+                        sycl_free_noexcept(partially_reduced_tmp, ctx);
+                        sycl_free_noexcept(partially_reduced_vals_tmp, ctx);
                     });
             });
 

--- a/dpctl/tensor/libtensor/include/utils/sycl_alloc_utils.hpp
+++ b/dpctl/tensor/libtensor/include/utils/sycl_alloc_utils.hpp
@@ -1,0 +1,83 @@
+//===-- sycl_alloc_utils.cpp - Allocation utilities ---*-C++-*- ----------====//
+//
+//
+//                      Data Parallel Control (dpctl)
+//
+// Copyright 2020-2024 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// This file defines CIndexer_array, and CIndexer_vector classes, as well
+/// iteration space simplifiers.
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include <exception>
+#include <iostream>
+
+#include "sycl/sycl.hpp"
+
+namespace dpctl
+{
+namespace tensor
+{
+namespace alloc_utils
+{
+
+template <typename T>
+class usm_host_allocator : public sycl::usm_allocator<T, sycl::usm::alloc::host>
+{
+public:
+    using baseT = sycl::usm_allocator<T, sycl::usm::alloc::host>;
+    using baseT::baseT;
+
+    template <typename U> struct rebind
+    {
+        typedef usm_host_allocator<U> other;
+    };
+
+    void deallocate(T *ptr, size_t n)
+    {
+        try {
+            baseT::deallocate(ptr, n);
+        } catch (const std::exception &e) {
+            std::cerr
+                << "Exception caught in `usm_host_allocator::deallocate`: "
+                << e.what() << std::endl;
+        }
+    }
+};
+
+template <typename T>
+void sycl_free_noexcept(T *ptr, const sycl::context &ctx) noexcept
+{
+    try {
+        sycl::free(ptr, ctx);
+    } catch (const std::exception &e) {
+        std::cerr << "Call to sycl::free caught exception: " << e.what()
+                  << std::endl;
+    }
+}
+
+template <typename T> void sycl_free_noexcept(T *ptr, sycl::queue &q) noexcept
+{
+    sycl_free_noexcept(ptr, q.get_context());
+}
+
+} // end of namespace alloc_utils
+} // end of namespace tensor
+} // end of namespace dpctl

--- a/dpctl/tensor/libtensor/source/accumulators.cpp
+++ b/dpctl/tensor/libtensor/source/accumulators.cpp
@@ -36,6 +36,7 @@
 #include "utils/memory_overlap.hpp"
 #include "utils/offset_utils.hpp"
 #include "utils/output_validation.hpp"
+#include "utils/sycl_alloc_utils.hpp"
 #include "utils/type_dispatch.hpp"
 
 namespace dpctl
@@ -207,7 +208,9 @@ size_t py_mask_positions(const dpctl::tensor::usm_ndarray &mask,
 
             copy_shape_ev.wait();
             sycl::event::wait(host_task_events);
-            sycl::free(shape_strides, exec_q);
+
+            using dpctl::tensor::alloc_utils::sycl_free_noexcept;
+            sycl_free_noexcept(shape_strides, exec_q);
         }
         throw std::runtime_error("Unexpected error");
     }
@@ -227,7 +230,8 @@ size_t py_mask_positions(const dpctl::tensor::usm_ndarray &mask,
                                cumsum_data, host_task_events, dependent_events);
 
         sycl::event::wait(host_task_events);
-        sycl::free(shape_strides, exec_q);
+        using dpctl::tensor::alloc_utils::sycl_free_noexcept;
+        sycl_free_noexcept(shape_strides, exec_q);
     }
 
     return total_set;
@@ -365,7 +369,8 @@ size_t py_cumsum_1d(const dpctl::tensor::usm_ndarray &src,
             copy_shape_ev.wait();
             sycl::event::wait(host_task_events);
         }
-        sycl::free(shape_strides, exec_q);
+        using dpctl::tensor::alloc_utils::sycl_free_noexcept;
+        sycl_free_noexcept(shape_strides, exec_q);
         throw std::runtime_error("Unexpected error");
     }
 
@@ -381,8 +386,10 @@ size_t py_cumsum_1d(const dpctl::tensor::usm_ndarray &src,
     {
         py::gil_scoped_release release;
         sycl::event::wait(host_task_events);
+
+        using dpctl::tensor::alloc_utils::sycl_free_noexcept;
+        sycl_free_noexcept(shape_strides, exec_q);
     }
-    sycl::free(shape_strides, exec_q);
 
     return total;
 }

--- a/dpctl/tensor/libtensor/source/accumulators/accumulate_over_axis.hpp
+++ b/dpctl/tensor/libtensor/source/accumulators/accumulate_over_axis.hpp
@@ -22,6 +22,8 @@
 /// This file defines functions of dpctl.tensor._tensor_impl extensions
 //===----------------------------------------------------------------------===//
 
+#pragma once
+
 #include "dpctl4pybind11.hpp"
 #include <cstdint>
 #include <limits>
@@ -37,6 +39,7 @@
 #include "utils/memory_overlap.hpp"
 #include "utils/offset_utils.hpp"
 #include "utils/output_validation.hpp"
+#include "utils/sycl_alloc_utils.hpp"
 #include "utils/type_dispatch.hpp"
 
 namespace dpctl
@@ -220,8 +223,9 @@ py_accumulate_over_axis(const dpctl::tensor::usm_ndarray &src,
     sycl::event temp_cleanup_ev = exec_q.submit([&](sycl::handler &cgh) {
         cgh.depends_on(acc_ev);
         const auto &ctx = exec_q.get_context();
+        using dpctl::tensor::alloc_utils::sycl_free_noexcept;
         cgh.host_task([ctx, packed_shapes_and_strides] {
-            sycl::free(packed_shapes_and_strides, ctx);
+            sycl_free_noexcept(packed_shapes_and_strides, ctx);
         });
     });
     host_task_events.push_back(temp_cleanup_ev);
@@ -403,8 +407,9 @@ std::pair<sycl::event, sycl::event> py_accumulate_final_axis_include_initial(
     sycl::event temp_cleanup_ev = exec_q.submit([&](sycl::handler &cgh) {
         cgh.depends_on(acc_ev);
         const auto &ctx = exec_q.get_context();
+        using dpctl::tensor::alloc_utils::sycl_free_noexcept;
         cgh.host_task([ctx, packed_shapes_and_strides] {
-            sycl::free(packed_shapes_and_strides, ctx);
+            sycl_free_noexcept(packed_shapes_and_strides, ctx);
         });
     });
     host_task_events.push_back(temp_cleanup_ev);

--- a/dpctl/tensor/libtensor/source/boolean_advanced_indexing.cpp
+++ b/dpctl/tensor/libtensor/source/boolean_advanced_indexing.cpp
@@ -38,6 +38,7 @@
 #include "utils/memory_overlap.hpp"
 #include "utils/offset_utils.hpp"
 #include "utils/output_validation.hpp"
+#include "utils/sycl_alloc_utils.hpp"
 #include "utils/type_dispatch.hpp"
 
 namespace dpctl
@@ -258,8 +259,9 @@ py_extract(const dpctl::tensor::usm_ndarray &src,
             exec_q.submit([&](sycl::handler &cgh) {
                 cgh.depends_on(extract_ev);
                 const auto &ctx = exec_q.get_context();
+                using dpctl::tensor::alloc_utils::sycl_free_noexcept;
                 cgh.host_task([ctx, packed_src_shape_strides] {
-                    sycl::free(packed_src_shape_strides, ctx);
+                    sycl_free_noexcept(packed_src_shape_strides, ctx);
                 });
             });
         host_task_events.push_back(cleanup_tmp_allocations_ev);
@@ -360,8 +362,9 @@ py_extract(const dpctl::tensor::usm_ndarray &src,
             exec_q.submit([&](sycl::handler &cgh) {
                 cgh.depends_on(extract_ev);
                 const auto &ctx = exec_q.get_context();
+                using dpctl::tensor::alloc_utils::sycl_free_noexcept;
                 cgh.host_task([ctx, packed_shapes_strides] {
-                    sycl::free(packed_shapes_strides, ctx);
+                    sycl_free_noexcept(packed_shapes_strides, ctx);
                 });
             });
         host_task_events.push_back(cleanup_tmp_allocations_ev);
@@ -580,8 +583,9 @@ py_place(const dpctl::tensor::usm_ndarray &dst,
             exec_q.submit([&](sycl::handler &cgh) {
                 cgh.depends_on(place_ev);
                 const auto &ctx = exec_q.get_context();
+                using dpctl::tensor::alloc_utils::sycl_free_noexcept;
                 cgh.host_task([ctx, packed_dst_shape_strides] {
-                    sycl::free(packed_dst_shape_strides, ctx);
+                    sycl_free_noexcept(packed_dst_shape_strides, ctx);
                 });
             });
         host_task_events.push_back(cleanup_tmp_allocations_ev);
@@ -679,8 +683,9 @@ py_place(const dpctl::tensor::usm_ndarray &dst,
             exec_q.submit([&](sycl::handler &cgh) {
                 cgh.depends_on(place_ev);
                 const auto &ctx = exec_q.get_context();
+                using dpctl::tensor::alloc_utils::sycl_free_noexcept;
                 cgh.host_task([ctx, packed_shapes_strides] {
-                    sycl::free(packed_shapes_strides, ctx);
+                    sycl_free_noexcept(packed_shapes_strides, ctx);
                 });
             });
         host_task_events.push_back(cleanup_tmp_allocations_ev);
@@ -816,8 +821,9 @@ py_nonzero(const dpctl::tensor::usm_ndarray
     sycl::event temporaries_cleanup_ev = exec_q.submit([&](sycl::handler &cgh) {
         cgh.depends_on(non_zero_indexes_ev);
         const auto &ctx = exec_q.get_context();
+        using dpctl::tensor::alloc_utils::sycl_free_noexcept;
         cgh.host_task([ctx, src_shape_device_ptr] {
-            sycl::free(src_shape_device_ptr, ctx);
+            sycl_free_noexcept(src_shape_device_ptr, ctx);
         });
     });
     host_task_events.push_back(temporaries_cleanup_ev);

--- a/dpctl/tensor/libtensor/source/clip.cpp
+++ b/dpctl/tensor/libtensor/source/clip.cpp
@@ -38,6 +38,7 @@
 #include "utils/memory_overlap.hpp"
 #include "utils/offset_utils.hpp"
 #include "utils/output_validation.hpp"
+#include "utils/sycl_alloc_utils.hpp"
 #include "utils/type_dispatch.hpp"
 
 namespace dpctl
@@ -245,8 +246,9 @@ py_clip(const dpctl::tensor::usm_ndarray &src,
     sycl::event temporaries_cleanup_ev = exec_q.submit([&](sycl::handler &cgh) {
         cgh.depends_on(clip_ev);
         const auto &ctx = exec_q.get_context();
+        using dpctl::tensor::alloc_utils::sycl_free_noexcept;
         cgh.host_task([packed_shape_strides, ctx]() {
-            sycl::free(packed_shape_strides, ctx);
+            sycl_free_noexcept(packed_shape_strides, ctx);
         });
     });
 

--- a/dpctl/tensor/libtensor/source/copy_and_cast_usm_to_usm.cpp
+++ b/dpctl/tensor/libtensor/source/copy_and_cast_usm_to_usm.cpp
@@ -37,7 +37,9 @@
 #include "dpctl4pybind11.hpp"
 #include "kernels/copy_and_cast.hpp"
 #include "utils/memory_overlap.hpp"
+#include "utils/offset_utils.hpp"
 #include "utils/output_validation.hpp"
+#include "utils/sycl_alloc_utils.hpp"
 #include "utils/type_dispatch.hpp"
 #include "utils/type_utils.hpp"
 
@@ -253,8 +255,9 @@ copy_usm_ndarray_into_usm_ndarray(const dpctl::tensor::usm_ndarray &src,
     const auto &ctx = exec_q.get_context();
     const auto &temporaries_cleanup_ev = exec_q.submit([&](sycl::handler &cgh) {
         cgh.depends_on(copy_and_cast_generic_ev);
+        using dpctl::tensor::alloc_utils::sycl_free_noexcept;
         cgh.host_task(
-            [ctx, shape_strides]() { sycl::free(shape_strides, ctx); });
+            [ctx, shape_strides]() { sycl_free_noexcept(shape_strides, ctx); });
     });
 
     host_task_events.push_back(temporaries_cleanup_ev);

--- a/dpctl/tensor/libtensor/source/copy_for_reshape.cpp
+++ b/dpctl/tensor/libtensor/source/copy_for_reshape.cpp
@@ -29,7 +29,9 @@
 #include "copy_for_reshape.hpp"
 #include "dpctl4pybind11.hpp"
 #include "kernels/copy_and_cast.hpp"
+#include "utils/offset_utils.hpp"
 #include "utils/output_validation.hpp"
+#include "utils/sycl_alloc_utils.hpp"
 #include "utils/type_dispatch.hpp"
 #include <pybind11/pybind11.h>
 
@@ -152,8 +154,9 @@ copy_usm_ndarray_for_reshape(const dpctl::tensor::usm_ndarray &src,
     auto temporaries_cleanup_ev = exec_q.submit([&](sycl::handler &cgh) {
         cgh.depends_on(copy_for_reshape_event);
         const auto &ctx = exec_q.get_context();
+        using dpctl::tensor::alloc_utils::sycl_free_noexcept;
         cgh.host_task(
-            [shape_strides, ctx]() { sycl::free(shape_strides, ctx); });
+            [shape_strides, ctx]() { sycl_free_noexcept(shape_strides, ctx); });
     });
 
     host_task_events.push_back(temporaries_cleanup_ev);

--- a/dpctl/tensor/libtensor/source/copy_for_roll.cpp
+++ b/dpctl/tensor/libtensor/source/copy_for_roll.cpp
@@ -29,7 +29,9 @@
 #include "copy_for_roll.hpp"
 #include "dpctl4pybind11.hpp"
 #include "kernels/copy_and_cast.hpp"
+#include "utils/offset_utils.hpp"
 #include "utils/output_validation.hpp"
+#include "utils/sycl_alloc_utils.hpp"
 #include "utils/type_dispatch.hpp"
 #include <pybind11/pybind11.h>
 
@@ -234,8 +236,9 @@ copy_usm_ndarray_for_roll_1d(const dpctl::tensor::usm_ndarray &src,
     auto temporaries_cleanup_ev = exec_q.submit([&](sycl::handler &cgh) {
         cgh.depends_on(copy_for_roll_event);
         const auto &ctx = exec_q.get_context();
+        using dpctl::tensor::alloc_utils::sycl_free_noexcept;
         cgh.host_task(
-            [shape_strides, ctx]() { sycl::free(shape_strides, ctx); });
+            [shape_strides, ctx]() { sycl_free_noexcept(shape_strides, ctx); });
     });
 
     host_task_events.push_back(temporaries_cleanup_ev);
@@ -364,8 +367,9 @@ copy_usm_ndarray_for_roll_nd(const dpctl::tensor::usm_ndarray &src,
     auto temporaries_cleanup_ev = exec_q.submit([&](sycl::handler &cgh) {
         cgh.depends_on(copy_for_roll_event);
         const auto &ctx = exec_q.get_context();
+        using dpctl::tensor::alloc_utils::sycl_free_noexcept;
         cgh.host_task([shape_strides_shifts, ctx]() {
-            sycl::free(shape_strides_shifts, ctx);
+            sycl_free_noexcept(shape_strides_shifts, ctx);
         });
     });
 

--- a/dpctl/tensor/libtensor/source/copy_numpy_ndarray_into_usm_ndarray.cpp
+++ b/dpctl/tensor/libtensor/source/copy_numpy_ndarray_into_usm_ndarray.cpp
@@ -31,7 +31,9 @@
 #include <pybind11/pybind11.h>
 
 #include "kernels/copy_and_cast.hpp"
+#include "utils/offset_utils.hpp"
 #include "utils/output_validation.hpp"
+#include "utils/sycl_alloc_utils.hpp"
 #include "utils/type_dispatch.hpp"
 
 #include "copy_numpy_ndarray_into_usm_ndarray.hpp"
@@ -276,7 +278,8 @@ void copy_numpy_ndarray_into_usm_ndarray(
             npy_src_min_nelem_offset, npy_src_max_nelem_offset, dst_data,
             dst_offset, depends, {copy_shape_ev});
 
-        sycl::free(shape_strides, exec_q);
+        using dpctl::tensor::alloc_utils::sycl_free_noexcept;
+        sycl_free_noexcept(shape_strides, exec_q);
     }
 
     return;

--- a/dpctl/tensor/libtensor/source/elementwise_functions/elementwise_functions.hpp
+++ b/dpctl/tensor/libtensor/source/elementwise_functions/elementwise_functions.hpp
@@ -39,6 +39,7 @@
 #include "utils/memory_overlap.hpp"
 #include "utils/offset_utils.hpp"
 #include "utils/output_validation.hpp"
+#include "utils/sycl_alloc_utils.hpp"
 #include "utils/type_dispatch.hpp"
 
 namespace py = pybind11;
@@ -236,8 +237,9 @@ py_unary_ufunc(const dpctl::tensor::usm_ndarray &src,
     auto ctx = q.get_context();
     sycl::event tmp_cleanup_ev = q.submit([&](sycl::handler &cgh) {
         cgh.depends_on(strided_fn_ev);
+        using dpctl::tensor::alloc_utils::sycl_free_noexcept;
         cgh.host_task(
-            [ctx, shape_strides]() { sycl::free(shape_strides, ctx); });
+            [ctx, shape_strides]() { sycl_free_noexcept(shape_strides, ctx); });
     });
     host_tasks.push_back(tmp_cleanup_ev);
 
@@ -562,8 +564,9 @@ std::pair<sycl::event, sycl::event> py_binary_ufunc(
 
     sycl::event tmp_cleanup_ev = exec_q.submit([&](sycl::handler &cgh) {
         cgh.depends_on(strided_fn_ev);
+        using dpctl::tensor::alloc_utils::sycl_free_noexcept;
         cgh.host_task(
-            [ctx, shape_strides]() { sycl::free(shape_strides, ctx); });
+            [ctx, shape_strides]() { sycl_free_noexcept(shape_strides, ctx); });
     });
 
     host_tasks.push_back(tmp_cleanup_ev);
@@ -815,8 +818,9 @@ py_binary_inplace_ufunc(const dpctl::tensor::usm_ndarray &lhs,
 
     sycl::event tmp_cleanup_ev = exec_q.submit([&](sycl::handler &cgh) {
         cgh.depends_on(strided_fn_ev);
+        using dpctl::tensor::alloc_utils::sycl_free_noexcept;
         cgh.host_task(
-            [ctx, shape_strides]() { sycl::free(shape_strides, ctx); });
+            [ctx, shape_strides]() { sycl_free_noexcept(shape_strides, ctx); });
     });
 
     host_tasks.push_back(tmp_cleanup_ev);

--- a/dpctl/tensor/libtensor/source/linalg_functions/dot.cpp
+++ b/dpctl/tensor/libtensor/source/linalg_functions/dot.cpp
@@ -42,6 +42,7 @@
 #include "utils/memory_overlap.hpp"
 #include "utils/offset_utils.hpp"
 #include "utils/output_validation.hpp"
+#include "utils/sycl_alloc_utils.hpp"
 
 namespace dpctl
 {
@@ -509,8 +510,9 @@ py_dot(const dpctl::tensor::usm_ndarray &x1,
         sycl::event temp_cleanup_ev = exec_q.submit([&](sycl::handler &cgh) {
             cgh.depends_on(dot_ev);
             const auto &ctx = exec_q.get_context();
+            using dpctl::tensor::alloc_utils::sycl_free_noexcept;
             cgh.host_task([ctx, temp_allocation_ptr] {
-                sycl::free(temp_allocation_ptr, ctx);
+                sycl_free_noexcept(temp_allocation_ptr, ctx);
             });
         });
         host_task_events.push_back(temp_cleanup_ev);
@@ -585,8 +587,9 @@ py_dot(const dpctl::tensor::usm_ndarray &x1,
                 exec_q.submit([&](sycl::handler &cgh) {
                     cgh.depends_on(dot_ev);
                     const auto &ctx = exec_q.get_context();
+                    using dpctl::tensor::alloc_utils::sycl_free_noexcept;
                     cgh.host_task([ctx, packed_shapes_strides] {
-                        sycl::free(packed_shapes_strides, ctx);
+                        sycl_free_noexcept(packed_shapes_strides, ctx);
                     });
                 });
             host_task_events.push_back(cleanup_tmp_allocations_ev);
@@ -793,8 +796,9 @@ py_dot(const dpctl::tensor::usm_ndarray &x1,
                 exec_q.submit([&](sycl::handler &cgh) {
                     cgh.depends_on(dot_ev);
                     const auto &ctx = exec_q.get_context();
+                    using dpctl::tensor::alloc_utils::sycl_free_noexcept;
                     cgh.host_task([ctx, packed_shapes_strides] {
-                        sycl::free(packed_shapes_strides, ctx);
+                        sycl_free_noexcept(packed_shapes_strides, ctx);
                     });
                 });
             host_task_events.push_back(cleanup_tmp_allocations_ev);

--- a/dpctl/tensor/libtensor/source/reductions/reduction_over_axis.hpp
+++ b/dpctl/tensor/libtensor/source/reductions/reduction_over_axis.hpp
@@ -42,6 +42,7 @@
 #include "utils/memory_overlap.hpp"
 #include "utils/offset_utils.hpp"
 #include "utils/output_validation.hpp"
+#include "utils/sycl_alloc_utils.hpp"
 #include "utils/type_dispatch.hpp"
 
 namespace dpctl
@@ -488,8 +489,9 @@ std::pair<sycl::event, sycl::event> py_reduction_over_axis(
     sycl::event temp_cleanup_ev = exec_q.submit([&](sycl::handler &cgh) {
         cgh.depends_on(reduction_ev);
         const auto &ctx = exec_q.get_context();
+        using dpctl::tensor::alloc_utils::sycl_free_noexcept;
         cgh.host_task([ctx, temp_allocation_ptr] {
-            sycl::free(temp_allocation_ptr, ctx);
+            sycl_free_noexcept(temp_allocation_ptr, ctx);
         });
     });
     host_task_events.push_back(temp_cleanup_ev);
@@ -778,8 +780,9 @@ std::pair<sycl::event, sycl::event> py_tree_reduction_over_axis(
     sycl::event temp_cleanup_ev = exec_q.submit([&](sycl::handler &cgh) {
         cgh.depends_on(reduction_ev);
         const auto &ctx = exec_q.get_context();
+        using dpctl::tensor::alloc_utils::sycl_free_noexcept;
         cgh.host_task([ctx, temp_allocation_ptr] {
-            sycl::free(temp_allocation_ptr, ctx);
+            sycl_free_noexcept(temp_allocation_ptr, ctx);
         });
     });
     host_task_events.push_back(temp_cleanup_ev);
@@ -1058,8 +1061,9 @@ std::pair<sycl::event, sycl::event> py_search_over_axis(
     sycl::event temp_cleanup_ev = exec_q.submit([&](sycl::handler &cgh) {
         cgh.depends_on(comp_ev);
         const auto &ctx = exec_q.get_context();
+        using dpctl::tensor::alloc_utils::sycl_free_noexcept;
         cgh.host_task([ctx, temp_allocation_ptr] {
-            sycl::free(temp_allocation_ptr, ctx);
+            sycl_free_noexcept(temp_allocation_ptr, ctx);
         });
     });
     host_task_events.push_back(temp_cleanup_ev);
@@ -1323,8 +1327,9 @@ py_boolean_reduction(const dpctl::tensor::usm_ndarray &src,
     sycl::event temp_cleanup_ev = exec_q.submit([&](sycl::handler &cgh) {
         cgh.depends_on(red_ev);
         const auto &ctx = exec_q.get_context();
+        using dpctl::tensor::alloc_utils::sycl_free_noexcept;
         cgh.host_task([ctx, packed_shapes_and_strides] {
-            sycl::free(packed_shapes_and_strides, ctx);
+            sycl_free_noexcept(packed_shapes_and_strides, ctx);
         });
     });
     host_task_events.push_back(temp_cleanup_ev);

--- a/dpctl/tensor/libtensor/source/repeat.cpp
+++ b/dpctl/tensor/libtensor/source/repeat.cpp
@@ -36,6 +36,7 @@
 #include "utils/memory_overlap.hpp"
 #include "utils/offset_utils.hpp"
 #include "utils/output_validation.hpp"
+#include "utils/sycl_alloc_utils.hpp"
 #include "utils/type_dispatch.hpp"
 
 namespace dpctl
@@ -262,8 +263,9 @@ py_repeat_by_sequence(const dpctl::tensor::usm_ndarray &src,
             exec_q.submit([&](sycl::handler &cgh) {
                 cgh.depends_on(repeat_ev);
                 const auto &ctx = exec_q.get_context();
+                using dpctl::tensor::alloc_utils::sycl_free_noexcept;
                 cgh.host_task([ctx, packed_src_shape_strides] {
-                    sycl::free(packed_src_shape_strides, ctx);
+                    sycl_free_noexcept(packed_src_shape_strides, ctx);
                 });
             });
         host_task_events.push_back(cleanup_tmp_allocations_ev);
@@ -346,8 +348,9 @@ py_repeat_by_sequence(const dpctl::tensor::usm_ndarray &src,
             exec_q.submit([&](sycl::handler &cgh) {
                 cgh.depends_on(repeat_ev);
                 const auto &ctx = exec_q.get_context();
+                using dpctl::tensor::alloc_utils::sycl_free_noexcept;
                 cgh.host_task([ctx, packed_shapes_strides] {
-                    sycl::free(packed_shapes_strides, ctx);
+                    sycl_free_noexcept(packed_shapes_strides, ctx);
                 });
             });
         host_task_events.push_back(cleanup_tmp_allocations_ev);
@@ -495,8 +498,9 @@ py_repeat_by_sequence(const dpctl::tensor::usm_ndarray &src,
         exec_q.submit([&](sycl::handler &cgh) {
             cgh.depends_on(repeat_ev);
             const auto &ctx = exec_q.get_context();
+            using dpctl::tensor::alloc_utils::sycl_free_noexcept;
             cgh.host_task([ctx, packed_src_shapes_strides] {
-                sycl::free(packed_src_shapes_strides, ctx);
+                sycl_free_noexcept(packed_src_shapes_strides, ctx);
             });
         });
     host_task_events.push_back(cleanup_tmp_allocations_ev);
@@ -638,8 +642,9 @@ py_repeat_by_scalar(const dpctl::tensor::usm_ndarray &src,
             exec_q.submit([&](sycl::handler &cgh) {
                 cgh.depends_on(repeat_ev);
                 const auto &ctx = exec_q.get_context();
+                using dpctl::tensor::alloc_utils::sycl_free_noexcept;
                 cgh.host_task([ctx, packed_src_shape_strides] {
-                    sycl::free(packed_src_shape_strides, ctx);
+                    sycl_free_noexcept(packed_src_shape_strides, ctx);
                 });
             });
         host_task_events.push_back(cleanup_tmp_allocations_ev);
@@ -721,8 +726,9 @@ py_repeat_by_scalar(const dpctl::tensor::usm_ndarray &src,
             exec_q.submit([&](sycl::handler &cgh) {
                 cgh.depends_on(repeat_ev);
                 const auto &ctx = exec_q.get_context();
+                using dpctl::tensor::alloc_utils::sycl_free_noexcept;
                 cgh.host_task([ctx, packed_shapes_strides] {
-                    sycl::free(packed_shapes_strides, ctx);
+                    sycl_free_noexcept(packed_shapes_strides, ctx);
                 });
             });
         host_task_events.push_back(cleanup_tmp_allocations_ev);
@@ -833,8 +839,9 @@ py_repeat_by_scalar(const dpctl::tensor::usm_ndarray &src,
         exec_q.submit([&](sycl::handler &cgh) {
             cgh.depends_on(repeat_ev);
             const auto &ctx = exec_q.get_context();
+            using dpctl::tensor::alloc_utils::sycl_free_noexcept;
             cgh.host_task([ctx, packed_src_shape_strides] {
-                sycl::free(packed_src_shape_strides, ctx);
+                sycl_free_noexcept(packed_src_shape_strides, ctx);
             });
         });
 

--- a/dpctl/tensor/libtensor/source/sorting/searchsorted.cpp
+++ b/dpctl/tensor/libtensor/source/sorting/searchsorted.cpp
@@ -32,6 +32,7 @@
 #include "kernels/sorting/searchsorted.hpp"
 #include "utils/memory_overlap.hpp"
 #include "utils/output_validation.hpp"
+#include "utils/sycl_alloc_utils.hpp"
 #include "utils/type_dispatch.hpp"
 #include "utils/type_utils.hpp"
 #include <dpctl4pybind11.hpp>
@@ -411,8 +412,9 @@ py_searchsorted(const dpctl::tensor::usm_ndarray &hay,
     sycl::event temporaries_cleanup_ev = exec_q.submit([&](sycl::handler &cgh) {
         cgh.depends_on(comp_ev);
         const auto &ctx = exec_q.get_context();
+        using dpctl::tensor::alloc_utils::sycl_free_noexcept;
         cgh.host_task([packed_shape_strides, ctx]() {
-            sycl::free(packed_shape_strides, ctx);
+            sycl_free_noexcept(packed_shape_strides, ctx);
         });
     });
 

--- a/dpctl/tensor/libtensor/source/where.cpp
+++ b/dpctl/tensor/libtensor/source/where.cpp
@@ -37,6 +37,7 @@
 #include "utils/memory_overlap.hpp"
 #include "utils/offset_utils.hpp"
 #include "utils/output_validation.hpp"
+#include "utils/sycl_alloc_utils.hpp"
 #include "utils/type_dispatch.hpp"
 #include "where.hpp"
 
@@ -228,8 +229,9 @@ py_where(const dpctl::tensor::usm_ndarray &condition,
     sycl::event temporaries_cleanup_ev = exec_q.submit([&](sycl::handler &cgh) {
         cgh.depends_on(where_ev);
         const auto &ctx = exec_q.get_context();
+        using dpctl::tensor::alloc_utils::sycl_free_noexcept;
         cgh.host_task([packed_shape_strides, ctx]() {
-            sycl::free(packed_shape_strides, ctx);
+            sycl_free_noexcept(packed_shape_strides, ctx);
         });
     });
 


### PR DESCRIPTION
Replace ``sycl::free`` with ``sycl_free_noexcept``.

Add implementation of ``dpctl::tensor::offset_utils::sycl_free_noexcept`` templated function that calls ``sycl::free`` from within try/catch. The exception is logged to ``std::cerr``, but otherwise ignored.

Replaced calls to `sycl::free` in `host_task` with use of ``sycl_free_noexcept``.

This change should improve stability of test suite run executed on CPU device due to a known issue.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
