### PR TITLE
Clean up uses of Strided1DIndexer

### DIFF
--- a/dpctl/tensor/libtensor/include/kernels/accumulators.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/accumulators.hpp
@@ -592,9 +592,8 @@ sycl::event inclusive_scan_iter(sycl::queue &exec_q,
             size_t src_size = acc_groups - 1;
             using LocalScanIndexerT =
                 dpctl::tensor::offset_utils::Strided1DIndexer;
-            const LocalScanIndexerT scan_iter_indexer{
-                0, static_cast<ssize_t>(iter_nelems),
-                static_cast<ssize_t>(src_size)};
+            const LocalScanIndexerT scan_iter_indexer{/* size */ iter_nelems,
+                                                      /* step */ src_size};
 
             using IterIndexerT =
                 dpctl::tensor::offset_utils::TwoOffsets_CombinedIndexer<
@@ -623,11 +622,10 @@ sycl::event inclusive_scan_iter(sycl::queue &exec_q,
             using LocalScanIndexerT =
                 dpctl::tensor::offset_utils::Strided1DIndexer;
             const LocalScanIndexerT scan1_iter_indexer{
-                0, static_cast<ssize_t>(iter_nelems),
-                static_cast<ssize_t>(size_to_update)};
-            const LocalScanIndexerT scan2_iter_indexer{
-                0, static_cast<ssize_t>(iter_nelems),
-                static_cast<ssize_t>(src_size)};
+                /* size */ iter_nelems,
+                /* step */ size_to_update};
+            const LocalScanIndexerT scan2_iter_indexer{/* size */ iter_nelems,
+                                                       /* step */ src_size};
 
             using IterIndexerT =
                 dpctl::tensor::offset_utils::TwoOffsets_CombinedIndexer<

--- a/dpctl/tensor/libtensor/include/kernels/boolean_advanced_indexing.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/boolean_advanced_indexing.hpp
@@ -233,7 +233,8 @@ sycl::event masked_extract_all_slices_strided_impl(
     /* StridedIndexer(int _nd, ssize_t _offset, ssize_t const
      * *_packed_shape_strides) */
     const StridedIndexer masked_src_indexer(nd, 0, packed_src_shape_strides);
-    const Strided1DIndexer masked_dst_indexer(0, dst_size, dst_stride);
+    const Strided1DIndexer masked_dst_indexer(/* size */ dst_size,
+                                              /* step */ dst_stride);
 
     sycl::event comp_ev = exec_q.submit([&](sycl::handler &cgh) {
         cgh.depends_on(depends);
@@ -309,8 +310,8 @@ sycl::event masked_extract_some_slices_strided_impl(
 
     const StridedIndexer masked_src_indexer{masked_nd, 0,
                                             packed_masked_src_shape_strides};
-    const Strided1DIndexer masked_dst_indexer{0, masked_dst_size,
-                                              masked_dst_stride};
+    const Strided1DIndexer masked_dst_indexer{/* size */ masked_dst_size,
+                                              /* step */ masked_dst_stride};
 
     sycl::event comp_ev = exec_q.submit([&](sycl::handler &cgh) {
         cgh.depends_on(depends);

--- a/dpctl/tensor/libtensor/include/kernels/linalg_functions/dot_product.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/linalg_functions/dot_product.hpp
@@ -576,9 +576,8 @@ dot_product_contig_impl(sycl::queue &exec_q,
             dpctl::tensor::offset_utils::TwoOffsets_CombinedIndexer<
                 NoOpIndexerT, NoOpIndexerT>;
 
-        const InputBatchIndexerT inp_batch_indexer{
-            0, static_cast<ssize_t>(batches),
-            static_cast<ssize_t>(reduction_nelems)};
+        const InputBatchIndexerT inp_batch_indexer{/* size */ batches,
+                                                   /* step */ reduction_nelems};
         const InputOutputBatchIndexerT inp_out_batch_indexer{
             inp_batch_indexer, inp_batch_indexer, NoOpIndexerT{}};
         constexpr ReductionIndexerT reduction_indexer{NoOpIndexerT{},
@@ -612,9 +611,8 @@ dot_product_contig_impl(sycl::queue &exec_q,
             dpctl::tensor::offset_utils::TwoOffsets_CombinedIndexer<
                 NoOpIndexerT, NoOpIndexerT>;
 
-        const InputBatchIndexerT inp_batch_indexer{
-            0, static_cast<ssize_t>(batches),
-            static_cast<ssize_t>(reduction_nelems)};
+        const InputBatchIndexerT inp_batch_indexer{/* size */ batches,
+                                                   /* step */ reduction_nelems};
         const InputOutputBatchIndexerT inp_out_batch_indexer{
             inp_batch_indexer, inp_batch_indexer, NoOpIndexerT{}};
         constexpr ReductionIndexerT reduction_indexer{NoOpIndexerT{},
@@ -1089,9 +1087,8 @@ sycl::event dot_product_tree_impl(sycl::queue &exec_q,
                     InputIndexerT, ResIndexerT>;
             using ReductionIndexerT = dpctl::tensor::offset_utils::NoOpIndexer;
 
-            const InputIndexerT inp_indexer{
-                0, static_cast<ssize_t>(batches),
-                static_cast<ssize_t>(reduction_groups_)};
+            const InputIndexerT inp_indexer{/* size */ batches,
+                                            /* step */ reduction_groups_};
             constexpr ResIndexerT res_iter_indexer{};
 
             const InputOutputIterIndexerT in_out_iter_indexer{inp_indexer,
@@ -1120,9 +1117,8 @@ sycl::event dot_product_tree_impl(sycl::queue &exec_q,
                 InputIndexerT, ResIndexerT>;
         using ReductionIndexerT = dpctl::tensor::offset_utils::NoOpIndexer;
 
-        const InputIndexerT inp_indexer{
-            0, static_cast<ssize_t>(batches),
-            static_cast<ssize_t>(remaining_reduction_nelems)};
+        const InputIndexerT inp_indexer{/* size */ batches,
+                                        /* step */ remaining_reduction_nelems};
         const ResIndexerT res_iter_indexer{
             batch_nd, batch_res_offset,
             /* shape */ batch_shape_and_strides,
@@ -1200,9 +1196,8 @@ dot_product_contig_tree_impl(sycl::queue &exec_q,
             dpctl::tensor::offset_utils::TwoOffsets_CombinedIndexer<
                 NoOpIndexerT, NoOpIndexerT>;
 
-        const InputBatchIndexerT inp_batch_indexer{
-            0, static_cast<ssize_t>(batches),
-            static_cast<ssize_t>(reduction_nelems)};
+        const InputBatchIndexerT inp_batch_indexer{/* size */ batches,
+                                                   /* step */ reduction_nelems};
         const InputOutputBatchIndexerT inp_out_batch_indexer{
             inp_batch_indexer, inp_batch_indexer, NoOpIndexerT{}};
         constexpr ReductionIndexerT reduction_indexer{NoOpIndexerT{},
@@ -1238,9 +1233,8 @@ dot_product_contig_tree_impl(sycl::queue &exec_q,
             dpctl::tensor::offset_utils::TwoOffsets_CombinedIndexer<
                 NoOpIndexerT, NoOpIndexerT>;
 
-        const InputBatchIndexerT inp_batch_indexer{
-            0, static_cast<ssize_t>(batches),
-            static_cast<ssize_t>(reduction_nelems)};
+        const InputBatchIndexerT inp_batch_indexer{/* size */ batches,
+                                                   /* step */ reduction_nelems};
         const InputOutputBatchIndexerT inp_out_batch_indexer{
             inp_batch_indexer, inp_batch_indexer, NoOpIndexerT{}};
         constexpr ReductionIndexerT reduction_indexer{NoOpIndexerT{},
@@ -1307,8 +1301,8 @@ dot_product_contig_tree_impl(sycl::queue &exec_q,
                     NoOpIndexerT, NoOpIndexerT>;
 
             const InputBatchIndexerT inp_batch_indexer{
-                0, static_cast<ssize_t>(batches),
-                static_cast<ssize_t>(reduction_nelems)};
+                /* size */ batches,
+                /* step */ reduction_nelems};
             const InputOutputBatchIndexerT inp_out_batch_indexer{
                 inp_batch_indexer, inp_batch_indexer, NoOpIndexerT{}};
             constexpr ReductionIndexerT reduction_indexer{NoOpIndexerT{},
@@ -1343,9 +1337,8 @@ dot_product_contig_tree_impl(sycl::queue &exec_q,
                     InputIndexerT, ResIndexerT>;
             using ReductionIndexerT = dpctl::tensor::offset_utils::NoOpIndexer;
 
-            const InputIndexerT inp_indexer{
-                0, static_cast<ssize_t>(batches),
-                static_cast<ssize_t>(reduction_groups_)};
+            const InputIndexerT inp_indexer{/* size */ batches,
+                                            /* step */ reduction_groups_};
             constexpr ResIndexerT res_iter_indexer{};
 
             const InputOutputIterIndexerT in_out_iter_indexer{inp_indexer,
@@ -1374,9 +1367,8 @@ dot_product_contig_tree_impl(sycl::queue &exec_q,
                 InputIndexerT, ResIndexerT>;
         using ReductionIndexerT = dpctl::tensor::offset_utils::NoOpIndexer;
 
-        const InputIndexerT inp_indexer{
-            0, static_cast<ssize_t>(batches),
-            static_cast<ssize_t>(remaining_reduction_nelems)};
+        const InputIndexerT inp_indexer{/* size */ batches,
+                                        /* step */ remaining_reduction_nelems};
         constexpr ResIndexerT res_iter_indexer{};
 
         const InputOutputIterIndexerT in_out_iter_indexer{inp_indexer,

--- a/dpctl/tensor/libtensor/include/kernels/reductions.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/reductions.hpp
@@ -886,8 +886,8 @@ sycl::event reduction_axis1_over_group_with_atomics_contig_impl(
         using ReductionIndexerT = NoOpIndexerT;
 
         const InputOutputIterIndexerT in_out_iter_indexer{
-            InputIterIndexerT{0, static_cast<ssize_t>(iter_nelems),
-                              static_cast<ssize_t>(reduction_nelems)},
+            InputIterIndexerT{/* size */ iter_nelems,
+                              /* step */ reduction_nelems},
             NoOpIndexerT{}};
         constexpr ReductionIndexerT reduction_indexer{};
 
@@ -912,8 +912,8 @@ sycl::event reduction_axis1_over_group_with_atomics_contig_impl(
                 RowsIndexerT, NoOpIndexerT>;
         using ReductionIndexerT = NoOpIndexerT;
 
-        const RowsIndexerT rows_indexer{0, static_cast<ssize_t>(iter_nelems),
-                                        static_cast<ssize_t>(reduction_nelems)};
+        const RowsIndexerT rows_indexer{/* size */ iter_nelems,
+                                        /* step */ reduction_nelems};
         constexpr NoOpIndexerT result_indexer{};
         const InputOutputIterIndexerT in_out_iter_indexer{rows_indexer,
                                                           result_indexer};
@@ -975,9 +975,8 @@ sycl::event reduction_axis0_over_group_with_atomics_contig_impl(
 
         const InputOutputIterIndexerT in_out_iter_indexer{NoOpIndexerT{},
                                                           NoOpIndexerT{}};
-        const ReductionIndexerT reduction_indexer{
-            0, static_cast<ssize_t>(reduction_nelems),
-            static_cast<ssize_t>(iter_nelems)};
+        const ReductionIndexerT reduction_indexer{/* size */ reduction_nelems,
+                                                  /* step */ iter_nelems};
 
         sycl::event comp_ev =
             sequential_reduction<argTy, resTy, ReductionOpT,
@@ -1004,9 +1003,8 @@ sycl::event reduction_axis0_over_group_with_atomics_contig_impl(
         constexpr NoOpIndexerT result_indexer{};
         const InputOutputIterIndexerT in_out_iter_indexer{columns_indexer,
                                                           result_indexer};
-        const ReductionIndexerT reduction_indexer{
-            0, /* size */ static_cast<ssize_t>(reduction_nelems),
-            /* step */ static_cast<ssize_t>(iter_nelems)};
+        const ReductionIndexerT reduction_indexer{/* size */ reduction_nelems,
+                                                  /* step */ iter_nelems};
 
         constexpr size_t preferred_reductions_per_wi = 8;
         size_t reductions_per_wi =
@@ -1311,9 +1309,8 @@ sycl::event reduction_over_group_temps_strided_impl(
                 using ReductionIndexerT =
                     dpctl::tensor::offset_utils::NoOpIndexer;
 
-                const InputIndexerT inp_indexer{
-                    0, static_cast<ssize_t>(iter_nelems),
-                    static_cast<ssize_t>(reduction_groups_)};
+                const InputIndexerT inp_indexer{/* size */ iter_nelems,
+                                                /* step */ reduction_groups_};
                 constexpr ResIndexerT res_iter_indexer{};
 
                 const InputOutputIterIndexerT in_out_iter_indexer{
@@ -1342,9 +1339,8 @@ sycl::event reduction_over_group_temps_strided_impl(
                 InputIndexerT, ResIndexerT>;
         using ReductionIndexerT = dpctl::tensor::offset_utils::NoOpIndexer;
 
-        const InputIndexerT inp_indexer{
-            0, static_cast<ssize_t>(iter_nelems),
-            static_cast<ssize_t>(remaining_reduction_nelems)};
+        const InputIndexerT inp_indexer{/* size */ iter_nelems,
+                                        /* step */ remaining_reduction_nelems};
         const ResIndexerT res_iter_indexer{
             iter_nd, iter_res_offset,
             /* shape */ iter_shape_and_strides,
@@ -1428,8 +1424,8 @@ sycl::event reduction_axis1_over_group_temps_contig_impl(
         using ReductionIndexerT = NoOpIndexerT;
 
         const InputOutputIterIndexerT in_out_iter_indexer{
-            InputIterIndexerT{0, static_cast<ssize_t>(iter_nelems),
-                              static_cast<ssize_t>(reduction_nelems)},
+            InputIterIndexerT{/* size */ iter_nelems,
+                              /* step */ reduction_nelems},
             NoOpIndexerT{}};
         constexpr ReductionIndexerT reduction_indexer{};
 
@@ -1461,8 +1457,8 @@ sycl::event reduction_axis1_over_group_temps_contig_impl(
         using ReductionIndexerT = NoOpIndexerT;
 
         const InputOutputIterIndexerT in_out_iter_indexer{
-            InputIterIndexerT{0, static_cast<ssize_t>(iter_nelems),
-                              static_cast<ssize_t>(reduction_nelems)},
+            InputIterIndexerT{/* size */ iter_nelems,
+                              /* step */ reduction_nelems},
             NoOpIndexerT{}};
         constexpr ReductionIndexerT reduction_indexer{};
 
@@ -1520,9 +1516,8 @@ sycl::event reduction_axis1_over_group_temps_contig_impl(
                     RowsIndexerT, NoOpIndexerT>;
             using ReductionIndexerT = NoOpIndexerT;
 
-            const RowsIndexerT rows_indexer{
-                0, static_cast<ssize_t>(iter_nelems),
-                static_cast<ssize_t>(reduction_nelems)};
+            const RowsIndexerT rows_indexer{/* size */ iter_nelems,
+                                            /* step */ reduction_nelems};
             constexpr NoOpIndexerT noop_tmp_indexer{};
             const InputOutputIterIndexerT in_out_iter_indexer{rows_indexer,
                                                               noop_tmp_indexer};
@@ -1559,9 +1554,8 @@ sycl::event reduction_axis1_over_group_temps_contig_impl(
                     InputIndexerT, ResIndexerT>;
             using ReductionIndexerT = dpctl::tensor::offset_utils::NoOpIndexer;
 
-            const InputIndexerT inp_indexer{
-                0, static_cast<ssize_t>(iter_nelems),
-                static_cast<ssize_t>(reduction_groups_)};
+            const InputIndexerT inp_indexer{/* size */ iter_nelems,
+                                            /* step */ reduction_groups_};
             constexpr ResIndexerT res_iter_indexer{};
 
             const InputOutputIterIndexerT in_out_iter_indexer{inp_indexer,
@@ -1589,9 +1583,8 @@ sycl::event reduction_axis1_over_group_temps_contig_impl(
                 InputIndexerT, ResIndexerT>;
         using ReductionIndexerT = dpctl::tensor::offset_utils::NoOpIndexer;
 
-        const InputIndexerT inp_indexer{
-            0, static_cast<ssize_t>(iter_nelems),
-            static_cast<ssize_t>(remaining_reduction_nelems)};
+        const InputIndexerT inp_indexer{/* size */ iter_nelems,
+                                        /* step */ remaining_reduction_nelems};
         constexpr ResIndexerT res_iter_indexer{};
 
         const InputOutputIterIndexerT in_out_iter_indexer{inp_indexer,
@@ -1672,9 +1665,8 @@ sycl::event reduction_axis0_over_group_temps_contig_impl(
 
         const InputOutputIterIndexerT in_out_iter_indexer{NoOpIndexerT{},
                                                           NoOpIndexerT{}};
-        const ReductionIndexerT reduction_indexer{
-            0, static_cast<ssize_t>(reduction_nelems),
-            static_cast<ssize_t>(iter_nelems)};
+        const ReductionIndexerT reduction_indexer{/* size */ reduction_nelems,
+                                                  /* step */ iter_nelems};
 
         sycl::event comp_ev =
             sequential_reduction<argTy, resTy, ReductionOpT,
@@ -1707,9 +1699,8 @@ sycl::event reduction_axis0_over_group_temps_contig_impl(
         constexpr NoOpIndexerT result_indexer{};
         const InputOutputIterIndexerT in_out_iter_indexer{columns_indexer,
                                                           result_indexer};
-        const ReductionIndexerT reduction_indexer{
-            0, /* size */ static_cast<ssize_t>(reduction_nelems),
-            /* step */ static_cast<ssize_t>(iter_nelems)};
+        const ReductionIndexerT reduction_indexer{/* size */ reduction_nelems,
+                                                  /* step */ iter_nelems};
 
         if (iter_nelems == 1) {
             // increase GPU occupancy
@@ -1770,8 +1761,8 @@ sycl::event reduction_axis0_over_group_temps_contig_impl(
             const InputOutputIterIndexerT in_out_iter_indexer{columns_indexer,
                                                               noop_tmp_indexer};
             const ReductionIndexerT reduction_indexer{
-                0, /* size */ static_cast<ssize_t>(reduction_nelems),
-                /* step */ static_cast<ssize_t>(iter_nelems)};
+                /* size */ reduction_nelems,
+                /* step */ iter_nelems};
 
             first_reduction_ev = submit_no_atomic_reduction<
                 argTy, resTy, ReductionOpT, InputOutputIterIndexerT,
@@ -1804,9 +1795,8 @@ sycl::event reduction_axis0_over_group_temps_contig_impl(
                     InputIndexerT, ResIndexerT>;
             using ReductionIndexerT = dpctl::tensor::offset_utils::NoOpIndexer;
 
-            const InputIndexerT inp_indexer{
-                0, static_cast<ssize_t>(iter_nelems),
-                static_cast<ssize_t>(reduction_groups_)};
+            const InputIndexerT inp_indexer{/* size */ iter_nelems,
+                                            /* step */ reduction_groups_};
             constexpr ResIndexerT res_iter_indexer{};
 
             const InputOutputIterIndexerT in_out_iter_indexer{inp_indexer,
@@ -1834,9 +1824,8 @@ sycl::event reduction_axis0_over_group_temps_contig_impl(
                 InputIndexerT, ResIndexerT>;
         using ReductionIndexerT = dpctl::tensor::offset_utils::NoOpIndexer;
 
-        const InputIndexerT inp_indexer{
-            0, static_cast<ssize_t>(iter_nelems),
-            static_cast<ssize_t>(remaining_reduction_nelems)};
+        const InputIndexerT inp_indexer{/* size */ iter_nelems,
+                                        /* step */ remaining_reduction_nelems};
         constexpr ResIndexerT res_iter_indexer{};
 
         const InputOutputIterIndexerT in_out_iter_indexer{inp_indexer,
@@ -2732,9 +2721,8 @@ sycl::event search_over_group_temps_strided_impl(
                     InputIndexerT, ResIndexerT>;
             using ReductionIndexerT = dpctl::tensor::offset_utils::NoOpIndexer;
 
-            const InputIndexerT inp_indexer{
-                0, static_cast<ssize_t>(iter_nelems),
-                static_cast<ssize_t>(reduction_groups_)};
+            const InputIndexerT inp_indexer{/* size */ iter_nelems,
+                                            /* step */ reduction_groups_};
             constexpr ResIndexerT res_iter_indexer{};
 
             const InputOutputIterIndexerT in_out_iter_indexer{inp_indexer,
@@ -2765,9 +2753,8 @@ sycl::event search_over_group_temps_strided_impl(
                 InputIndexerT, ResIndexerT>;
         using ReductionIndexerT = dpctl::tensor::offset_utils::NoOpIndexer;
 
-        const InputIndexerT inp_indexer{
-            0, static_cast<ssize_t>(iter_nelems),
-            static_cast<ssize_t>(remaining_reduction_nelems)};
+        const InputIndexerT inp_indexer{/* size */ iter_nelems,
+                                        /* step */ remaining_reduction_nelems};
         const ResIndexerT res_iter_indexer{
             iter_nd, iter_res_offset,
             /* shape */ iter_shape_and_strides,
@@ -2870,8 +2857,8 @@ sycl::event search_axis1_over_group_temps_contig_impl(
         using ReductionIndexerT = NoOpIndexerT;
 
         const InputOutputIterIndexerT in_out_iter_indexer{
-            InputIterIndexerT{0, static_cast<ssize_t>(iter_nelems),
-                              static_cast<ssize_t>(reduction_nelems)},
+            InputIterIndexerT{/* size */ iter_nelems,
+                              /* step */ reduction_nelems},
             NoOpIndexerT{}};
         constexpr ReductionIndexerT reduction_indexer{};
 
@@ -2909,8 +2896,8 @@ sycl::event search_axis1_over_group_temps_contig_impl(
         using ReductionIndexerT = NoOpIndexerT;
 
         const InputOutputIterIndexerT in_out_iter_indexer{
-            InputIterIndexerT{0, static_cast<ssize_t>(iter_nelems),
-                              static_cast<ssize_t>(reduction_nelems)},
+            InputIterIndexerT{/* size */ iter_nelems,
+                              /* step */ reduction_nelems},
             NoOpIndexerT{}};
         constexpr ReductionIndexerT reduction_indexer{};
 
@@ -2985,8 +2972,8 @@ sycl::event search_axis1_over_group_temps_contig_impl(
             using ReductionIndexerT = NoOpIndexerT;
 
             const InputOutputIterIndexerT in_out_iter_indexer{
-                InputIterIndexerT{0, static_cast<ssize_t>(iter_nelems),
-                                  static_cast<ssize_t>(reduction_nelems)},
+                InputIterIndexerT{/* size */ iter_nelems,
+                                  /* step */ reduction_nelems},
                 NoOpIndexerT{}};
             constexpr ReductionIndexerT reduction_indexer{};
 
@@ -3027,9 +3014,8 @@ sycl::event search_axis1_over_group_temps_contig_impl(
                     InputIndexerT, ResIndexerT>;
             using ReductionIndexerT = dpctl::tensor::offset_utils::NoOpIndexer;
 
-            const InputIndexerT inp_indexer{
-                0, static_cast<ssize_t>(iter_nelems),
-                static_cast<ssize_t>(reduction_groups_)};
+            const InputIndexerT inp_indexer{/* size */ iter_nelems,
+                                            /* step */ reduction_groups_};
             constexpr ResIndexerT res_iter_indexer{};
 
             const InputOutputIterIndexerT in_out_iter_indexer{inp_indexer,
@@ -3060,9 +3046,8 @@ sycl::event search_axis1_over_group_temps_contig_impl(
                 InputIndexerT, ResIndexerT>;
         using ReductionIndexerT = dpctl::tensor::offset_utils::NoOpIndexer;
 
-        const InputIndexerT inp_indexer{
-            0, static_cast<ssize_t>(iter_nelems),
-            static_cast<ssize_t>(remaining_reduction_nelems)};
+        const InputIndexerT inp_indexer{/* size */ iter_nelems,
+                                        /* step */ remaining_reduction_nelems};
         constexpr ResIndexerT res_iter_indexer{};
 
         const InputOutputIterIndexerT in_out_iter_indexer{inp_indexer,
@@ -3151,9 +3136,8 @@ sycl::event search_axis0_over_group_temps_contig_impl(
 
         const InputOutputIterIndexerT in_out_iter_indexer{NoOpIndexerT{},
                                                           NoOpIndexerT{}};
-        const ReductionIndexerT reduction_indexer{
-            0, static_cast<ssize_t>(reduction_nelems),
-            static_cast<ssize_t>(iter_nelems)};
+        const ReductionIndexerT reduction_indexer{/* size */ reduction_nelems,
+                                                  /* step */ iter_nelems};
 
         sycl::event comp_ev = exec_q.submit([&](sycl::handler &cgh) {
             cgh.depends_on(depends);
@@ -3197,9 +3181,8 @@ sycl::event search_axis0_over_group_temps_contig_impl(
         constexpr NoOpIndexerT result_indexer{};
         const InputOutputIterIndexerT in_out_iter_indexer{columns_indexer,
                                                           result_indexer};
-        const ReductionIndexerT reduction_indexer{
-            0, /* size */ static_cast<ssize_t>(reduction_nelems),
-            /* step */ static_cast<ssize_t>(iter_nelems)};
+        const ReductionIndexerT reduction_indexer{/* size */ reduction_nelems,
+                                                  /* step */ iter_nelems};
 
         if (iter_nelems == 1) {
             // increase GPU occupancy
@@ -3275,8 +3258,8 @@ sycl::event search_axis0_over_group_temps_contig_impl(
             const InputOutputIterIndexerT in_out_iter_indexer{columns_indexer,
                                                               result_indexer};
             const ReductionIndexerT reduction_indexer{
-                0, /* size */ static_cast<ssize_t>(reduction_nelems),
-                /* step */ static_cast<ssize_t>(iter_nelems)};
+                /* size */ reduction_nelems,
+                /* step */ iter_nelems};
 
             first_reduction_ev =
                 submit_search_reduction<argTy, resTy, ReductionOpT, IndexOpT,
@@ -3315,9 +3298,8 @@ sycl::event search_axis0_over_group_temps_contig_impl(
                     InputIndexerT, ResIndexerT>;
             using ReductionIndexerT = dpctl::tensor::offset_utils::NoOpIndexer;
 
-            const InputIndexerT inp_indexer{
-                0, static_cast<ssize_t>(iter_nelems),
-                static_cast<ssize_t>(reduction_groups_)};
+            const InputIndexerT inp_indexer{/* size */ iter_nelems,
+                                            /* step */ reduction_groups_};
             constexpr ResIndexerT res_iter_indexer{};
 
             const InputOutputIterIndexerT in_out_iter_indexer{inp_indexer,
@@ -3348,9 +3330,8 @@ sycl::event search_axis0_over_group_temps_contig_impl(
                 InputIndexerT, ResIndexerT>;
         using ReductionIndexerT = dpctl::tensor::offset_utils::NoOpIndexer;
 
-        const InputIndexerT inp_indexer{
-            0, static_cast<ssize_t>(iter_nelems),
-            static_cast<ssize_t>(remaining_reduction_nelems)};
+        const InputIndexerT inp_indexer{/* size */ iter_nelems,
+                                        /* step */ remaining_reduction_nelems};
         constexpr ResIndexerT res_iter_indexer{};
 
         const InputOutputIterIndexerT in_out_iter_indexer{inp_indexer,

--- a/dpctl/tensor/libtensor/include/kernels/repeat.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/repeat.hpp
@@ -161,12 +161,13 @@ repeat_by_sequence_impl(sycl::queue &q,
             orthog_nd, src_offset, dst_offset,
             orthog_src_dst_shape_and_strides};
         // indexers along repeated axis
-        const Strided1DIndexer src_axis_indexer{0, src_axis_shape,
-                                                src_axis_stride};
-        const Strided1DIndexer dst_axis_indexer{0, dst_axis_shape,
-                                                dst_axis_stride};
+        const Strided1DIndexer src_axis_indexer{/* size */ src_axis_shape,
+                                                /* step */ src_axis_stride};
+        const Strided1DIndexer dst_axis_indexer{/* size */ dst_axis_shape,
+                                                /* step */ dst_axis_stride};
         // indexer along reps array
-        const Strided1DIndexer reps_indexer{0, reps_shape, reps_stride};
+        const Strided1DIndexer reps_indexer{/* size */ reps_shape,
+                                            /* step */ reps_stride};
 
         const size_t gws = orthog_nelems * src_axis_nelems;
 
@@ -235,9 +236,11 @@ sycl::event repeat_by_sequence_1d_impl(sycl::queue &q,
         constexpr TwoZeroOffsets_Indexer orthog_indexer{};
         // indexers along repeated axis
         const StridedIndexer src_indexer{src_nd, 0, src_shape_strides};
-        const Strided1DIndexer dst_indexer{0, dst_shape, dst_stride};
+        const Strided1DIndexer dst_indexer{/* size */ dst_shape,
+                                           /* step */ dst_stride};
         // indexer along reps array
-        const Strided1DIndexer reps_indexer{0, reps_shape, reps_stride};
+        const Strided1DIndexer reps_indexer{/* size */ reps_shape,
+                                            /* step */ reps_stride};
 
         const size_t gws = src_nelems;
 
@@ -358,10 +361,10 @@ sycl::event repeat_by_scalar_impl(sycl::queue &q,
         const TwoOffsets_StridedIndexer orthog_indexer{
             orthog_nd, src_offset, dst_offset, orthog_shape_and_strides};
         // indexers along repeated axis
-        const Strided1DIndexer src_axis_indexer{0, src_axis_shape,
-                                                src_axis_stride};
-        const Strided1DIndexer dst_axis_indexer{0, dst_axis_shape,
-                                                dst_axis_stride};
+        const Strided1DIndexer src_axis_indexer{/* size */ src_axis_shape,
+                                                /* step */ src_axis_stride};
+        const Strided1DIndexer dst_axis_indexer{/* size */ dst_axis_shape,
+                                                /* step */ dst_axis_stride};
 
         const size_t gws = orthog_nelems * dst_axis_nelems;
 
@@ -420,7 +423,8 @@ sycl::event repeat_by_scalar_1d_impl(sycl::queue &q,
         constexpr TwoZeroOffsets_Indexer orthog_indexer{};
         // indexers along repeated axis
         const StridedIndexer src_indexer(src_nd, 0, src_shape_strides);
-        const Strided1DIndexer dst_indexer{0, dst_shape, dst_stride};
+        const Strided1DIndexer dst_indexer{/* size */ dst_shape,
+                                           /* step */ dst_stride};
 
         const size_t gws = dst_nelems;
 

--- a/dpctl/tensor/libtensor/include/kernels/sorting/searchsorted.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/sorting/searchsorted.hpp
@@ -218,8 +218,8 @@ sycl::event searchsorted_strided_impl(
         using HayIndexerT = dpctl::tensor::offset_utils::Strided1DIndexer;
         const HayIndexerT hay_indexer(
             /* offset */ hay_offset,
-            /* size   */ static_cast<ssize_t>(hay_nelems),
-            /* step   */ static_cast<ssize_t>(hay_stride));
+            /* size   */ hay_nelems,
+            /* step   */ hay_stride);
 
         using NeedlesIndexerT = dpctl::tensor::offset_utils::StridedIndexer;
         const ssize_t *needles_shape_strides = packed_shape_strides;

--- a/dpctl/tensor/libtensor/include/utils/offset_utils.hpp
+++ b/dpctl/tensor/libtensor/include/utils/offset_utils.hpp
@@ -213,6 +213,31 @@ private:
 
 struct Strided1DIndexer
 {
+    Strided1DIndexer(size_t _size) : offset{}, size(_size), step(1) {}
+    Strided1DIndexer(ssize_t _size)
+        : offset{}, size(static_cast<size_t>(_size)), step(1)
+    {
+    }
+    Strided1DIndexer(size_t _size, ssize_t _step)
+        : offset{}, size(_size), step(_step)
+    {
+    }
+    Strided1DIndexer(size_t _size, size_t _step)
+        : offset{}, size(_size), step(static_cast<ssize_t>(_step))
+    {
+    }
+    Strided1DIndexer(ssize_t _size, ssize_t _step)
+        : offset{}, size(static_cast<size_t>(_size)), step(_step)
+    {
+    }
+    Strided1DIndexer(ssize_t _offset, size_t _size, ssize_t _step)
+        : offset(_offset), size(_size), step(_step)
+    {
+    }
+    Strided1DIndexer(ssize_t _offset, size_t _size, size_t _step)
+        : offset(_offset), size(_size), step(static_cast<ssize_t>(_step))
+    {
+    }
     Strided1DIndexer(ssize_t _offset, ssize_t _size, ssize_t _step)
         : offset(_offset), size(static_cast<size_t>(_size)), step(_step)
     {


### PR DESCRIPTION
Provide overloaded constructor signatures to `Strided1DIndexer` class to avoid uses of `static_cast` at constructor call sites.

Provide shortcut constructors (for zero offset).

Constructor call site use comments to specify meaning of constructor parameters.

Added few comments to GEMM code too.

---

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
