### PR TITLE
Fix additional compute events added to lists of host tasks

### DIFF
--- a/dpctl/tensor/libtensor/source/boolean_advanced_indexing.cpp
+++ b/dpctl/tensor/libtensor/source/boolean_advanced_indexing.cpp
@@ -689,8 +689,6 @@ py_place(const dpctl::tensor::usm_ndarray &dst,
         host_task_events.push_back(cleanup_tmp_allocations_ev);
     }
 
-    host_task_events.push_back(place_ev);
-
     sycl::event py_obj_management_host_task_ev = dpctl::utils::keep_args_alive(
         exec_q, {dst, cumsum, rhs}, host_task_events);
 

--- a/dpctl/tensor/libtensor/source/linalg_functions/dot.cpp
+++ b/dpctl/tensor/libtensor/source/linalg_functions/dot.cpp
@@ -593,7 +593,6 @@ py_dot(const dpctl::tensor::usm_ndarray &x1,
                     });
                 });
             host_task_events.push_back(cleanup_tmp_allocations_ev);
-            host_task_events.push_back(dot_ev);
         }
         else { // if (call_batched)
             using shT = std::vector<py::ssize_t>;

--- a/dpctl/tensor/libtensor/source/repeat.cpp
+++ b/dpctl/tensor/libtensor/source/repeat.cpp
@@ -502,7 +502,6 @@ py_repeat_by_sequence(const dpctl::tensor::usm_ndarray &src,
             });
         });
     host_task_events.push_back(cleanup_tmp_allocations_ev);
-    host_task_events.push_back(repeat_ev);
 
     sycl::event py_obj_management_host_task_ev = dpctl::utils::keep_args_alive(
         exec_q, {src, reps, cumsum, dst}, host_task_events);
@@ -732,8 +731,6 @@ py_repeat_by_scalar(const dpctl::tensor::usm_ndarray &src,
         host_task_events.push_back(cleanup_tmp_allocations_ev);
     }
 
-    host_task_events.push_back(repeat_ev);
-
     sycl::event py_obj_management_host_task_ev =
         dpctl::utils::keep_args_alive(exec_q, {src, dst}, host_task_events);
 
@@ -844,7 +841,6 @@ py_repeat_by_scalar(const dpctl::tensor::usm_ndarray &src,
         });
 
     host_task_events.push_back(cleanup_tmp_allocations_ev);
-    host_task_events.push_back(repeat_ev);
 
     sycl::event py_obj_management_host_task_ev =
         dpctl::utils::keep_args_alive(exec_q, {src, dst}, host_task_events);


### PR DESCRIPTION
This PR fixes remaining cases of compute events added to lists of host tasks in `repeat.cpp`, `boolean_advanced_indexing.cpp`, and `dot.cpp`

- [X] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [X] Have you tested your changes locally for CPU and GPU devices?
- [X] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
