### PR TITLE
Implement dedicated strided `full` kernel and add `order="K"` support to constructors

### DIFF
--- a/dpctl/tensor/_ctors.py
+++ b/dpctl/tensor/_ctors.py
@@ -904,7 +904,7 @@ def zeros(
             data type of the array. Can be typestring,
             a :class:`numpy.dtype` object, :mod:`numpy` char string,
             or a NumPy scalar type. Default: ``None``
-        order ("C", or F"):
+        order ("C", or "F"):
             memory layout for the array. Default: ``"C"``
         device (optional): array API concept of device where the output array
             is created. ``device`` can be ``None``, a oneAPI filter selector
@@ -975,7 +975,7 @@ def ones(
             data type of the array. Can be typestring,
             a :class:`numpy.dtype` object, :mod:`numpy` char string,
             or a NumPy scalar type. Default: ``None``
-        order ("C", or F"): memory layout for the array. Default: ``"C"``
+        order ("C", or "F"): memory layout for the array. Default: ``"C"``
         device (optional): array API concept of device where the output array
             is created. ``device`` can be ``None``, a oneAPI filter selector
             string, an instance of :class:`dpctl.SyclDevice` corresponding to
@@ -1043,7 +1043,7 @@ def full(
         dtype (optional): data type of the array. Can be typestring,
             a :class:`numpy.dtype` object, :mod:`numpy` char string,
             or a NumPy scalar type. Default: ``None``
-        order ("C", or F"):
+        order ("C", or "F"):
             memory layout for the array. Default: ``"C"``
         device (optional): array API concept of device where the output array
             is created. ``device`` can be ``None``, a oneAPI filter selector
@@ -1121,7 +1121,7 @@ def full(
 
 
 def empty_like(
-    x, /, *, dtype=None, order="C", device=None, usm_type=None, sycl_queue=None
+    x, /, *, dtype=None, order="K", device=None, usm_type=None, sycl_queue=None
 ):
     """
     Returns an uninitialized :class:`dpctl.tensor.usm_ndarray` with the
@@ -1134,8 +1134,8 @@ def empty_like(
             data type of the array. Can be a typestring,
             a :class:`numpy.dtype` object, NumPy char string,
             or a NumPy scalar type. Default: ``None``
-        order ("C", or F"):
-            memory layout for the array. Default: ``"C"``
+        order ("C", "F", "A", or "K"):
+            memory layout for the array. Default: ``"K"``
         device (optional): array API concept of device where the output array
             is created. ``device`` can be ``None``, a oneAPI filter selector
             string, an instance of :class:`dpctl.SyclDevice` corresponding to
@@ -1161,11 +1161,8 @@ def empty_like(
     """
     if not isinstance(x, dpt.usm_ndarray):
         raise TypeError(f"Expected instance of dpt.usm_ndarray, got {type(x)}.")
-    if not isinstance(order, str) or len(order) == 0 or order[0] not in "CcFf":
-        raise ValueError(
-            "Unrecognized order keyword value, expecting 'F' or 'C'."
-        )
-    order = order[0].upper()
+    if order not in ("K", "C", "F", "A"):
+        order = "K"
     if dtype is None:
         dtype = x.dtype
     if usm_type is None:
@@ -1174,17 +1171,28 @@ def empty_like(
     if device is None and sycl_queue is None:
         device = x.device
     sycl_queue = normalize_queue_device(sycl_queue=sycl_queue, device=device)
-    shape = x.shape
     dtype = dpt.dtype(dtype)
-    _ensure_native_dtype_device_support(dtype, sycl_queue.sycl_device)
-    res = dpt.usm_ndarray(
-        shape,
-        dtype=dtype,
-        buffer=usm_type,
-        order=order,
-        buffer_ctor_kwargs={"queue": sycl_queue},
-    )
-    return res
+    x_flags = x.flags
+    f_contig = x_flags["F"]
+    c_contig = x_flags["C"]
+    if order == "A":
+        order = "F" if f_contig and not c_contig else "C"
+    if order == "K" and (f_contig or c_contig):
+        order = "C" if c_contig else "F"
+    if order == "K":
+        _ensure_native_dtype_device_support(dtype, sycl_queue.sycl_device)
+        return _empty_like_orderK(x, dtype, usm_type, sycl_queue)
+    else:
+        shape = x.shape
+        _ensure_native_dtype_device_support(dtype, sycl_queue.sycl_device)
+        res = dpt.usm_ndarray(
+            shape,
+            dtype=dtype,
+            buffer=usm_type,
+            order=order,
+            buffer_ctor_kwargs={"queue": sycl_queue},
+        )
+        return res
 
 
 def zeros_like(
@@ -1203,7 +1211,7 @@ def zeros_like(
             a :class:`numpy.dtype` object, :mod:`numpy` char string, or a
             NumPy scalar type. If `None`, output array has the same data
             type as the input array. Default: ``None``
-        order ("C", or F"):
+        order ("C", or "F"):
             memory layout for the array. Default: ``"C"``
         device (optional):
             array API concept of device where the output array
@@ -1231,11 +1239,8 @@ def zeros_like(
     """
     if not isinstance(x, dpt.usm_ndarray):
         raise TypeError(f"Expected instance of dpt.usm_ndarray, got {type(x)}.")
-    if not isinstance(order, str) or len(order) == 0 or order[0] not in "CcFf":
-        raise ValueError(
-            "Unrecognized order keyword value, expecting 'F' or 'C'."
-        )
-    order = order[0].upper()
+    if order not in ("K", "C", "F", "A"):
+        order = "K"
     if dtype is None:
         dtype = x.dtype
     if usm_type is None:
@@ -1244,20 +1249,37 @@ def zeros_like(
     if device is None and sycl_queue is None:
         device = x.device
     sycl_queue = normalize_queue_device(sycl_queue=sycl_queue, device=device)
-    sh = x.shape
     dtype = dpt.dtype(dtype)
-    return zeros(
-        sh,
-        dtype=dtype,
-        order=order,
-        device=device,
-        usm_type=usm_type,
-        sycl_queue=sycl_queue,
-    )
+    x_flags = x.flags
+    f_contig = x_flags["F"]
+    c_contig = x_flags["C"]
+    if order == "A":
+        order = "F" if f_contig and not c_contig else "C"
+    if order == "K" and (f_contig or c_contig):
+        order = "C" if c_contig else "F"
+    if order == "K":
+        _ensure_native_dtype_device_support(dtype, sycl_queue.sycl_device)
+        res = _empty_like_orderK(x, dtype, usm_type, sycl_queue)
+        _manager = dpctl.utils.SequentialOrderManager[sycl_queue]
+        # populating new allocation, no dependent events
+        hev, full_ev = ti._full_usm_ndarray(0, res, sycl_queue)
+        _manager.add_event_pair(hev, full_ev)
+        return res
+    else:
+        _ensure_native_dtype_device_support(dtype, sycl_queue.sycl_device)
+        sh = x.shape
+        return zeros(
+            sh,
+            dtype=dtype,
+            order=order,
+            device=device,
+            usm_type=usm_type,
+            sycl_queue=sycl_queue,
+        )
 
 
 def ones_like(
-    x, /, *, dtype=None, order="C", device=None, usm_type=None, sycl_queue=None
+    x, /, *, dtype=None, order="K", device=None, usm_type=None, sycl_queue=None
 ):
     """
     Returns a new :class:`dpctl.tensor.usm_ndarray` filled with ones and
@@ -1270,7 +1292,7 @@ def ones_like(
             data type of the array. Can be typestring,
             a :class:`numpy.dtype` object, :mod:`numpy` char string,
             or a NumPy scalar type. Default: `None`
-        order ("C", or F"):
+        order ("C", "F", "A", or "K"):
             memory layout for the array. Default: ``"C"``
         device (optional):
             array API concept of device where the output array
@@ -1298,11 +1320,8 @@ def ones_like(
     """
     if not isinstance(x, dpt.usm_ndarray):
         raise TypeError(f"Expected instance of dpt.usm_ndarray, got {type(x)}.")
-    if not isinstance(order, str) or len(order) == 0 or order[0] not in "CcFf":
-        raise ValueError(
-            "Unrecognized order keyword value, expecting 'F' or 'C'."
-        )
-    order = order[0].upper()
+    if order not in ("K", "C", "F", "A"):
+        order = "K"
     if dtype is None:
         dtype = x.dtype
     if usm_type is None:
@@ -1311,16 +1330,32 @@ def ones_like(
     if device is None and sycl_queue is None:
         device = x.device
     sycl_queue = normalize_queue_device(sycl_queue=sycl_queue, device=device)
-    sh = x.shape
     dtype = dpt.dtype(dtype)
-    return ones(
-        sh,
-        dtype=dtype,
-        order=order,
-        device=device,
-        usm_type=usm_type,
-        sycl_queue=sycl_queue,
-    )
+    x_flags = x.flags
+    f_contig = x_flags["F"]
+    c_contig = x_flags["C"]
+    if order == "A":
+        order = "F" if f_contig and not c_contig else "C"
+    if order == "K" and (f_contig or c_contig):
+        order = "C" if c_contig else "F"
+    if order == "K":
+        _ensure_native_dtype_device_support(dtype, sycl_queue.sycl_device)
+        res = _empty_like_orderK(x, dtype, usm_type, sycl_queue)
+        _manager = dpctl.utils.SequentialOrderManager[sycl_queue]
+        # populating new allocation, no dependent events
+        hev, full_ev = ti._full_usm_ndarray(1, res, sycl_queue)
+        _manager.add_event_pair(hev, full_ev)
+        return res
+    else:
+        sh = x.shape
+        return ones(
+            sh,
+            dtype=dtype,
+            order=order,
+            device=device,
+            usm_type=usm_type,
+            sycl_queue=sycl_queue,
+        )
 
 
 def full_like(
@@ -1334,7 +1369,7 @@ def full_like(
     usm_type=None,
     sycl_queue=None,
 ):
-    """ full_like(x, fill_value, dtype=None, order="C", \
+    """ full_like(x, fill_value, dtype=None, order="K", \
                   device=None, usm_type=None, sycl_queue=None)
 
     Returns a new :class:`dpctl.tensor.usm_ndarray` filled with `fill_value`
@@ -1349,8 +1384,8 @@ def full_like(
             a :class:`numpy.dtype` object, :mod:`numpy` char string, or a
             NumPy scalar type. If ``dtype`` is ``None``, the output array data
             type is inferred from ``x``. Default: ``None``
-        order ("C", or F"):
-            memory layout for the array. Default: ``"C"``
+        order ("C", "F", "A", or "K"):
+            memory layout for the array. Default: ``"K"``
         device (optional):
             array API concept of device where the output array
             is created. ``device`` can be ``None``, a oneAPI filter selector
@@ -1377,11 +1412,8 @@ def full_like(
     """
     if not isinstance(x, dpt.usm_ndarray):
         raise TypeError(f"Expected instance of dpt.usm_ndarray, got {type(x)}.")
-    if not isinstance(order, str) or len(order) == 0 or order[0] not in "CcFf":
-        raise ValueError(
-            "Unrecognized order keyword value, expecting 'F' or 'C'."
-        )
-    order = order[0].upper()
+    if order not in ("K", "C", "F", "A"):
+        order = "K"
     if dtype is None:
         dtype = x.dtype
     if usm_type is None:
@@ -1392,15 +1424,49 @@ def full_like(
     sycl_queue = normalize_queue_device(sycl_queue=sycl_queue, device=device)
     sh = x.shape
     dtype = dpt.dtype(dtype)
-    return full(
-        sh,
-        fill_value,
-        dtype=dtype,
-        order=order,
-        device=device,
-        usm_type=usm_type,
-        sycl_queue=sycl_queue,
-    )
+    x_flags = x.flags
+    f_contig = x_flags["F"]
+    c_contig = x_flags["C"]
+    if order == "A":
+        order = "F" if f_contig and not c_contig else "C"
+    if order == "K" and (f_contig or c_contig):
+        order = "C" if c_contig else "F"
+    if order == "K":
+        _ensure_native_dtype_device_support(dtype, sycl_queue.sycl_device)
+        if isinstance(fill_value, (dpt.usm_ndarray, np.ndarray, tuple, list)):
+            X = dpt.asarray(
+                fill_value,
+                dtype=dtype,
+                order=order,
+                usm_type=usm_type,
+                sycl_queue=sycl_queue,
+            )
+            X = dpt.broadcast_to(X, sh)
+            res = _empty_like_orderK(x, dtype, usm_type, sycl_queue)
+            _manager = dpctl.utils.SequentialOrderManager[sycl_queue]
+            # populating new allocation, no dependent events
+            hev, copy_ev = ti._copy_usm_ndarray_into_usm_ndarray(
+                src=X, dst=res, sycl_queue=sycl_queue
+            )
+            _manager.add_event_pair(hev, copy_ev)
+            return res
+        else:
+            res = _empty_like_orderK(x, dtype, usm_type, sycl_queue)
+            _manager = dpctl.utils.SequentialOrderManager[sycl_queue]
+            # populating new allocation, no dependent events
+            hev, full_ev = ti._full_usm_ndarray(fill_value, res, sycl_queue)
+            _manager.add_event_pair(hev, full_ev)
+            return res
+    else:
+        return full(
+            sh,
+            fill_value,
+            dtype=dtype,
+            order=order,
+            device=device,
+            usm_type=usm_type,
+            sycl_queue=sycl_queue,
+        )
 
 
 def linspace(
@@ -1536,7 +1602,7 @@ def eye(
             data type of the array. Can be typestring,
             a :class:`numpy.dtype` object, :mod:`numpy` char string, or
             a NumPy scalar type. Default: ``None``
-        order ("C" or F"):
+        order ("C" or "F"):
             memory layout for the array. Default: ``"C"``
         device (optional):
             array API concept of device where the output array

--- a/dpctl/tensor/_ctors.py
+++ b/dpctl/tensor/_ctors.py
@@ -1130,6 +1130,21 @@ def full(
     return res
 
 
+def _normalize_order(order, arr):
+    """
+    Utility function for processing the `order` keyword of array-like
+    constructors, which support `"K"` and `"A"` orders.
+    """
+    arr_flags = arr.flags
+    f_contig = arr_flags["F"]
+    c_contig = arr_flags["C"]
+    if order == "A":
+        order = "F" if f_contig and not c_contig else "C"
+    if order == "K" and (f_contig or c_contig):
+        order = "C" if c_contig else "F"
+    return order
+
+
 def empty_like(
     x, /, *, dtype=None, order="K", device=None, usm_type=None, sycl_queue=None
 ):
@@ -1189,13 +1204,7 @@ def empty_like(
         device = x.device
     sycl_queue = normalize_queue_device(sycl_queue=sycl_queue, device=device)
     dtype = dpt.dtype(dtype)
-    x_flags = x.flags
-    f_contig = x_flags["F"]
-    c_contig = x_flags["C"]
-    if order == "A":
-        order = "F" if f_contig and not c_contig else "C"
-    if order == "K" and (f_contig or c_contig):
-        order = "C" if c_contig else "F"
+    order = _normalize_order(order, x)
     if order == "K":
         _ensure_native_dtype_device_support(dtype, sycl_queue.sycl_device)
         return _empty_like_orderK(x, dtype, usm_type, sycl_queue)
@@ -1274,13 +1283,7 @@ def zeros_like(
         device = x.device
     sycl_queue = normalize_queue_device(sycl_queue=sycl_queue, device=device)
     dtype = dpt.dtype(dtype)
-    x_flags = x.flags
-    f_contig = x_flags["F"]
-    c_contig = x_flags["C"]
-    if order == "A":
-        order = "F" if f_contig and not c_contig else "C"
-    if order == "K" and (f_contig or c_contig):
-        order = "C" if c_contig else "F"
+    order = _normalize_order(order, x)
     if order == "K":
         _ensure_native_dtype_device_support(dtype, sycl_queue.sycl_device)
         res = _empty_like_orderK(x, dtype, usm_type, sycl_queue)
@@ -1362,13 +1365,7 @@ def ones_like(
         device = x.device
     sycl_queue = normalize_queue_device(sycl_queue=sycl_queue, device=device)
     dtype = dpt.dtype(dtype)
-    x_flags = x.flags
-    f_contig = x_flags["F"]
-    c_contig = x_flags["C"]
-    if order == "A":
-        order = "F" if f_contig and not c_contig else "C"
-    if order == "K" and (f_contig or c_contig):
-        order = "C" if c_contig else "F"
+    order = _normalize_order(order, x)
     if order == "K":
         _ensure_native_dtype_device_support(dtype, sycl_queue.sycl_device)
         res = _empty_like_orderK(x, dtype, usm_type, sycl_queue)
@@ -1462,13 +1459,7 @@ def full_like(
     sycl_queue = normalize_queue_device(sycl_queue=sycl_queue, device=device)
     sh = x.shape
     dtype = dpt.dtype(dtype)
-    x_flags = x.flags
-    f_contig = x_flags["F"]
-    c_contig = x_flags["C"]
-    if order == "A":
-        order = "F" if f_contig and not c_contig else "C"
-    if order == "K" and (f_contig or c_contig):
-        order = "C" if c_contig else "F"
+    order = _normalize_order(order, x)
     if order == "K":
         _ensure_native_dtype_device_support(dtype, sycl_queue.sycl_device)
         if isinstance(fill_value, (dpt.usm_ndarray, np.ndarray, tuple, list)):

--- a/dpctl/tensor/_ctors.py
+++ b/dpctl/tensor/_ctors.py
@@ -1161,8 +1161,15 @@ def empty_like(
     """
     if not isinstance(x, dpt.usm_ndarray):
         raise TypeError(f"Expected instance of dpt.usm_ndarray, got {type(x)}.")
-    if order not in ("K", "C", "F", "A"):
-        order = "K"
+    if (
+        not isinstance(order, str)
+        or len(order) == 0
+        or order[0] not in "CcFfAaKk"
+    ):
+        raise ValueError(
+            "Unrecognized order keyword value, expecting 'C', 'F', 'A', or 'K'."
+        )
+    order = order[0].upper()
     if dtype is None:
         dtype = x.dtype
     if usm_type is None:
@@ -1196,7 +1203,7 @@ def empty_like(
 
 
 def zeros_like(
-    x, /, *, dtype=None, order="C", device=None, usm_type=None, sycl_queue=None
+    x, /, *, dtype=None, order="K", device=None, usm_type=None, sycl_queue=None
 ):
     """
     Creates :class:`dpctl.tensor.usm_ndarray` from USM allocation
@@ -1239,8 +1246,15 @@ def zeros_like(
     """
     if not isinstance(x, dpt.usm_ndarray):
         raise TypeError(f"Expected instance of dpt.usm_ndarray, got {type(x)}.")
-    if order not in ("K", "C", "F", "A"):
-        order = "K"
+    if (
+        not isinstance(order, str)
+        or len(order) == 0
+        or order[0] not in "CcFfAaKk"
+    ):
+        raise ValueError(
+            "Unrecognized order keyword value, expecting 'C', 'F', 'A', or 'K'."
+        )
+    order = order[0].upper()
     if dtype is None:
         dtype = x.dtype
     if usm_type is None:
@@ -1320,8 +1334,15 @@ def ones_like(
     """
     if not isinstance(x, dpt.usm_ndarray):
         raise TypeError(f"Expected instance of dpt.usm_ndarray, got {type(x)}.")
-    if order not in ("K", "C", "F", "A"):
-        order = "K"
+    if (
+        not isinstance(order, str)
+        or len(order) == 0
+        or order[0] not in "CcFfAaKk"
+    ):
+        raise ValueError(
+            "Unrecognized order keyword value, expecting 'C', 'F', 'A', or 'K'."
+        )
+    order = order[0].upper()
     if dtype is None:
         dtype = x.dtype
     if usm_type is None:
@@ -1364,7 +1385,7 @@ def full_like(
     fill_value,
     *,
     dtype=None,
-    order="C",
+    order="K",
     device=None,
     usm_type=None,
     sycl_queue=None,
@@ -1412,8 +1433,15 @@ def full_like(
     """
     if not isinstance(x, dpt.usm_ndarray):
         raise TypeError(f"Expected instance of dpt.usm_ndarray, got {type(x)}.")
-    if order not in ("K", "C", "F", "A"):
-        order = "K"
+    if (
+        not isinstance(order, str)
+        or len(order) == 0
+        or order[0] not in "CcFfAaKk"
+    ):
+        raise ValueError(
+            "Unrecognized order keyword value, expecting 'C', 'F', 'A', or 'K'."
+        )
+    order = order[0].upper()
     if dtype is None:
         dtype = x.dtype
     if usm_type is None:

--- a/dpctl/tensor/libtensor/source/full_ctor.cpp
+++ b/dpctl/tensor/libtensor/source/full_ctor.cpp
@@ -61,9 +61,9 @@ typedef sycl::event (*full_contig_fn_ptr_t)(sycl::queue &,
  *
  * @param exec_q  Sycl queue to which kernel is submitted for execution.
  * @param nelems  Length of the sequence
- * @param py_value Python object representing the value to fill the array with.
+ * @param py_value  Python object representing the value to fill the array with.
  * Must be convertible to `dstTy`.
- * @param dst_p Kernel accessible USM pointer to the start of array to be
+ * @param dst_p  Kernel accessible USM pointer to the start of array to be
  * populated.
  * @param depends  List of events to wait for before starting computations, if
  * any.
@@ -152,7 +152,62 @@ template <typename fnT, typename Ty> struct FullContigFactory
     }
 };
 
+typedef sycl::event (*full_strided_fn_ptr_t)(sycl::queue &,
+                                             int,
+                                             size_t,
+                                             py::ssize_t *,
+                                             const py::object &,
+                                             char *,
+                                             const std::vector<sycl::event> &);
+
+/*!
+ * @brief Function to submit kernel to fill given strided memory allocation
+ * with specified value.
+ *
+ * @param exec_q  Sycl queue to which kernel is submitted for execution.
+ * @param nd  Array dimensionality
+ * @param nelems  Length of the sequence
+ * @param shape_strides  Kernel accessible USM pointer to packed shape and
+ * strides of array.
+ * @param py_value  Python object representing the value to fill the array with.
+ * Must be convertible to `dstTy`.
+ * @param dst_p  Kernel accessible USM pointer to the start of array to be
+ * populated.
+ * @param depends  List of events to wait for before starting computations, if
+ * any.
+ *
+ * @return Event to wait on to ensure that computation completes.
+ * @defgroup CtorKernels
+ */
+template <typename dstTy>
+sycl::event full_strided_impl(sycl::queue &exec_q,
+                              int nd,
+                              size_t nelems,
+                              py::ssize_t *shape_strides,
+                              const py::object &py_value,
+                              char *dst_p,
+                              const std::vector<sycl::event> &depends)
+{
+    dstTy fill_v = py::cast<dstTy>(py_value);
+
+    using dpctl::tensor::kernels::constructors::full_strided_impl;
+    sycl::event fill_ev = full_strided_impl<dstTy>(
+        exec_q, nd, nelems, shape_strides, fill_v, dst_p, depends);
+
+    return fill_ev;
+}
+
+template <typename fnT, typename Ty> struct FullStridedFactory
+{
+    fnT get()
+    {
+        fnT f = full_strided_impl<Ty>;
+        return f;
+    }
+};
+
 static full_contig_fn_ptr_t full_contig_dispatch_vector[td_ns::num_types];
+static full_strided_fn_ptr_t full_strided_dispatch_vector[td_ns::num_types];
 
 std::pair<sycl::event, sycl::event>
 usm_ndarray_full(const py::object &py_value,
@@ -194,8 +249,42 @@ usm_ndarray_full(const py::object &py_value,
             full_contig_event);
     }
     else {
-        throw std::runtime_error(
-            "Only population of contiguous usm_ndarray objects is supported.");
+        int nd = dst.get_ndim();
+        auto const &dst_shape = dst.get_shape_vector();
+        auto const &dst_strides = dst.get_strides_vector();
+
+        auto fn = full_strided_dispatch_vector[dst_typeid];
+
+        std::vector<sycl::event> host_task_events;
+        host_task_events.reserve(2);
+        using dpctl::tensor::offset_utils::device_allocate_and_pack;
+        const auto &ptr_size_event_tuple =
+            device_allocate_and_pack<py::ssize_t>(exec_q, host_task_events,
+                                                  dst_shape, dst_strides);
+        py::ssize_t *shape_strides = std::get<0>(ptr_size_event_tuple);
+        if (shape_strides == nullptr) {
+            throw std::runtime_error("Unable to allocate device memory");
+        }
+        const sycl::event &copy_shape_ev = std::get<2>(ptr_size_event_tuple);
+
+        const sycl::event &full_strided_ev =
+            fn(exec_q, nd, dst_nelems, shape_strides, py_value, dst_data,
+               {copy_shape_ev});
+
+        // free shape_strides
+        const auto &ctx = exec_q.get_context();
+        const auto &temporaries_cleanup_ev =
+            exec_q.submit([&](sycl::handler &cgh) {
+                cgh.depends_on(full_strided_ev);
+                using dpctl::tensor::alloc_utils::sycl_free_noexcept;
+                cgh.host_task([ctx, shape_strides]() {
+                    sycl_free_noexcept(shape_strides, ctx);
+                });
+            });
+        host_task_events.push_back(temporaries_cleanup_ev);
+
+        return std::make_pair(keep_args_alive(exec_q, {dst}, host_task_events),
+                              full_strided_ev);
     }
 }
 
@@ -204,10 +293,12 @@ void init_full_ctor_dispatch_vectors(void)
     using namespace td_ns;
 
     DispatchVectorBuilder<full_contig_fn_ptr_t, FullContigFactory, num_types>
-        dvb;
-    dvb.populate_dispatch_vector(full_contig_dispatch_vector);
+        dvb1;
+    dvb1.populate_dispatch_vector(full_contig_dispatch_vector);
 
-    return;
+    DispatchVectorBuilder<full_strided_fn_ptr_t, FullStridedFactory, num_types>
+        dvb2;
+    dvb2.populate_dispatch_vector(full_strided_dispatch_vector);
 }
 
 } // namespace py_internal


### PR DESCRIPTION
This PR implements a strided kernel for `full` to enable `order="K"` support in `empty_like`, `full_like`, `ones_like`, and `zeros_like`.

- [X] Have you provided a meaningful PR description?
- [x] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
