### PR TITLE
Overloads for array-scalar and scalar-array broadcast element-wise functions

### DIFF
--- a/dpctl/tensor/_type_utils.py
+++ b/dpctl/tensor/_type_utils.py
@@ -140,11 +140,9 @@ def _acceptance_fn_default_unary(arg_dtype, ret_buf_dt, res_dt, sycl_dev):
 
 
 def _acceptance_fn_reciprocal(arg_dtype, buf_dt, res_dt, sycl_dev):
-    # if the kind of result is different from
-    # the kind of input, use the default data
-    # we use default dtype for the resulting kind.
-    # This guarantees alignment of reciprocal and
-    # divide output types.
+    # if the kind of result is different from the kind of input, we use the
+    # default floating-point dtype for the resulting kind. This guarantees
+    # alignment of reciprocal and divide output types.
     if buf_dt.kind != arg_dtype.kind:
         default_dt = _get_device_default_dtype(res_dt.kind, sycl_dev)
         if res_dt == default_dt:

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/add.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/add.hpp
@@ -438,6 +438,53 @@ template <typename argT,
           unsigned int n_vecs>
 class add_inplace_contig_kernel;
 
+/* @brief Types supported by in-place add */
+template <typename argTy, typename resTy> struct AddInplaceTypePairSupport
+{
+    /* value if true a kernel for <argTy, resTy> must be instantiated  */
+    static constexpr bool is_defined = std::disjunction< // disjunction is
+                                                         // C++17 feature,
+                                                         // supported by
+                                                         // DPC++ input bool
+        td_ns::TypePairDefinedEntry<argTy, bool, resTy, bool>,
+        td_ns::TypePairDefinedEntry<argTy, std::int8_t, resTy, std::int8_t>,
+        td_ns::TypePairDefinedEntry<argTy, std::uint8_t, resTy, std::uint8_t>,
+        td_ns::TypePairDefinedEntry<argTy, std::int16_t, resTy, std::int16_t>,
+        td_ns::TypePairDefinedEntry<argTy, std::uint16_t, resTy, std::uint16_t>,
+        td_ns::TypePairDefinedEntry<argTy, std::int32_t, resTy, std::int32_t>,
+        td_ns::TypePairDefinedEntry<argTy, std::uint32_t, resTy, std::uint32_t>,
+        td_ns::TypePairDefinedEntry<argTy, std::int64_t, resTy, std::int64_t>,
+        td_ns::TypePairDefinedEntry<argTy, std::uint64_t, resTy, std::uint64_t>,
+        td_ns::TypePairDefinedEntry<argTy, sycl::half, resTy, sycl::half>,
+        td_ns::TypePairDefinedEntry<argTy, float, resTy, float>,
+        td_ns::TypePairDefinedEntry<argTy, double, resTy, double>,
+        td_ns::TypePairDefinedEntry<argTy,
+                                    std::complex<float>,
+                                    resTy,
+                                    std::complex<float>>,
+        td_ns::TypePairDefinedEntry<argTy,
+                                    std::complex<double>,
+                                    resTy,
+                                    std::complex<double>>,
+        // fall-through
+        td_ns::NotDefinedEntry>::is_defined;
+};
+
+template <typename fnT, typename argT, typename resT>
+struct AddInplaceTypeMapFactory
+{
+    /*! @brief get typeid for output type of x += y */
+    std::enable_if_t<std::is_same<fnT, int>::value, int> get()
+    {
+        if constexpr (AddInplaceTypePairSupport<argT, resT>::is_defined) {
+            return td_ns::GetTypeid<resT>{}.get();
+        }
+        else {
+            return td_ns::GetTypeid<void>{}.get();
+        }
+    }
+};
+
 template <typename argTy, typename resTy>
 sycl::event
 add_inplace_contig_impl(sycl::queue &exec_q,
@@ -457,9 +504,7 @@ template <typename fnT, typename T1, typename T2> struct AddInplaceContigFactory
 {
     fnT get()
     {
-        if constexpr (std::is_same_v<typename AddOutputType<T1, T2>::value_type,
-                                     void>)
-        {
+        if constexpr (!AddInplaceTypePairSupport<T1, T2>::is_defined) {
             fnT fn = nullptr;
             return fn;
         }
@@ -497,9 +542,7 @@ struct AddInplaceStridedFactory
 {
     fnT get()
     {
-        if constexpr (std::is_same_v<typename AddOutputType<T1, T2>::value_type,
-                                     void>)
-        {
+        if constexpr (!AddInplaceTypePairSupport<T1, T2>::is_defined) {
             fnT fn = nullptr;
             return fn;
         }
@@ -544,8 +587,7 @@ struct AddInplaceRowMatrixBroadcastFactory
 {
     fnT get()
     {
-        using resT = typename AddOutputType<T1, T2>::value_type;
-        if constexpr (!std::is_same_v<resT, T2>) {
+        if constexpr (!AddInplaceTypePairSupport<T1, T2>::is_defined) {
             fnT fn = nullptr;
             return fn;
         }

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/bitwise_and.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/bitwise_and.hpp
@@ -322,6 +322,44 @@ template <typename argT,
           unsigned int n_vecs>
 class bitwise_and_inplace_contig_kernel;
 
+/* @brief Types supported by in-place bitwise AND */
+template <typename argTy, typename resTy>
+struct BitwiseAndInplaceTypePairSupport
+{
+    /* value if true a kernel for <argTy, resTy> must be instantiated  */
+    static constexpr bool is_defined = std::disjunction< // disjunction is
+                                                         // C++17 feature,
+                                                         // supported by
+                                                         // DPC++ input bool
+        td_ns::TypePairDefinedEntry<argTy, bool, resTy, bool>,
+        td_ns::TypePairDefinedEntry<argTy, std::int8_t, resTy, std::int8_t>,
+        td_ns::TypePairDefinedEntry<argTy, std::uint8_t, resTy, std::uint8_t>,
+        td_ns::TypePairDefinedEntry<argTy, std::int16_t, resTy, std::int16_t>,
+        td_ns::TypePairDefinedEntry<argTy, std::uint16_t, resTy, std::uint16_t>,
+        td_ns::TypePairDefinedEntry<argTy, std::int32_t, resTy, std::int32_t>,
+        td_ns::TypePairDefinedEntry<argTy, std::uint32_t, resTy, std::uint32_t>,
+        td_ns::TypePairDefinedEntry<argTy, std::int64_t, resTy, std::int64_t>,
+        td_ns::TypePairDefinedEntry<argTy, std::uint64_t, resTy, std::uint64_t>,
+        // fall-through
+        td_ns::NotDefinedEntry>::is_defined;
+};
+
+template <typename fnT, typename argT, typename resT>
+struct BitwiseAndInplaceTypeMapFactory
+{
+    /*! @brief get typeid for output type of x &= y */
+    std::enable_if_t<std::is_same<fnT, int>::value, int> get()
+    {
+        if constexpr (BitwiseAndInplaceTypePairSupport<argT, resT>::is_defined)
+        {
+            return td_ns::GetTypeid<resT>{}.get();
+        }
+        else {
+            return td_ns::GetTypeid<void>{}.get();
+        }
+    }
+};
+
 template <typename argTy, typename resTy>
 sycl::event
 bitwise_and_inplace_contig_impl(sycl::queue &exec_q,
@@ -343,10 +381,7 @@ struct BitwiseAndInplaceContigFactory
 {
     fnT get()
     {
-        if constexpr (std::is_same_v<
-                          typename BitwiseAndOutputType<T1, T2>::value_type,
-                          void>)
-        {
+        if constexpr (!BitwiseAndInplaceTypePairSupport<T1, T2>::is_defined) {
             fnT fn = nullptr;
             return fn;
         }
@@ -385,10 +420,7 @@ struct BitwiseAndInplaceStridedFactory
 {
     fnT get()
     {
-        if constexpr (std::is_same_v<
-                          typename BitwiseAndOutputType<T1, T2>::value_type,
-                          void>)
-        {
+        if constexpr (!BitwiseAndInplaceTypePairSupport<T1, T2>::is_defined) {
             fnT fn = nullptr;
             return fn;
         }

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/bitwise_left_shift.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/bitwise_left_shift.hpp
@@ -336,6 +336,44 @@ template <typename argT,
           unsigned int n_vecs>
 class bitwise_left_shift_inplace_contig_kernel;
 
+/* @brief Types supported by in-place bitwise left shift */
+template <typename argTy, typename resTy>
+struct BitwiseLeftShiftInplaceTypePairSupport
+{
+    /* value if true a kernel for <argTy, resTy> must be instantiated  */
+    static constexpr bool is_defined = std::disjunction< // disjunction is
+                                                         // C++17 feature,
+                                                         // supported by
+                                                         // DPC++ input bool
+        td_ns::TypePairDefinedEntry<argTy, std::int8_t, resTy, std::int8_t>,
+        td_ns::TypePairDefinedEntry<argTy, std::uint8_t, resTy, std::uint8_t>,
+        td_ns::TypePairDefinedEntry<argTy, std::int16_t, resTy, std::int16_t>,
+        td_ns::TypePairDefinedEntry<argTy, std::uint16_t, resTy, std::uint16_t>,
+        td_ns::TypePairDefinedEntry<argTy, std::int32_t, resTy, std::int32_t>,
+        td_ns::TypePairDefinedEntry<argTy, std::uint32_t, resTy, std::uint32_t>,
+        td_ns::TypePairDefinedEntry<argTy, std::int64_t, resTy, std::int64_t>,
+        td_ns::TypePairDefinedEntry<argTy, std::uint64_t, resTy, std::uint64_t>,
+        // fall-through
+        td_ns::NotDefinedEntry>::is_defined;
+};
+
+template <typename fnT, typename argT, typename resT>
+struct BitwiseLeftShiftInplaceTypeMapFactory
+{
+    /*! @brief get typeid for output type of x <<= y */
+    std::enable_if_t<std::is_same<fnT, int>::value, int> get()
+    {
+        if constexpr (BitwiseLeftShiftInplaceTypePairSupport<argT,
+                                                             resT>::is_defined)
+        {
+            return td_ns::GetTypeid<resT>{}.get();
+        }
+        else {
+            return td_ns::GetTypeid<void>{}.get();
+        }
+    }
+};
+
 template <typename argTy, typename resTy>
 sycl::event bitwise_left_shift_inplace_contig_impl(
     sycl::queue &exec_q,
@@ -357,9 +395,8 @@ struct BitwiseLeftShiftInplaceContigFactory
 {
     fnT get()
     {
-        if constexpr (std::is_same_v<typename BitwiseLeftShiftOutputType<
-                                         T1, T2>::value_type,
-                                     void>)
+        if constexpr (!BitwiseLeftShiftInplaceTypePairSupport<T1,
+                                                              T2>::is_defined)
         {
             fnT fn = nullptr;
             return fn;
@@ -399,9 +436,8 @@ struct BitwiseLeftShiftInplaceStridedFactory
 {
     fnT get()
     {
-        if constexpr (std::is_same_v<typename BitwiseLeftShiftOutputType<
-                                         T1, T2>::value_type,
-                                     void>)
+        if constexpr (!BitwiseLeftShiftInplaceTypePairSupport<T1,
+                                                              T2>::is_defined)
         {
             fnT fn = nullptr;
             return fn;

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/bitwise_xor.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/bitwise_xor.hpp
@@ -322,6 +322,44 @@ template <typename argT,
           unsigned int n_vecs>
 class bitwise_xor_inplace_contig_kernel;
 
+/* @brief Types supported by in-place bitwise XOR */
+template <typename argTy, typename resTy>
+struct BitwiseXorInplaceTypePairSupport
+{
+    /* value if true a kernel for <argTy, resTy> must be instantiated  */
+    static constexpr bool is_defined = std::disjunction< // disjunction is
+                                                         // C++17 feature,
+                                                         // supported by
+                                                         // DPC++ input bool
+        td_ns::TypePairDefinedEntry<argTy, bool, resTy, bool>,
+        td_ns::TypePairDefinedEntry<argTy, std::int8_t, resTy, std::int8_t>,
+        td_ns::TypePairDefinedEntry<argTy, std::uint8_t, resTy, std::uint8_t>,
+        td_ns::TypePairDefinedEntry<argTy, std::int16_t, resTy, std::int16_t>,
+        td_ns::TypePairDefinedEntry<argTy, std::uint16_t, resTy, std::uint16_t>,
+        td_ns::TypePairDefinedEntry<argTy, std::int32_t, resTy, std::int32_t>,
+        td_ns::TypePairDefinedEntry<argTy, std::uint32_t, resTy, std::uint32_t>,
+        td_ns::TypePairDefinedEntry<argTy, std::int64_t, resTy, std::int64_t>,
+        td_ns::TypePairDefinedEntry<argTy, std::uint64_t, resTy, std::uint64_t>,
+        // fall-through
+        td_ns::NotDefinedEntry>::is_defined;
+};
+
+template <typename fnT, typename argT, typename resT>
+struct BitwiseXorInplaceTypeMapFactory
+{
+    /*! @brief get typeid for output type of x ^= y */
+    std::enable_if_t<std::is_same<fnT, int>::value, int> get()
+    {
+        if constexpr (BitwiseXorInplaceTypePairSupport<argT, resT>::is_defined)
+        {
+            return td_ns::GetTypeid<resT>{}.get();
+        }
+        else {
+            return td_ns::GetTypeid<void>{}.get();
+        }
+    }
+};
+
 template <typename argTy, typename resTy>
 sycl::event
 bitwise_xor_inplace_contig_impl(sycl::queue &exec_q,
@@ -343,10 +381,7 @@ struct BitwiseXorInplaceContigFactory
 {
     fnT get()
     {
-        if constexpr (std::is_same_v<
-                          typename BitwiseXorOutputType<T1, T2>::value_type,
-                          void>)
-        {
+        if constexpr (!BitwiseXorInplaceTypePairSupport<T1, T2>::is_defined) {
             fnT fn = nullptr;
             return fn;
         }
@@ -385,10 +420,7 @@ struct BitwiseXorInplaceStridedFactory
 {
     fnT get()
     {
-        if constexpr (std::is_same_v<
-                          typename BitwiseXorOutputType<T1, T2>::value_type,
-                          void>)
-        {
+        if constexpr (!BitwiseXorInplaceTypePairSupport<T1, T2>::is_defined) {
             fnT fn = nullptr;
             return fn;
         }

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/common_inplace.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/common_inplace.hpp
@@ -262,6 +262,120 @@ public:
     }
 };
 
+template <typename argT,
+          typename resT,
+          typename BinaryInplaceOperatorT,
+          unsigned int vec_sz = 4,
+          unsigned int n_vecs = 2,
+          bool enable_sg_loadstore = true>
+struct BinaryInplaceScalarContigFunctor
+{
+private:
+    const argT *rhs = nullptr;
+    resT *lhs = nullptr;
+    const size_t nelems_;
+
+public:
+    BinaryInplaceScalarContigFunctor(const argT *rhs_tp,
+                                     resT *lhs_tp,
+                                     const size_t n_elems)
+        : rhs(rhs_tp), lhs(lhs_tp), nelems_(n_elems)
+    {
+    }
+
+    void operator()(sycl::nd_item<1> ndit) const
+    {
+        BinaryInplaceOperatorT op{};
+        /* Each work-item processes vec_sz elements, contiguous in memory */
+        argT rhs_scl = rhs[0];
+        if constexpr (enable_sg_loadstore &&
+                      BinaryInplaceOperatorT::supports_sg_loadstore::value &&
+                      BinaryInplaceOperatorT::supports_vec::value)
+        {
+            auto sg = ndit.get_sub_group();
+            std::uint8_t sgSize = sg.get_local_range()[0];
+            std::uint8_t maxsgSize = sg.get_max_local_range()[0];
+
+            size_t base = n_vecs * vec_sz *
+                          (ndit.get_group(0) * ndit.get_local_range(0) +
+                           sg.get_group_id()[0] * sgSize);
+
+            if ((base + n_vecs * vec_sz * sgSize < nelems_) &&
+                (sgSize == maxsgSize))
+            {
+                sycl::vec<resT, vec_sz> res_vec;
+#pragma unroll
+                for (std::uint8_t it = 0; it < n_vecs * vec_sz; it += vec_sz) {
+                    auto lhs_multi_ptr = sycl::address_space_cast<
+                        sycl::access::address_space::global_space,
+                        sycl::access::decorated::yes>(&lhs[base + it * sgSize]);
+
+                    res_vec = sg.load<vec_sz>(lhs_multi_ptr);
+                    op(res_vec, rhs_scl);
+
+                    sg.store<vec_sz>(lhs_multi_ptr, res_vec);
+                }
+            }
+            else {
+                for (size_t k = base + sg.get_local_id()[0]; k < nelems_;
+                     k += sgSize)
+                {
+                    op(lhs[k], rhs_scl);
+                }
+            }
+        }
+        else if constexpr (enable_sg_loadstore &&
+                           BinaryInplaceOperatorT::supports_sg_loadstore::value)
+        {
+            auto sg = ndit.get_sub_group();
+            std::uint8_t sgSize = sg.get_local_range()[0];
+            std::uint8_t maxsgSize = sg.get_max_local_range()[0];
+
+            size_t base = n_vecs * vec_sz *
+                          (ndit.get_group(0) * ndit.get_local_range(0) +
+                           sg.get_group_id()[0] * sgSize);
+
+            if ((base + n_vecs * vec_sz * sgSize < nelems_) &&
+                (sgSize == maxsgSize))
+            {
+                sycl::vec<resT, vec_sz> res_vec;
+#pragma unroll
+                for (std::uint8_t it = 0; it < n_vecs * vec_sz; it += vec_sz) {
+                    auto lhs_multi_ptr = sycl::address_space_cast<
+                        sycl::access::address_space::global_space,
+                        sycl::access::decorated::yes>(&lhs[base + it * sgSize]);
+
+                    res_vec = sg.load<vec_sz>(lhs_multi_ptr);
+#pragma unroll
+                    for (std::uint8_t vec_id = 0; vec_id < vec_sz; ++vec_id) {
+                        op(res_vec[vec_id], rhs_scl);
+                    }
+                    sg.store<vec_sz>(lhs_multi_ptr, res_vec);
+                }
+            }
+            else {
+                for (size_t k = base + sg.get_local_id()[0]; k < nelems_;
+                     k += sgSize)
+                {
+                    op(lhs[k], rhs_scl);
+                }
+            }
+        }
+        else {
+            std::uint8_t sgSize = ndit.get_sub_group().get_local_range()[0];
+            size_t base = ndit.get_global_linear_id();
+
+            base = (base / sgSize) * sgSize * n_vecs * vec_sz + (base % sgSize);
+            for (size_t offset = base;
+                 offset < std::min(nelems_, base + sgSize * (n_vecs * vec_sz));
+                 offset += sgSize)
+            {
+                op(lhs[offset], rhs_scl);
+            }
+        }
+    }
+};
+
 // Typedefs for function pointers
 
 typedef sycl::event (*binary_inplace_contig_impl_fn_ptr_t)(
@@ -289,6 +403,15 @@ typedef sycl::event (*binary_inplace_row_matrix_broadcast_impl_fn_ptr_t)(
     sycl::queue &,
     std::vector<sycl::event> &,
     size_t,
+    size_t,
+    const char *,
+    ssize_t,
+    char *,
+    ssize_t,
+    const std::vector<sycl::event> &);
+
+typedef sycl::event (*binary_inplace_scalar_contig_impl_fn_ptr_t)(
+    sycl::queue &,
     size_t,
     const char *,
     ssize_t,
@@ -466,6 +589,67 @@ sycl::event binary_inplace_row_matrix_broadcast_impl(
     });
     host_tasks.push_back(tmp_cleanup_ev);
 
+    return comp_ev;
+}
+
+template <typename argTy,
+          typename resTy,
+          template <typename T1,
+                    typename T2,
+                    unsigned int vs,
+                    unsigned int nv,
+                    bool enable_sg_loadstore>
+          class BinaryInplaceScalarContigFunctorT,
+          template <typename T1, typename T2, unsigned int vs, unsigned int nv>
+          class kernel_name,
+          unsigned int vec_sz = 4,
+          unsigned int n_vecs = 2>
+sycl::event
+binary_inplace_scalar_contig_impl(sycl::queue &exec_q,
+                                  size_t nelems,
+                                  const char *rhs_p,
+                                  ssize_t rhs_offset,
+                                  char *lhs_p,
+                                  ssize_t lhs_offset,
+                                  const std::vector<sycl::event> &depends = {})
+{
+    sycl::event comp_ev = exec_q.submit([&](sycl::handler &cgh) {
+        cgh.depends_on(depends);
+
+        const size_t lws = 128;
+        const size_t n_groups =
+            ((nelems + lws * n_vecs * vec_sz - 1) / (lws * n_vecs * vec_sz));
+        const auto gws_range = sycl::range<1>(n_groups * lws);
+        const auto lws_range = sycl::range<1>(lws);
+
+        const argTy *arg_tp =
+            reinterpret_cast<const argTy *>(rhs_p) + rhs_offset;
+        resTy *res_tp = reinterpret_cast<resTy *>(lhs_p) + lhs_offset;
+
+        // scalar rhs, so rhs is not required to be aligned
+        // as no vec of rhs is ever loaded
+        if (is_aligned<required_alignment>(res_tp)) {
+            constexpr bool enable_sg_loadstore = true;
+            using KernelName = kernel_name<argTy, resTy, vec_sz, n_vecs>;
+            cgh.parallel_for<KernelName>(
+                sycl::nd_range<1>(gws_range, lws_range),
+                BinaryInplaceScalarContigFunctorT<argTy, resTy, vec_sz, n_vecs,
+                                                  enable_sg_loadstore>(
+                    arg_tp, res_tp, nelems));
+        }
+        else {
+            constexpr bool disable_sg_loadstore = true;
+            using InnerKernelName = kernel_name<argTy, resTy, vec_sz, n_vecs>;
+            using KernelName =
+                disabled_sg_loadstore_wrapper_krn<InnerKernelName>;
+
+            cgh.parallel_for<KernelName>(
+                sycl::nd_range<1>(gws_range, lws_range),
+                BinaryInplaceScalarContigFunctorT<argTy, resTy, vec_sz, n_vecs,
+                                                  disable_sg_loadstore>(
+                    arg_tp, res_tp, nelems));
+        }
+    });
     return comp_ev;
 }
 

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/floor_divide.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/floor_divide.hpp
@@ -398,6 +398,46 @@ template <typename argT,
           unsigned int n_vecs>
 class floor_divide_inplace_contig_kernel;
 
+/* @brief Types supported by in-place floor division */
+template <typename argTy, typename resTy>
+struct FloorDivideInplaceTypePairSupport
+{
+    /* value if true a kernel for <argTy, resTy> must be instantiated  */
+    static constexpr bool is_defined = std::disjunction< // disjunction is
+                                                         // C++17 feature,
+                                                         // supported by
+                                                         // DPC++ input bool
+        td_ns::TypePairDefinedEntry<argTy, std::int8_t, resTy, std::int8_t>,
+        td_ns::TypePairDefinedEntry<argTy, std::uint8_t, resTy, std::uint8_t>,
+        td_ns::TypePairDefinedEntry<argTy, std::int16_t, resTy, std::int16_t>,
+        td_ns::TypePairDefinedEntry<argTy, std::uint16_t, resTy, std::uint16_t>,
+        td_ns::TypePairDefinedEntry<argTy, std::int32_t, resTy, std::int32_t>,
+        td_ns::TypePairDefinedEntry<argTy, std::uint32_t, resTy, std::uint32_t>,
+        td_ns::TypePairDefinedEntry<argTy, std::int64_t, resTy, std::int64_t>,
+        td_ns::TypePairDefinedEntry<argTy, std::uint64_t, resTy, std::uint64_t>,
+        td_ns::TypePairDefinedEntry<argTy, sycl::half, resTy, sycl::half>,
+        td_ns::TypePairDefinedEntry<argTy, float, resTy, float>,
+        td_ns::TypePairDefinedEntry<argTy, double, resTy, double>,
+        // fall-through
+        td_ns::NotDefinedEntry>::is_defined;
+};
+
+template <typename fnT, typename argT, typename resT>
+struct FloorDivideInplaceTypeMapFactory
+{
+    /*! @brief get typeid for output type of x //= y */
+    std::enable_if_t<std::is_same<fnT, int>::value, int> get()
+    {
+        if constexpr (FloorDivideInplaceTypePairSupport<argT, resT>::is_defined)
+        {
+            return td_ns::GetTypeid<resT>{}.get();
+        }
+        else {
+            return td_ns::GetTypeid<void>{}.get();
+        }
+    }
+};
+
 template <typename argTy, typename resTy>
 sycl::event
 floor_divide_inplace_contig_impl(sycl::queue &exec_q,
@@ -419,10 +459,7 @@ struct FloorDivideInplaceContigFactory
 {
     fnT get()
     {
-        if constexpr (std::is_same_v<
-                          typename FloorDivideOutputType<T1, T2>::value_type,
-                          void>)
-        {
+        if constexpr (!FloorDivideInplaceTypePairSupport<T1, T2>::is_defined) {
             fnT fn = nullptr;
             return fn;
         }
@@ -461,10 +498,7 @@ struct FloorDivideInplaceStridedFactory
 {
     fnT get()
     {
-        if constexpr (std::is_same_v<
-                          typename FloorDivideOutputType<T1, T2>::value_type,
-                          void>)
-        {
+        if constexpr (!FloorDivideInplaceTypePairSupport<T1, T2>::is_defined) {
             fnT fn = nullptr;
             return fn;
         }

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/pow.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/pow.hpp
@@ -446,6 +446,52 @@ template <typename argT,
           unsigned int n_vecs>
 class pow_inplace_contig_kernel;
 
+/* @brief Types supported by in-place pow */
+template <typename argTy, typename resTy> struct PowInplaceTypePairSupport
+{
+    /* value if true a kernel for <argTy, resTy> must be instantiated  */
+    static constexpr bool is_defined = std::disjunction< // disjunction is
+                                                         // C++17 feature,
+                                                         // supported by
+                                                         // DPC++ input bool
+        td_ns::TypePairDefinedEntry<argTy, std::int8_t, resTy, std::int8_t>,
+        td_ns::TypePairDefinedEntry<argTy, std::uint8_t, resTy, std::uint8_t>,
+        td_ns::TypePairDefinedEntry<argTy, std::int16_t, resTy, std::int16_t>,
+        td_ns::TypePairDefinedEntry<argTy, std::uint16_t, resTy, std::uint16_t>,
+        td_ns::TypePairDefinedEntry<argTy, std::int32_t, resTy, std::int32_t>,
+        td_ns::TypePairDefinedEntry<argTy, std::uint32_t, resTy, std::uint32_t>,
+        td_ns::TypePairDefinedEntry<argTy, std::int64_t, resTy, std::int64_t>,
+        td_ns::TypePairDefinedEntry<argTy, std::uint64_t, resTy, std::uint64_t>,
+        td_ns::TypePairDefinedEntry<argTy, sycl::half, resTy, sycl::half>,
+        td_ns::TypePairDefinedEntry<argTy, float, resTy, float>,
+        td_ns::TypePairDefinedEntry<argTy, double, resTy, double>,
+        td_ns::TypePairDefinedEntry<argTy,
+                                    std::complex<float>,
+                                    resTy,
+                                    std::complex<float>>,
+        td_ns::TypePairDefinedEntry<argTy,
+                                    std::complex<double>,
+                                    resTy,
+                                    std::complex<double>>,
+        // fall-through
+        td_ns::NotDefinedEntry>::is_defined;
+};
+
+template <typename fnT, typename argT, typename resT>
+struct PowInplaceTypeMapFactory
+{
+    /*! @brief get typeid for output type of x **= y */
+    std::enable_if_t<std::is_same<fnT, int>::value, int> get()
+    {
+        if constexpr (PowInplaceTypePairSupport<argT, resT>::is_defined) {
+            return td_ns::GetTypeid<resT>{}.get();
+        }
+        else {
+            return td_ns::GetTypeid<void>{}.get();
+        }
+    }
+};
+
 template <typename argTy, typename resTy>
 sycl::event
 pow_inplace_contig_impl(sycl::queue &exec_q,
@@ -465,9 +511,7 @@ template <typename fnT, typename T1, typename T2> struct PowInplaceContigFactory
 {
     fnT get()
     {
-        if constexpr (std::is_same_v<typename PowOutputType<T1, T2>::value_type,
-                                     void>)
-        {
+        if constexpr (!PowInplaceTypePairSupport<T1, T2>::is_defined) {
             fnT fn = nullptr;
             return fn;
         }
@@ -505,9 +549,7 @@ struct PowInplaceStridedFactory
 {
     fnT get()
     {
-        if constexpr (std::is_same_v<typename PowOutputType<T1, T2>::value_type,
-                                     void>)
-        {
+        if constexpr (!PowInplaceTypePairSupport<T1, T2>::is_defined) {
             fnT fn = nullptr;
             return fn;
         }

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/remainder.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/remainder.hpp
@@ -424,6 +424,44 @@ template <typename argT,
           unsigned int n_vecs>
 class remainder_inplace_contig_kernel;
 
+/* @brief Types supported by in-place remainder */
+template <typename argTy, typename resTy> struct RemainderInplaceTypePairSupport
+{
+    /* value if true a kernel for <argTy, resTy> must be instantiated  */
+    static constexpr bool is_defined = std::disjunction< // disjunction is
+                                                         // C++17 feature,
+                                                         // supported by
+                                                         // DPC++ input
+        td_ns::TypePairDefinedEntry<argTy, std::int8_t, resTy, std::int8_t>,
+        td_ns::TypePairDefinedEntry<argTy, std::uint8_t, resTy, std::uint8_t>,
+        td_ns::TypePairDefinedEntry<argTy, std::int16_t, resTy, std::int16_t>,
+        td_ns::TypePairDefinedEntry<argTy, std::uint16_t, resTy, std::uint16_t>,
+        td_ns::TypePairDefinedEntry<argTy, std::int32_t, resTy, std::int32_t>,
+        td_ns::TypePairDefinedEntry<argTy, std::uint32_t, resTy, std::uint32_t>,
+        td_ns::TypePairDefinedEntry<argTy, std::int64_t, resTy, std::int64_t>,
+        td_ns::TypePairDefinedEntry<argTy, std::uint64_t, resTy, std::uint64_t>,
+        td_ns::TypePairDefinedEntry<argTy, sycl::half, resTy, sycl::half>,
+        td_ns::TypePairDefinedEntry<argTy, float, resTy, float>,
+        td_ns::TypePairDefinedEntry<argTy, double, resTy, double>,
+        // fall-through
+        td_ns::NotDefinedEntry>::is_defined;
+};
+
+template <typename fnT, typename argT, typename resT>
+struct RemainderInplaceTypeMapFactory
+{
+    /*! @brief get typeid for output type of x %= y */
+    std::enable_if_t<std::is_same<fnT, int>::value, int> get()
+    {
+        if constexpr (RemainderInplaceTypePairSupport<argT, resT>::is_defined) {
+            return td_ns::GetTypeid<resT>{}.get();
+        }
+        else {
+            return td_ns::GetTypeid<void>{}.get();
+        }
+    }
+};
+
 template <typename argTy, typename resTy>
 sycl::event
 remainder_inplace_contig_impl(sycl::queue &exec_q,
@@ -445,10 +483,7 @@ struct RemainderInplaceContigFactory
 {
     fnT get()
     {
-        if constexpr (std::is_same_v<
-                          typename RemainderOutputType<T1, T2>::value_type,
-                          void>)
-        {
+        if constexpr (!RemainderInplaceTypePairSupport<T1, T2>::is_defined) {
             fnT fn = nullptr;
             return fn;
         }
@@ -487,10 +522,7 @@ struct RemainderInplaceStridedFactory
 {
     fnT get()
     {
-        if constexpr (std::is_same_v<
-                          typename RemainderOutputType<T1, T2>::value_type,
-                          void>)
-        {
+        if constexpr (!RemainderInplaceTypePairSupport<T1, T2>::is_defined) {
             fnT fn = nullptr;
             return fn;
         }

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/subtract.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/subtract.hpp
@@ -435,6 +435,52 @@ template <typename argT,
           unsigned int n_vecs>
 class subtract_inplace_contig_kernel;
 
+/* @brief Types supported by in-place subtraction */
+template <typename argTy, typename resTy> struct SubtractInplaceTypePairSupport
+{
+    /* value if true a kernel for <argTy, resTy> must be instantiated  */
+    static constexpr bool is_defined = std::disjunction< // disjunction is
+                                                         // C++17 feature,
+                                                         // supported by
+                                                         // DPC++ input
+        td_ns::TypePairDefinedEntry<argTy, std::int8_t, resTy, std::int8_t>,
+        td_ns::TypePairDefinedEntry<argTy, std::uint8_t, resTy, std::uint8_t>,
+        td_ns::TypePairDefinedEntry<argTy, std::int16_t, resTy, std::int16_t>,
+        td_ns::TypePairDefinedEntry<argTy, std::uint16_t, resTy, std::uint16_t>,
+        td_ns::TypePairDefinedEntry<argTy, std::int32_t, resTy, std::int32_t>,
+        td_ns::TypePairDefinedEntry<argTy, std::uint32_t, resTy, std::uint32_t>,
+        td_ns::TypePairDefinedEntry<argTy, std::int64_t, resTy, std::int64_t>,
+        td_ns::TypePairDefinedEntry<argTy, std::uint64_t, resTy, std::uint64_t>,
+        td_ns::TypePairDefinedEntry<argTy, sycl::half, resTy, sycl::half>,
+        td_ns::TypePairDefinedEntry<argTy, float, resTy, float>,
+        td_ns::TypePairDefinedEntry<argTy, double, resTy, double>,
+        td_ns::TypePairDefinedEntry<argTy,
+                                    std::complex<float>,
+                                    resTy,
+                                    std::complex<float>>,
+        td_ns::TypePairDefinedEntry<argTy,
+                                    std::complex<double>,
+                                    resTy,
+                                    std::complex<double>>,
+        // fall-through
+        td_ns::NotDefinedEntry>::is_defined;
+};
+
+template <typename fnT, typename argT, typename resT>
+struct SubtractInplaceTypeMapFactory
+{
+    /*! @brief get typeid for output type of x -= y */
+    std::enable_if_t<std::is_same<fnT, int>::value, int> get()
+    {
+        if constexpr (SubtractInplaceTypePairSupport<argT, resT>::is_defined) {
+            return td_ns::GetTypeid<resT>{}.get();
+        }
+        else {
+            return td_ns::GetTypeid<void>{}.get();
+        }
+    }
+};
+
 template <typename argTy, typename resTy>
 sycl::event
 subtract_inplace_contig_impl(sycl::queue &exec_q,
@@ -456,10 +502,7 @@ struct SubtractInplaceContigFactory
 {
     fnT get()
     {
-        if constexpr (std::is_same_v<
-                          typename SubtractOutputType<T1, T2>::value_type,
-                          void>)
-        {
+        if constexpr (!SubtractInplaceTypePairSupport<T1, T2>::is_defined) {
             fnT fn = nullptr;
             return fn;
         }
@@ -498,10 +541,7 @@ struct SubtractInplaceStridedFactory
 {
     fnT get()
     {
-        if constexpr (std::is_same_v<
-                          typename SubtractOutputType<T1, T2>::value_type,
-                          void>)
-        {
+        if constexpr (!SubtractInplaceTypePairSupport<T1, T2>::is_defined) {
             fnT fn = nullptr;
             return fn;
         }
@@ -546,8 +586,7 @@ struct SubtractInplaceRowMatrixBroadcastFactory
 {
     fnT get()
     {
-        using resT = typename SubtractOutputType<T1, T2>::value_type;
-        if constexpr (!std::is_same_v<resT, T2>) {
+        if constexpr (!SubtractInplaceTypePairSupport<T1, T2>::is_defined) {
             fnT fn = nullptr;
             return fn;
         }

--- a/dpctl/tensor/libtensor/source/elementwise_functions/atan2.cpp
+++ b/dpctl/tensor/libtensor/source/elementwise_functions/atan2.cpp
@@ -49,9 +49,11 @@ namespace py_internal
 namespace td_ns = dpctl::tensor::type_dispatch;
 
 namespace ew_cmn_ns = dpctl::tensor::kernels::elementwise_common;
+using ew_cmn_ns::binary_contig_array_scalar_broadcast_impl_fn_ptr_t;
 using ew_cmn_ns::binary_contig_impl_fn_ptr_t;
 using ew_cmn_ns::binary_contig_matrix_contig_row_broadcast_impl_fn_ptr_t;
 using ew_cmn_ns::binary_contig_row_contig_matrix_broadcast_impl_fn_ptr_t;
+using ew_cmn_ns::binary_scalar_contig_array_broadcast_impl_fn_ptr_t;
 using ew_cmn_ns::binary_strided_impl_fn_ptr_t;
 
 // B02: ===== ATAN2 (x1, x2)
@@ -121,7 +123,15 @@ void init_atan2(py::module_ m)
                 // function pointers to handle operation of c-contig matrix and
                 // c-contig row with broadcasting (may be nullptr)
                 td_ns::NullPtrTable<
-                    binary_contig_row_contig_matrix_broadcast_impl_fn_ptr_t>{});
+                    binary_contig_row_contig_matrix_broadcast_impl_fn_ptr_t>{},
+                // function pointers to handle operation of contiguous array
+                // and scalar with broadcasting (may be nullptr)
+                td_ns::NullPtrTable<
+                    binary_contig_array_scalar_broadcast_impl_fn_ptr_t>{},
+                // function pointers to handle operation of scalar and
+                // contiguous array with broadcasting (may be nullptr)
+                td_ns::NullPtrTable<
+                    binary_scalar_contig_array_broadcast_impl_fn_ptr_t>{});
         };
         auto atan2_result_type_pyapi = [&](const py::dtype &dtype1,
                                            const py::dtype &dtype2) {

--- a/dpctl/tensor/libtensor/source/elementwise_functions/bitwise_and.cpp
+++ b/dpctl/tensor/libtensor/source/elementwise_functions/bitwise_and.cpp
@@ -50,13 +50,16 @@ namespace py_internal
 namespace td_ns = dpctl::tensor::type_dispatch;
 
 namespace ew_cmn_ns = dpctl::tensor::kernels::elementwise_common;
+using ew_cmn_ns::binary_contig_array_scalar_broadcast_impl_fn_ptr_t;
 using ew_cmn_ns::binary_contig_impl_fn_ptr_t;
 using ew_cmn_ns::binary_contig_matrix_contig_row_broadcast_impl_fn_ptr_t;
 using ew_cmn_ns::binary_contig_row_contig_matrix_broadcast_impl_fn_ptr_t;
+using ew_cmn_ns::binary_scalar_contig_array_broadcast_impl_fn_ptr_t;
 using ew_cmn_ns::binary_strided_impl_fn_ptr_t;
 
 using ew_cmn_ns::binary_inplace_contig_impl_fn_ptr_t;
 using ew_cmn_ns::binary_inplace_row_matrix_broadcast_impl_fn_ptr_t;
+using ew_cmn_ns::binary_inplace_scalar_contig_impl_fn_ptr_t;
 using ew_cmn_ns::binary_inplace_strided_impl_fn_ptr_t;
 
 // B03: ===== BITWISE_AND (x1, x2)
@@ -155,7 +158,15 @@ void init_bitwise_and(py::module_ m)
                 // function pointers to handle operation of c-contig matrix and
                 // c-contig row with broadcasting (may be nullptr)
                 td_ns::NullPtrTable<
-                    binary_contig_row_contig_matrix_broadcast_impl_fn_ptr_t>{});
+                    binary_contig_row_contig_matrix_broadcast_impl_fn_ptr_t>{},
+                // function pointers to handle operation of contiguous array
+                // and scalar with broadcasting (may be nullptr)
+                td_ns::NullPtrTable<
+                    binary_contig_array_scalar_broadcast_impl_fn_ptr_t>{},
+                // function pointers to handle operation of scalar and
+                // contiguous array with broadcasting (may be nullptr)
+                td_ns::NullPtrTable<
+                    binary_scalar_contig_array_broadcast_impl_fn_ptr_t>{});
         };
         auto bitwise_and_result_type_pyapi = [&](const py::dtype &dtype1,
                                                  const py::dtype &dtype2) {
@@ -187,7 +198,12 @@ void init_bitwise_and(py::module_ m)
                 // c-contig matrix with c-contig row with broadcasting
                 // (may be nullptr)
                 td_ns::NullPtrTable<
-                    binary_inplace_row_matrix_broadcast_impl_fn_ptr_t>{});
+                    binary_inplace_row_matrix_broadcast_impl_fn_ptr_t>{},
+                // function pointers to handle in-place operation on
+                // contiguous array with scalar with broadcasting
+                // (may be nullptr)
+                td_ns::NullPtrTable<
+                    binary_inplace_scalar_contig_impl_fn_ptr_t>{});
         };
         m.def("_bitwise_and_inplace", bitwise_and_inplace_pyapi, "",
               py::arg("lhs"), py::arg("rhs"), py::arg("sycl_queue"),

--- a/dpctl/tensor/libtensor/source/elementwise_functions/bitwise_and.cpp
+++ b/dpctl/tensor/libtensor/source/elementwise_functions/bitwise_and.cpp
@@ -66,7 +66,10 @@ namespace bitwise_and_fn_ns = dpctl::tensor::kernels::bitwise_and;
 
 static binary_contig_impl_fn_ptr_t
     bitwise_and_contig_dispatch_table[td_ns::num_types][td_ns::num_types];
+
 static int bitwise_and_output_id_table[td_ns::num_types][td_ns::num_types];
+static int bitwise_and_inplace_output_id_table[td_ns::num_types]
+                                              [td_ns::num_types];
 
 static binary_strided_impl_fn_ptr_t
     bitwise_and_strided_dispatch_table[td_ns::num_types][td_ns::num_types];
@@ -115,6 +118,11 @@ void populate_bitwise_and_dispatch_tables(void)
                          BitwiseAndInplaceContigFactory, num_types>
         dtb5;
     dtb5.populate_dispatch_table(bitwise_and_inplace_contig_dispatch_table);
+
+    // which types are supported by the in-place kernels
+    using fn_ns::BitwiseAndInplaceTypeMapFactory;
+    DispatchTableBuilder<int, BitwiseAndInplaceTypeMapFactory, num_types> dtb6;
+    dtb6.populate_dispatch_table(bitwise_and_inplace_output_id_table);
 };
 
 } // namespace impl
@@ -160,25 +168,27 @@ void init_bitwise_and(py::module_ m)
         m.def("_bitwise_and_result_type", bitwise_and_result_type_pyapi, "");
 
         using impl::bitwise_and_inplace_contig_dispatch_table;
+        using impl::bitwise_and_inplace_output_id_table;
         using impl::bitwise_and_inplace_strided_dispatch_table;
 
-        auto bitwise_and_inplace_pyapi =
-            [&](const arrayT &src, const arrayT &dst, sycl::queue &exec_q,
-                const event_vecT &depends = {}) {
-                return py_binary_inplace_ufunc(
-                    src, dst, exec_q, depends, bitwise_and_output_id_table,
-                    // function pointers to handle inplace operation on
-                    // contiguous arrays (pointers may be nullptr)
-                    bitwise_and_inplace_contig_dispatch_table,
-                    // function pointers to handle inplace operation on strided
-                    // arrays (most general case)
-                    bitwise_and_inplace_strided_dispatch_table,
-                    // function pointers to handle inplace operation on
-                    // c-contig matrix with c-contig row with broadcasting
-                    // (may be nullptr)
-                    td_ns::NullPtrTable<
-                        binary_inplace_row_matrix_broadcast_impl_fn_ptr_t>{});
-            };
+        auto bitwise_and_inplace_pyapi = [&](const arrayT &src,
+                                             const arrayT &dst,
+                                             sycl::queue &exec_q,
+                                             const event_vecT &depends = {}) {
+            return py_binary_inplace_ufunc(
+                src, dst, exec_q, depends, bitwise_and_inplace_output_id_table,
+                // function pointers to handle inplace operation on
+                // contiguous arrays (pointers may be nullptr)
+                bitwise_and_inplace_contig_dispatch_table,
+                // function pointers to handle inplace operation on strided
+                // arrays (most general case)
+                bitwise_and_inplace_strided_dispatch_table,
+                // function pointers to handle inplace operation on
+                // c-contig matrix with c-contig row with broadcasting
+                // (may be nullptr)
+                td_ns::NullPtrTable<
+                    binary_inplace_row_matrix_broadcast_impl_fn_ptr_t>{});
+        };
         m.def("_bitwise_and_inplace", bitwise_and_inplace_pyapi, "",
               py::arg("lhs"), py::arg("rhs"), py::arg("sycl_queue"),
               py::arg("depends") = py::list());

--- a/dpctl/tensor/libtensor/source/elementwise_functions/bitwise_left_shift.cpp
+++ b/dpctl/tensor/libtensor/source/elementwise_functions/bitwise_left_shift.cpp
@@ -50,13 +50,16 @@ namespace py_internal
 namespace td_ns = dpctl::tensor::type_dispatch;
 
 namespace ew_cmn_ns = dpctl::tensor::kernels::elementwise_common;
+using ew_cmn_ns::binary_contig_array_scalar_broadcast_impl_fn_ptr_t;
 using ew_cmn_ns::binary_contig_impl_fn_ptr_t;
 using ew_cmn_ns::binary_contig_matrix_contig_row_broadcast_impl_fn_ptr_t;
 using ew_cmn_ns::binary_contig_row_contig_matrix_broadcast_impl_fn_ptr_t;
+using ew_cmn_ns::binary_scalar_contig_array_broadcast_impl_fn_ptr_t;
 using ew_cmn_ns::binary_strided_impl_fn_ptr_t;
 
 using ew_cmn_ns::binary_inplace_contig_impl_fn_ptr_t;
 using ew_cmn_ns::binary_inplace_row_matrix_broadcast_impl_fn_ptr_t;
+using ew_cmn_ns::binary_inplace_scalar_contig_impl_fn_ptr_t;
 using ew_cmn_ns::binary_inplace_strided_impl_fn_ptr_t;
 
 // B04: ===== BITWISE_LEFT_SHIFT (x1, x2)
@@ -164,7 +167,15 @@ void init_bitwise_left_shift(py::module_ m)
                 // function pointers to handle operation of c-contig matrix and
                 // c-contig row with broadcasting (may be nullptr)
                 td_ns::NullPtrTable<
-                    binary_contig_row_contig_matrix_broadcast_impl_fn_ptr_t>{});
+                    binary_contig_row_contig_matrix_broadcast_impl_fn_ptr_t>{},
+                // function pointers to handle operation of contiguous array
+                // and scalar with broadcasting (may be nullptr)
+                td_ns::NullPtrTable<
+                    binary_contig_array_scalar_broadcast_impl_fn_ptr_t>{},
+                // function pointers to handle operation of scalar and
+                // contiguous array with broadcasting (may be nullptr)
+                td_ns::NullPtrTable<
+                    binary_scalar_contig_array_broadcast_impl_fn_ptr_t>{});
         };
         auto bitwise_left_shift_result_type_pyapi =
             [&](const py::dtype &dtype1, const py::dtype &dtype2) {
@@ -197,7 +208,12 @@ void init_bitwise_left_shift(py::module_ m)
                     // c-contig matrix with c-contig row with broadcasting
                     // (may be nullptr)
                     td_ns::NullPtrTable<
-                        binary_inplace_row_matrix_broadcast_impl_fn_ptr_t>{});
+                        binary_inplace_row_matrix_broadcast_impl_fn_ptr_t>{},
+                    // function pointers to handle in-place operation on
+                    // contiguous array with scalar with broadcasting
+                    // (may be nullptr)
+                    td_ns::NullPtrTable<
+                        binary_inplace_scalar_contig_impl_fn_ptr_t>{});
             };
         m.def("_bitwise_left_shift_inplace", bitwise_left_shift_inplace_pyapi,
               "", py::arg("lhs"), py::arg("rhs"), py::arg("sycl_queue"),

--- a/dpctl/tensor/libtensor/source/elementwise_functions/bitwise_left_shift.cpp
+++ b/dpctl/tensor/libtensor/source/elementwise_functions/bitwise_left_shift.cpp
@@ -67,8 +67,11 @@ namespace bitwise_left_shift_fn_ns = dpctl::tensor::kernels::bitwise_left_shift;
 static binary_contig_impl_fn_ptr_t
     bitwise_left_shift_contig_dispatch_table[td_ns::num_types]
                                             [td_ns::num_types];
+
 static int bitwise_left_shift_output_id_table[td_ns::num_types]
                                              [td_ns::num_types];
+static int bitwise_left_shift_inplace_output_id_table[td_ns::num_types]
+                                                     [td_ns::num_types];
 
 static binary_strided_impl_fn_ptr_t
     bitwise_left_shift_strided_dispatch_table[td_ns::num_types]
@@ -120,6 +123,12 @@ void populate_bitwise_left_shift_dispatch_tables(void)
         dtb5;
     dtb5.populate_dispatch_table(
         bitwise_left_shift_inplace_contig_dispatch_table);
+
+    // which types are supported by the in-place kernels
+    using fn_ns::BitwiseLeftShiftInplaceTypeMapFactory;
+    DispatchTableBuilder<int, BitwiseLeftShiftInplaceTypeMapFactory, num_types>
+        dtb6;
+    dtb6.populate_dispatch_table(bitwise_left_shift_inplace_output_id_table);
 };
 
 } // namespace impl
@@ -169,6 +178,7 @@ void init_bitwise_left_shift(py::module_ m)
               bitwise_left_shift_result_type_pyapi, "");
 
         using impl::bitwise_left_shift_inplace_contig_dispatch_table;
+        using impl::bitwise_left_shift_inplace_output_id_table;
         using impl::bitwise_left_shift_inplace_strided_dispatch_table;
 
         auto bitwise_left_shift_inplace_pyapi =
@@ -176,7 +186,7 @@ void init_bitwise_left_shift(py::module_ m)
                 const event_vecT &depends = {}) {
                 return py_binary_inplace_ufunc(
                     src, dst, exec_q, depends,
-                    bitwise_left_shift_output_id_table,
+                    bitwise_left_shift_inplace_output_id_table,
                     // function pointers to handle inplace operation on
                     // contiguous arrays (pointers may be nullptr)
                     bitwise_left_shift_inplace_contig_dispatch_table,

--- a/dpctl/tensor/libtensor/source/elementwise_functions/bitwise_or.cpp
+++ b/dpctl/tensor/libtensor/source/elementwise_functions/bitwise_or.cpp
@@ -50,13 +50,16 @@ namespace py_internal
 namespace td_ns = dpctl::tensor::type_dispatch;
 
 namespace ew_cmn_ns = dpctl::tensor::kernels::elementwise_common;
+using ew_cmn_ns::binary_contig_array_scalar_broadcast_impl_fn_ptr_t;
 using ew_cmn_ns::binary_contig_impl_fn_ptr_t;
 using ew_cmn_ns::binary_contig_matrix_contig_row_broadcast_impl_fn_ptr_t;
 using ew_cmn_ns::binary_contig_row_contig_matrix_broadcast_impl_fn_ptr_t;
+using ew_cmn_ns::binary_scalar_contig_array_broadcast_impl_fn_ptr_t;
 using ew_cmn_ns::binary_strided_impl_fn_ptr_t;
 
 using ew_cmn_ns::binary_inplace_contig_impl_fn_ptr_t;
 using ew_cmn_ns::binary_inplace_row_matrix_broadcast_impl_fn_ptr_t;
+using ew_cmn_ns::binary_inplace_scalar_contig_impl_fn_ptr_t;
 using ew_cmn_ns::binary_inplace_strided_impl_fn_ptr_t;
 
 // B05: ===== BITWISE_OR (x1, x2)
@@ -155,7 +158,15 @@ void init_bitwise_or(py::module_ m)
                 // function pointers to handle operation of c-contig matrix and
                 // c-contig row with broadcasting (may be nullptr)
                 td_ns::NullPtrTable<
-                    binary_contig_row_contig_matrix_broadcast_impl_fn_ptr_t>{});
+                    binary_contig_row_contig_matrix_broadcast_impl_fn_ptr_t>{},
+                // function pointers to handle operation of contiguous array
+                // and scalar with broadcasting (may be nullptr)
+                td_ns::NullPtrTable<
+                    binary_contig_array_scalar_broadcast_impl_fn_ptr_t>{},
+                // function pointers to handle operation of scalar and
+                // contiguous array with broadcasting (may be nullptr)
+                td_ns::NullPtrTable<
+                    binary_scalar_contig_array_broadcast_impl_fn_ptr_t>{});
         };
         auto bitwise_or_result_type_pyapi = [&](const py::dtype &dtype1,
                                                 const py::dtype &dtype2) {
@@ -187,7 +198,12 @@ void init_bitwise_or(py::module_ m)
                 // c-contig matrix with c-contig row with broadcasting
                 // (may be nullptr)
                 td_ns::NullPtrTable<
-                    binary_inplace_row_matrix_broadcast_impl_fn_ptr_t>{});
+                    binary_inplace_row_matrix_broadcast_impl_fn_ptr_t>{},
+                // function pointers to handle in-place operation on
+                // contiguous array with scalar with broadcasting
+                // (may be nullptr)
+                td_ns::NullPtrTable<
+                    binary_inplace_scalar_contig_impl_fn_ptr_t>{});
         };
         m.def("_bitwise_or_inplace", bitwise_or_inplace_pyapi, "",
               py::arg("lhs"), py::arg("rhs"), py::arg("sycl_queue"),

--- a/dpctl/tensor/libtensor/source/elementwise_functions/bitwise_or.cpp
+++ b/dpctl/tensor/libtensor/source/elementwise_functions/bitwise_or.cpp
@@ -66,7 +66,10 @@ namespace bitwise_or_fn_ns = dpctl::tensor::kernels::bitwise_or;
 
 static binary_contig_impl_fn_ptr_t
     bitwise_or_contig_dispatch_table[td_ns::num_types][td_ns::num_types];
+
 static int bitwise_or_output_id_table[td_ns::num_types][td_ns::num_types];
+static int bitwise_or_inplace_output_id_table[td_ns::num_types]
+                                             [td_ns::num_types];
 
 static binary_strided_impl_fn_ptr_t
     bitwise_or_strided_dispatch_table[td_ns::num_types][td_ns::num_types];
@@ -115,6 +118,11 @@ void populate_bitwise_or_dispatch_tables(void)
                          BitwiseOrInplaceContigFactory, num_types>
         dtb5;
     dtb5.populate_dispatch_table(bitwise_or_inplace_contig_dispatch_table);
+
+    // which types are supported by the in-place kernels
+    using fn_ns::BitwiseOrInplaceTypeMapFactory;
+    DispatchTableBuilder<int, BitwiseOrInplaceTypeMapFactory, num_types> dtb6;
+    dtb6.populate_dispatch_table(bitwise_or_inplace_output_id_table);
 };
 
 } // namespace impl
@@ -160,25 +168,27 @@ void init_bitwise_or(py::module_ m)
         m.def("_bitwise_or_result_type", bitwise_or_result_type_pyapi, "");
 
         using impl::bitwise_or_inplace_contig_dispatch_table;
+        using impl::bitwise_or_inplace_output_id_table;
         using impl::bitwise_or_inplace_strided_dispatch_table;
 
-        auto bitwise_or_inplace_pyapi =
-            [&](const arrayT &src, const arrayT &dst, sycl::queue &exec_q,
-                const event_vecT &depends = {}) {
-                return py_binary_inplace_ufunc(
-                    src, dst, exec_q, depends, bitwise_or_output_id_table,
-                    // function pointers to handle inplace operation on
-                    // contiguous arrays (pointers may be nullptr)
-                    bitwise_or_inplace_contig_dispatch_table,
-                    // function pointers to handle inplace operation on strided
-                    // arrays (most general case)
-                    bitwise_or_inplace_strided_dispatch_table,
-                    // function pointers to handle inplace operation on
-                    // c-contig matrix with c-contig row with broadcasting
-                    // (may be nullptr)
-                    td_ns::NullPtrTable<
-                        binary_inplace_row_matrix_broadcast_impl_fn_ptr_t>{});
-            };
+        auto bitwise_or_inplace_pyapi = [&](const arrayT &src,
+                                            const arrayT &dst,
+                                            sycl::queue &exec_q,
+                                            const event_vecT &depends = {}) {
+            return py_binary_inplace_ufunc(
+                src, dst, exec_q, depends, bitwise_or_inplace_output_id_table,
+                // function pointers to handle inplace operation on
+                // contiguous arrays (pointers may be nullptr)
+                bitwise_or_inplace_contig_dispatch_table,
+                // function pointers to handle inplace operation on strided
+                // arrays (most general case)
+                bitwise_or_inplace_strided_dispatch_table,
+                // function pointers to handle inplace operation on
+                // c-contig matrix with c-contig row with broadcasting
+                // (may be nullptr)
+                td_ns::NullPtrTable<
+                    binary_inplace_row_matrix_broadcast_impl_fn_ptr_t>{});
+        };
         m.def("_bitwise_or_inplace", bitwise_or_inplace_pyapi, "",
               py::arg("lhs"), py::arg("rhs"), py::arg("sycl_queue"),
               py::arg("depends") = py::list());

--- a/dpctl/tensor/libtensor/source/elementwise_functions/bitwise_right_shift.cpp
+++ b/dpctl/tensor/libtensor/source/elementwise_functions/bitwise_right_shift.cpp
@@ -50,13 +50,16 @@ namespace py_internal
 namespace td_ns = dpctl::tensor::type_dispatch;
 
 namespace ew_cmn_ns = dpctl::tensor::kernels::elementwise_common;
+using ew_cmn_ns::binary_contig_array_scalar_broadcast_impl_fn_ptr_t;
 using ew_cmn_ns::binary_contig_impl_fn_ptr_t;
 using ew_cmn_ns::binary_contig_matrix_contig_row_broadcast_impl_fn_ptr_t;
 using ew_cmn_ns::binary_contig_row_contig_matrix_broadcast_impl_fn_ptr_t;
+using ew_cmn_ns::binary_scalar_contig_array_broadcast_impl_fn_ptr_t;
 using ew_cmn_ns::binary_strided_impl_fn_ptr_t;
 
 using ew_cmn_ns::binary_inplace_contig_impl_fn_ptr_t;
 using ew_cmn_ns::binary_inplace_row_matrix_broadcast_impl_fn_ptr_t;
+using ew_cmn_ns::binary_inplace_scalar_contig_impl_fn_ptr_t;
 using ew_cmn_ns::binary_inplace_strided_impl_fn_ptr_t;
 
 // B06: ===== BITWISE_RIGHT_SHIFT (x1, x2)
@@ -165,7 +168,15 @@ void init_bitwise_right_shift(py::module_ m)
                 // function pointers to handle operation of c-contig matrix and
                 // c-contig row with broadcasting (may be nullptr)
                 td_ns::NullPtrTable<
-                    binary_contig_row_contig_matrix_broadcast_impl_fn_ptr_t>{});
+                    binary_contig_row_contig_matrix_broadcast_impl_fn_ptr_t>{},
+                // function pointers to handle operation of contiguous array
+                // and scalar with broadcasting (may be nullptr)
+                td_ns::NullPtrTable<
+                    binary_contig_array_scalar_broadcast_impl_fn_ptr_t>{},
+                // function pointers to handle operation of scalar and
+                // contiguous array with broadcasting (may be nullptr)
+                td_ns::NullPtrTable<
+                    binary_scalar_contig_array_broadcast_impl_fn_ptr_t>{});
         };
         auto bitwise_right_shift_result_type_pyapi =
             [&](const py::dtype &dtype1, const py::dtype &dtype2) {
@@ -198,7 +209,12 @@ void init_bitwise_right_shift(py::module_ m)
                     // c-contig matrix with c-contig row with broadcasting
                     // (may be nullptr)
                     td_ns::NullPtrTable<
-                        binary_inplace_row_matrix_broadcast_impl_fn_ptr_t>{});
+                        binary_inplace_row_matrix_broadcast_impl_fn_ptr_t>{},
+                    // function pointers to handle in-place operation on
+                    // contiguous array with scalar with broadcasting
+                    // (may be nullptr)
+                    td_ns::NullPtrTable<
+                        binary_inplace_scalar_contig_impl_fn_ptr_t>{});
             };
         m.def("_bitwise_right_shift_inplace", bitwise_right_shift_inplace_pyapi,
               "", py::arg("lhs"), py::arg("rhs"), py::arg("sycl_queue"),

--- a/dpctl/tensor/libtensor/source/elementwise_functions/bitwise_right_shift.cpp
+++ b/dpctl/tensor/libtensor/source/elementwise_functions/bitwise_right_shift.cpp
@@ -68,8 +68,11 @@ namespace bitwise_right_shift_fn_ns =
 static binary_contig_impl_fn_ptr_t
     bitwise_right_shift_contig_dispatch_table[td_ns::num_types]
                                              [td_ns::num_types];
+
 static int bitwise_right_shift_output_id_table[td_ns::num_types]
                                               [td_ns::num_types];
+static int bitwise_right_shift_inplace_output_id_table[td_ns::num_types]
+                                                      [td_ns::num_types];
 
 static binary_strided_impl_fn_ptr_t
     bitwise_right_shift_strided_dispatch_table[td_ns::num_types]
@@ -121,6 +124,12 @@ void populate_bitwise_right_shift_dispatch_tables(void)
         dtb5;
     dtb5.populate_dispatch_table(
         bitwise_right_shift_inplace_contig_dispatch_table);
+
+    // which types are supported by the in-place kernels
+    using fn_ns::BitwiseRightShiftInplaceTypeMapFactory;
+    DispatchTableBuilder<int, BitwiseRightShiftInplaceTypeMapFactory, num_types>
+        dtb6;
+    dtb6.populate_dispatch_table(bitwise_right_shift_inplace_output_id_table);
 };
 
 } // namespace impl
@@ -170,6 +179,7 @@ void init_bitwise_right_shift(py::module_ m)
               bitwise_right_shift_result_type_pyapi, "");
 
         using impl::bitwise_right_shift_inplace_contig_dispatch_table;
+        using impl::bitwise_right_shift_inplace_output_id_table;
         using impl::bitwise_right_shift_inplace_strided_dispatch_table;
 
         auto bitwise_right_shift_inplace_pyapi =
@@ -177,7 +187,7 @@ void init_bitwise_right_shift(py::module_ m)
                 const event_vecT &depends = {}) {
                 return py_binary_inplace_ufunc(
                     src, dst, exec_q, depends,
-                    bitwise_right_shift_output_id_table,
+                    bitwise_right_shift_inplace_output_id_table,
                     // function pointers to handle inplace operation on
                     // contiguous arrays (pointers may be nullptr)
                     bitwise_right_shift_inplace_contig_dispatch_table,

--- a/dpctl/tensor/libtensor/source/elementwise_functions/bitwise_xor.cpp
+++ b/dpctl/tensor/libtensor/source/elementwise_functions/bitwise_xor.cpp
@@ -50,13 +50,16 @@ namespace py_internal
 namespace td_ns = dpctl::tensor::type_dispatch;
 
 namespace ew_cmn_ns = dpctl::tensor::kernels::elementwise_common;
+using ew_cmn_ns::binary_contig_array_scalar_broadcast_impl_fn_ptr_t;
 using ew_cmn_ns::binary_contig_impl_fn_ptr_t;
 using ew_cmn_ns::binary_contig_matrix_contig_row_broadcast_impl_fn_ptr_t;
 using ew_cmn_ns::binary_contig_row_contig_matrix_broadcast_impl_fn_ptr_t;
+using ew_cmn_ns::binary_scalar_contig_array_broadcast_impl_fn_ptr_t;
 using ew_cmn_ns::binary_strided_impl_fn_ptr_t;
 
 using ew_cmn_ns::binary_inplace_contig_impl_fn_ptr_t;
 using ew_cmn_ns::binary_inplace_row_matrix_broadcast_impl_fn_ptr_t;
+using ew_cmn_ns::binary_inplace_scalar_contig_impl_fn_ptr_t;
 using ew_cmn_ns::binary_inplace_strided_impl_fn_ptr_t;
 
 // B07: ===== BITWISE_XOR (x1, x2)
@@ -155,7 +158,15 @@ void init_bitwise_xor(py::module_ m)
                 // function pointers to handle operation of c-contig matrix and
                 // c-contig row with broadcasting (may be nullptr)
                 td_ns::NullPtrTable<
-                    binary_contig_row_contig_matrix_broadcast_impl_fn_ptr_t>{});
+                    binary_contig_row_contig_matrix_broadcast_impl_fn_ptr_t>{},
+                // function pointers to handle operation of contiguous array
+                // and scalar with broadcasting (may be nullptr)
+                td_ns::NullPtrTable<
+                    binary_contig_array_scalar_broadcast_impl_fn_ptr_t>{},
+                // function pointers to handle operation of scalar and
+                // contiguous array with broadcasting (may be nullptr)
+                td_ns::NullPtrTable<
+                    binary_scalar_contig_array_broadcast_impl_fn_ptr_t>{});
         };
         auto bitwise_xor_result_type_pyapi = [&](const py::dtype &dtype1,
                                                  const py::dtype &dtype2) {
@@ -187,7 +198,12 @@ void init_bitwise_xor(py::module_ m)
                 // c-contig matrix with c-contig row with broadcasting
                 // (may be nullptr)
                 td_ns::NullPtrTable<
-                    binary_inplace_row_matrix_broadcast_impl_fn_ptr_t>{});
+                    binary_inplace_row_matrix_broadcast_impl_fn_ptr_t>{},
+                // function pointers to handle in-place operation on
+                // contiguous array with scalar with broadcasting
+                // (may be nullptr)
+                td_ns::NullPtrTable<
+                    binary_inplace_scalar_contig_impl_fn_ptr_t>{});
         };
         m.def("_bitwise_xor_inplace", bitwise_xor_inplace_pyapi, "",
               py::arg("lhs"), py::arg("rhs"), py::arg("sycl_queue"),

--- a/dpctl/tensor/libtensor/source/elementwise_functions/copysign.cpp
+++ b/dpctl/tensor/libtensor/source/elementwise_functions/copysign.cpp
@@ -49,9 +49,11 @@ namespace py_internal
 namespace td_ns = dpctl::tensor::type_dispatch;
 
 namespace ew_cmn_ns = dpctl::tensor::kernels::elementwise_common;
+using ew_cmn_ns::binary_contig_array_scalar_broadcast_impl_fn_ptr_t;
 using ew_cmn_ns::binary_contig_impl_fn_ptr_t;
 using ew_cmn_ns::binary_contig_matrix_contig_row_broadcast_impl_fn_ptr_t;
 using ew_cmn_ns::binary_contig_row_contig_matrix_broadcast_impl_fn_ptr_t;
+using ew_cmn_ns::binary_scalar_contig_array_broadcast_impl_fn_ptr_t;
 using ew_cmn_ns::binary_strided_impl_fn_ptr_t;
 
 // B25: ===== COPYSIGN (x1, x2)
@@ -121,7 +123,15 @@ void init_copysign(py::module_ m)
                 // function pointers to handle operation of c-contig matrix and
                 // c-contig row with broadcasting (may be nullptr)
                 td_ns::NullPtrTable<
-                    binary_contig_row_contig_matrix_broadcast_impl_fn_ptr_t>{});
+                    binary_contig_row_contig_matrix_broadcast_impl_fn_ptr_t>{},
+                // function pointers to handle operation of contiguous array
+                // and scalar with broadcasting (may be nullptr)
+                td_ns::NullPtrTable<
+                    binary_contig_array_scalar_broadcast_impl_fn_ptr_t>{},
+                // function pointers to handle operation of scalar and
+                // contiguous array with broadcasting (may be nullptr)
+                td_ns::NullPtrTable<
+                    binary_scalar_contig_array_broadcast_impl_fn_ptr_t>{});
         };
         auto copysign_result_type_pyapi = [&](const py::dtype &dtype1,
                                               const py::dtype &dtype2) {

--- a/dpctl/tensor/libtensor/source/elementwise_functions/equal.cpp
+++ b/dpctl/tensor/libtensor/source/elementwise_functions/equal.cpp
@@ -49,9 +49,11 @@ namespace py_internal
 namespace td_ns = dpctl::tensor::type_dispatch;
 
 namespace ew_cmn_ns = dpctl::tensor::kernels::elementwise_common;
+using ew_cmn_ns::binary_contig_array_scalar_broadcast_impl_fn_ptr_t;
 using ew_cmn_ns::binary_contig_impl_fn_ptr_t;
 using ew_cmn_ns::binary_contig_matrix_contig_row_broadcast_impl_fn_ptr_t;
 using ew_cmn_ns::binary_contig_row_contig_matrix_broadcast_impl_fn_ptr_t;
+using ew_cmn_ns::binary_scalar_contig_array_broadcast_impl_fn_ptr_t;
 using ew_cmn_ns::binary_strided_impl_fn_ptr_t;
 
 // B09: ===== EQUAL (x1, x2)
@@ -121,7 +123,15 @@ void init_equal(py::module_ m)
                 // function pointers to handle operation of c-contig matrix and
                 // c-contig row with broadcasting (may be nullptr)
                 td_ns::NullPtrTable<
-                    binary_contig_row_contig_matrix_broadcast_impl_fn_ptr_t>{});
+                    binary_contig_row_contig_matrix_broadcast_impl_fn_ptr_t>{},
+                // function pointers to handle operation of contiguous array
+                // and scalar with broadcasting (may be nullptr)
+                td_ns::NullPtrTable<
+                    binary_contig_array_scalar_broadcast_impl_fn_ptr_t>{},
+                // function pointers to handle operation of scalar and
+                // contiguous array with broadcasting (may be nullptr)
+                td_ns::NullPtrTable<
+                    binary_scalar_contig_array_broadcast_impl_fn_ptr_t>{});
         };
         auto equal_result_type_pyapi = [&](const py::dtype &dtype1,
                                            const py::dtype &dtype2) {

--- a/dpctl/tensor/libtensor/source/elementwise_functions/floor_divide.cpp
+++ b/dpctl/tensor/libtensor/source/elementwise_functions/floor_divide.cpp
@@ -50,13 +50,16 @@ namespace py_internal
 namespace td_ns = dpctl::tensor::type_dispatch;
 
 namespace ew_cmn_ns = dpctl::tensor::kernels::elementwise_common;
+using ew_cmn_ns::binary_contig_array_scalar_broadcast_impl_fn_ptr_t;
 using ew_cmn_ns::binary_contig_impl_fn_ptr_t;
 using ew_cmn_ns::binary_contig_matrix_contig_row_broadcast_impl_fn_ptr_t;
 using ew_cmn_ns::binary_contig_row_contig_matrix_broadcast_impl_fn_ptr_t;
+using ew_cmn_ns::binary_scalar_contig_array_broadcast_impl_fn_ptr_t;
 using ew_cmn_ns::binary_strided_impl_fn_ptr_t;
 
 using ew_cmn_ns::binary_inplace_contig_impl_fn_ptr_t;
 using ew_cmn_ns::binary_inplace_row_matrix_broadcast_impl_fn_ptr_t;
+using ew_cmn_ns::binary_inplace_scalar_contig_impl_fn_ptr_t;
 using ew_cmn_ns::binary_inplace_strided_impl_fn_ptr_t;
 
 // B10: ===== FLOOR_DIVIDE (x1, x2)
@@ -155,7 +158,15 @@ void init_floor_divide(py::module_ m)
                 // function pointers to handle operation of c-contig matrix and
                 // c-contig row with broadcasting (may be nullptr)
                 td_ns::NullPtrTable<
-                    binary_contig_row_contig_matrix_broadcast_impl_fn_ptr_t>{});
+                    binary_contig_row_contig_matrix_broadcast_impl_fn_ptr_t>{},
+                // function pointers to handle operation of contiguous array
+                // and scalar with broadcasting (may be nullptr)
+                td_ns::NullPtrTable<
+                    binary_contig_array_scalar_broadcast_impl_fn_ptr_t>{},
+                // function pointers to handle operation of scalar and
+                // contiguous array with broadcasting (may be nullptr)
+                td_ns::NullPtrTable<
+                    binary_scalar_contig_array_broadcast_impl_fn_ptr_t>{});
         };
         auto floor_divide_result_type_pyapi = [&](const py::dtype &dtype1,
                                                   const py::dtype &dtype2) {
@@ -187,7 +198,12 @@ void init_floor_divide(py::module_ m)
                 // c-contig matrix with c-contig row with broadcasting
                 // (may be nullptr)
                 td_ns::NullPtrTable<
-                    binary_inplace_row_matrix_broadcast_impl_fn_ptr_t>{});
+                    binary_inplace_row_matrix_broadcast_impl_fn_ptr_t>{},
+                // function pointers to handle in-place operation on
+                // contiguous array with scalar with broadcasting
+                // (may be nullptr)
+                td_ns::NullPtrTable<
+                    binary_inplace_scalar_contig_impl_fn_ptr_t>{});
         };
         m.def("_floor_divide_inplace", floor_divide_inplace_pyapi, "",
               py::arg("lhs"), py::arg("rhs"), py::arg("sycl_queue"),

--- a/dpctl/tensor/libtensor/source/elementwise_functions/greater.cpp
+++ b/dpctl/tensor/libtensor/source/elementwise_functions/greater.cpp
@@ -49,9 +49,11 @@ namespace py_internal
 namespace td_ns = dpctl::tensor::type_dispatch;
 
 namespace ew_cmn_ns = dpctl::tensor::kernels::elementwise_common;
+using ew_cmn_ns::binary_contig_array_scalar_broadcast_impl_fn_ptr_t;
 using ew_cmn_ns::binary_contig_impl_fn_ptr_t;
 using ew_cmn_ns::binary_contig_matrix_contig_row_broadcast_impl_fn_ptr_t;
 using ew_cmn_ns::binary_contig_row_contig_matrix_broadcast_impl_fn_ptr_t;
+using ew_cmn_ns::binary_scalar_contig_array_broadcast_impl_fn_ptr_t;
 using ew_cmn_ns::binary_strided_impl_fn_ptr_t;
 
 // B11: ===== GREATER (x1, x2)
@@ -121,7 +123,15 @@ void init_greater(py::module_ m)
                 // function pointers to handle operation of c-contig matrix and
                 // c-contig row with broadcasting (may be nullptr)
                 td_ns::NullPtrTable<
-                    binary_contig_row_contig_matrix_broadcast_impl_fn_ptr_t>{});
+                    binary_contig_row_contig_matrix_broadcast_impl_fn_ptr_t>{},
+                // function pointers to handle operation of contiguous array
+                // and scalar with broadcasting (may be nullptr)
+                td_ns::NullPtrTable<
+                    binary_contig_array_scalar_broadcast_impl_fn_ptr_t>{},
+                // function pointers to handle operation of scalar and
+                // contiguous array with broadcasting (may be nullptr)
+                td_ns::NullPtrTable<
+                    binary_scalar_contig_array_broadcast_impl_fn_ptr_t>{});
         };
         auto greater_result_type_pyapi = [&](const py::dtype &dtype1,
                                              const py::dtype &dtype2) {

--- a/dpctl/tensor/libtensor/source/elementwise_functions/greater_equal.cpp
+++ b/dpctl/tensor/libtensor/source/elementwise_functions/greater_equal.cpp
@@ -49,9 +49,11 @@ namespace py_internal
 namespace td_ns = dpctl::tensor::type_dispatch;
 
 namespace ew_cmn_ns = dpctl::tensor::kernels::elementwise_common;
+using ew_cmn_ns::binary_contig_array_scalar_broadcast_impl_fn_ptr_t;
 using ew_cmn_ns::binary_contig_impl_fn_ptr_t;
 using ew_cmn_ns::binary_contig_matrix_contig_row_broadcast_impl_fn_ptr_t;
 using ew_cmn_ns::binary_contig_row_contig_matrix_broadcast_impl_fn_ptr_t;
+using ew_cmn_ns::binary_scalar_contig_array_broadcast_impl_fn_ptr_t;
 using ew_cmn_ns::binary_strided_impl_fn_ptr_t;
 
 // B12: ===== GREATER_EQUAL (x1, x2)
@@ -121,7 +123,15 @@ void init_greater_equal(py::module_ m)
                 // function pointers to handle operation of c-contig matrix and
                 // c-contig row with broadcasting (may be nullptr)
                 td_ns::NullPtrTable<
-                    binary_contig_row_contig_matrix_broadcast_impl_fn_ptr_t>{});
+                    binary_contig_row_contig_matrix_broadcast_impl_fn_ptr_t>{},
+                // function pointers to handle operation of contiguous array
+                // and scalar with broadcasting (may be nullptr)
+                td_ns::NullPtrTable<
+                    binary_contig_array_scalar_broadcast_impl_fn_ptr_t>{},
+                // function pointers to handle operation of scalar and
+                // contiguous array with broadcasting (may be nullptr)
+                td_ns::NullPtrTable<
+                    binary_scalar_contig_array_broadcast_impl_fn_ptr_t>{});
         };
         auto greater_equal_result_type_pyapi = [&](const py::dtype &dtype1,
                                                    const py::dtype &dtype2) {

--- a/dpctl/tensor/libtensor/source/elementwise_functions/hypot.cpp
+++ b/dpctl/tensor/libtensor/source/elementwise_functions/hypot.cpp
@@ -49,9 +49,11 @@ namespace py_internal
 namespace td_ns = dpctl::tensor::type_dispatch;
 
 namespace ew_cmn_ns = dpctl::tensor::kernels::elementwise_common;
+using ew_cmn_ns::binary_contig_array_scalar_broadcast_impl_fn_ptr_t;
 using ew_cmn_ns::binary_contig_impl_fn_ptr_t;
 using ew_cmn_ns::binary_contig_matrix_contig_row_broadcast_impl_fn_ptr_t;
 using ew_cmn_ns::binary_contig_row_contig_matrix_broadcast_impl_fn_ptr_t;
+using ew_cmn_ns::binary_scalar_contig_array_broadcast_impl_fn_ptr_t;
 using ew_cmn_ns::binary_strided_impl_fn_ptr_t;
 
 // B24: ===== HYPOT (x1, x2)
@@ -121,7 +123,15 @@ void init_hypot(py::module_ m)
                 // function pointers to handle operation of c-contig matrix and
                 // c-contig row with broadcasting (may be nullptr)
                 td_ns::NullPtrTable<
-                    binary_contig_row_contig_matrix_broadcast_impl_fn_ptr_t>{});
+                    binary_contig_row_contig_matrix_broadcast_impl_fn_ptr_t>{},
+                // function pointers to handle operation of contiguous array
+                // and scalar with broadcasting (may be nullptr)
+                td_ns::NullPtrTable<
+                    binary_contig_array_scalar_broadcast_impl_fn_ptr_t>{},
+                // function pointers to handle operation of scalar and
+                // contiguous array with broadcasting (may be nullptr)
+                td_ns::NullPtrTable<
+                    binary_scalar_contig_array_broadcast_impl_fn_ptr_t>{});
         };
         auto hypot_result_type_pyapi = [&](const py::dtype &dtype1,
                                            const py::dtype &dtype2) {

--- a/dpctl/tensor/libtensor/source/elementwise_functions/less.cpp
+++ b/dpctl/tensor/libtensor/source/elementwise_functions/less.cpp
@@ -49,9 +49,11 @@ namespace py_internal
 namespace td_ns = dpctl::tensor::type_dispatch;
 
 namespace ew_cmn_ns = dpctl::tensor::kernels::elementwise_common;
+using ew_cmn_ns::binary_contig_array_scalar_broadcast_impl_fn_ptr_t;
 using ew_cmn_ns::binary_contig_impl_fn_ptr_t;
 using ew_cmn_ns::binary_contig_matrix_contig_row_broadcast_impl_fn_ptr_t;
 using ew_cmn_ns::binary_contig_row_contig_matrix_broadcast_impl_fn_ptr_t;
+using ew_cmn_ns::binary_scalar_contig_array_broadcast_impl_fn_ptr_t;
 using ew_cmn_ns::binary_strided_impl_fn_ptr_t;
 
 // B13: ===== LESS (x1, x2)
@@ -121,7 +123,15 @@ void init_less(py::module_ m)
                 // function pointers to handle operation of c-contig matrix and
                 // c-contig row with broadcasting (may be nullptr)
                 td_ns::NullPtrTable<
-                    binary_contig_row_contig_matrix_broadcast_impl_fn_ptr_t>{});
+                    binary_contig_row_contig_matrix_broadcast_impl_fn_ptr_t>{},
+                // function pointers to handle operation of contiguous array
+                // and scalar with broadcasting (may be nullptr)
+                td_ns::NullPtrTable<
+                    binary_contig_array_scalar_broadcast_impl_fn_ptr_t>{},
+                // function pointers to handle operation of scalar and
+                // contiguous array with broadcasting (may be nullptr)
+                td_ns::NullPtrTable<
+                    binary_scalar_contig_array_broadcast_impl_fn_ptr_t>{});
         };
         auto less_result_type_pyapi = [&](const py::dtype &dtype1,
                                           const py::dtype &dtype2) {

--- a/dpctl/tensor/libtensor/source/elementwise_functions/less_equal.cpp
+++ b/dpctl/tensor/libtensor/source/elementwise_functions/less_equal.cpp
@@ -49,9 +49,11 @@ namespace py_internal
 namespace td_ns = dpctl::tensor::type_dispatch;
 
 namespace ew_cmn_ns = dpctl::tensor::kernels::elementwise_common;
+using ew_cmn_ns::binary_contig_array_scalar_broadcast_impl_fn_ptr_t;
 using ew_cmn_ns::binary_contig_impl_fn_ptr_t;
 using ew_cmn_ns::binary_contig_matrix_contig_row_broadcast_impl_fn_ptr_t;
 using ew_cmn_ns::binary_contig_row_contig_matrix_broadcast_impl_fn_ptr_t;
+using ew_cmn_ns::binary_scalar_contig_array_broadcast_impl_fn_ptr_t;
 using ew_cmn_ns::binary_strided_impl_fn_ptr_t;
 
 // B14: ===== LESS_EQUAL (x1, x2)
@@ -121,7 +123,15 @@ void init_less_equal(py::module_ m)
                 // function pointers to handle operation of c-contig matrix and
                 // c-contig row with broadcasting (may be nullptr)
                 td_ns::NullPtrTable<
-                    binary_contig_row_contig_matrix_broadcast_impl_fn_ptr_t>{});
+                    binary_contig_row_contig_matrix_broadcast_impl_fn_ptr_t>{},
+                // function pointers to handle operation of contiguous array
+                // and scalar with broadcasting (may be nullptr)
+                td_ns::NullPtrTable<
+                    binary_contig_array_scalar_broadcast_impl_fn_ptr_t>{},
+                // function pointers to handle operation of scalar and
+                // contiguous array with broadcasting (may be nullptr)
+                td_ns::NullPtrTable<
+                    binary_scalar_contig_array_broadcast_impl_fn_ptr_t>{});
         };
         auto less_equal_result_type_pyapi = [&](const py::dtype &dtype1,
                                                 const py::dtype &dtype2) {

--- a/dpctl/tensor/libtensor/source/elementwise_functions/logaddexp.cpp
+++ b/dpctl/tensor/libtensor/source/elementwise_functions/logaddexp.cpp
@@ -49,9 +49,11 @@ namespace py_internal
 namespace td_ns = dpctl::tensor::type_dispatch;
 
 namespace ew_cmn_ns = dpctl::tensor::kernels::elementwise_common;
+using ew_cmn_ns::binary_contig_array_scalar_broadcast_impl_fn_ptr_t;
 using ew_cmn_ns::binary_contig_impl_fn_ptr_t;
 using ew_cmn_ns::binary_contig_matrix_contig_row_broadcast_impl_fn_ptr_t;
 using ew_cmn_ns::binary_contig_row_contig_matrix_broadcast_impl_fn_ptr_t;
+using ew_cmn_ns::binary_scalar_contig_array_broadcast_impl_fn_ptr_t;
 using ew_cmn_ns::binary_strided_impl_fn_ptr_t;
 
 // B15: ===== LOGADDEXP (x1, x2)
@@ -121,7 +123,15 @@ void init_logaddexp(py::module_ m)
                 // function pointers to handle operation of c-contig matrix and
                 // c-contig row with broadcasting (may be nullptr)
                 td_ns::NullPtrTable<
-                    binary_contig_row_contig_matrix_broadcast_impl_fn_ptr_t>{});
+                    binary_contig_row_contig_matrix_broadcast_impl_fn_ptr_t>{},
+                // function pointers to handle operation of contiguous array
+                // and scalar with broadcasting (may be nullptr)
+                td_ns::NullPtrTable<
+                    binary_contig_array_scalar_broadcast_impl_fn_ptr_t>{},
+                // function pointers to handle operation of scalar and
+                // contiguous array with broadcasting (may be nullptr)
+                td_ns::NullPtrTable<
+                    binary_scalar_contig_array_broadcast_impl_fn_ptr_t>{});
         };
         auto logaddexp_result_type_pyapi = [&](const py::dtype &dtype1,
                                                const py::dtype &dtype2) {

--- a/dpctl/tensor/libtensor/source/elementwise_functions/logical_and.cpp
+++ b/dpctl/tensor/libtensor/source/elementwise_functions/logical_and.cpp
@@ -49,9 +49,11 @@ namespace py_internal
 namespace td_ns = dpctl::tensor::type_dispatch;
 
 namespace ew_cmn_ns = dpctl::tensor::kernels::elementwise_common;
+using ew_cmn_ns::binary_contig_array_scalar_broadcast_impl_fn_ptr_t;
 using ew_cmn_ns::binary_contig_impl_fn_ptr_t;
 using ew_cmn_ns::binary_contig_matrix_contig_row_broadcast_impl_fn_ptr_t;
 using ew_cmn_ns::binary_contig_row_contig_matrix_broadcast_impl_fn_ptr_t;
+using ew_cmn_ns::binary_scalar_contig_array_broadcast_impl_fn_ptr_t;
 using ew_cmn_ns::binary_strided_impl_fn_ptr_t;
 
 // B16: ===== LOGICAL_AND (x1, x2)
@@ -121,7 +123,15 @@ void init_logical_and(py::module_ m)
                 // function pointers to handle operation of c-contig matrix and
                 // c-contig row with broadcasting (may be nullptr)
                 td_ns::NullPtrTable<
-                    binary_contig_row_contig_matrix_broadcast_impl_fn_ptr_t>{});
+                    binary_contig_row_contig_matrix_broadcast_impl_fn_ptr_t>{},
+                // function pointers to handle operation of contiguous array
+                // and scalar with broadcasting (may be nullptr)
+                td_ns::NullPtrTable<
+                    binary_contig_array_scalar_broadcast_impl_fn_ptr_t>{},
+                // function pointers to handle operation of scalar and
+                // contiguous array with broadcasting (may be nullptr)
+                td_ns::NullPtrTable<
+                    binary_scalar_contig_array_broadcast_impl_fn_ptr_t>{});
         };
         auto logical_and_result_type_pyapi = [&](const py::dtype &dtype1,
                                                  const py::dtype &dtype2) {

--- a/dpctl/tensor/libtensor/source/elementwise_functions/logical_or.cpp
+++ b/dpctl/tensor/libtensor/source/elementwise_functions/logical_or.cpp
@@ -49,9 +49,11 @@ namespace py_internal
 namespace td_ns = dpctl::tensor::type_dispatch;
 
 namespace ew_cmn_ns = dpctl::tensor::kernels::elementwise_common;
+using ew_cmn_ns::binary_contig_array_scalar_broadcast_impl_fn_ptr_t;
 using ew_cmn_ns::binary_contig_impl_fn_ptr_t;
 using ew_cmn_ns::binary_contig_matrix_contig_row_broadcast_impl_fn_ptr_t;
 using ew_cmn_ns::binary_contig_row_contig_matrix_broadcast_impl_fn_ptr_t;
+using ew_cmn_ns::binary_scalar_contig_array_broadcast_impl_fn_ptr_t;
 using ew_cmn_ns::binary_strided_impl_fn_ptr_t;
 
 // B17: ===== LOGICAL_OR (x1, x2)
@@ -121,7 +123,15 @@ void init_logical_or(py::module_ m)
                 // function pointers to handle operation of c-contig matrix and
                 // c-contig row with broadcasting (may be nullptr)
                 td_ns::NullPtrTable<
-                    binary_contig_row_contig_matrix_broadcast_impl_fn_ptr_t>{});
+                    binary_contig_row_contig_matrix_broadcast_impl_fn_ptr_t>{},
+                // function pointers to handle operation of contiguous array
+                // and scalar with broadcasting (may be nullptr)
+                td_ns::NullPtrTable<
+                    binary_contig_array_scalar_broadcast_impl_fn_ptr_t>{},
+                // function pointers to handle operation of scalar and
+                // contiguous array with broadcasting (may be nullptr)
+                td_ns::NullPtrTable<
+                    binary_scalar_contig_array_broadcast_impl_fn_ptr_t>{});
         };
         auto logical_or_result_type_pyapi = [&](const py::dtype &dtype1,
                                                 const py::dtype &dtype2) {

--- a/dpctl/tensor/libtensor/source/elementwise_functions/logical_xor.cpp
+++ b/dpctl/tensor/libtensor/source/elementwise_functions/logical_xor.cpp
@@ -49,9 +49,11 @@ namespace py_internal
 namespace td_ns = dpctl::tensor::type_dispatch;
 
 namespace ew_cmn_ns = dpctl::tensor::kernels::elementwise_common;
+using ew_cmn_ns::binary_contig_array_scalar_broadcast_impl_fn_ptr_t;
 using ew_cmn_ns::binary_contig_impl_fn_ptr_t;
 using ew_cmn_ns::binary_contig_matrix_contig_row_broadcast_impl_fn_ptr_t;
 using ew_cmn_ns::binary_contig_row_contig_matrix_broadcast_impl_fn_ptr_t;
+using ew_cmn_ns::binary_scalar_contig_array_broadcast_impl_fn_ptr_t;
 using ew_cmn_ns::binary_strided_impl_fn_ptr_t;
 
 // B18: ===== LOGICAL_XOR (x1, x2)
@@ -121,7 +123,15 @@ void init_logical_xor(py::module_ m)
                 // function pointers to handle operation of c-contig matrix and
                 // c-contig row with broadcasting (may be nullptr)
                 td_ns::NullPtrTable<
-                    binary_contig_row_contig_matrix_broadcast_impl_fn_ptr_t>{});
+                    binary_contig_row_contig_matrix_broadcast_impl_fn_ptr_t>{},
+                // function pointers to handle operation of contiguous array
+                // and scalar with broadcasting (may be nullptr)
+                td_ns::NullPtrTable<
+                    binary_contig_array_scalar_broadcast_impl_fn_ptr_t>{},
+                // function pointers to handle operation of scalar and
+                // contiguous array with broadcasting (may be nullptr)
+                td_ns::NullPtrTable<
+                    binary_scalar_contig_array_broadcast_impl_fn_ptr_t>{});
         };
         auto logical_xor_result_type_pyapi = [&](const py::dtype &dtype1,
                                                  const py::dtype &dtype2) {

--- a/dpctl/tensor/libtensor/source/elementwise_functions/maximum.cpp
+++ b/dpctl/tensor/libtensor/source/elementwise_functions/maximum.cpp
@@ -49,9 +49,11 @@ namespace py_internal
 namespace td_ns = dpctl::tensor::type_dispatch;
 
 namespace ew_cmn_ns = dpctl::tensor::kernels::elementwise_common;
+using ew_cmn_ns::binary_contig_array_scalar_broadcast_impl_fn_ptr_t;
 using ew_cmn_ns::binary_contig_impl_fn_ptr_t;
 using ew_cmn_ns::binary_contig_matrix_contig_row_broadcast_impl_fn_ptr_t;
 using ew_cmn_ns::binary_contig_row_contig_matrix_broadcast_impl_fn_ptr_t;
+using ew_cmn_ns::binary_scalar_contig_array_broadcast_impl_fn_ptr_t;
 using ew_cmn_ns::binary_strided_impl_fn_ptr_t;
 
 // B26: ===== MAXIMUM (x1, x2)
@@ -121,7 +123,15 @@ void init_maximum(py::module_ m)
                 // function pointers to handle operation of c-contig matrix and
                 // c-contig row with broadcasting (may be nullptr)
                 td_ns::NullPtrTable<
-                    binary_contig_row_contig_matrix_broadcast_impl_fn_ptr_t>{});
+                    binary_contig_row_contig_matrix_broadcast_impl_fn_ptr_t>{},
+                // function pointers to handle operation of contiguous array
+                // and scalar with broadcasting (may be nullptr)
+                td_ns::NullPtrTable<
+                    binary_contig_array_scalar_broadcast_impl_fn_ptr_t>{},
+                // function pointers to handle operation of scalar and
+                // contiguous array with broadcasting (may be nullptr)
+                td_ns::NullPtrTable<
+                    binary_scalar_contig_array_broadcast_impl_fn_ptr_t>{});
         };
         auto maximum_result_type_pyapi = [&](const py::dtype &dtype1,
                                              const py::dtype &dtype2) {

--- a/dpctl/tensor/libtensor/source/elementwise_functions/minimum.cpp
+++ b/dpctl/tensor/libtensor/source/elementwise_functions/minimum.cpp
@@ -49,9 +49,11 @@ namespace py_internal
 namespace td_ns = dpctl::tensor::type_dispatch;
 
 namespace ew_cmn_ns = dpctl::tensor::kernels::elementwise_common;
+using ew_cmn_ns::binary_contig_array_scalar_broadcast_impl_fn_ptr_t;
 using ew_cmn_ns::binary_contig_impl_fn_ptr_t;
 using ew_cmn_ns::binary_contig_matrix_contig_row_broadcast_impl_fn_ptr_t;
 using ew_cmn_ns::binary_contig_row_contig_matrix_broadcast_impl_fn_ptr_t;
+using ew_cmn_ns::binary_scalar_contig_array_broadcast_impl_fn_ptr_t;
 using ew_cmn_ns::binary_strided_impl_fn_ptr_t;
 
 // B27: ===== MINIMUM (x1, x2)
@@ -121,7 +123,15 @@ void init_minimum(py::module_ m)
                 // function pointers to handle operation of c-contig matrix and
                 // c-contig row with broadcasting (may be nullptr)
                 td_ns::NullPtrTable<
-                    binary_contig_row_contig_matrix_broadcast_impl_fn_ptr_t>{});
+                    binary_contig_row_contig_matrix_broadcast_impl_fn_ptr_t>{},
+                // function pointers to handle operation of contiguous array
+                // and scalar with broadcasting (may be nullptr)
+                td_ns::NullPtrTable<
+                    binary_contig_array_scalar_broadcast_impl_fn_ptr_t>{},
+                // function pointers to handle operation of scalar and
+                // contiguous array with broadcasting (may be nullptr)
+                td_ns::NullPtrTable<
+                    binary_scalar_contig_array_broadcast_impl_fn_ptr_t>{});
         };
         auto minimum_result_type_pyapi = [&](const py::dtype &dtype1,
                                              const py::dtype &dtype2) {

--- a/dpctl/tensor/libtensor/source/elementwise_functions/multiply.cpp
+++ b/dpctl/tensor/libtensor/source/elementwise_functions/multiply.cpp
@@ -50,13 +50,16 @@ namespace py_internal
 namespace td_ns = dpctl::tensor::type_dispatch;
 
 namespace ew_cmn_ns = dpctl::tensor::kernels::elementwise_common;
+using ew_cmn_ns::binary_contig_array_scalar_broadcast_impl_fn_ptr_t;
 using ew_cmn_ns::binary_contig_impl_fn_ptr_t;
 using ew_cmn_ns::binary_contig_matrix_contig_row_broadcast_impl_fn_ptr_t;
 using ew_cmn_ns::binary_contig_row_contig_matrix_broadcast_impl_fn_ptr_t;
+using ew_cmn_ns::binary_scalar_contig_array_broadcast_impl_fn_ptr_t;
 using ew_cmn_ns::binary_strided_impl_fn_ptr_t;
 
 using ew_cmn_ns::binary_inplace_contig_impl_fn_ptr_t;
 using ew_cmn_ns::binary_inplace_row_matrix_broadcast_impl_fn_ptr_t;
+using ew_cmn_ns::binary_inplace_scalar_contig_impl_fn_ptr_t;
 using ew_cmn_ns::binary_inplace_strided_impl_fn_ptr_t;
 
 // B19: ===== MULTIPLY (x1, x2)
@@ -194,7 +197,15 @@ void init_multiply(py::module_ m)
                 multiply_contig_matrix_contig_row_broadcast_dispatch_table,
                 // function pointers to handle operation of c-contig matrix
                 // and c-contig row with broadcasting (may be nullptr)
-                multiply_contig_row_contig_matrix_broadcast_dispatch_table);
+                multiply_contig_row_contig_matrix_broadcast_dispatch_table,
+                // function pointers to handle operation of contiguous array
+                // and scalar with broadcasting (may be nullptr)
+                td_ns::NullPtrTable<
+                    binary_contig_array_scalar_broadcast_impl_fn_ptr_t>{},
+                // function pointers to handle operation of scalar and
+                // contiguous array with broadcasting (may be nullptr)
+                td_ns::NullPtrTable<
+                    binary_scalar_contig_array_broadcast_impl_fn_ptr_t>{});
         };
         auto multiply_result_type_pyapi = [&](const py::dtype &dtype1,
                                               const py::dtype &dtype2) {
@@ -225,7 +236,12 @@ void init_multiply(py::module_ m)
                 // function pointers to handle inplace operation on
                 // c-contig matrix with c-contig row with broadcasting
                 // (may be nullptr)
-                multiply_inplace_row_matrix_dispatch_table);
+                multiply_inplace_row_matrix_dispatch_table,
+                // function pointers to handle in-place operation on
+                // contiguous array with scalar with broadcasting
+                // (may be nullptr)
+                td_ns::NullPtrTable<
+                    binary_inplace_scalar_contig_impl_fn_ptr_t>{});
         };
         m.def("_multiply_inplace", multiply_inplace_pyapi, "", py::arg("lhs"),
               py::arg("rhs"), py::arg("sycl_queue"),

--- a/dpctl/tensor/libtensor/source/elementwise_functions/nextafter.cpp
+++ b/dpctl/tensor/libtensor/source/elementwise_functions/nextafter.cpp
@@ -49,9 +49,11 @@ namespace py_internal
 namespace td_ns = dpctl::tensor::type_dispatch;
 
 namespace ew_cmn_ns = dpctl::tensor::kernels::elementwise_common;
+using ew_cmn_ns::binary_contig_array_scalar_broadcast_impl_fn_ptr_t;
 using ew_cmn_ns::binary_contig_impl_fn_ptr_t;
 using ew_cmn_ns::binary_contig_matrix_contig_row_broadcast_impl_fn_ptr_t;
 using ew_cmn_ns::binary_contig_row_contig_matrix_broadcast_impl_fn_ptr_t;
+using ew_cmn_ns::binary_scalar_contig_array_broadcast_impl_fn_ptr_t;
 using ew_cmn_ns::binary_strided_impl_fn_ptr_t;
 
 // B28: ===== NEXTAFTER (x1, x2)
@@ -121,7 +123,15 @@ void init_nextafter(py::module_ m)
                 // function pointers to handle operation of c-contig matrix and
                 // c-contig row with broadcasting (may be nullptr)
                 td_ns::NullPtrTable<
-                    binary_contig_row_contig_matrix_broadcast_impl_fn_ptr_t>{});
+                    binary_contig_row_contig_matrix_broadcast_impl_fn_ptr_t>{},
+                // function pointers to handle operation of contiguous array
+                // and scalar with broadcasting (may be nullptr)
+                td_ns::NullPtrTable<
+                    binary_contig_array_scalar_broadcast_impl_fn_ptr_t>{},
+                // function pointers to handle operation of scalar and
+                // contiguous array with broadcasting (may be nullptr)
+                td_ns::NullPtrTable<
+                    binary_scalar_contig_array_broadcast_impl_fn_ptr_t>{});
         };
         auto nextafter_result_type_pyapi = [&](const py::dtype &dtype1,
                                                const py::dtype &dtype2) {

--- a/dpctl/tensor/libtensor/source/elementwise_functions/not_equal.cpp
+++ b/dpctl/tensor/libtensor/source/elementwise_functions/not_equal.cpp
@@ -49,9 +49,11 @@ namespace py_internal
 namespace td_ns = dpctl::tensor::type_dispatch;
 
 namespace ew_cmn_ns = dpctl::tensor::kernels::elementwise_common;
+using ew_cmn_ns::binary_contig_array_scalar_broadcast_impl_fn_ptr_t;
 using ew_cmn_ns::binary_contig_impl_fn_ptr_t;
 using ew_cmn_ns::binary_contig_matrix_contig_row_broadcast_impl_fn_ptr_t;
 using ew_cmn_ns::binary_contig_row_contig_matrix_broadcast_impl_fn_ptr_t;
+using ew_cmn_ns::binary_scalar_contig_array_broadcast_impl_fn_ptr_t;
 using ew_cmn_ns::binary_strided_impl_fn_ptr_t;
 
 // B20: ===== NOT_EQUAL (x1, x2)
@@ -121,7 +123,15 @@ void init_not_equal(py::module_ m)
                 // function pointers to handle operation of c-contig matrix and
                 // c-contig row with broadcasting (may be nullptr)
                 td_ns::NullPtrTable<
-                    binary_contig_row_contig_matrix_broadcast_impl_fn_ptr_t>{});
+                    binary_contig_row_contig_matrix_broadcast_impl_fn_ptr_t>{},
+                // function pointers to handle operation of contiguous array
+                // and scalar with broadcasting (may be nullptr)
+                td_ns::NullPtrTable<
+                    binary_contig_array_scalar_broadcast_impl_fn_ptr_t>{},
+                // function pointers to handle operation of scalar and
+                // contiguous array with broadcasting (may be nullptr)
+                td_ns::NullPtrTable<
+                    binary_scalar_contig_array_broadcast_impl_fn_ptr_t>{});
         };
         auto not_equal_result_type_pyapi = [&](const py::dtype &dtype1,
                                                const py::dtype &dtype2) {

--- a/dpctl/tensor/libtensor/source/elementwise_functions/pow.cpp
+++ b/dpctl/tensor/libtensor/source/elementwise_functions/pow.cpp
@@ -50,13 +50,16 @@ namespace py_internal
 namespace td_ns = dpctl::tensor::type_dispatch;
 
 namespace ew_cmn_ns = dpctl::tensor::kernels::elementwise_common;
+using ew_cmn_ns::binary_contig_array_scalar_broadcast_impl_fn_ptr_t;
 using ew_cmn_ns::binary_contig_impl_fn_ptr_t;
 using ew_cmn_ns::binary_contig_matrix_contig_row_broadcast_impl_fn_ptr_t;
 using ew_cmn_ns::binary_contig_row_contig_matrix_broadcast_impl_fn_ptr_t;
+using ew_cmn_ns::binary_scalar_contig_array_broadcast_impl_fn_ptr_t;
 using ew_cmn_ns::binary_strided_impl_fn_ptr_t;
 
 using ew_cmn_ns::binary_inplace_contig_impl_fn_ptr_t;
 using ew_cmn_ns::binary_inplace_row_matrix_broadcast_impl_fn_ptr_t;
+using ew_cmn_ns::binary_inplace_scalar_contig_impl_fn_ptr_t;
 using ew_cmn_ns::binary_inplace_strided_impl_fn_ptr_t;
 
 // B21: ===== POW (x1, x2)
@@ -153,7 +156,15 @@ void init_pow(py::module_ m)
                 // function pointers to handle operation of c-contig matrix and
                 // c-contig row with broadcasting (may be nullptr)
                 td_ns::NullPtrTable<
-                    binary_contig_row_contig_matrix_broadcast_impl_fn_ptr_t>{});
+                    binary_contig_row_contig_matrix_broadcast_impl_fn_ptr_t>{},
+                // function pointers to handle operation of contiguous array
+                // and scalar with broadcasting (may be nullptr)
+                td_ns::NullPtrTable<
+                    binary_contig_array_scalar_broadcast_impl_fn_ptr_t>{},
+                // function pointers to handle operation of scalar and
+                // contiguous array with broadcasting (may be nullptr)
+                td_ns::NullPtrTable<
+                    binary_scalar_contig_array_broadcast_impl_fn_ptr_t>{});
         };
         auto pow_result_type_pyapi = [&](const py::dtype &dtype1,
                                          const py::dtype &dtype2) {
@@ -184,7 +195,12 @@ void init_pow(py::module_ m)
                 // c-contig matrix with c-contig row with broadcasting
                 // (may be nullptr)
                 td_ns::NullPtrTable<
-                    binary_inplace_row_matrix_broadcast_impl_fn_ptr_t>{});
+                    binary_inplace_row_matrix_broadcast_impl_fn_ptr_t>{},
+                // function pointers to handle in-place operation on
+                // contiguous array with scalar with broadcasting
+                // (may be nullptr)
+                td_ns::NullPtrTable<
+                    binary_inplace_scalar_contig_impl_fn_ptr_t>{});
         };
         m.def("_pow_inplace", pow_inplace_pyapi, "", py::arg("lhs"),
               py::arg("rhs"), py::arg("sycl_queue"),

--- a/dpctl/tensor/libtensor/source/elementwise_functions/remainder.cpp
+++ b/dpctl/tensor/libtensor/source/elementwise_functions/remainder.cpp
@@ -50,13 +50,16 @@ namespace py_internal
 namespace td_ns = dpctl::tensor::type_dispatch;
 
 namespace ew_cmn_ns = dpctl::tensor::kernels::elementwise_common;
+using ew_cmn_ns::binary_contig_array_scalar_broadcast_impl_fn_ptr_t;
 using ew_cmn_ns::binary_contig_impl_fn_ptr_t;
 using ew_cmn_ns::binary_contig_matrix_contig_row_broadcast_impl_fn_ptr_t;
 using ew_cmn_ns::binary_contig_row_contig_matrix_broadcast_impl_fn_ptr_t;
+using ew_cmn_ns::binary_scalar_contig_array_broadcast_impl_fn_ptr_t;
 using ew_cmn_ns::binary_strided_impl_fn_ptr_t;
 
 using ew_cmn_ns::binary_inplace_contig_impl_fn_ptr_t;
 using ew_cmn_ns::binary_inplace_row_matrix_broadcast_impl_fn_ptr_t;
+using ew_cmn_ns::binary_inplace_scalar_contig_impl_fn_ptr_t;
 using ew_cmn_ns::binary_inplace_strided_impl_fn_ptr_t;
 
 // B22: ===== REMAINDER (x1, x2)
@@ -155,7 +158,15 @@ void init_remainder(py::module_ m)
                 // function pointers to handle operation of c-contig matrix and
                 // c-contig row with broadcasting (may be nullptr)
                 td_ns::NullPtrTable<
-                    binary_contig_row_contig_matrix_broadcast_impl_fn_ptr_t>{});
+                    binary_contig_row_contig_matrix_broadcast_impl_fn_ptr_t>{},
+                // function pointers to handle operation of contiguous array
+                // and scalar with broadcasting (may be nullptr)
+                td_ns::NullPtrTable<
+                    binary_contig_array_scalar_broadcast_impl_fn_ptr_t>{},
+                // function pointers to handle operation of scalar and
+                // contiguous array with broadcasting (may be nullptr)
+                td_ns::NullPtrTable<
+                    binary_scalar_contig_array_broadcast_impl_fn_ptr_t>{});
         };
         auto remainder_result_type_pyapi = [&](const py::dtype &dtype1,
                                                const py::dtype &dtype2) {
@@ -186,7 +197,12 @@ void init_remainder(py::module_ m)
                 // c-contig matrix with c-contig row with broadcasting
                 // (may be nullptr)
                 td_ns::NullPtrTable<
-                    binary_inplace_row_matrix_broadcast_impl_fn_ptr_t>{});
+                    binary_inplace_row_matrix_broadcast_impl_fn_ptr_t>{},
+                // function pointers to handle in-place operation on
+                // contiguous array with scalar with broadcasting
+                // (may be nullptr)
+                td_ns::NullPtrTable<
+                    binary_inplace_scalar_contig_impl_fn_ptr_t>{});
         };
         m.def("_remainder_inplace", remainder_inplace_pyapi, "", py::arg("lhs"),
               py::arg("rhs"), py::arg("sycl_queue"),

--- a/dpctl/tensor/libtensor/source/elementwise_functions/subtract.cpp
+++ b/dpctl/tensor/libtensor/source/elementwise_functions/subtract.cpp
@@ -50,13 +50,16 @@ namespace py_internal
 namespace td_ns = dpctl::tensor::type_dispatch;
 
 namespace ew_cmn_ns = dpctl::tensor::kernels::elementwise_common;
+using ew_cmn_ns::binary_contig_array_scalar_broadcast_impl_fn_ptr_t;
 using ew_cmn_ns::binary_contig_impl_fn_ptr_t;
 using ew_cmn_ns::binary_contig_matrix_contig_row_broadcast_impl_fn_ptr_t;
 using ew_cmn_ns::binary_contig_row_contig_matrix_broadcast_impl_fn_ptr_t;
+using ew_cmn_ns::binary_scalar_contig_array_broadcast_impl_fn_ptr_t;
 using ew_cmn_ns::binary_strided_impl_fn_ptr_t;
 
 using ew_cmn_ns::binary_inplace_contig_impl_fn_ptr_t;
 using ew_cmn_ns::binary_inplace_row_matrix_broadcast_impl_fn_ptr_t;
+using ew_cmn_ns::binary_inplace_scalar_contig_impl_fn_ptr_t;
 using ew_cmn_ns::binary_inplace_strided_impl_fn_ptr_t;
 
 // B23: ===== SUBTRACT (x1, x2)
@@ -193,7 +196,15 @@ void init_subtract(py::module_ m)
                 subtract_contig_matrix_contig_row_broadcast_dispatch_table,
                 // function pointers to handle operation of c-contig matrix
                 // and c-contig row with broadcasting (may be nullptr)
-                subtract_contig_row_contig_matrix_broadcast_dispatch_table);
+                subtract_contig_row_contig_matrix_broadcast_dispatch_table,
+                // function pointers to handle operation of contiguous array
+                // and scalar with broadcasting (may be nullptr)
+                td_ns::NullPtrTable<
+                    binary_contig_array_scalar_broadcast_impl_fn_ptr_t>{},
+                // function pointers to handle operation of scalar and
+                // contiguous array with broadcasting (may be nullptr)
+                td_ns::NullPtrTable<
+                    binary_scalar_contig_array_broadcast_impl_fn_ptr_t>{});
         };
         auto subtract_result_type_pyapi = [&](const py::dtype &dtype1,
                                               const py::dtype &dtype2) {
@@ -224,7 +235,12 @@ void init_subtract(py::module_ m)
                 // function pointers to handle inplace operation on
                 // c-contig matrix with c-contig row with broadcasting
                 // (may be nullptr)
-                subtract_inplace_row_matrix_dispatch_table);
+                subtract_inplace_row_matrix_dispatch_table,
+                // function pointers to handle in-place operation on
+                // contiguous array with scalar with broadcasting
+                // (may be nullptr)
+                td_ns::NullPtrTable<
+                    binary_inplace_scalar_contig_impl_fn_ptr_t>{});
         };
         m.def("_subtract_inplace", subtract_inplace_pyapi, "", py::arg("lhs"),
               py::arg("rhs"), py::arg("sycl_queue"),

--- a/dpctl/tensor/libtensor/source/elementwise_functions/true_divide.cpp
+++ b/dpctl/tensor/libtensor/source/elementwise_functions/true_divide.cpp
@@ -137,7 +137,7 @@ void populate_true_divide_dispatch_tables(void)
     dtb5.populate_dispatch_table(
         true_divide_contig_row_contig_matrix_broadcast_dispatch_table);
 
-    // which input types are supported, and what is the type of the result
+    // which types are supported by the in-place kernels
     using fn_ns::TrueDivideInplaceTypeMapFactory;
     DispatchTableBuilder<int, TrueDivideInplaceTypeMapFactory, num_types> dtb6;
     dtb6.populate_dispatch_table(true_divide_inplace_output_id_table);

--- a/dpctl/tensor/libtensor/source/elementwise_functions/true_divide.cpp
+++ b/dpctl/tensor/libtensor/source/elementwise_functions/true_divide.cpp
@@ -50,13 +50,16 @@ namespace py_internal
 namespace td_ns = dpctl::tensor::type_dispatch;
 
 namespace ew_cmn_ns = dpctl::tensor::kernels::elementwise_common;
+using ew_cmn_ns::binary_contig_array_scalar_broadcast_impl_fn_ptr_t;
 using ew_cmn_ns::binary_contig_impl_fn_ptr_t;
 using ew_cmn_ns::binary_contig_matrix_contig_row_broadcast_impl_fn_ptr_t;
 using ew_cmn_ns::binary_contig_row_contig_matrix_broadcast_impl_fn_ptr_t;
+using ew_cmn_ns::binary_scalar_contig_array_broadcast_impl_fn_ptr_t;
 using ew_cmn_ns::binary_strided_impl_fn_ptr_t;
 
 using ew_cmn_ns::binary_inplace_contig_impl_fn_ptr_t;
 using ew_cmn_ns::binary_inplace_row_matrix_broadcast_impl_fn_ptr_t;
+using ew_cmn_ns::binary_inplace_scalar_contig_impl_fn_ptr_t;
 using ew_cmn_ns::binary_inplace_strided_impl_fn_ptr_t;
 
 // B08: ===== DIVIDE (x1, x2)
@@ -197,7 +200,15 @@ void init_divide(py::module_ m)
                 true_divide_contig_matrix_contig_row_broadcast_dispatch_table,
                 // function pointers to handle operation of c-contig matrix and
                 // c-contig row with broadcasting (may be nullptr)
-                true_divide_contig_row_contig_matrix_broadcast_dispatch_table);
+                true_divide_contig_row_contig_matrix_broadcast_dispatch_table,
+                // function pointers to handle operation of contiguous array
+                // and scalar with broadcasting (may be nullptr)
+                td_ns::NullPtrTable<
+                    binary_contig_array_scalar_broadcast_impl_fn_ptr_t>{},
+                // function pointers to handle operation of scalar and
+                // contiguous array with broadcasting (may be nullptr)
+                td_ns::NullPtrTable<
+                    binary_scalar_contig_array_broadcast_impl_fn_ptr_t>{});
         };
         auto divide_result_type_pyapi = [&](const py::dtype &dtype1,
                                             const py::dtype &dtype2) {
@@ -228,7 +239,12 @@ void init_divide(py::module_ m)
                 // function pointers to handle inplace operation on
                 // c-contig matrix with c-contig row with broadcasting
                 // (may be nullptr)
-                true_divide_inplace_row_matrix_dispatch_table);
+                true_divide_inplace_row_matrix_dispatch_table,
+                // function pointers to handle in-place operation on
+                // contiguous array with scalar with broadcasting
+                // (may be nullptr)
+                td_ns::NullPtrTable<
+                    binary_inplace_scalar_contig_impl_fn_ptr_t>{});
         };
         m.def("_divide_inplace", divide_inplace_pyapi, "", py::arg("lhs"),
               py::arg("rhs"), py::arg("sycl_queue"),


### PR DESCRIPTION
Supersedes #1814 

This pull request implements overloads for broadcast arrays and scalars for element-wise functions, and adds kernels for these overloads for addition.

Also refactors how the type maps for in-place operators are implemented to improve code readability.

- [X] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [X] Have you tested your changes locally for CPU and GPU devices?
- [X] Have you made sure that new changes do not introduce compiler warnings?
- [X] Have you checked performance impact of proposed changes?
- [X] If this PR is a work in progress, are you opening the PR as a draft?
