### PR TITLE
Contributions to strided full like pr

### DIFF
--- a/dpctl/tensor/_ctors.py
+++ b/dpctl/tensor/_ctors.py
@@ -1472,9 +1472,10 @@ def full_like(
             X = dpt.broadcast_to(X, sh)
             res = _empty_like_orderK(x, dtype, usm_type, sycl_queue)
             _manager = dpctl.utils.SequentialOrderManager[sycl_queue]
-            # populating new allocation, no dependent events
+            # order copy after tasks populating X
+            dep_evs = _manager.submitted_events
             hev, copy_ev = ti._copy_usm_ndarray_into_usm_ndarray(
-                src=X, dst=res, sycl_queue=sycl_queue
+                src=X, dst=res, sycl_queue=sycl_queue, depends=dep_evs
             )
             _manager.add_event_pair(hev, copy_ev)
             return res

--- a/dpctl/tensor/libtensor/source/full_ctor.cpp
+++ b/dpctl/tensor/libtensor/source/full_ctor.cpp
@@ -215,7 +215,7 @@ usm_ndarray_full(const py::object &py_value,
                  sycl::queue &exec_q,
                  const std::vector<sycl::event> &depends)
 {
-    // start, end should be coercible into data type of dst
+    // py_value should be coercible into data type of dst
 
     py::ssize_t dst_nelems = dst.get_size();
 


### PR DESCRIPTION

In `full_like(proto_array, fill_value=value_array, order='K')` the change orders kernel to copy from `value_array` into new allocation after tasks that may be populating `value_array`.

Also corrected comment in `py_internal::usm_ndarray_full` C++ function.

---

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
