### PR TITLE
Explicitly include headers used in the c++ file pertaining to reduction

### DIFF
--- a/dpctl/tensor/libtensor/include/kernels/reductions.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/reductions.hpp
@@ -39,15 +39,15 @@
 #include "utils/type_dispatch_building.hpp"
 #include "utils/type_utils.hpp"
 
-namespace td_ns = dpctl::tensor::type_dispatch;
-namespace su_ns = dpctl::tensor::sycl_utils;
-
 namespace dpctl
 {
 namespace tensor
 {
 namespace kernels
 {
+
+namespace td_ns = dpctl::tensor::type_dispatch;
+namespace su_ns = dpctl::tensor::sycl_utils;
 
 namespace reduction_detail
 {

--- a/dpctl/tensor/libtensor/source/linalg_functions/dot_dispatch.hpp
+++ b/dpctl/tensor/libtensor/source/linalg_functions/dot_dispatch.hpp
@@ -30,6 +30,7 @@
 
 #include "kernels/linalg_functions/dot_product.hpp"
 #include "kernels/linalg_functions/gemm.hpp"
+#include "utils/type_dispatch_building.hpp"
 
 namespace dpctl
 {
@@ -37,6 +38,8 @@ namespace tensor
 {
 namespace py_internal
 {
+
+namespace td_ns = dpctl::tensor::type_dispatch;
 
 template <typename T1, typename T2> struct DotAtomicOutputType
 {

--- a/dpctl/tensor/libtensor/source/reductions/argmax.cpp
+++ b/dpctl/tensor/libtensor/source/reductions/argmax.cpp
@@ -32,6 +32,7 @@
 
 #include "kernels/reductions.hpp"
 #include "reduction_over_axis.hpp"
+#include "utils/sycl_utils.hpp"
 #include "utils/type_dispatch_building.hpp"
 
 namespace py = pybind11;
@@ -44,6 +45,7 @@ namespace py_internal
 {
 
 namespace td_ns = dpctl::tensor::type_dispatch;
+namespace su_ns = dpctl::tensor::sycl_utils;
 
 namespace impl
 {

--- a/dpctl/tensor/libtensor/source/reductions/argmin.cpp
+++ b/dpctl/tensor/libtensor/source/reductions/argmin.cpp
@@ -32,6 +32,8 @@
 
 #include "kernels/reductions.hpp"
 #include "reduction_over_axis.hpp"
+
+#include "utils/sycl_utils.hpp"
 #include "utils/type_dispatch_building.hpp"
 
 namespace py = pybind11;
@@ -44,6 +46,7 @@ namespace py_internal
 {
 
 namespace td_ns = dpctl::tensor::type_dispatch;
+namespace su_ns = dpctl::tensor::sycl_utils;
 
 namespace impl
 {

--- a/dpctl/tensor/libtensor/source/reductions/logsumexp.cpp
+++ b/dpctl/tensor/libtensor/source/reductions/logsumexp.cpp
@@ -32,6 +32,7 @@
 
 #include "kernels/reductions.hpp"
 #include "reduction_over_axis.hpp"
+#include "utils/sycl_utils.hpp"
 #include "utils/type_dispatch_building.hpp"
 
 namespace py = pybind11;
@@ -44,6 +45,7 @@ namespace py_internal
 {
 
 namespace td_ns = dpctl::tensor::type_dispatch;
+namespace su_ns = dpctl::tensor::sycl_utils;
 
 namespace impl
 {
@@ -68,6 +70,7 @@ struct TypePairSupportDataForLogSumExpReductionTemps
     static constexpr bool is_defined = std::disjunction< // disjunction is C++17
                                                          // feature, supported
                                                          // by DPC++ input bool
+#if 1
         td_ns::TypePairDefinedEntry<argTy, bool, outTy, sycl::half>,
         td_ns::TypePairDefinedEntry<argTy, bool, outTy, float>,
         td_ns::TypePairDefinedEntry<argTy, bool, outTy, double>,
@@ -105,7 +108,6 @@ struct TypePairSupportDataForLogSumExpReductionTemps
         // input uint64_t
         td_ns::TypePairDefinedEntry<argTy, std::uint64_t, outTy, float>,
         td_ns::TypePairDefinedEntry<argTy, std::uint64_t, outTy, double>,
-
         // input half
         td_ns::TypePairDefinedEntry<argTy, sycl::half, outTy, sycl::half>,
         td_ns::TypePairDefinedEntry<argTy, sycl::half, outTy, float>,
@@ -117,6 +119,7 @@ struct TypePairSupportDataForLogSumExpReductionTemps
 
         // input double
         td_ns::TypePairDefinedEntry<argTy, double, outTy, double>,
+#endif
 
         // fall-through
         td_ns::NotDefinedEntry>::is_defined;

--- a/dpctl/tensor/libtensor/source/reductions/max.cpp
+++ b/dpctl/tensor/libtensor/source/reductions/max.cpp
@@ -31,6 +31,7 @@
 #include <vector>
 
 #include "kernels/reductions.hpp"
+#include "utils/sycl_utils.hpp"
 #include "utils/type_dispatch_building.hpp"
 
 #include "reduction_atomic_support.hpp"
@@ -46,6 +47,7 @@ namespace py_internal
 {
 
 namespace td_ns = dpctl::tensor::type_dispatch;
+namespace su_ns = dpctl::tensor::sycl_utils;
 
 namespace impl
 {

--- a/dpctl/tensor/libtensor/source/reductions/min.cpp
+++ b/dpctl/tensor/libtensor/source/reductions/min.cpp
@@ -31,6 +31,7 @@
 #include <vector>
 
 #include "kernels/reductions.hpp"
+#include "utils/sycl_utils.hpp"
 #include "utils/type_dispatch_building.hpp"
 
 #include "reduction_atomic_support.hpp"
@@ -46,6 +47,7 @@ namespace py_internal
 {
 
 namespace td_ns = dpctl::tensor::type_dispatch;
+namespace su_ns = dpctl::tensor::sycl_utils;
 
 namespace impl
 {

--- a/dpctl/tensor/libtensor/source/reductions/reduce_hypot.cpp
+++ b/dpctl/tensor/libtensor/source/reductions/reduce_hypot.cpp
@@ -32,6 +32,7 @@
 
 #include "kernels/reductions.hpp"
 #include "reduction_over_axis.hpp"
+#include "utils/sycl_utils.hpp"
 #include "utils/type_dispatch_building.hpp"
 
 namespace py = pybind11;
@@ -44,6 +45,7 @@ namespace py_internal
 {
 
 namespace td_ns = dpctl::tensor::type_dispatch;
+namespace su_ns = dpctl::tensor::sycl_utils;
 
 namespace impl
 {

--- a/dpctl/tensor/libtensor/source/reductions/reduction_over_axis.hpp
+++ b/dpctl/tensor/libtensor/source/reductions/reduction_over_axis.hpp
@@ -52,6 +52,8 @@ namespace tensor
 namespace py_internal
 {
 
+namespace td_ns = dpctl::tensor::type_dispatch;
+
 /* ====================== dtype supported ======================== */
 
 /*! @brief Template implementing Python API for querying type support by


### PR DESCRIPTION
This is a good, recommended practice.

Moved global definition of namespaces `td_ns` and `su_ns` in 'reductions.hpp' into namespace.

Fixed resulting build breakage by including needed headers and defining those namespaces locally in affected files.

Changed definition of `logaddexp` in `math_utils.hpp` to use selector instead of if/else branches to improve performance. Switch revealed silent inefficiency from using `std::log1`p for all types (for `sycl::half` it would silently upcast to float and evaluate ``std::log1p<float>(sycl::half)``).

Used `if constexpr` to use sycl::log1p for half and single FP types. For double, use std::log1p until the issue is fixed.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
