### PR TITLE
Fixed obvious unreferenced bug in copy-and-cast logic 

### DIFF
--- a/dpctl/tensor/libtensor/source/copy_and_cast_usm_to_usm.cpp
+++ b/dpctl/tensor/libtensor/source/copy_and_cast_usm_to_usm.cpp
@@ -197,7 +197,7 @@ copy_usm_ndarray_into_usm_ndarray(const dpctl::tensor::usm_ndarray &src,
                 auto contig_fn =
                     copy_and_cast_contig_dispatch_table[dst_type_id]
                                                        [src_type_id];
-                sycl::event copy_and_cast_1d_event =
+                copy_and_cast_1d_event =
                     contig_fn(exec_q, src_nelems, src_data, dst_data, depends);
             }
             else {


### PR DESCRIPTION
The special casing of copy-and-cast operation after stride simplification, the branch where memcpy is applicable did not set returned event to the intended variable, but rather to the local-scoped one.

This change fixes that logic.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
