### PR TITLE
Use pybind11 `2.13.5` to build dpctl and examples

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,8 +69,8 @@ include(FetchContent)
 
 FetchContent_Declare(
     pybind11
-    URL https://github.com/pybind/pybind11/archive/refs/tags/v2.13.1.tar.gz
-    URL_HASH SHA256=51631e88960a8856f9c497027f55c9f2f9115cafb08c0005439838a05ba17bfc
+    URL https://github.com/pybind/pybind11/archive/refs/tags/v2.13.5.tar.gz
+    URL_HASH SHA256=b1e209c42b3a9ed74da3e0b25a4f4cd478d89d5efbb48f04b277df427faf6252
     FIND_PACKAGE_ARGS NAMES pybind11
 )
 FetchContent_MakeAvailable(pybind11)

--- a/examples/pybind11/external_usm_allocation/CMakeLists.txt
+++ b/examples/pybind11/external_usm_allocation/CMakeLists.txt
@@ -14,8 +14,8 @@ set(CMAKE_CXX_STANDARD_REQUIRED True)
 include(FetchContent)
 FetchContent_Declare(
   pybind11
-  URL https://github.com/pybind/pybind11/archive/refs/tags/v2.11.1.tar.gz
-  URL_HASH SHA256=d475978da0cdc2d43b73f30910786759d593a9d8ee05b1b6846d1eb16c6d2e0c
+  URL https://github.com/pybind/pybind11/archive/refs/tags/v2.13.5.tar.gz
+  URL_HASH SHA256=b1e209c42b3a9ed74da3e0b25a4f4cd478d89d5efbb48f04b277df427faf6252
 )
 FetchContent_MakeAvailable(pybind11)
 

--- a/examples/pybind11/onemkl_gemv/CMakeLists.txt
+++ b/examples/pybind11/onemkl_gemv/CMakeLists.txt
@@ -18,8 +18,8 @@ include(GNUInstallDirs)
 include(FetchContent)
 FetchContent_Declare(
   pybind11
-  URL https://github.com/pybind/pybind11/archive/refs/tags/v2.11.1.tar.gz
-  URL_HASH SHA256=d475978da0cdc2d43b73f30910786759d593a9d8ee05b1b6846d1eb16c6d2e0c
+  URL https://github.com/pybind/pybind11/archive/refs/tags/v2.13.5.tar.gz
+  URL_HASH SHA256=b1e209c42b3a9ed74da3e0b25a4f4cd478d89d5efbb48f04b277df427faf6252
 )
 FetchContent_MakeAvailable(pybind11)
 

--- a/examples/pybind11/use_dpctl_sycl_kernel/CMakeLists.txt
+++ b/examples/pybind11/use_dpctl_sycl_kernel/CMakeLists.txt
@@ -15,8 +15,8 @@ set(CMAKE_BUILD_TYPE Debug)
 include(FetchContent)
 FetchContent_Declare(
   pybind11
-  URL https://github.com/pybind/pybind11/archive/refs/tags/v2.10.2.tar.gz
-  URL_HASH SHA256=93bd1e625e43e03028a3ea7389bba5d3f9f2596abc074b068e70f4ef9b1314ae
+  URL https://github.com/pybind/pybind11/archive/refs/tags/v2.13.5.tar.gz
+  URL_HASH SHA256=b1e209c42b3a9ed74da3e0b25a4f4cd478d89d5efbb48f04b277df427faf6252
 )
 FetchContent_MakeAvailable(pybind11)
 

--- a/examples/pybind11/use_dpctl_sycl_queue/CMakeLists.txt
+++ b/examples/pybind11/use_dpctl_sycl_queue/CMakeLists.txt
@@ -14,8 +14,8 @@ set(CMAKE_CXX_STANDARD_REQUIRED True)
 include(FetchContent)
 FetchContent_Declare(
   pybind11
-  URL https://github.com/pybind/pybind11/archive/refs/tags/v2.11.1.tar.gz
-  URL_HASH SHA256=d475978da0cdc2d43b73f30910786759d593a9d8ee05b1b6846d1eb16c6d2e0c
+  URL https://github.com/pybind/pybind11/archive/refs/tags/v2.13.5.tar.gz
+  URL_HASH SHA256=b1e209c42b3a9ed74da3e0b25a4f4cd478d89d5efbb48f04b277df427faf6252
 )
 FetchContent_MakeAvailable(pybind11)
 


### PR DESCRIPTION
This PR updates dpctl to use the latest pybind11 release.

Experimentally updating examples to use the latest version as well.

- [X] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [X] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [X] If this PR is a work in progress, are you opening the PR as a draft?
