### PR TITLE
Do not push_back compute event to host_tasks list

### DIFF
--- a/dpctl/tensor/libtensor/source/boolean_advanced_indexing.cpp
+++ b/dpctl/tensor/libtensor/source/boolean_advanced_indexing.cpp
@@ -370,8 +370,6 @@ py_extract(const dpctl::tensor::usm_ndarray &src,
         host_task_events.push_back(cleanup_tmp_allocations_ev);
     }
 
-    host_task_events.push_back(extract_ev);
-
     sycl::event py_obj_management_host_task_ev = dpctl::utils::keep_args_alive(
         exec_q, {src, cumsum, dst}, host_task_events);
 

--- a/dpctl/tensor/libtensor/source/linalg_functions/dot.cpp
+++ b/dpctl/tensor/libtensor/source/linalg_functions/dot.cpp
@@ -802,7 +802,6 @@ py_dot(const dpctl::tensor::usm_ndarray &x1,
                     });
                 });
             host_task_events.push_back(cleanup_tmp_allocations_ev);
-            host_task_events.push_back(dot_ev);
         }
     }
     return std::make_pair(

--- a/dpctl/tensor/libtensor/source/repeat.cpp
+++ b/dpctl/tensor/libtensor/source/repeat.cpp
@@ -356,8 +356,6 @@ py_repeat_by_sequence(const dpctl::tensor::usm_ndarray &src,
         host_task_events.push_back(cleanup_tmp_allocations_ev);
     }
 
-    host_task_events.push_back(repeat_ev);
-
     sycl::event py_obj_management_host_task_ev = dpctl::utils::keep_args_alive(
         exec_q, {src, reps, cumsum, dst}, host_task_events);
 


### PR DESCRIPTION
Do not push_back compute event to host_tasks list.

This is even though sequence of tasks represented by dot_ev does contain host_task to manage temporary USM allocations.

---

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
