### PR TITLE
Introduce dedicated type support matrices for in-place element-wise operations

### DIFF
--- a/dpctl/tensor/_type_utils.py
+++ b/dpctl/tensor/_type_utils.py
@@ -140,11 +140,9 @@ def _acceptance_fn_default_unary(arg_dtype, ret_buf_dt, res_dt, sycl_dev):
 
 
 def _acceptance_fn_reciprocal(arg_dtype, buf_dt, res_dt, sycl_dev):
-    # if the kind of result is different from
-    # the kind of input, use the default data
-    # we use default dtype for the resulting kind.
-    # This guarantees alignment of reciprocal and
-    # divide output types.
+    # if the kind of result is different from the kind of input, we use the
+    # default floating-point dtype for the resulting kind. This guarantees
+    # alignment of reciprocal and divide output types.
     if buf_dt.kind != arg_dtype.kind:
         default_dt = _get_device_default_dtype(res_dt.kind, sycl_dev)
         if res_dt == default_dt:

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/abs.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/abs.hpp
@@ -118,6 +118,8 @@ template <typename T> struct AbsOutputType
         td_ns::TypeMapResultEntry<T, std::complex<float>, float>,
         td_ns::TypeMapResultEntry<T, std::complex<double>, double>,
         td_ns::DefaultResultEntry<void>>::result_type;
+
+    static constexpr bool is_defined = !std::is_same_v<value_type, void>;
 };
 
 template <typename T1, typename T2, unsigned int vec_sz, unsigned int n_vecs>
@@ -139,9 +141,7 @@ template <typename fnT, typename T> struct AbsContigFactory
 {
     fnT get()
     {
-        if constexpr (std::is_same_v<typename AbsOutputType<T>::value_type,
-                                     void>)
-        {
+        if constexpr (!AbsOutputType<T>::is_defined) {
             fnT fn = nullptr;
             return fn;
         }
@@ -190,9 +190,7 @@ template <typename fnT, typename T> struct AbsStridedFactory
 {
     fnT get()
     {
-        if constexpr (std::is_same_v<typename AbsOutputType<T>::value_type,
-                                     void>)
-        {
+        if constexpr (!AbsOutputType<T>::is_defined) {
             fnT fn = nullptr;
             return fn;
         }

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/abs.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/abs.hpp
@@ -102,8 +102,7 @@ using AbsContigFunctor =
 
 template <typename T> struct AbsOutputType
 {
-    using value_type = typename std::disjunction< // disjunction is C++17
-                                                  // feature, supported by DPC++
+    using value_type = typename std::disjunction<
         td_ns::TypeMapResultEntry<T, bool>,
         td_ns::TypeMapResultEntry<T, std::uint8_t>,
         td_ns::TypeMapResultEntry<T, std::uint16_t>,

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/acos.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/acos.hpp
@@ -145,8 +145,7 @@ using AcosStridedFunctor = elementwise_common::
 
 template <typename T> struct AcosOutputType
 {
-    using value_type = typename std::disjunction< // disjunction is C++17
-                                                  // feature, supported by DPC++
+    using value_type = typename std::disjunction<
         td_ns::TypeMapResultEntry<T, sycl::half>,
         td_ns::TypeMapResultEntry<T, float>,
         td_ns::TypeMapResultEntry<T, double>,

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/acos.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/acos.hpp
@@ -152,6 +152,8 @@ template <typename T> struct AcosOutputType
         td_ns::TypeMapResultEntry<T, std::complex<float>>,
         td_ns::TypeMapResultEntry<T, std::complex<double>>,
         td_ns::DefaultResultEntry<void>>::result_type;
+
+    static constexpr bool is_defined = !std::is_same_v<value_type, void>;
 };
 
 template <typename T1, typename T2, unsigned int vec_sz, unsigned int n_vecs>
@@ -173,9 +175,7 @@ template <typename fnT, typename T> struct AcosContigFactory
 {
     fnT get()
     {
-        if constexpr (std::is_same_v<typename AcosOutputType<T>::value_type,
-                                     void>)
-        {
+        if constexpr (!AcosOutputType<T>::is_defined) {
             fnT fn = nullptr;
             return fn;
         }
@@ -221,9 +221,7 @@ template <typename fnT, typename T> struct AcosStridedFactory
 {
     fnT get()
     {
-        if constexpr (std::is_same_v<typename AcosOutputType<T>::value_type,
-                                     void>)
-        {
+        if constexpr (!AcosOutputType<T>::is_defined) {
             fnT fn = nullptr;
             return fn;
         }

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/acosh.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/acosh.hpp
@@ -179,6 +179,8 @@ template <typename T> struct AcoshOutputType
         td_ns::TypeMapResultEntry<T, std::complex<float>>,
         td_ns::TypeMapResultEntry<T, std::complex<double>>,
         td_ns::DefaultResultEntry<void>>::result_type;
+
+    static constexpr bool is_defined = !std::is_same_v<value_type, void>;
 };
 
 template <typename T1, typename T2, unsigned int vec_sz, unsigned int n_vecs>
@@ -200,9 +202,7 @@ template <typename fnT, typename T> struct AcoshContigFactory
 {
     fnT get()
     {
-        if constexpr (std::is_same_v<typename AcoshOutputType<T>::value_type,
-                                     void>)
-        {
+        if constexpr (!AcoshOutputType<T>::is_defined) {
             fnT fn = nullptr;
             return fn;
         }
@@ -248,9 +248,7 @@ template <typename fnT, typename T> struct AcoshStridedFactory
 {
     fnT get()
     {
-        if constexpr (std::is_same_v<typename AcoshOutputType<T>::value_type,
-                                     void>)
-        {
+        if constexpr (!AcoshOutputType<T>::is_defined) {
             fnT fn = nullptr;
             return fn;
         }

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/acosh.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/acosh.hpp
@@ -172,8 +172,7 @@ using AcoshStridedFunctor = elementwise_common::
 
 template <typename T> struct AcoshOutputType
 {
-    using value_type = typename std::disjunction< // disjunction is C++17
-                                                  // feature, supported by DPC++
+    using value_type = typename std::disjunction<
         td_ns::TypeMapResultEntry<T, sycl::half>,
         td_ns::TypeMapResultEntry<T, float>,
         td_ns::TypeMapResultEntry<T, double>,

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/add.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/add.hpp
@@ -438,6 +438,53 @@ template <typename argT,
           unsigned int n_vecs>
 class add_inplace_contig_kernel;
 
+/* @brief Types supported by in-place add */
+template <typename argTy, typename resTy> struct AddInplaceTypePairSupport
+{
+    /* value if true a kernel for <argTy, resTy> must be instantiated  */
+    static constexpr bool is_defined = std::disjunction< // disjunction is
+                                                         // C++17 feature,
+                                                         // supported by
+                                                         // DPC++ input bool
+        td_ns::TypePairDefinedEntry<argTy, bool, resTy, bool>,
+        td_ns::TypePairDefinedEntry<argTy, std::int8_t, resTy, std::int8_t>,
+        td_ns::TypePairDefinedEntry<argTy, std::uint8_t, resTy, std::uint8_t>,
+        td_ns::TypePairDefinedEntry<argTy, std::int16_t, resTy, std::int16_t>,
+        td_ns::TypePairDefinedEntry<argTy, std::uint16_t, resTy, std::uint16_t>,
+        td_ns::TypePairDefinedEntry<argTy, std::int32_t, resTy, std::int32_t>,
+        td_ns::TypePairDefinedEntry<argTy, std::uint32_t, resTy, std::uint32_t>,
+        td_ns::TypePairDefinedEntry<argTy, std::int64_t, resTy, std::int64_t>,
+        td_ns::TypePairDefinedEntry<argTy, std::uint64_t, resTy, std::uint64_t>,
+        td_ns::TypePairDefinedEntry<argTy, sycl::half, resTy, sycl::half>,
+        td_ns::TypePairDefinedEntry<argTy, float, resTy, float>,
+        td_ns::TypePairDefinedEntry<argTy, double, resTy, double>,
+        td_ns::TypePairDefinedEntry<argTy,
+                                    std::complex<float>,
+                                    resTy,
+                                    std::complex<float>>,
+        td_ns::TypePairDefinedEntry<argTy,
+                                    std::complex<double>,
+                                    resTy,
+                                    std::complex<double>>,
+        // fall-through
+        td_ns::NotDefinedEntry>::is_defined;
+};
+
+template <typename fnT, typename argT, typename resT>
+struct AddInplaceTypeMapFactory
+{
+    /*! @brief get typeid for output type of x += y */
+    std::enable_if_t<std::is_same<fnT, int>::value, int> get()
+    {
+        if constexpr (AddInplaceTypePairSupport<argT, resT>::is_defined) {
+            return td_ns::GetTypeid<resT>{}.get();
+        }
+        else {
+            return td_ns::GetTypeid<void>{}.get();
+        }
+    }
+};
+
 template <typename argTy, typename resTy>
 sycl::event
 add_inplace_contig_impl(sycl::queue &exec_q,
@@ -457,9 +504,7 @@ template <typename fnT, typename T1, typename T2> struct AddInplaceContigFactory
 {
     fnT get()
     {
-        if constexpr (std::is_same_v<typename AddOutputType<T1, T2>::value_type,
-                                     void>)
-        {
+        if constexpr (!AddInplaceTypePairSupport<T1, T2>::is_defined) {
             fnT fn = nullptr;
             return fn;
         }
@@ -497,9 +542,7 @@ struct AddInplaceStridedFactory
 {
     fnT get()
     {
-        if constexpr (std::is_same_v<typename AddOutputType<T1, T2>::value_type,
-                                     void>)
-        {
+        if constexpr (!AddInplaceTypePairSupport<T1, T2>::is_defined) {
             fnT fn = nullptr;
             return fn;
         }
@@ -544,8 +587,7 @@ struct AddInplaceRowMatrixBroadcastFactory
 {
     fnT get()
     {
-        using resT = typename AddOutputType<T1, T2>::value_type;
-        if constexpr (!std::is_same_v<resT, T2>) {
+        if constexpr (!AddInplaceTypePairSupport<T1, T2>::is_defined) {
             fnT fn = nullptr;
             return fn;
         }

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/add.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/add.hpp
@@ -132,8 +132,7 @@ using AddStridedFunctor =
 
 template <typename T1, typename T2> struct AddOutputType
 {
-    using value_type = typename std::disjunction< // disjunction is C++17
-                                                  // feature, supported by DPC++
+    using value_type = typename std::disjunction<
         td_ns::BinaryTypeMapResultEntry<T1, bool, T2, bool, bool>,
         td_ns::BinaryTypeMapResultEntry<T1,
                                         std::uint8_t,
@@ -442,10 +441,7 @@ class add_inplace_contig_kernel;
 template <typename argTy, typename resTy> struct AddInplaceTypePairSupport
 {
     /* value if true a kernel for <argTy, resTy> must be instantiated  */
-    static constexpr bool is_defined = std::disjunction< // disjunction is
-                                                         // C++17 feature,
-                                                         // supported by
-                                                         // DPC++ input bool
+    static constexpr bool is_defined = std::disjunction<
         td_ns::TypePairDefinedEntry<argTy, bool, resTy, bool>,
         td_ns::TypePairDefinedEntry<argTy, std::int8_t, resTy, std::int8_t>,
         td_ns::TypePairDefinedEntry<argTy, std::uint8_t, resTy, std::uint8_t>,

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/add.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/add.hpp
@@ -192,6 +192,8 @@ template <typename T1, typename T2> struct AddOutputType
                                         std::complex<double>,
                                         std::complex<double>>,
         td_ns::DefaultResultEntry<void>>::result_type;
+
+    static constexpr bool is_defined = !std::is_same_v<value_type, void>;
 };
 
 template <typename argT1,
@@ -222,9 +224,7 @@ template <typename fnT, typename T1, typename T2> struct AddContigFactory
 {
     fnT get()
     {
-        if constexpr (std::is_same_v<typename AddOutputType<T1, T2>::value_type,
-                                     void>)
-        {
+        if constexpr (!AddOutputType<T1, T2>::is_defined) {
             fnT fn = nullptr;
             return fn;
         }
@@ -272,9 +272,7 @@ template <typename fnT, typename T1, typename T2> struct AddStridedFactory
 {
     fnT get()
     {
-        if constexpr (std::is_same_v<typename AddOutputType<T1, T2>::value_type,
-                                     void>)
-        {
+        if constexpr (!AddOutputType<T1, T2>::is_defined) {
             fnT fn = nullptr;
             return fn;
         }
@@ -323,12 +321,12 @@ struct AddContigMatrixContigRowBroadcastFactory
 {
     fnT get()
     {
-        using resT = typename AddOutputType<T1, T2>::value_type;
-        if constexpr (std::is_same_v<resT, void>) {
+        if constexpr (!AddOutputType<T1, T2>::is_defined) {
             fnT fn = nullptr;
             return fn;
         }
         else {
+            using resT = typename AddOutputType<T1, T2>::value_type;
             if constexpr (dpctl::tensor::type_utils::is_complex<T1>::value ||
                           dpctl::tensor::type_utils::is_complex<T2>::value ||
                           dpctl::tensor::type_utils::is_complex<resT>::value)
@@ -370,12 +368,12 @@ struct AddContigRowContigMatrixBroadcastFactory
 {
     fnT get()
     {
-        using resT = typename AddOutputType<T1, T2>::value_type;
-        if constexpr (std::is_same_v<resT, void>) {
+        if constexpr (!AddOutputType<T1, T2>::is_defined) {
             fnT fn = nullptr;
             return fn;
         }
         else {
+            using resT = typename AddOutputType<T1, T2>::value_type;
             if constexpr (dpctl::tensor::type_utils::is_complex<T1>::value ||
                           dpctl::tensor::type_utils::is_complex<T2>::value ||
                           dpctl::tensor::type_utils::is_complex<resT>::value)

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/angle.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/angle.hpp
@@ -95,6 +95,8 @@ template <typename T> struct AngleOutputType
         td_ns::TypeMapResultEntry<T, std::complex<float>, float>,
         td_ns::TypeMapResultEntry<T, std::complex<double>, double>,
         td_ns::DefaultResultEntry<void>>::result_type;
+
+    static constexpr bool is_defined = !std::is_same_v<value_type, void>;
 };
 
 template <typename T1, typename T2, unsigned int vec_sz, unsigned int n_vecs>
@@ -116,9 +118,7 @@ template <typename fnT, typename T> struct AngleContigFactory
 {
     fnT get()
     {
-        if constexpr (std::is_same_v<typename AngleOutputType<T>::value_type,
-                                     void>)
-        {
+        if constexpr (!AngleOutputType<T>::is_defined) {
             fnT fn = nullptr;
             return fn;
         }
@@ -164,9 +164,7 @@ template <typename fnT, typename T> struct AngleStridedFactory
 {
     fnT get()
     {
-        if constexpr (std::is_same_v<typename AngleOutputType<T>::value_type,
-                                     void>)
-        {
+        if constexpr (!AngleOutputType<T>::is_defined) {
             fnT fn = nullptr;
             return fn;
         }

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/angle.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/angle.hpp
@@ -91,8 +91,7 @@ using AngleStridedFunctor = elementwise_common::
 
 template <typename T> struct AngleOutputType
 {
-    using value_type = typename std::disjunction< // disjunction is C++17
-                                                  // feature, supported by DPC++
+    using value_type = typename std::disjunction<
         td_ns::TypeMapResultEntry<T, std::complex<float>, float>,
         td_ns::TypeMapResultEntry<T, std::complex<double>, double>,
         td_ns::DefaultResultEntry<void>>::result_type;

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/asin.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/asin.hpp
@@ -165,8 +165,7 @@ using AsinStridedFunctor = elementwise_common::
 
 template <typename T> struct AsinOutputType
 {
-    using value_type = typename std::disjunction< // disjunction is C++17
-                                                  // feature, supported by DPC++
+    using value_type = typename std::disjunction<
         td_ns::TypeMapResultEntry<T, sycl::half>,
         td_ns::TypeMapResultEntry<T, float>,
         td_ns::TypeMapResultEntry<T, double>,

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/asin.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/asin.hpp
@@ -172,6 +172,8 @@ template <typename T> struct AsinOutputType
         td_ns::TypeMapResultEntry<T, std::complex<float>>,
         td_ns::TypeMapResultEntry<T, std::complex<double>>,
         td_ns::DefaultResultEntry<void>>::result_type;
+
+    static constexpr bool is_defined = !std::is_same_v<value_type, void>;
 };
 
 template <typename T1, typename T2, unsigned int vec_sz, unsigned int n_vecs>
@@ -193,9 +195,7 @@ template <typename fnT, typename T> struct AsinContigFactory
 {
     fnT get()
     {
-        if constexpr (std::is_same_v<typename AsinOutputType<T>::value_type,
-                                     void>)
-        {
+        if constexpr (!AsinOutputType<T>::is_defined) {
             fnT fn = nullptr;
             return fn;
         }
@@ -241,9 +241,7 @@ template <typename fnT, typename T> struct AsinStridedFactory
 {
     fnT get()
     {
-        if constexpr (std::is_same_v<typename AsinOutputType<T>::value_type,
-                                     void>)
-        {
+        if constexpr (!AsinOutputType<T>::is_defined) {
             fnT fn = nullptr;
             return fn;
         }

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/asinh.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/asinh.hpp
@@ -155,6 +155,8 @@ template <typename T> struct AsinhOutputType
         td_ns::TypeMapResultEntry<T, std::complex<float>>,
         td_ns::TypeMapResultEntry<T, std::complex<double>>,
         td_ns::DefaultResultEntry<void>>::result_type;
+
+    static constexpr bool is_defined = !std::is_same_v<value_type, void>;
 };
 
 template <typename T1, typename T2, unsigned int vec_sz, unsigned int n_vecs>
@@ -176,9 +178,7 @@ template <typename fnT, typename T> struct AsinhContigFactory
 {
     fnT get()
     {
-        if constexpr (std::is_same_v<typename AsinhOutputType<T>::value_type,
-                                     void>)
-        {
+        if constexpr (!AsinhOutputType<T>::is_defined) {
             fnT fn = nullptr;
             return fn;
         }
@@ -224,9 +224,7 @@ template <typename fnT, typename T> struct AsinhStridedFactory
 {
     fnT get()
     {
-        if constexpr (std::is_same_v<typename AsinhOutputType<T>::value_type,
-                                     void>)
-        {
+        if constexpr (!AsinhOutputType<T>::is_defined) {
             fnT fn = nullptr;
             return fn;
         }

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/asinh.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/asinh.hpp
@@ -148,8 +148,7 @@ using AsinhStridedFunctor = elementwise_common::
 
 template <typename T> struct AsinhOutputType
 {
-    using value_type = typename std::disjunction< // disjunction is C++17
-                                                  // feature, supported by DPC++
+    using value_type = typename std::disjunction<
         td_ns::TypeMapResultEntry<T, sycl::half>,
         td_ns::TypeMapResultEntry<T, float>,
         td_ns::TypeMapResultEntry<T, double>,

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/atan.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/atan.hpp
@@ -155,8 +155,7 @@ using AtanStridedFunctor = elementwise_common::
 
 template <typename T> struct AtanOutputType
 {
-    using value_type = typename std::disjunction< // disjunction is C++17
-                                                  // feature, supported by DPC++
+    using value_type = typename std::disjunction<
         td_ns::TypeMapResultEntry<T, sycl::half>,
         td_ns::TypeMapResultEntry<T, float>,
         td_ns::TypeMapResultEntry<T, double>,

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/atan.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/atan.hpp
@@ -162,6 +162,8 @@ template <typename T> struct AtanOutputType
         td_ns::TypeMapResultEntry<T, std::complex<float>>,
         td_ns::TypeMapResultEntry<T, std::complex<double>>,
         td_ns::DefaultResultEntry<void>>::result_type;
+
+    static constexpr bool is_defined = !std::is_same_v<value_type, void>;
 };
 
 template <typename T1, typename T2, unsigned int vec_sz, unsigned int n_vecs>
@@ -183,9 +185,7 @@ template <typename fnT, typename T> struct AtanContigFactory
 {
     fnT get()
     {
-        if constexpr (std::is_same_v<typename AtanOutputType<T>::value_type,
-                                     void>)
-        {
+        if constexpr (!AtanOutputType<T>::is_defined) {
             fnT fn = nullptr;
             return fn;
         }
@@ -231,9 +231,7 @@ template <typename fnT, typename T> struct AtanStridedFactory
 {
     fnT get()
     {
-        if constexpr (std::is_same_v<typename AtanOutputType<T>::value_type,
-                                     void>)
-        {
+        if constexpr (!AtanOutputType<T>::is_defined) {
             fnT fn = nullptr;
             return fn;
         }

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/atan2.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/atan2.hpp
@@ -90,8 +90,7 @@ using Atan2StridedFunctor =
 
 template <typename T1, typename T2> struct Atan2OutputType
 {
-    using value_type = typename std::disjunction< // disjunction is C++17
-                                                  // feature, supported by DPC++
+    using value_type = typename std::disjunction<
         td_ns::BinaryTypeMapResultEntry<T1,
                                         sycl::half,
                                         T2,

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/atan2.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/atan2.hpp
@@ -99,6 +99,8 @@ template <typename T1, typename T2> struct Atan2OutputType
         td_ns::BinaryTypeMapResultEntry<T1, float, T2, float, float>,
         td_ns::BinaryTypeMapResultEntry<T1, double, T2, double, double>,
         td_ns::DefaultResultEntry<void>>::result_type;
+
+    static constexpr bool is_defined = !std::is_same_v<value_type, void>;
 };
 
 template <typename argT1,
@@ -129,9 +131,7 @@ template <typename fnT, typename T1, typename T2> struct Atan2ContigFactory
 {
     fnT get()
     {
-        if constexpr (std::is_same_v<
-                          typename Atan2OutputType<T1, T2>::value_type, void>)
-        {
+        if constexpr (!Atan2OutputType<T1, T2>::is_defined) {
             fnT fn = nullptr;
             return fn;
         }
@@ -148,7 +148,6 @@ template <typename fnT, typename T1, typename T2> struct Atan2TypeMapFactory
     std::enable_if_t<std::is_same<fnT, int>::value, int> get()
     {
         using rT = typename Atan2OutputType<T1, T2>::value_type;
-        ;
         return td_ns::GetTypeid<rT>{}.get();
     }
 };
@@ -182,9 +181,7 @@ template <typename fnT, typename T1, typename T2> struct Atan2StridedFactory
 {
     fnT get()
     {
-        if constexpr (std::is_same_v<
-                          typename Atan2OutputType<T1, T2>::value_type, void>)
-        {
+        if constexpr (!Atan2OutputType<T1, T2>::is_defined) {
             fnT fn = nullptr;
             return fn;
         }

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/atanh.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/atanh.hpp
@@ -149,8 +149,7 @@ using AtanhStridedFunctor = elementwise_common::
 
 template <typename T> struct AtanhOutputType
 {
-    using value_type = typename std::disjunction< // disjunction is C++17
-                                                  // feature, supported by DPC++
+    using value_type = typename std::disjunction<
         td_ns::TypeMapResultEntry<T, sycl::half>,
         td_ns::TypeMapResultEntry<T, float>,
         td_ns::TypeMapResultEntry<T, double>,

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/atanh.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/atanh.hpp
@@ -156,6 +156,8 @@ template <typename T> struct AtanhOutputType
         td_ns::TypeMapResultEntry<T, std::complex<float>>,
         td_ns::TypeMapResultEntry<T, std::complex<double>>,
         td_ns::DefaultResultEntry<void>>::result_type;
+
+    static constexpr bool is_defined = !std::is_same_v<value_type, void>;
 };
 
 template <typename T1, typename T2, unsigned int vec_sz, unsigned int n_vecs>
@@ -177,9 +179,7 @@ template <typename fnT, typename T> struct AtanhContigFactory
 {
     fnT get()
     {
-        if constexpr (std::is_same_v<typename AtanhOutputType<T>::value_type,
-                                     void>)
-        {
+        if constexpr (!AtanhOutputType<T>::is_defined) {
             fnT fn = nullptr;
             return fn;
         }
@@ -225,9 +225,7 @@ template <typename fnT, typename T> struct AtanhStridedFactory
 {
     fnT get()
     {
-        if constexpr (std::is_same_v<typename AtanhOutputType<T>::value_type,
-                                     void>)
-        {
+        if constexpr (!AtanhOutputType<T>::is_defined) {
             fnT fn = nullptr;
             return fn;
         }

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/bitwise_and.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/bitwise_and.hpp
@@ -156,6 +156,8 @@ template <typename T1, typename T2> struct BitwiseAndOutputType
                                         std::int64_t,
                                         std::int64_t>,
         td_ns::DefaultResultEntry<void>>::result_type;
+
+    static constexpr bool is_defined = !std::is_same_v<value_type, void>;
 };
 
 template <typename argT1,
@@ -187,10 +189,7 @@ template <typename fnT, typename T1, typename T2> struct BitwiseAndContigFactory
 {
     fnT get()
     {
-        if constexpr (std::is_same_v<
-                          typename BitwiseAndOutputType<T1, T2>::value_type,
-                          void>)
-        {
+        if constexpr (!BitwiseAndOutputType<T1, T2>::is_defined) {
             fnT fn = nullptr;
             return fn;
         }
@@ -243,10 +242,7 @@ struct BitwiseAndStridedFactory
 {
     fnT get()
     {
-        if constexpr (std::is_same_v<
-                          typename BitwiseAndOutputType<T1, T2>::value_type,
-                          void>)
-        {
+        if constexpr (!BitwiseAndOutputType<T1, T2>::is_defined) {
             fnT fn = nullptr;
             return fn;
         }

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/bitwise_and.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/bitwise_and.hpp
@@ -322,6 +322,44 @@ template <typename argT,
           unsigned int n_vecs>
 class bitwise_and_inplace_contig_kernel;
 
+/* @brief Types supported by in-place bitwise AND */
+template <typename argTy, typename resTy>
+struct BitwiseAndInplaceTypePairSupport
+{
+    /* value if true a kernel for <argTy, resTy> must be instantiated  */
+    static constexpr bool is_defined = std::disjunction< // disjunction is
+                                                         // C++17 feature,
+                                                         // supported by
+                                                         // DPC++ input bool
+        td_ns::TypePairDefinedEntry<argTy, bool, resTy, bool>,
+        td_ns::TypePairDefinedEntry<argTy, std::int8_t, resTy, std::int8_t>,
+        td_ns::TypePairDefinedEntry<argTy, std::uint8_t, resTy, std::uint8_t>,
+        td_ns::TypePairDefinedEntry<argTy, std::int16_t, resTy, std::int16_t>,
+        td_ns::TypePairDefinedEntry<argTy, std::uint16_t, resTy, std::uint16_t>,
+        td_ns::TypePairDefinedEntry<argTy, std::int32_t, resTy, std::int32_t>,
+        td_ns::TypePairDefinedEntry<argTy, std::uint32_t, resTy, std::uint32_t>,
+        td_ns::TypePairDefinedEntry<argTy, std::int64_t, resTy, std::int64_t>,
+        td_ns::TypePairDefinedEntry<argTy, std::uint64_t, resTy, std::uint64_t>,
+        // fall-through
+        td_ns::NotDefinedEntry>::is_defined;
+};
+
+template <typename fnT, typename argT, typename resT>
+struct BitwiseAndInplaceTypeMapFactory
+{
+    /*! @brief get typeid for output type of x &= y */
+    std::enable_if_t<std::is_same<fnT, int>::value, int> get()
+    {
+        if constexpr (BitwiseAndInplaceTypePairSupport<argT, resT>::is_defined)
+        {
+            return td_ns::GetTypeid<resT>{}.get();
+        }
+        else {
+            return td_ns::GetTypeid<void>{}.get();
+        }
+    }
+};
+
 template <typename argTy, typename resTy>
 sycl::event
 bitwise_and_inplace_contig_impl(sycl::queue &exec_q,
@@ -343,10 +381,7 @@ struct BitwiseAndInplaceContigFactory
 {
     fnT get()
     {
-        if constexpr (std::is_same_v<
-                          typename BitwiseAndOutputType<T1, T2>::value_type,
-                          void>)
-        {
+        if constexpr (!BitwiseAndInplaceTypePairSupport<T1, T2>::is_defined) {
             fnT fn = nullptr;
             return fn;
         }
@@ -385,10 +420,7 @@ struct BitwiseAndInplaceStridedFactory
 {
     fnT get()
     {
-        if constexpr (std::is_same_v<
-                          typename BitwiseAndOutputType<T1, T2>::value_type,
-                          void>)
-        {
+        if constexpr (!BitwiseAndInplaceTypePairSupport<T1, T2>::is_defined) {
             fnT fn = nullptr;
             return fn;
         }

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/bitwise_and.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/bitwise_and.hpp
@@ -113,9 +113,7 @@ using BitwiseAndStridedFunctor = elementwise_common::BinaryStridedFunctor<
 
 template <typename T1, typename T2> struct BitwiseAndOutputType
 {
-    using value_type = typename std::disjunction< // disjunction is C++17
-                                                  // feature, supported by
-                                                  // DPC++
+    using value_type = typename std::disjunction<
         td_ns::BinaryTypeMapResultEntry<T1, bool, T2, bool, bool>,
         td_ns::BinaryTypeMapResultEntry<T1,
                                         std::uint8_t,
@@ -327,10 +325,7 @@ template <typename argTy, typename resTy>
 struct BitwiseAndInplaceTypePairSupport
 {
     /* value if true a kernel for <argTy, resTy> must be instantiated  */
-    static constexpr bool is_defined = std::disjunction< // disjunction is
-                                                         // C++17 feature,
-                                                         // supported by
-                                                         // DPC++ input bool
+    static constexpr bool is_defined = std::disjunction<
         td_ns::TypePairDefinedEntry<argTy, bool, resTy, bool>,
         td_ns::TypePairDefinedEntry<argTy, std::int8_t, resTy, std::int8_t>,
         td_ns::TypePairDefinedEntry<argTy, std::uint8_t, resTy, std::uint8_t>,

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/bitwise_invert.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/bitwise_invert.hpp
@@ -111,6 +111,8 @@ template <typename argTy> struct BitwiseInvertOutputType
         td_ns::TypeMapResultEntry<argTy, std::int32_t>,
         td_ns::TypeMapResultEntry<argTy, std::int64_t>,
         td_ns::DefaultResultEntry<void>>::result_type;
+
+    static constexpr bool is_defined = !std::is_same_v<value_type, void>;
 };
 
 template <typename T1, typename T2, unsigned int vec_sz, unsigned int n_vecs>
@@ -134,10 +136,7 @@ template <typename fnT, typename T> struct BitwiseInvertContigFactory
 {
     fnT get()
     {
-        if constexpr (std::is_same_v<
-                          typename BitwiseInvertOutputType<T>::value_type,
-                          void>)
-        {
+        if constexpr (!BitwiseInvertOutputType<T>::is_defined) {
             fnT fn = nullptr;
             return fn;
         }
@@ -185,10 +184,7 @@ template <typename fnT, typename T> struct BitwiseInvertStridedFactory
 {
     fnT get()
     {
-        if constexpr (std::is_same_v<
-                          typename BitwiseInvertOutputType<T>::value_type,
-                          void>)
-        {
+        if constexpr (!BitwiseInvertOutputType<T>::is_defined) {
             fnT fn = nullptr;
             return fn;
         }

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/bitwise_invert.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/bitwise_invert.hpp
@@ -100,8 +100,7 @@ using BitwiseInvertStridedFunctor =
 
 template <typename argTy> struct BitwiseInvertOutputType
 {
-    using value_type = typename std::disjunction< // disjunction is C++17
-                                                  // feature, supported by DPC++
+    using value_type = typename std::disjunction<
         td_ns::TypeMapResultEntry<argTy, bool>,
         td_ns::TypeMapResultEntry<argTy, std::uint8_t>,
         td_ns::TypeMapResultEntry<argTy, std::uint16_t>,

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/bitwise_left_shift.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/bitwise_left_shift.hpp
@@ -336,6 +336,44 @@ template <typename argT,
           unsigned int n_vecs>
 class bitwise_left_shift_inplace_contig_kernel;
 
+/* @brief Types supported by in-place bitwise left shift */
+template <typename argTy, typename resTy>
+struct BitwiseLeftShiftInplaceTypePairSupport
+{
+    /* value if true a kernel for <argTy, resTy> must be instantiated  */
+    static constexpr bool is_defined = std::disjunction< // disjunction is
+                                                         // C++17 feature,
+                                                         // supported by
+                                                         // DPC++ input bool
+        td_ns::TypePairDefinedEntry<argTy, std::int8_t, resTy, std::int8_t>,
+        td_ns::TypePairDefinedEntry<argTy, std::uint8_t, resTy, std::uint8_t>,
+        td_ns::TypePairDefinedEntry<argTy, std::int16_t, resTy, std::int16_t>,
+        td_ns::TypePairDefinedEntry<argTy, std::uint16_t, resTy, std::uint16_t>,
+        td_ns::TypePairDefinedEntry<argTy, std::int32_t, resTy, std::int32_t>,
+        td_ns::TypePairDefinedEntry<argTy, std::uint32_t, resTy, std::uint32_t>,
+        td_ns::TypePairDefinedEntry<argTy, std::int64_t, resTy, std::int64_t>,
+        td_ns::TypePairDefinedEntry<argTy, std::uint64_t, resTy, std::uint64_t>,
+        // fall-through
+        td_ns::NotDefinedEntry>::is_defined;
+};
+
+template <typename fnT, typename argT, typename resT>
+struct BitwiseLeftShiftInplaceTypeMapFactory
+{
+    /*! @brief get typeid for output type of x <<= y */
+    std::enable_if_t<std::is_same<fnT, int>::value, int> get()
+    {
+        if constexpr (BitwiseLeftShiftInplaceTypePairSupport<argT,
+                                                             resT>::is_defined)
+        {
+            return td_ns::GetTypeid<resT>{}.get();
+        }
+        else {
+            return td_ns::GetTypeid<void>{}.get();
+        }
+    }
+};
+
 template <typename argTy, typename resTy>
 sycl::event bitwise_left_shift_inplace_contig_impl(
     sycl::queue &exec_q,
@@ -357,9 +395,8 @@ struct BitwiseLeftShiftInplaceContigFactory
 {
     fnT get()
     {
-        if constexpr (std::is_same_v<typename BitwiseLeftShiftOutputType<
-                                         T1, T2>::value_type,
-                                     void>)
+        if constexpr (!BitwiseLeftShiftInplaceTypePairSupport<T1,
+                                                              T2>::is_defined)
         {
             fnT fn = nullptr;
             return fn;
@@ -399,9 +436,8 @@ struct BitwiseLeftShiftInplaceStridedFactory
 {
     fnT get()
     {
-        if constexpr (std::is_same_v<typename BitwiseLeftShiftOutputType<
-                                         T1, T2>::value_type,
-                                     void>)
+        if constexpr (!BitwiseLeftShiftInplaceTypePairSupport<T1,
+                                                              T2>::is_defined)
         {
             fnT fn = nullptr;
             return fn;

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/bitwise_left_shift.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/bitwise_left_shift.hpp
@@ -165,6 +165,8 @@ template <typename T1, typename T2> struct BitwiseLeftShiftOutputType
                                         std::uint64_t,
                                         std::uint64_t>,
         td_ns::DefaultResultEntry<void>>::result_type;
+
+    static constexpr bool is_defined = !std::is_same_v<value_type, void>;
 };
 
 template <typename argT1,
@@ -198,10 +200,7 @@ struct BitwiseLeftShiftContigFactory
 {
     fnT get()
     {
-        if constexpr (std::is_same_v<typename BitwiseLeftShiftOutputType<
-                                         T1, T2>::value_type,
-                                     void>)
-        {
+        if constexpr (!BitwiseLeftShiftOutputType<T1, T2>::is_defined) {
             fnT fn = nullptr;
             return fn;
         }
@@ -254,10 +253,7 @@ struct BitwiseLeftShiftStridedFactory
 {
     fnT get()
     {
-        if constexpr (std::is_same_v<typename BitwiseLeftShiftOutputType<
-                                         T1, T2>::value_type,
-                                     void>)
-        {
+        if constexpr (!BitwiseLeftShiftOutputType<T1, T2>::is_defined) {
             fnT fn = nullptr;
             return fn;
         }

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/bitwise_left_shift.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/bitwise_left_shift.hpp
@@ -123,9 +123,7 @@ using BitwiseLeftShiftStridedFunctor = elementwise_common::BinaryStridedFunctor<
 template <typename T1, typename T2> struct BitwiseLeftShiftOutputType
 {
     using ResT = T1;
-    using value_type = typename std::disjunction< // disjunction is C++17
-                                                  // feature, supported by
-                                                  // DPC++
+    using value_type = typename std::disjunction<
         td_ns::BinaryTypeMapResultEntry<T1,
                                         std::int8_t,
                                         T2,
@@ -341,10 +339,7 @@ template <typename argTy, typename resTy>
 struct BitwiseLeftShiftInplaceTypePairSupport
 {
     /* value if true a kernel for <argTy, resTy> must be instantiated  */
-    static constexpr bool is_defined = std::disjunction< // disjunction is
-                                                         // C++17 feature,
-                                                         // supported by
-                                                         // DPC++ input bool
+    static constexpr bool is_defined = std::disjunction<
         td_ns::TypePairDefinedEntry<argTy, std::int8_t, resTy, std::int8_t>,
         td_ns::TypePairDefinedEntry<argTy, std::uint8_t, resTy, std::uint8_t>,
         td_ns::TypePairDefinedEntry<argTy, std::int16_t, resTy, std::int16_t>,

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/bitwise_or.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/bitwise_or.hpp
@@ -155,6 +155,8 @@ template <typename T1, typename T2> struct BitwiseOrOutputType
                                         std::int64_t,
                                         std::int64_t>,
         td_ns::DefaultResultEntry<void>>::result_type;
+
+    static constexpr bool is_defined = !std::is_same_v<value_type, void>;
 };
 
 template <typename argT1,
@@ -185,10 +187,7 @@ template <typename fnT, typename T1, typename T2> struct BitwiseOrContigFactory
 {
     fnT get()
     {
-        if constexpr (std::is_same_v<
-                          typename BitwiseOrOutputType<T1, T2>::value_type,
-                          void>)
-        {
+        if constexpr (!BitwiseOrOutputType<T1, T2>::is_defined) {
             fnT fn = nullptr;
             return fn;
         }
@@ -239,10 +238,7 @@ template <typename fnT, typename T1, typename T2> struct BitwiseOrStridedFactory
 {
     fnT get()
     {
-        if constexpr (std::is_same_v<
-                          typename BitwiseOrOutputType<T1, T2>::value_type,
-                          void>)
-        {
+        if constexpr (!BitwiseOrOutputType<T1, T2>::is_defined) {
             fnT fn = nullptr;
             return fn;
         }

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/bitwise_or.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/bitwise_or.hpp
@@ -112,9 +112,7 @@ using BitwiseOrStridedFunctor = elementwise_common::BinaryStridedFunctor<
 
 template <typename T1, typename T2> struct BitwiseOrOutputType
 {
-    using value_type = typename std::disjunction< // disjunction is C++17
-                                                  // feature, supported by
-                                                  // DPC++
+    using value_type = typename std::disjunction<
         td_ns::BinaryTypeMapResultEntry<T1, bool, T2, bool, bool>,
         td_ns::BinaryTypeMapResultEntry<T1,
                                         std::uint8_t,
@@ -322,10 +320,7 @@ class bitwise_or_inplace_contig_kernel;
 template <typename argTy, typename resTy> struct BitwiseOrInplaceTypePairSupport
 {
     /* value if true a kernel for <argTy, resTy> must be instantiated  */
-    static constexpr bool is_defined = std::disjunction< // disjunction is
-                                                         // C++17 feature,
-                                                         // supported by
-                                                         // DPC++ input bool
+    static constexpr bool is_defined = std::disjunction<
         td_ns::TypePairDefinedEntry<argTy, bool, resTy, bool>,
         td_ns::TypePairDefinedEntry<argTy, std::int8_t, resTy, std::int8_t>,
         td_ns::TypePairDefinedEntry<argTy, std::uint8_t, resTy, std::uint8_t>,

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/bitwise_right_shift.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/bitwise_right_shift.hpp
@@ -125,9 +125,7 @@ using BitwiseRightShiftStridedFunctor =
 template <typename T1, typename T2> struct BitwiseRightShiftOutputType
 {
     using ResT = T1;
-    using value_type = typename std::disjunction< // disjunction is C++17
-                                                  // feature, supported by
-                                                  // DPC++
+    using value_type = typename std::disjunction<
         td_ns::BinaryTypeMapResultEntry<T1,
                                         std::int8_t,
                                         T2,
@@ -345,10 +343,7 @@ template <typename argTy, typename resTy>
 struct BitwiseRightShiftInplaceTypePairSupport
 {
     /* value if true a kernel for <argTy, resTy> must be instantiated  */
-    static constexpr bool is_defined = std::disjunction< // disjunction is
-                                                         // C++17 feature,
-                                                         // supported by
-                                                         // DPC++ input bool
+    static constexpr bool is_defined = std::disjunction<
         td_ns::TypePairDefinedEntry<argTy, std::int8_t, resTy, std::int8_t>,
         td_ns::TypePairDefinedEntry<argTy, std::uint8_t, resTy, std::uint8_t>,
         td_ns::TypePairDefinedEntry<argTy, std::int16_t, resTy, std::int16_t>,

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/bitwise_right_shift.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/bitwise_right_shift.hpp
@@ -167,6 +167,8 @@ template <typename T1, typename T2> struct BitwiseRightShiftOutputType
                                         std::uint64_t,
                                         std::uint64_t>,
         td_ns::DefaultResultEntry<void>>::result_type;
+
+    static constexpr bool is_defined = !std::is_same_v<value_type, void>;
 };
 
 template <typename argT1,
@@ -200,10 +202,7 @@ struct BitwiseRightShiftContigFactory
 {
     fnT get()
     {
-        if constexpr (std::is_same_v<typename BitwiseRightShiftOutputType<
-                                         T1, T2>::value_type,
-                                     void>)
-        {
+        if constexpr (!BitwiseRightShiftOutputType<T1, T2>::is_defined) {
             fnT fn = nullptr;
             return fn;
         }
@@ -256,10 +255,7 @@ struct BitwiseRightShiftStridedFactory
 {
     fnT get()
     {
-        if constexpr (std::is_same_v<typename BitwiseRightShiftOutputType<
-                                         T1, T2>::value_type,
-                                     void>)
-        {
+        if constexpr (!BitwiseRightShiftOutputType<T1, T2>::is_defined) {
             fnT fn = nullptr;
             return fn;
         }

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/bitwise_xor.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/bitwise_xor.hpp
@@ -322,6 +322,44 @@ template <typename argT,
           unsigned int n_vecs>
 class bitwise_xor_inplace_contig_kernel;
 
+/* @brief Types supported by in-place bitwise XOR */
+template <typename argTy, typename resTy>
+struct BitwiseXorInplaceTypePairSupport
+{
+    /* value if true a kernel for <argTy, resTy> must be instantiated  */
+    static constexpr bool is_defined = std::disjunction< // disjunction is
+                                                         // C++17 feature,
+                                                         // supported by
+                                                         // DPC++ input bool
+        td_ns::TypePairDefinedEntry<argTy, bool, resTy, bool>,
+        td_ns::TypePairDefinedEntry<argTy, std::int8_t, resTy, std::int8_t>,
+        td_ns::TypePairDefinedEntry<argTy, std::uint8_t, resTy, std::uint8_t>,
+        td_ns::TypePairDefinedEntry<argTy, std::int16_t, resTy, std::int16_t>,
+        td_ns::TypePairDefinedEntry<argTy, std::uint16_t, resTy, std::uint16_t>,
+        td_ns::TypePairDefinedEntry<argTy, std::int32_t, resTy, std::int32_t>,
+        td_ns::TypePairDefinedEntry<argTy, std::uint32_t, resTy, std::uint32_t>,
+        td_ns::TypePairDefinedEntry<argTy, std::int64_t, resTy, std::int64_t>,
+        td_ns::TypePairDefinedEntry<argTy, std::uint64_t, resTy, std::uint64_t>,
+        // fall-through
+        td_ns::NotDefinedEntry>::is_defined;
+};
+
+template <typename fnT, typename argT, typename resT>
+struct BitwiseXorInplaceTypeMapFactory
+{
+    /*! @brief get typeid for output type of x ^= y */
+    std::enable_if_t<std::is_same<fnT, int>::value, int> get()
+    {
+        if constexpr (BitwiseXorInplaceTypePairSupport<argT, resT>::is_defined)
+        {
+            return td_ns::GetTypeid<resT>{}.get();
+        }
+        else {
+            return td_ns::GetTypeid<void>{}.get();
+        }
+    }
+};
+
 template <typename argTy, typename resTy>
 sycl::event
 bitwise_xor_inplace_contig_impl(sycl::queue &exec_q,
@@ -343,10 +381,7 @@ struct BitwiseXorInplaceContigFactory
 {
     fnT get()
     {
-        if constexpr (std::is_same_v<
-                          typename BitwiseXorOutputType<T1, T2>::value_type,
-                          void>)
-        {
+        if constexpr (!BitwiseXorInplaceTypePairSupport<T1, T2>::is_defined) {
             fnT fn = nullptr;
             return fn;
         }
@@ -385,10 +420,7 @@ struct BitwiseXorInplaceStridedFactory
 {
     fnT get()
     {
-        if constexpr (std::is_same_v<
-                          typename BitwiseXorOutputType<T1, T2>::value_type,
-                          void>)
-        {
+        if constexpr (!BitwiseXorInplaceTypePairSupport<T1, T2>::is_defined) {
             fnT fn = nullptr;
             return fn;
         }

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/bitwise_xor.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/bitwise_xor.hpp
@@ -156,6 +156,8 @@ template <typename T1, typename T2> struct BitwiseXorOutputType
                                         std::int64_t,
                                         std::int64_t>,
         td_ns::DefaultResultEntry<void>>::result_type;
+
+    static constexpr bool is_defined = !std::is_same_v<value_type, void>;
 };
 
 template <typename argT1,
@@ -187,10 +189,7 @@ template <typename fnT, typename T1, typename T2> struct BitwiseXorContigFactory
 {
     fnT get()
     {
-        if constexpr (std::is_same_v<
-                          typename BitwiseXorOutputType<T1, T2>::value_type,
-                          void>)
-        {
+        if constexpr (!BitwiseXorOutputType<T1, T2>::is_defined) {
             fnT fn = nullptr;
             return fn;
         }
@@ -243,10 +242,7 @@ struct BitwiseXorStridedFactory
 {
     fnT get()
     {
-        if constexpr (std::is_same_v<
-                          typename BitwiseXorOutputType<T1, T2>::value_type,
-                          void>)
-        {
+        if constexpr (!BitwiseXorOutputType<T1, T2>::is_defined) {
             fnT fn = nullptr;
             return fn;
         }

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/bitwise_xor.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/bitwise_xor.hpp
@@ -113,9 +113,7 @@ using BitwiseXorStridedFunctor = elementwise_common::BinaryStridedFunctor<
 
 template <typename T1, typename T2> struct BitwiseXorOutputType
 {
-    using value_type = typename std::disjunction< // disjunction is C++17
-                                                  // feature, supported by
-                                                  // DPC++
+    using value_type = typename std::disjunction<
         td_ns::BinaryTypeMapResultEntry<T1, bool, T2, bool, bool>,
         td_ns::BinaryTypeMapResultEntry<T1,
                                         std::uint8_t,
@@ -327,10 +325,7 @@ template <typename argTy, typename resTy>
 struct BitwiseXorInplaceTypePairSupport
 {
     /* value if true a kernel for <argTy, resTy> must be instantiated  */
-    static constexpr bool is_defined = std::disjunction< // disjunction is
-                                                         // C++17 feature,
-                                                         // supported by
-                                                         // DPC++ input bool
+    static constexpr bool is_defined = std::disjunction<
         td_ns::TypePairDefinedEntry<argTy, bool, resTy, bool>,
         td_ns::TypePairDefinedEntry<argTy, std::int8_t, resTy, std::int8_t>,
         td_ns::TypePairDefinedEntry<argTy, std::uint8_t, resTy, std::uint8_t>,

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/cbrt.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/cbrt.hpp
@@ -87,6 +87,8 @@ template <typename T> struct CbrtOutputType
         td_ns::TypeMapResultEntry<T, float, float>,
         td_ns::TypeMapResultEntry<T, double, double>,
         td_ns::DefaultResultEntry<void>>::result_type;
+
+    static constexpr bool is_defined = !std::is_same_v<value_type, void>;
 };
 
 template <typename T1, typename T2, unsigned int vec_sz, unsigned int n_vecs>
@@ -108,9 +110,7 @@ template <typename fnT, typename T> struct CbrtContigFactory
 {
     fnT get()
     {
-        if constexpr (std::is_same_v<typename CbrtOutputType<T>::value_type,
-                                     void>)
-        {
+        if constexpr (!CbrtOutputType<T>::is_defined) {
             fnT fn = nullptr;
             return fn;
         }
@@ -156,9 +156,7 @@ template <typename fnT, typename T> struct CbrtStridedFactory
 {
     fnT get()
     {
-        if constexpr (std::is_same_v<typename CbrtOutputType<T>::value_type,
-                                     void>)
-        {
+        if constexpr (!CbrtOutputType<T>::is_defined) {
             fnT fn = nullptr;
             return fn;
         }

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/cbrt.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/cbrt.hpp
@@ -82,8 +82,7 @@ using CbrtStridedFunctor = elementwise_common::
 
 template <typename T> struct CbrtOutputType
 {
-    using value_type = typename std::disjunction< // disjunction is C++17
-                                                  // feature, supported by DPC++
+    using value_type = typename std::disjunction<
         td_ns::TypeMapResultEntry<T, sycl::half, sycl::half>,
         td_ns::TypeMapResultEntry<T, float, float>,
         td_ns::TypeMapResultEntry<T, double, double>,

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/ceil.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/ceil.hpp
@@ -95,20 +95,19 @@ using CeilStridedFunctor = elementwise_common::
 
 template <typename T> struct CeilOutputType
 {
-    using value_type = typename std::disjunction< // disjunction is C++17
-                                                  // feature, supported by DPC++
-        td_ns::TypeMapResultEntry<T, std::uint8_t>,
-        td_ns::TypeMapResultEntry<T, std::uint16_t>,
-        td_ns::TypeMapResultEntry<T, std::uint32_t>,
-        td_ns::TypeMapResultEntry<T, std::uint64_t>,
-        td_ns::TypeMapResultEntry<T, std::int8_t>,
-        td_ns::TypeMapResultEntry<T, std::int16_t>,
-        td_ns::TypeMapResultEntry<T, std::int32_t>,
-        td_ns::TypeMapResultEntry<T, std::int64_t>,
-        td_ns::TypeMapResultEntry<T, sycl::half>,
-        td_ns::TypeMapResultEntry<T, float>,
-        td_ns::TypeMapResultEntry<T, double>,
-        td_ns::DefaultResultEntry<void>>::result_type;
+    using value_type =
+        typename std::disjunction<td_ns::TypeMapResultEntry<T, std::uint8_t>,
+                                  td_ns::TypeMapResultEntry<T, std::uint16_t>,
+                                  td_ns::TypeMapResultEntry<T, std::uint32_t>,
+                                  td_ns::TypeMapResultEntry<T, std::uint64_t>,
+                                  td_ns::TypeMapResultEntry<T, std::int8_t>,
+                                  td_ns::TypeMapResultEntry<T, std::int16_t>,
+                                  td_ns::TypeMapResultEntry<T, std::int32_t>,
+                                  td_ns::TypeMapResultEntry<T, std::int64_t>,
+                                  td_ns::TypeMapResultEntry<T, sycl::half>,
+                                  td_ns::TypeMapResultEntry<T, float>,
+                                  td_ns::TypeMapResultEntry<T, double>,
+                                  td_ns::DefaultResultEntry<void>>::result_type;
 };
 
 template <typename T1, typename T2, unsigned int vec_sz, unsigned int n_vecs>

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/ceil.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/ceil.hpp
@@ -108,6 +108,8 @@ template <typename T> struct CeilOutputType
                                   td_ns::TypeMapResultEntry<T, float>,
                                   td_ns::TypeMapResultEntry<T, double>,
                                   td_ns::DefaultResultEntry<void>>::result_type;
+
+    static constexpr bool is_defined = !std::is_same_v<value_type, void>;
 };
 
 template <typename T1, typename T2, unsigned int vec_sz, unsigned int n_vecs>
@@ -129,9 +131,7 @@ template <typename fnT, typename T> struct CeilContigFactory
 {
     fnT get()
     {
-        if constexpr (std::is_same_v<typename CeilOutputType<T>::value_type,
-                                     void>)
-        {
+        if constexpr (!CeilOutputType<T>::is_defined) {
             fnT fn = nullptr;
             return fn;
         }
@@ -177,9 +177,7 @@ template <typename fnT, typename T> struct CeilStridedFactory
 {
     fnT get()
     {
-        if constexpr (std::is_same_v<typename CeilOutputType<T>::value_type,
-                                     void>)
-        {
+        if constexpr (!CeilOutputType<T>::is_defined) {
             fnT fn = nullptr;
             return fn;
         }

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/conj.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/conj.hpp
@@ -99,8 +99,7 @@ using ConjStridedFunctor = elementwise_common::
 
 template <typename T> struct ConjOutputType
 {
-    using value_type = typename std::disjunction< // disjunction is C++17
-                                                  // feature, supported by DPC++
+    using value_type = typename std::disjunction<
         td_ns::TypeMapResultEntry<T, bool, int8_t>,
         td_ns::TypeMapResultEntry<T, std::uint8_t>,
         td_ns::TypeMapResultEntry<T, std::uint16_t>,

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/conj.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/conj.hpp
@@ -115,6 +115,8 @@ template <typename T> struct ConjOutputType
         td_ns::TypeMapResultEntry<T, std::complex<float>>,
         td_ns::TypeMapResultEntry<T, std::complex<double>>,
         td_ns::DefaultResultEntry<void>>::result_type;
+
+    static constexpr bool is_defined = !std::is_same_v<value_type, void>;
 };
 
 template <typename T1, typename T2, unsigned int vec_sz, unsigned int n_vecs>
@@ -136,9 +138,7 @@ template <typename fnT, typename T> struct ConjContigFactory
 {
     fnT get()
     {
-        if constexpr (std::is_same_v<typename ConjOutputType<T>::value_type,
-                                     void>)
-        {
+        if constexpr (!ConjOutputType<T>::is_defined) {
             fnT fn = nullptr;
             return fn;
         }
@@ -184,9 +184,7 @@ template <typename fnT, typename T> struct ConjStridedFactory
 {
     fnT get()
     {
-        if constexpr (std::is_same_v<typename ConjOutputType<T>::value_type,
-                                     void>)
-        {
+        if constexpr (!ConjOutputType<T>::is_defined) {
             fnT fn = nullptr;
             return fn;
         }

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/copysign.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/copysign.hpp
@@ -113,6 +113,8 @@ template <typename T1, typename T2> struct CopysignOutputType
         td_ns::BinaryTypeMapResultEntry<T1, float, T2, float, float>,
         td_ns::BinaryTypeMapResultEntry<T1, double, T2, double, double>,
         td_ns::DefaultResultEntry<void>>::result_type;
+
+    static constexpr bool is_defined = !std::is_same_v<value_type, void>;
 };
 
 template <typename argT1,
@@ -143,10 +145,7 @@ template <typename fnT, typename T1, typename T2> struct CopysignContigFactory
 {
     fnT get()
     {
-        if constexpr (std::is_same_v<
-                          typename CopysignOutputType<T1, T2>::value_type,
-                          void>)
-        {
+        if constexpr (!CopysignOutputType<T1, T2>::is_defined) {
             fnT fn = nullptr;
             return fn;
         }
@@ -196,10 +195,7 @@ template <typename fnT, typename T1, typename T2> struct CopysignStridedFactory
 {
     fnT get()
     {
-        if constexpr (std::is_same_v<
-                          typename CopysignOutputType<T1, T2>::value_type,
-                          void>)
-        {
+        if constexpr (!CopysignOutputType<T1, T2>::is_defined) {
             fnT fn = nullptr;
             return fn;
         }

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/copysign.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/copysign.hpp
@@ -104,8 +104,7 @@ using CopysignStridedFunctor = elementwise_common::BinaryStridedFunctor<
 
 template <typename T1, typename T2> struct CopysignOutputType
 {
-    using value_type = typename std::disjunction< // disjunction is C++17
-                                                  // feature, supported by DPC++
+    using value_type = typename std::disjunction<
         td_ns::BinaryTypeMapResultEntry<T1,
                                         sycl::half,
                                         T2,

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/cos.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/cos.hpp
@@ -188,6 +188,8 @@ template <typename T> struct CosOutputType
         td_ns::
             TypeMapResultEntry<T, std::complex<double>, std::complex<double>>,
         td_ns::DefaultResultEntry<void>>::result_type;
+
+    static constexpr bool is_defined = !std::is_same_v<value_type, void>;
 };
 
 template <typename T1, typename T2, unsigned int vec_sz, unsigned int n_vecs>
@@ -209,9 +211,7 @@ template <typename fnT, typename T> struct CosContigFactory
 {
     fnT get()
     {
-        if constexpr (std::is_same_v<typename CosOutputType<T>::value_type,
-                                     void>)
-        {
+        if constexpr (!CosOutputType<T>::is_defined) {
             fnT fn = nullptr;
             return fn;
         }
@@ -256,9 +256,7 @@ template <typename fnT, typename T> struct CosStridedFactory
 {
     fnT get()
     {
-        if constexpr (std::is_same_v<typename CosOutputType<T>::value_type,
-                                     void>)
-        {
+        if constexpr (!CosOutputType<T>::is_defined) {
             fnT fn = nullptr;
             return fn;
         }

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/cos.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/cos.hpp
@@ -180,8 +180,7 @@ using CosStridedFunctor = elementwise_common::
 
 template <typename T> struct CosOutputType
 {
-    using value_type = typename std::disjunction< // disjunction is C++17
-                                                  // feature, supported by DPC++
+    using value_type = typename std::disjunction<
         td_ns::TypeMapResultEntry<T, sycl::half, sycl::half>,
         td_ns::TypeMapResultEntry<T, float, float>,
         td_ns::TypeMapResultEntry<T, double, double>,

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/cosh.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/cosh.hpp
@@ -170,8 +170,7 @@ using CoshStridedFunctor = elementwise_common::
 
 template <typename T> struct CoshOutputType
 {
-    using value_type = typename std::disjunction< // disjunction is C++17
-                                                  // feature, supported by DPC++
+    using value_type = typename std::disjunction<
         td_ns::TypeMapResultEntry<T, sycl::half>,
         td_ns::TypeMapResultEntry<T, float>,
         td_ns::TypeMapResultEntry<T, double>,

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/cosh.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/cosh.hpp
@@ -177,6 +177,8 @@ template <typename T> struct CoshOutputType
         td_ns::TypeMapResultEntry<T, std::complex<float>>,
         td_ns::TypeMapResultEntry<T, std::complex<double>>,
         td_ns::DefaultResultEntry<void>>::result_type;
+
+    static constexpr bool is_defined = !std::is_same_v<value_type, void>;
 };
 
 template <typename T1, typename T2, unsigned int vec_sz, unsigned int n_vecs>
@@ -198,9 +200,7 @@ template <typename fnT, typename T> struct CoshContigFactory
 {
     fnT get()
     {
-        if constexpr (std::is_same_v<typename CoshOutputType<T>::value_type,
-                                     void>)
-        {
+        if constexpr (!CoshOutputType<T>::is_defined) {
             fnT fn = nullptr;
             return fn;
         }
@@ -246,9 +246,7 @@ template <typename fnT, typename T> struct CoshStridedFactory
 {
     fnT get()
     {
-        if constexpr (std::is_same_v<typename CoshOutputType<T>::value_type,
-                                     void>)
-        {
+        if constexpr (!CoshOutputType<T>::is_defined) {
             fnT fn = nullptr;
             return fn;
         }

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/equal.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/equal.hpp
@@ -185,6 +185,8 @@ template <typename T1, typename T2> struct EqualOutputType
                                         std::complex<double>,
                                         bool>,
         td_ns::DefaultResultEntry<void>>::result_type;
+
+    static constexpr bool is_defined = !std::is_same_v<value_type, void>;
 };
 
 template <typename argT1,
@@ -215,9 +217,7 @@ template <typename fnT, typename T1, typename T2> struct EqualContigFactory
 {
     fnT get()
     {
-        if constexpr (std::is_same_v<
-                          typename EqualOutputType<T1, T2>::value_type, void>)
-        {
+        if constexpr (!EqualOutputType<T1, T2>::is_defined) {
             fnT fn = nullptr;
             return fn;
         }
@@ -267,9 +267,7 @@ template <typename fnT, typename T1, typename T2> struct EqualStridedFactory
 {
     fnT get()
     {
-        if constexpr (std::is_same_v<
-                          typename EqualOutputType<T1, T2>::value_type, void>)
-        {
+        if constexpr (!EqualOutputType<T1, T2>::is_defined) {
             fnT fn = nullptr;
             return fn;
         }

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/equal.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/equal.hpp
@@ -141,8 +141,7 @@ using EqualStridedFunctor =
 
 template <typename T1, typename T2> struct EqualOutputType
 {
-    using value_type = typename std::disjunction< // disjunction is C++17
-                                                  // feature, supported by DPC++
+    using value_type = typename std::disjunction<
         td_ns::BinaryTypeMapResultEntry<T1, bool, T2, bool, bool>,
         td_ns::
             BinaryTypeMapResultEntry<T1, std::uint8_t, T2, std::uint8_t, bool>,

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/exp.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/exp.hpp
@@ -146,6 +146,8 @@ template <typename T> struct ExpOutputType
         td_ns::TypeMapResultEntry<T, std::complex<float>>,
         td_ns::TypeMapResultEntry<T, std::complex<double>>,
         td_ns::DefaultResultEntry<void>>::result_type;
+
+    static constexpr bool is_defined = !std::is_same_v<value_type, void>;
 };
 
 template <typename T1, typename T2, unsigned int vec_sz, unsigned int n_vecs>
@@ -167,9 +169,7 @@ template <typename fnT, typename T> struct ExpContigFactory
 {
     fnT get()
     {
-        if constexpr (std::is_same_v<typename ExpOutputType<T>::value_type,
-                                     void>)
-        {
+        if constexpr (!ExpOutputType<T>::is_defined) {
             fnT fn = nullptr;
             return fn;
         }
@@ -214,9 +214,7 @@ template <typename fnT, typename T> struct ExpStridedFactory
 {
     fnT get()
     {
-        if constexpr (std::is_same_v<typename ExpOutputType<T>::value_type,
-                                     void>)
-        {
+        if constexpr (!ExpOutputType<T>::is_defined) {
             fnT fn = nullptr;
             return fn;
         }

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/exp.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/exp.hpp
@@ -139,8 +139,7 @@ using ExpStridedFunctor = elementwise_common::
 
 template <typename T> struct ExpOutputType
 {
-    using value_type = typename std::disjunction< // disjunction is C++17
-                                                  // feature, supported by DPC++
+    using value_type = typename std::disjunction<
         td_ns::TypeMapResultEntry<T, sycl::half>,
         td_ns::TypeMapResultEntry<T, float>,
         td_ns::TypeMapResultEntry<T, double>,

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/exp2.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/exp2.hpp
@@ -141,8 +141,7 @@ using Exp2StridedFunctor = elementwise_common::
 
 template <typename T> struct Exp2OutputType
 {
-    using value_type = typename std::disjunction< // disjunction is C++17
-                                                  // feature, supported by DPC++
+    using value_type = typename std::disjunction<
         td_ns::TypeMapResultEntry<T, sycl::half>,
         td_ns::TypeMapResultEntry<T, float>,
         td_ns::TypeMapResultEntry<T, double>,

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/exp2.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/exp2.hpp
@@ -148,6 +148,8 @@ template <typename T> struct Exp2OutputType
         td_ns::TypeMapResultEntry<T, std::complex<float>>,
         td_ns::TypeMapResultEntry<T, std::complex<double>>,
         td_ns::DefaultResultEntry<void>>::result_type;
+
+    static constexpr bool is_defined = !std::is_same_v<value_type, void>;
 };
 
 template <typename T1, typename T2, unsigned int vec_sz, unsigned int n_vecs>
@@ -169,9 +171,7 @@ template <typename fnT, typename T> struct Exp2ContigFactory
 {
     fnT get()
     {
-        if constexpr (std::is_same_v<typename Exp2OutputType<T>::value_type,
-                                     void>)
-        {
+        if constexpr (!Exp2OutputType<T>::is_defined) {
             fnT fn = nullptr;
             return fn;
         }
@@ -217,9 +217,7 @@ template <typename fnT, typename T> struct Exp2StridedFactory
 {
     fnT get()
     {
-        if constexpr (std::is_same_v<typename Exp2OutputType<T>::value_type,
-                                     void>)
-        {
+        if constexpr (!Exp2OutputType<T>::is_defined) {
             fnT fn = nullptr;
             return fn;
         }

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/expm1.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/expm1.hpp
@@ -153,8 +153,7 @@ using Expm1StridedFunctor = elementwise_common::
 
 template <typename T> struct Expm1OutputType
 {
-    using value_type = typename std::disjunction< // disjunction is C++17
-                                                  // feature, supported by DPC++
+    using value_type = typename std::disjunction<
         td_ns::TypeMapResultEntry<T, sycl::half, sycl::half>,
         td_ns::TypeMapResultEntry<T, float, float>,
         td_ns::TypeMapResultEntry<T, double, double>,

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/expm1.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/expm1.hpp
@@ -161,6 +161,8 @@ template <typename T> struct Expm1OutputType
         td_ns::
             TypeMapResultEntry<T, std::complex<double>, std::complex<double>>,
         td_ns::DefaultResultEntry<void>>::result_type;
+
+    static constexpr bool is_defined = !std::is_same_v<value_type, void>;
 };
 
 template <typename T1, typename T2, unsigned int vec_sz, unsigned int n_vecs>
@@ -182,9 +184,7 @@ template <typename fnT, typename T> struct Expm1ContigFactory
 {
     fnT get()
     {
-        if constexpr (std::is_same_v<typename Expm1OutputType<T>::value_type,
-                                     void>)
-        {
+        if constexpr (!Expm1OutputType<T>::is_defined) {
             fnT fn = nullptr;
             return fn;
         }
@@ -201,7 +201,6 @@ template <typename fnT, typename T> struct Expm1TypeMapFactory
     std::enable_if_t<std::is_same<fnT, int>::value, int> get()
     {
         using rT = typename Expm1OutputType<T>::value_type;
-        ;
         return td_ns::GetTypeid<rT>{}.get();
     }
 };
@@ -231,9 +230,7 @@ template <typename fnT, typename T> struct Expm1StridedFactory
 {
     fnT get()
     {
-        if constexpr (std::is_same_v<typename Expm1OutputType<T>::value_type,
-                                     void>)
-        {
+        if constexpr (!Expm1OutputType<T>::is_defined) {
             fnT fn = nullptr;
             return fn;
         }

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/floor.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/floor.hpp
@@ -108,6 +108,8 @@ template <typename T> struct FloorOutputType
                                   td_ns::TypeMapResultEntry<T, float>,
                                   td_ns::TypeMapResultEntry<T, double>,
                                   td_ns::DefaultResultEntry<void>>::result_type;
+
+    static constexpr bool is_defined = !std::is_same_v<value_type, void>;
 };
 
 template <typename T1, typename T2, unsigned int vec_sz, unsigned int n_vecs>
@@ -129,9 +131,7 @@ template <typename fnT, typename T> struct FloorContigFactory
 {
     fnT get()
     {
-        if constexpr (std::is_same_v<typename FloorOutputType<T>::value_type,
-                                     void>)
-        {
+        if constexpr (!FloorOutputType<T>::is_defined) {
             fnT fn = nullptr;
             return fn;
         }
@@ -177,9 +177,7 @@ template <typename fnT, typename T> struct FloorStridedFactory
 {
     fnT get()
     {
-        if constexpr (std::is_same_v<typename FloorOutputType<T>::value_type,
-                                     void>)
-        {
+        if constexpr (!FloorOutputType<T>::is_defined) {
             fnT fn = nullptr;
             return fn;
         }

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/floor.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/floor.hpp
@@ -95,20 +95,19 @@ using FloorStridedFunctor = elementwise_common::
 
 template <typename T> struct FloorOutputType
 {
-    using value_type = typename std::disjunction< // disjunction is C++17
-                                                  // feature, supported by DPC++
-        td_ns::TypeMapResultEntry<T, std::uint8_t>,
-        td_ns::TypeMapResultEntry<T, std::uint16_t>,
-        td_ns::TypeMapResultEntry<T, std::uint32_t>,
-        td_ns::TypeMapResultEntry<T, std::uint64_t>,
-        td_ns::TypeMapResultEntry<T, std::int8_t>,
-        td_ns::TypeMapResultEntry<T, std::int16_t>,
-        td_ns::TypeMapResultEntry<T, std::int32_t>,
-        td_ns::TypeMapResultEntry<T, std::int64_t>,
-        td_ns::TypeMapResultEntry<T, sycl::half>,
-        td_ns::TypeMapResultEntry<T, float>,
-        td_ns::TypeMapResultEntry<T, double>,
-        td_ns::DefaultResultEntry<void>>::result_type;
+    using value_type =
+        typename std::disjunction<td_ns::TypeMapResultEntry<T, std::uint8_t>,
+                                  td_ns::TypeMapResultEntry<T, std::uint16_t>,
+                                  td_ns::TypeMapResultEntry<T, std::uint32_t>,
+                                  td_ns::TypeMapResultEntry<T, std::uint64_t>,
+                                  td_ns::TypeMapResultEntry<T, std::int8_t>,
+                                  td_ns::TypeMapResultEntry<T, std::int16_t>,
+                                  td_ns::TypeMapResultEntry<T, std::int32_t>,
+                                  td_ns::TypeMapResultEntry<T, std::int64_t>,
+                                  td_ns::TypeMapResultEntry<T, sycl::half>,
+                                  td_ns::TypeMapResultEntry<T, float>,
+                                  td_ns::TypeMapResultEntry<T, double>,
+                                  td_ns::DefaultResultEntry<void>>::result_type;
 };
 
 template <typename T1, typename T2, unsigned int vec_sz, unsigned int n_vecs>

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/floor_divide.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/floor_divide.hpp
@@ -197,6 +197,8 @@ template <typename T1, typename T2> struct FloorDivideOutputType
         td_ns::BinaryTypeMapResultEntry<T1, float, T2, float, float>,
         td_ns::BinaryTypeMapResultEntry<T1, double, T2, double, double>,
         td_ns::DefaultResultEntry<void>>::result_type;
+
+    static constexpr bool is_defined = !std::is_same_v<value_type, void>;
 };
 
 template <typename argT1,
@@ -229,10 +231,7 @@ struct FloorDivideContigFactory
 {
     fnT get()
     {
-        if constexpr (std::is_same_v<
-                          typename FloorDivideOutputType<T1, T2>::value_type,
-                          void>)
-        {
+        if constexpr (!FloorDivideOutputType<T1, T2>::is_defined) {
             fnT fn = nullptr;
             return fn;
         }
@@ -284,10 +283,7 @@ struct FloorDivideStridedFactory
 {
     fnT get()
     {
-        if constexpr (std::is_same_v<
-                          typename FloorDivideOutputType<T1, T2>::value_type,
-                          void>)
-        {
+        if constexpr (!FloorDivideOutputType<T1, T2>::is_defined) {
             fnT fn = nullptr;
             return fn;
         }

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/floor_divide.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/floor_divide.hpp
@@ -148,8 +148,7 @@ using FloorDivideStridedFunctor = elementwise_common::BinaryStridedFunctor<
 
 template <typename T1, typename T2> struct FloorDivideOutputType
 {
-    using value_type = typename std::disjunction< // disjunction is C++17
-                                                  // feature, supported by DPC++
+    using value_type = typename std::disjunction<
         td_ns::BinaryTypeMapResultEntry<T1,
                                         std::uint8_t,
                                         T2,
@@ -403,10 +402,7 @@ template <typename argTy, typename resTy>
 struct FloorDivideInplaceTypePairSupport
 {
     /* value if true a kernel for <argTy, resTy> must be instantiated  */
-    static constexpr bool is_defined = std::disjunction< // disjunction is
-                                                         // C++17 feature,
-                                                         // supported by
-                                                         // DPC++ input bool
+    static constexpr bool is_defined = std::disjunction<
         td_ns::TypePairDefinedEntry<argTy, std::int8_t, resTy, std::int8_t>,
         td_ns::TypePairDefinedEntry<argTy, std::uint8_t, resTy, std::uint8_t>,
         td_ns::TypePairDefinedEntry<argTy, std::int16_t, resTy, std::int16_t>,

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/floor_divide.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/floor_divide.hpp
@@ -398,6 +398,46 @@ template <typename argT,
           unsigned int n_vecs>
 class floor_divide_inplace_contig_kernel;
 
+/* @brief Types supported by in-place floor division */
+template <typename argTy, typename resTy>
+struct FloorDivideInplaceTypePairSupport
+{
+    /* value if true a kernel for <argTy, resTy> must be instantiated  */
+    static constexpr bool is_defined = std::disjunction< // disjunction is
+                                                         // C++17 feature,
+                                                         // supported by
+                                                         // DPC++ input bool
+        td_ns::TypePairDefinedEntry<argTy, std::int8_t, resTy, std::int8_t>,
+        td_ns::TypePairDefinedEntry<argTy, std::uint8_t, resTy, std::uint8_t>,
+        td_ns::TypePairDefinedEntry<argTy, std::int16_t, resTy, std::int16_t>,
+        td_ns::TypePairDefinedEntry<argTy, std::uint16_t, resTy, std::uint16_t>,
+        td_ns::TypePairDefinedEntry<argTy, std::int32_t, resTy, std::int32_t>,
+        td_ns::TypePairDefinedEntry<argTy, std::uint32_t, resTy, std::uint32_t>,
+        td_ns::TypePairDefinedEntry<argTy, std::int64_t, resTy, std::int64_t>,
+        td_ns::TypePairDefinedEntry<argTy, std::uint64_t, resTy, std::uint64_t>,
+        td_ns::TypePairDefinedEntry<argTy, sycl::half, resTy, sycl::half>,
+        td_ns::TypePairDefinedEntry<argTy, float, resTy, float>,
+        td_ns::TypePairDefinedEntry<argTy, double, resTy, double>,
+        // fall-through
+        td_ns::NotDefinedEntry>::is_defined;
+};
+
+template <typename fnT, typename argT, typename resT>
+struct FloorDivideInplaceTypeMapFactory
+{
+    /*! @brief get typeid for output type of x //= y */
+    std::enable_if_t<std::is_same<fnT, int>::value, int> get()
+    {
+        if constexpr (FloorDivideInplaceTypePairSupport<argT, resT>::is_defined)
+        {
+            return td_ns::GetTypeid<resT>{}.get();
+        }
+        else {
+            return td_ns::GetTypeid<void>{}.get();
+        }
+    }
+};
+
 template <typename argTy, typename resTy>
 sycl::event
 floor_divide_inplace_contig_impl(sycl::queue &exec_q,
@@ -419,10 +459,7 @@ struct FloorDivideInplaceContigFactory
 {
     fnT get()
     {
-        if constexpr (std::is_same_v<
-                          typename FloorDivideOutputType<T1, T2>::value_type,
-                          void>)
-        {
+        if constexpr (!FloorDivideInplaceTypePairSupport<T1, T2>::is_defined) {
             fnT fn = nullptr;
             return fn;
         }
@@ -461,10 +498,7 @@ struct FloorDivideInplaceStridedFactory
 {
     fnT get()
     {
-        if constexpr (std::is_same_v<
-                          typename FloorDivideOutputType<T1, T2>::value_type,
-                          void>)
-        {
+        if constexpr (!FloorDivideInplaceTypePairSupport<T1, T2>::is_defined) {
             fnT fn = nullptr;
             return fn;
         }

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/greater.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/greater.hpp
@@ -186,6 +186,8 @@ template <typename T1, typename T2> struct GreaterOutputType
                                         std::complex<double>,
                                         bool>,
         td_ns::DefaultResultEntry<void>>::result_type;
+
+    static constexpr bool is_defined = !std::is_same_v<value_type, void>;
 };
 
 template <typename argT1,
@@ -216,9 +218,7 @@ template <typename fnT, typename T1, typename T2> struct GreaterContigFactory
 {
     fnT get()
     {
-        if constexpr (std::is_same_v<
-                          typename GreaterOutputType<T1, T2>::value_type, void>)
-        {
+        if constexpr (!GreaterOutputType<T1, T2>::is_defined) {
             fnT fn = nullptr;
             return fn;
         }
@@ -268,9 +268,7 @@ template <typename fnT, typename T1, typename T2> struct GreaterStridedFactory
 {
     fnT get()
     {
-        if constexpr (std::is_same_v<
-                          typename GreaterOutputType<T1, T2>::value_type, void>)
-        {
+        if constexpr (!GreaterOutputType<T1, T2>::is_defined) {
             fnT fn = nullptr;
             return fn;
         }

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/greater.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/greater.hpp
@@ -142,8 +142,7 @@ using GreaterStridedFunctor = elementwise_common::BinaryStridedFunctor<
 
 template <typename T1, typename T2> struct GreaterOutputType
 {
-    using value_type = typename std::disjunction< // disjunction is C++17
-                                                  // feature, supported by DPC++
+    using value_type = typename std::disjunction<
         td_ns::BinaryTypeMapResultEntry<T1, bool, T2, bool, bool>,
         td_ns::
             BinaryTypeMapResultEntry<T1, std::uint8_t, T2, std::uint8_t, bool>,

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/greater_equal.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/greater_equal.hpp
@@ -187,6 +187,8 @@ template <typename T1, typename T2> struct GreaterEqualOutputType
                                         std::complex<double>,
                                         bool>,
         td_ns::DefaultResultEntry<void>>::result_type;
+
+    static constexpr bool is_defined = !std::is_same_v<value_type, void>;
 };
 
 template <typename argT1,
@@ -220,10 +222,7 @@ struct GreaterEqualContigFactory
 {
     fnT get()
     {
-        if constexpr (std::is_same_v<
-                          typename GreaterEqualOutputType<T1, T2>::value_type,
-                          void>)
-        {
+        if constexpr (!GreaterEqualOutputType<T1, T2>::is_defined) {
             fnT fn = nullptr;
             return fn;
         }
@@ -275,10 +274,7 @@ struct GreaterEqualStridedFactory
 {
     fnT get()
     {
-        if constexpr (std::is_same_v<
-                          typename GreaterEqualOutputType<T1, T2>::value_type,
-                          void>)
-        {
+        if constexpr (!GreaterEqualOutputType<T1, T2>::is_defined) {
             fnT fn = nullptr;
             return fn;
         }

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/greater_equal.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/greater_equal.hpp
@@ -143,8 +143,7 @@ using GreaterEqualStridedFunctor = elementwise_common::BinaryStridedFunctor<
 
 template <typename T1, typename T2> struct GreaterEqualOutputType
 {
-    using value_type = typename std::disjunction< // disjunction is C++17
-                                                  // feature, supported by DPC++
+    using value_type = typename std::disjunction<
         td_ns::BinaryTypeMapResultEntry<T1, bool, T2, bool, bool>,
         td_ns::
             BinaryTypeMapResultEntry<T1, std::uint8_t, T2, std::uint8_t, bool>,

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/hypot.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/hypot.hpp
@@ -106,8 +106,7 @@ using HypotStridedFunctor =
 
 template <typename T1, typename T2> struct HypotOutputType
 {
-    using value_type = typename std::disjunction< // disjunction is C++17
-                                                  // feature, supported by DPC++
+    using value_type = typename std::disjunction<
         td_ns::BinaryTypeMapResultEntry<T1,
                                         sycl::half,
                                         T2,

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/hypot.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/hypot.hpp
@@ -115,6 +115,8 @@ template <typename T1, typename T2> struct HypotOutputType
         td_ns::BinaryTypeMapResultEntry<T1, float, T2, float, float>,
         td_ns::BinaryTypeMapResultEntry<T1, double, T2, double, double>,
         td_ns::DefaultResultEntry<void>>::result_type;
+
+    static constexpr bool is_defined = !std::is_same_v<value_type, void>;
 };
 
 template <typename argT1,
@@ -145,9 +147,7 @@ template <typename fnT, typename T1, typename T2> struct HypotContigFactory
 {
     fnT get()
     {
-        if constexpr (std::is_same_v<
-                          typename HypotOutputType<T1, T2>::value_type, void>)
-        {
+        if constexpr (!HypotOutputType<T1, T2>::is_defined) {
             fnT fn = nullptr;
             return fn;
         }
@@ -164,7 +164,6 @@ template <typename fnT, typename T1, typename T2> struct HypotTypeMapFactory
     std::enable_if_t<std::is_same<fnT, int>::value, int> get()
     {
         using rT = typename HypotOutputType<T1, T2>::value_type;
-        ;
         return td_ns::GetTypeid<rT>{}.get();
     }
 };
@@ -198,9 +197,7 @@ template <typename fnT, typename T1, typename T2> struct HypotStridedFactory
 {
     fnT get()
     {
-        if constexpr (std::is_same_v<
-                          typename HypotOutputType<T1, T2>::value_type, void>)
-        {
+        if constexpr (!HypotOutputType<T1, T2>::is_defined) {
             fnT fn = nullptr;
             return fn;
         }

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/imag.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/imag.hpp
@@ -95,8 +95,7 @@ using ImagStridedFunctor = elementwise_common::
 
 template <typename T> struct ImagOutputType
 {
-    using value_type = typename std::disjunction< // disjunction is C++17
-                                                  // feature, supported by DPC++
+    using value_type = typename std::disjunction<
         td_ns::TypeMapResultEntry<T, bool>,
         td_ns::TypeMapResultEntry<T, std::uint8_t>,
         td_ns::TypeMapResultEntry<T, std::uint16_t>,

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/imag.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/imag.hpp
@@ -111,6 +111,8 @@ template <typename T> struct ImagOutputType
         td_ns::TypeMapResultEntry<T, std::complex<float>, float>,
         td_ns::TypeMapResultEntry<T, std::complex<double>, double>,
         td_ns::DefaultResultEntry<void>>::result_type;
+
+    static constexpr bool is_defined = !std::is_same_v<value_type, void>;
 };
 
 template <typename T1, typename T2, unsigned int vec_sz, unsigned int n_vecs>
@@ -132,9 +134,7 @@ template <typename fnT, typename T> struct ImagContigFactory
 {
     fnT get()
     {
-        if constexpr (std::is_same_v<typename ImagOutputType<T>::value_type,
-                                     void>)
-        {
+        if constexpr (!ImagOutputType<T>::is_defined) {
             fnT fn = nullptr;
             return fn;
         }
@@ -180,9 +180,7 @@ template <typename fnT, typename T> struct ImagStridedFactory
 {
     fnT get()
     {
-        if constexpr (std::is_same_v<typename ImagOutputType<T>::value_type,
-                                     void>)
-        {
+        if constexpr (!ImagOutputType<T>::is_defined) {
             fnT fn = nullptr;
             return fn;
         }

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/less.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/less.hpp
@@ -140,8 +140,7 @@ using LessStridedFunctor =
 
 template <typename T1, typename T2> struct LessOutputType
 {
-    using value_type = typename std::disjunction< // disjunction is C++17
-                                                  // feature, supported by DPC++
+    using value_type = typename std::disjunction<
         td_ns::BinaryTypeMapResultEntry<T1, bool, T2, bool, bool>,
         td_ns::
             BinaryTypeMapResultEntry<T1, std::uint8_t, T2, std::uint8_t, bool>,

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/less.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/less.hpp
@@ -184,6 +184,8 @@ template <typename T1, typename T2> struct LessOutputType
                                         std::complex<double>,
                                         bool>,
         td_ns::DefaultResultEntry<void>>::result_type;
+
+    static constexpr bool is_defined = !std::is_same_v<value_type, void>;
 };
 
 template <typename argT1,
@@ -214,9 +216,7 @@ template <typename fnT, typename T1, typename T2> struct LessContigFactory
 {
     fnT get()
     {
-        if constexpr (std::is_same_v<
-                          typename LessOutputType<T1, T2>::value_type, void>)
-        {
+        if constexpr (!LessOutputType<T1, T2>::is_defined) {
             fnT fn = nullptr;
             return fn;
         }
@@ -266,9 +266,7 @@ template <typename fnT, typename T1, typename T2> struct LessStridedFactory
 {
     fnT get()
     {
-        if constexpr (std::is_same_v<
-                          typename LessOutputType<T1, T2>::value_type, void>)
-        {
+        if constexpr (!LessOutputType<T1, T2>::is_defined) {
             fnT fn = nullptr;
             return fn;
         }

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/less_equal.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/less_equal.hpp
@@ -185,6 +185,8 @@ template <typename T1, typename T2> struct LessEqualOutputType
                                         std::complex<double>,
                                         bool>,
         td_ns::DefaultResultEntry<void>>::result_type;
+
+    static constexpr bool is_defined = !std::is_same_v<value_type, void>;
 };
 
 template <typename argT1,
@@ -215,10 +217,7 @@ template <typename fnT, typename T1, typename T2> struct LessEqualContigFactory
 {
     fnT get()
     {
-        if constexpr (std::is_same_v<
-                          typename LessEqualOutputType<T1, T2>::value_type,
-                          void>)
-        {
+        if constexpr (!LessEqualOutputType<T1, T2>::is_defined) {
             fnT fn = nullptr;
             return fn;
         }
@@ -268,10 +267,7 @@ template <typename fnT, typename T1, typename T2> struct LessEqualStridedFactory
 {
     fnT get()
     {
-        if constexpr (std::is_same_v<
-                          typename LessEqualOutputType<T1, T2>::value_type,
-                          void>)
-        {
+        if constexpr (!LessEqualOutputType<T1, T2>::is_defined) {
             fnT fn = nullptr;
             return fn;
         }

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/less_equal.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/less_equal.hpp
@@ -141,8 +141,7 @@ using LessEqualStridedFunctor = elementwise_common::BinaryStridedFunctor<
 
 template <typename T1, typename T2> struct LessEqualOutputType
 {
-    using value_type = typename std::disjunction< // disjunction is C++17
-                                                  // feature, supported by DPC++
+    using value_type = typename std::disjunction<
         td_ns::BinaryTypeMapResultEntry<T1, bool, T2, bool, bool>,
         td_ns::
             BinaryTypeMapResultEntry<T1, std::uint8_t, T2, std::uint8_t, bool>,

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/log.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/log.hpp
@@ -95,8 +95,7 @@ using LogStridedFunctor = elementwise_common::
 
 template <typename T> struct LogOutputType
 {
-    using value_type = typename std::disjunction< // disjunction is C++17
-                                                  // feature, supported by DPC++
+    using value_type = typename std::disjunction<
         td_ns::TypeMapResultEntry<T, sycl::half, sycl::half>,
         td_ns::TypeMapResultEntry<T, float, float>,
         td_ns::TypeMapResultEntry<T, double, double>,

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/log.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/log.hpp
@@ -103,6 +103,8 @@ template <typename T> struct LogOutputType
         td_ns::
             TypeMapResultEntry<T, std::complex<double>, std::complex<double>>,
         td_ns::DefaultResultEntry<void>>::result_type;
+
+    static constexpr bool is_defined = !std::is_same_v<value_type, void>;
 };
 
 template <typename T1, typename T2, unsigned int vec_sz, unsigned int n_vecs>
@@ -124,9 +126,7 @@ template <typename fnT, typename T> struct LogContigFactory
 {
     fnT get()
     {
-        if constexpr (std::is_same_v<typename LogOutputType<T>::value_type,
-                                     void>)
-        {
+        if constexpr (!LogOutputType<T>::is_defined) {
             fnT fn = nullptr;
             return fn;
         }
@@ -143,7 +143,6 @@ template <typename fnT, typename T> struct LogTypeMapFactory
     std::enable_if_t<std::is_same<fnT, int>::value, int> get()
     {
         using rT = typename LogOutputType<T>::value_type;
-        ;
         return td_ns::GetTypeid<rT>{}.get();
     }
 };
@@ -172,9 +171,7 @@ template <typename fnT, typename T> struct LogStridedFactory
 {
     fnT get()
     {
-        if constexpr (std::is_same_v<typename LogOutputType<T>::value_type,
-                                     void>)
-        {
+        if constexpr (!LogOutputType<T>::is_defined) {
             fnT fn = nullptr;
             return fn;
         }

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/log10.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/log10.hpp
@@ -114,8 +114,7 @@ using Log10StridedFunctor = elementwise_common::
 
 template <typename T> struct Log10OutputType
 {
-    using value_type = typename std::disjunction< // disjunction is C++17
-                                                  // feature, supported by DPC++
+    using value_type = typename std::disjunction<
         td_ns::TypeMapResultEntry<T, sycl::half, sycl::half>,
         td_ns::TypeMapResultEntry<T, float, float>,
         td_ns::TypeMapResultEntry<T, double, double>,

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/log10.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/log10.hpp
@@ -122,6 +122,8 @@ template <typename T> struct Log10OutputType
         td_ns::
             TypeMapResultEntry<T, std::complex<double>, std::complex<double>>,
         td_ns::DefaultResultEntry<void>>::result_type;
+
+    static constexpr bool is_defined = !std::is_same_v<value_type, void>;
 };
 
 template <typename T1, typename T2, unsigned int vec_sz, unsigned int n_vecs>
@@ -143,9 +145,7 @@ template <typename fnT, typename T> struct Log10ContigFactory
 {
     fnT get()
     {
-        if constexpr (std::is_same_v<typename Log10OutputType<T>::value_type,
-                                     void>)
-        {
+        if constexpr (!Log10OutputType<T>::is_defined) {
             fnT fn = nullptr;
             return fn;
         }
@@ -162,7 +162,6 @@ template <typename fnT, typename T> struct Log10TypeMapFactory
     std::enable_if_t<std::is_same<fnT, int>::value, int> get()
     {
         using rT = typename Log10OutputType<T>::value_type;
-        ;
         return td_ns::GetTypeid<rT>{}.get();
     }
 };
@@ -192,9 +191,7 @@ template <typename fnT, typename T> struct Log10StridedFactory
 {
     fnT get()
     {
-        if constexpr (std::is_same_v<typename Log10OutputType<T>::value_type,
-                                     void>)
-        {
+        if constexpr (!Log10OutputType<T>::is_defined) {
             fnT fn = nullptr;
             return fn;
         }

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/log1p.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/log1p.hpp
@@ -127,6 +127,8 @@ template <typename T> struct Log1pOutputType
         td_ns::
             TypeMapResultEntry<T, std::complex<double>, std::complex<double>>,
         td_ns::DefaultResultEntry<void>>::result_type;
+
+    static constexpr bool is_defined = !std::is_same_v<value_type, void>;
 };
 
 template <typename T1, typename T2, unsigned int vec_sz, unsigned int n_vecs>
@@ -148,9 +150,7 @@ template <typename fnT, typename T> struct Log1pContigFactory
 {
     fnT get()
     {
-        if constexpr (std::is_same_v<typename Log1pOutputType<T>::value_type,
-                                     void>)
-        {
+        if constexpr (!Log1pOutputType<T>::is_defined) {
             fnT fn = nullptr;
             return fn;
         }
@@ -167,7 +167,6 @@ template <typename fnT, typename T> struct Log1pTypeMapFactory
     std::enable_if_t<std::is_same<fnT, int>::value, int> get()
     {
         using rT = typename Log1pOutputType<T>::value_type;
-        ;
         return td_ns::GetTypeid<rT>{}.get();
     }
 };
@@ -197,9 +196,7 @@ template <typename fnT, typename T> struct Log1pStridedFactory
 {
     fnT get()
     {
-        if constexpr (std::is_same_v<typename Log1pOutputType<T>::value_type,
-                                     void>)
-        {
+        if constexpr (!Log1pOutputType<T>::is_defined) {
             fnT fn = nullptr;
             return fn;
         }

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/log1p.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/log1p.hpp
@@ -119,8 +119,7 @@ using Log1pStridedFunctor = elementwise_common::
 
 template <typename T> struct Log1pOutputType
 {
-    using value_type = typename std::disjunction< // disjunction is C++17
-                                                  // feature, supported by DPC++
+    using value_type = typename std::disjunction<
         td_ns::TypeMapResultEntry<T, sycl::half, sycl::half>,
         td_ns::TypeMapResultEntry<T, float, float>,
         td_ns::TypeMapResultEntry<T, double, double>,

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/log2.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/log2.hpp
@@ -115,8 +115,7 @@ using Log2StridedFunctor = elementwise_common::
 
 template <typename T> struct Log2OutputType
 {
-    using value_type = typename std::disjunction< // disjunction is C++17
-                                                  // feature, supported by DPC++
+    using value_type = typename std::disjunction<
         td_ns::TypeMapResultEntry<T, sycl::half, sycl::half>,
         td_ns::TypeMapResultEntry<T, float, float>,
         td_ns::TypeMapResultEntry<T, double, double>,

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/log2.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/log2.hpp
@@ -123,6 +123,8 @@ template <typename T> struct Log2OutputType
         td_ns::
             TypeMapResultEntry<T, std::complex<double>, std::complex<double>>,
         td_ns::DefaultResultEntry<void>>::result_type;
+
+    static constexpr bool is_defined = !std::is_same_v<value_type, void>;
 };
 
 template <typename T1, typename T2, unsigned int vec_sz, unsigned int n_vecs>
@@ -144,9 +146,7 @@ template <typename fnT, typename T> struct Log2ContigFactory
 {
     fnT get()
     {
-        if constexpr (std::is_same_v<typename Log2OutputType<T>::value_type,
-                                     void>)
-        {
+        if constexpr (!Log2OutputType<T>::is_defined) {
             fnT fn = nullptr;
             return fn;
         }
@@ -163,7 +163,6 @@ template <typename fnT, typename T> struct Log2TypeMapFactory
     std::enable_if_t<std::is_same<fnT, int>::value, int> get()
     {
         using rT = typename Log2OutputType<T>::value_type;
-        ;
         return td_ns::GetTypeid<rT>{}.get();
     }
 };
@@ -193,9 +192,7 @@ template <typename fnT, typename T> struct Log2StridedFactory
 {
     fnT get()
     {
-        if constexpr (std::is_same_v<typename Log2OutputType<T>::value_type,
-                                     void>)
-        {
+        if constexpr (!Log2OutputType<T>::is_defined) {
             fnT fn = nullptr;
             return fn;
         }

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/logaddexp.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/logaddexp.hpp
@@ -121,8 +121,7 @@ using LogAddExpStridedFunctor = elementwise_common::BinaryStridedFunctor<
 
 template <typename T1, typename T2> struct LogAddExpOutputType
 {
-    using value_type = typename std::disjunction< // disjunction is C++17
-                                                  // feature, supported by DPC++
+    using value_type = typename std::disjunction<
         td_ns::BinaryTypeMapResultEntry<T1,
                                         sycl::half,
                                         T2,

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/logaddexp.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/logaddexp.hpp
@@ -130,6 +130,8 @@ template <typename T1, typename T2> struct LogAddExpOutputType
         td_ns::BinaryTypeMapResultEntry<T1, float, T2, float, float>,
         td_ns::BinaryTypeMapResultEntry<T1, double, T2, double, double>,
         td_ns::DefaultResultEntry<void>>::result_type;
+
+    static constexpr bool is_defined = !std::is_same_v<value_type, void>;
 };
 
 template <typename argT1,
@@ -160,10 +162,7 @@ template <typename fnT, typename T1, typename T2> struct LogAddExpContigFactory
 {
     fnT get()
     {
-        if constexpr (std::is_same_v<
-                          typename LogAddExpOutputType<T1, T2>::value_type,
-                          void>)
-        {
+        if constexpr (!LogAddExpOutputType<T1, T2>::is_defined) {
             fnT fn = nullptr;
             return fn;
         }
@@ -180,7 +179,6 @@ template <typename fnT, typename T1, typename T2> struct LogAddExpTypeMapFactory
     std::enable_if_t<std::is_same<fnT, int>::value, int> get()
     {
         using rT = typename LogAddExpOutputType<T1, T2>::value_type;
-        ;
         return td_ns::GetTypeid<rT>{}.get();
     }
 };
@@ -214,10 +212,7 @@ template <typename fnT, typename T1, typename T2> struct LogAddExpStridedFactory
 {
     fnT get()
     {
-        if constexpr (std::is_same_v<
-                          typename LogAddExpOutputType<T1, T2>::value_type,
-                          void>)
-        {
+        if constexpr (!LogAddExpOutputType<T1, T2>::is_defined) {
             fnT fn = nullptr;
             return fn;
         }

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/logical_and.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/logical_and.hpp
@@ -115,9 +115,7 @@ using LogicalAndStridedFunctor = elementwise_common::BinaryStridedFunctor<
 
 template <typename T1, typename T2> struct LogicalAndOutputType
 {
-    using value_type = typename std::disjunction< // disjunction is C++17
-                                                  // feature, supported by
-                                                  // DPC++
+    using value_type = typename std::disjunction<
         td_ns::BinaryTypeMapResultEntry<T1, bool, T2, bool, bool>,
         td_ns::
             BinaryTypeMapResultEntry<T1, std::uint8_t, T2, std::uint8_t, bool>,

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/logical_and.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/logical_and.hpp
@@ -155,6 +155,8 @@ template <typename T1, typename T2> struct LogicalAndOutputType
                                         std::complex<double>,
                                         bool>,
         td_ns::DefaultResultEntry<void>>::result_type;
+
+    static constexpr bool is_defined = !std::is_same_v<value_type, void>;
 };
 
 template <typename argT1,
@@ -186,10 +188,7 @@ template <typename fnT, typename T1, typename T2> struct LogicalAndContigFactory
 {
     fnT get()
     {
-        if constexpr (std::is_same_v<
-                          typename LogicalAndOutputType<T1, T2>::value_type,
-                          void>)
-        {
+        if constexpr (!LogicalAndOutputType<T1, T2>::is_defined) {
             fnT fn = nullptr;
             return fn;
         }
@@ -242,10 +241,7 @@ struct LogicalAndStridedFactory
 {
     fnT get()
     {
-        if constexpr (std::is_same_v<
-                          typename LogicalAndOutputType<T1, T2>::value_type,
-                          void>)
-        {
+        if constexpr (!LogicalAndOutputType<T1, T2>::is_defined) {
             fnT fn = nullptr;
             return fn;
         }

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/logical_or.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/logical_or.hpp
@@ -154,6 +154,8 @@ template <typename T1, typename T2> struct LogicalOrOutputType
                                         std::complex<double>,
                                         bool>,
         td_ns::DefaultResultEntry<void>>::result_type;
+
+    static constexpr bool is_defined = !std::is_same_v<value_type, void>;
 };
 
 template <typename argT1,
@@ -184,10 +186,7 @@ template <typename fnT, typename T1, typename T2> struct LogicalOrContigFactory
 {
     fnT get()
     {
-        if constexpr (std::is_same_v<
-                          typename LogicalOrOutputType<T1, T2>::value_type,
-                          void>)
-        {
+        if constexpr (!LogicalOrOutputType<T1, T2>::is_defined) {
             fnT fn = nullptr;
             return fn;
         }
@@ -238,10 +237,7 @@ template <typename fnT, typename T1, typename T2> struct LogicalOrStridedFactory
 {
     fnT get()
     {
-        if constexpr (std::is_same_v<
-                          typename LogicalOrOutputType<T1, T2>::value_type,
-                          void>)
-        {
+        if constexpr (!LogicalOrOutputType<T1, T2>::is_defined) {
             fnT fn = nullptr;
             return fn;
         }

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/logical_or.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/logical_or.hpp
@@ -114,9 +114,7 @@ using LogicalOrStridedFunctor = elementwise_common::BinaryStridedFunctor<
 
 template <typename T1, typename T2> struct LogicalOrOutputType
 {
-    using value_type = typename std::disjunction< // disjunction is C++17
-                                                  // feature, supported by
-                                                  // DPC++
+    using value_type = typename std::disjunction<
         td_ns::BinaryTypeMapResultEntry<T1, bool, T2, bool, bool>,
         td_ns::
             BinaryTypeMapResultEntry<T1, std::uint8_t, T2, std::uint8_t, bool>,

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/logical_xor.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/logical_xor.hpp
@@ -116,9 +116,7 @@ using LogicalXorStridedFunctor = elementwise_common::BinaryStridedFunctor<
 
 template <typename T1, typename T2> struct LogicalXorOutputType
 {
-    using value_type = typename std::disjunction< // disjunction is C++17
-                                                  // feature, supported by
-                                                  // DPC++
+    using value_type = typename std::disjunction<
         td_ns::BinaryTypeMapResultEntry<T1, bool, T2, bool, bool>,
         td_ns::
             BinaryTypeMapResultEntry<T1, std::uint8_t, T2, std::uint8_t, bool>,

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/logical_xor.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/logical_xor.hpp
@@ -156,6 +156,8 @@ template <typename T1, typename T2> struct LogicalXorOutputType
                                         std::complex<double>,
                                         bool>,
         td_ns::DefaultResultEntry<void>>::result_type;
+
+    static constexpr bool is_defined = !std::is_same_v<value_type, void>;
 };
 
 template <typename argT1,
@@ -187,10 +189,7 @@ template <typename fnT, typename T1, typename T2> struct LogicalXorContigFactory
 {
     fnT get()
     {
-        if constexpr (std::is_same_v<
-                          typename LogicalXorOutputType<T1, T2>::value_type,
-                          void>)
-        {
+        if constexpr (!LogicalXorOutputType<T1, T2>::is_defined) {
             fnT fn = nullptr;
             return fn;
         }
@@ -243,10 +242,7 @@ struct LogicalXorStridedFactory
 {
     fnT get()
     {
-        if constexpr (std::is_same_v<
-                          typename LogicalXorOutputType<T1, T2>::value_type,
-                          void>)
-        {
+        if constexpr (!LogicalXorOutputType<T1, T2>::is_defined) {
             fnT fn = nullptr;
             return fn;
         }

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/maximum.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/maximum.hpp
@@ -118,8 +118,7 @@ using MaximumStridedFunctor = elementwise_common::BinaryStridedFunctor<
 
 template <typename T1, typename T2> struct MaximumOutputType
 {
-    using value_type = typename std::disjunction< // disjunction is C++17
-                                                  // feature, supported by DPC++
+    using value_type = typename std::disjunction<
         td_ns::BinaryTypeMapResultEntry<T1, bool, T2, bool, bool>,
         td_ns::BinaryTypeMapResultEntry<T1,
                                         std::uint8_t,

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/maximum.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/maximum.hpp
@@ -178,6 +178,8 @@ template <typename T1, typename T2> struct MaximumOutputType
                                         std::complex<double>,
                                         std::complex<double>>,
         td_ns::DefaultResultEntry<void>>::result_type;
+
+    static constexpr bool is_defined = !std::is_same_v<value_type, void>;
 };
 
 template <typename argT1,
@@ -208,9 +210,7 @@ template <typename fnT, typename T1, typename T2> struct MaximumContigFactory
 {
     fnT get()
     {
-        if constexpr (std::is_same_v<
-                          typename MaximumOutputType<T1, T2>::value_type, void>)
-        {
+        if constexpr (!MaximumOutputType<T1, T2>::is_defined) {
             fnT fn = nullptr;
             return fn;
         }
@@ -227,7 +227,6 @@ template <typename fnT, typename T1, typename T2> struct MaximumTypeMapFactory
     std::enable_if_t<std::is_same<fnT, int>::value, int> get()
     {
         using rT = typename MaximumOutputType<T1, T2>::value_type;
-        ;
         return td_ns::GetTypeid<rT>{}.get();
     }
 };
@@ -261,9 +260,7 @@ template <typename fnT, typename T1, typename T2> struct MaximumStridedFactory
 {
     fnT get()
     {
-        if constexpr (std::is_same_v<
-                          typename MaximumOutputType<T1, T2>::value_type, void>)
-        {
+        if constexpr (!MaximumOutputType<T1, T2>::is_defined) {
             fnT fn = nullptr;
             return fn;
         }

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/minimum.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/minimum.hpp
@@ -118,8 +118,7 @@ using MinimumStridedFunctor = elementwise_common::BinaryStridedFunctor<
 
 template <typename T1, typename T2> struct MinimumOutputType
 {
-    using value_type = typename std::disjunction< // disjunction is C++17
-                                                  // feature, supported by DPC++
+    using value_type = typename std::disjunction<
         td_ns::BinaryTypeMapResultEntry<T1, bool, T2, bool, bool>,
         td_ns::BinaryTypeMapResultEntry<T1,
                                         std::uint8_t,

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/minimum.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/minimum.hpp
@@ -178,6 +178,8 @@ template <typename T1, typename T2> struct MinimumOutputType
                                         std::complex<double>,
                                         std::complex<double>>,
         td_ns::DefaultResultEntry<void>>::result_type;
+
+    static constexpr bool is_defined = !std::is_same_v<value_type, void>;
 };
 
 template <typename argT1,
@@ -208,9 +210,7 @@ template <typename fnT, typename T1, typename T2> struct MinimumContigFactory
 {
     fnT get()
     {
-        if constexpr (std::is_same_v<
-                          typename MinimumOutputType<T1, T2>::value_type, void>)
-        {
+        if constexpr (!MinimumOutputType<T1, T2>::is_defined) {
             fnT fn = nullptr;
             return fn;
         }
@@ -227,7 +227,6 @@ template <typename fnT, typename T1, typename T2> struct MinimumTypeMapFactory
     std::enable_if_t<std::is_same<fnT, int>::value, int> get()
     {
         using rT = typename MinimumOutputType<T1, T2>::value_type;
-        ;
         return td_ns::GetTypeid<rT>{}.get();
     }
 };
@@ -261,9 +260,7 @@ template <typename fnT, typename T1, typename T2> struct MinimumStridedFactory
 {
     fnT get()
     {
-        if constexpr (std::is_same_v<
-                          typename MinimumOutputType<T1, T2>::value_type, void>)
-        {
+        if constexpr (!MinimumOutputType<T1, T2>::is_defined) {
             fnT fn = nullptr;
             return fn;
         }

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/multiply.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/multiply.hpp
@@ -120,8 +120,7 @@ using MultiplyStridedFunctor = elementwise_common::BinaryStridedFunctor<
 
 template <typename T1, typename T2> struct MultiplyOutputType
 {
-    using value_type = typename std::disjunction< // disjunction is C++17
-                                                  // feature, supported by DPC++
+    using value_type = typename std::disjunction<
         td_ns::BinaryTypeMapResultEntry<T1, bool, T2, bool, bool>,
         td_ns::BinaryTypeMapResultEntry<T1,
                                         std::uint8_t,
@@ -438,10 +437,7 @@ class multiply_inplace_contig_kernel;
 template <typename argTy, typename resTy> struct MultiplyInplaceTypePairSupport
 {
     /* value if true a kernel for <argTy, resTy> must be instantiated  */
-    static constexpr bool is_defined = std::disjunction< // disjunction is
-                                                         // C++17 feature,
-                                                         // supported by
-                                                         // DPC++ input
+    static constexpr bool is_defined = std::disjunction<
         td_ns::TypePairDefinedEntry<argTy, bool, resTy, bool>,
         td_ns::TypePairDefinedEntry<argTy, std::int8_t, resTy, std::int8_t>,
         td_ns::TypePairDefinedEntry<argTy, std::uint8_t, resTy, std::uint8_t>,

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/multiply.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/multiply.hpp
@@ -180,6 +180,8 @@ template <typename T1, typename T2> struct MultiplyOutputType
                                         std::complex<double>,
                                         std::complex<double>>,
         td_ns::DefaultResultEntry<void>>::result_type;
+
+    static constexpr bool is_defined = !std::is_same_v<value_type, void>;
 };
 
 template <typename argT1,
@@ -210,10 +212,7 @@ template <typename fnT, typename T1, typename T2> struct MultiplyContigFactory
 {
     fnT get()
     {
-        if constexpr (std::is_same_v<
-                          typename MultiplyOutputType<T1, T2>::value_type,
-                          void>)
-        {
+        if constexpr (!MultiplyOutputType<T1, T2>::is_defined) {
             fnT fn = nullptr;
             return fn;
         }
@@ -230,7 +229,6 @@ template <typename fnT, typename T1, typename T2> struct MultiplyTypeMapFactory
     std::enable_if_t<std::is_same<fnT, int>::value, int> get()
     {
         using rT = typename MultiplyOutputType<T1, T2>::value_type;
-        ;
         return td_ns::GetTypeid<rT>{}.get();
     }
 };
@@ -264,10 +262,7 @@ template <typename fnT, typename T1, typename T2> struct MultiplyStridedFactory
 {
     fnT get()
     {
-        if constexpr (std::is_same_v<
-                          typename MultiplyOutputType<T1, T2>::value_type,
-                          void>)
-        {
+        if constexpr (!MultiplyOutputType<T1, T2>::is_defined) {
             fnT fn = nullptr;
             return fn;
         }
@@ -316,12 +311,12 @@ struct MultiplyContigMatrixContigRowBroadcastFactory
 {
     fnT get()
     {
-        using resT = typename MultiplyOutputType<T1, T2>::value_type;
-        if constexpr (std::is_same_v<resT, void>) {
+        if constexpr (!MultiplyOutputType<T1, T2>::is_defined) {
             fnT fn = nullptr;
             return fn;
         }
         else {
+            using resT = typename MultiplyOutputType<T1, T2>::value_type;
             if constexpr (dpctl::tensor::type_utils::is_complex<T1>::value ||
                           dpctl::tensor::type_utils::is_complex<T2>::value ||
                           dpctl::tensor::type_utils::is_complex<resT>::value)
@@ -364,12 +359,12 @@ struct MultiplyContigRowContigMatrixBroadcastFactory
 {
     fnT get()
     {
-        using resT = typename MultiplyOutputType<T1, T2>::value_type;
-        if constexpr (std::is_same_v<resT, void>) {
+        if constexpr (!MultiplyOutputType<T1, T2>::is_defined) {
             fnT fn = nullptr;
             return fn;
         }
         else {
+            using resT = typename MultiplyOutputType<T1, T2>::value_type;
             if constexpr (dpctl::tensor::type_utils::is_complex<T1>::value ||
                           dpctl::tensor::type_utils::is_complex<T2>::value ||
                           dpctl::tensor::type_utils::is_complex<resT>::value)

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/negative.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/negative.hpp
@@ -78,8 +78,7 @@ using NegativeContigFunctor =
 
 template <typename T> struct NegativeOutputType
 {
-    using value_type = typename std::disjunction< // disjunction is C++17
-                                                  // feature, supported by DPC++
+    using value_type = typename std::disjunction<
         td_ns::TypeMapResultEntry<T, std::uint8_t>,
         td_ns::TypeMapResultEntry<T, std::uint16_t>,
         td_ns::TypeMapResultEntry<T, std::uint32_t>,

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/negative.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/negative.hpp
@@ -93,6 +93,8 @@ template <typename T> struct NegativeOutputType
         td_ns::TypeMapResultEntry<T, std::complex<float>>,
         td_ns::TypeMapResultEntry<T, std::complex<double>>,
         td_ns::DefaultResultEntry<void>>::result_type;
+
+    static constexpr bool is_defined = !std::is_same_v<value_type, void>;
 };
 
 template <typename T1, typename T2, unsigned int vec_sz, unsigned int n_vecs>
@@ -115,9 +117,7 @@ template <typename fnT, typename T> struct NegativeContigFactory
 {
     fnT get()
     {
-        if constexpr (std::is_same_v<typename NegativeOutputType<T>::value_type,
-                                     void>)
-        {
+        if constexpr (!NegativeOutputType<T>::is_defined) {
             fnT fn = nullptr;
             return fn;
         }
@@ -134,7 +134,6 @@ template <typename fnT, typename T> struct NegativeTypeMapFactory
     std::enable_if_t<std::is_same<fnT, int>::value, int> get()
     {
         using rT = typename NegativeOutputType<T>::value_type;
-        ;
         return td_ns::GetTypeid<rT>{}.get();
     }
 };
@@ -169,9 +168,7 @@ template <typename fnT, typename T> struct NegativeStridedFactory
 {
     fnT get()
     {
-        if constexpr (std::is_same_v<typename NegativeOutputType<T>::value_type,
-                                     void>)
-        {
+        if constexpr (!NegativeOutputType<T>::is_defined) {
             fnT fn = nullptr;
             return fn;
         }

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/nextafter.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/nextafter.hpp
@@ -104,8 +104,7 @@ using NextafterStridedFunctor = elementwise_common::BinaryStridedFunctor<
 
 template <typename T1, typename T2> struct NextafterOutputType
 {
-    using value_type = typename std::disjunction< // disjunction is C++17
-                                                  // feature, supported by DPC++
+    using value_type = typename std::disjunction<
         td_ns::BinaryTypeMapResultEntry<T1,
                                         sycl::half,
                                         T2,

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/nextafter.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/nextafter.hpp
@@ -113,6 +113,8 @@ template <typename T1, typename T2> struct NextafterOutputType
         td_ns::BinaryTypeMapResultEntry<T1, float, T2, float, float>,
         td_ns::BinaryTypeMapResultEntry<T1, double, T2, double, double>,
         td_ns::DefaultResultEntry<void>>::result_type;
+
+    static constexpr bool is_defined = !std::is_same_v<value_type, void>;
 };
 
 template <typename argT1,
@@ -143,10 +145,7 @@ template <typename fnT, typename T1, typename T2> struct NextafterContigFactory
 {
     fnT get()
     {
-        if constexpr (std::is_same_v<
-                          typename NextafterOutputType<T1, T2>::value_type,
-                          void>)
-        {
+        if constexpr (!NextafterOutputType<T1, T2>::is_defined) {
             fnT fn = nullptr;
             return fn;
         }
@@ -163,7 +162,6 @@ template <typename fnT, typename T1, typename T2> struct NextafterTypeMapFactory
     std::enable_if_t<std::is_same<fnT, int>::value, int> get()
     {
         using rT = typename NextafterOutputType<T1, T2>::value_type;
-        ;
         return td_ns::GetTypeid<rT>{}.get();
     }
 };
@@ -197,10 +195,7 @@ template <typename fnT, typename T1, typename T2> struct NextafterStridedFactory
 {
     fnT get()
     {
-        if constexpr (std::is_same_v<
-                          typename NextafterOutputType<T1, T2>::value_type,
-                          void>)
-        {
+        if constexpr (!NextafterOutputType<T1, T2>::is_defined) {
             fnT fn = nullptr;
             return fn;
         }

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/not_equal.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/not_equal.hpp
@@ -169,6 +169,8 @@ template <typename T1, typename T2> struct NotEqualOutputType
                                         std::complex<double>,
                                         bool>,
         td_ns::DefaultResultEntry<void>>::result_type;
+
+    static constexpr bool is_defined = !std::is_same_v<value_type, void>;
 };
 
 template <typename argT1,
@@ -199,10 +201,7 @@ template <typename fnT, typename T1, typename T2> struct NotEqualContigFactory
 {
     fnT get()
     {
-        if constexpr (std::is_same_v<
-                          typename NotEqualOutputType<T1, T2>::value_type,
-                          void>)
-        {
+        if constexpr (!NotEqualOutputType<T1, T2>::is_defined) {
             fnT fn = nullptr;
             return fn;
         }
@@ -252,10 +251,7 @@ template <typename fnT, typename T1, typename T2> struct NotEqualStridedFactory
 {
     fnT get()
     {
-        if constexpr (std::is_same_v<
-                          typename NotEqualOutputType<T1, T2>::value_type,
-                          void>)
-        {
+        if constexpr (!NotEqualOutputType<T1, T2>::is_defined) {
             fnT fn = nullptr;
             return fn;
         }

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/not_equal.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/not_equal.hpp
@@ -125,8 +125,7 @@ using NotEqualStridedFunctor = elementwise_common::BinaryStridedFunctor<
 
 template <typename T1, typename T2> struct NotEqualOutputType
 {
-    using value_type = typename std::disjunction< // disjunction is C++17
-                                                  // feature, supported by DPC++
+    using value_type = typename std::disjunction<
         td_ns::BinaryTypeMapResultEntry<T1, bool, T2, bool, bool>,
         td_ns::
             BinaryTypeMapResultEntry<T1, std::uint8_t, T2, std::uint8_t, bool>,

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/positive.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/positive.hpp
@@ -108,6 +108,8 @@ template <typename T> struct PositiveOutputType
         td_ns::TypeMapResultEntry<T, std::complex<float>>,
         td_ns::TypeMapResultEntry<T, std::complex<double>>,
         td_ns::DefaultResultEntry<void>>::result_type;
+
+    static constexpr bool is_defined = !std::is_same_v<value_type, void>;
 };
 
 template <typename T1, typename T2, unsigned int vec_sz, unsigned int n_vecs>
@@ -130,9 +132,7 @@ template <typename fnT, typename T> struct PositiveContigFactory
 {
     fnT get()
     {
-        if constexpr (std::is_same_v<typename PositiveOutputType<T>::value_type,
-                                     void>)
-        {
+        if constexpr (!PositiveOutputType<T>::is_defined) {
             fnT fn = nullptr;
             return fn;
         }
@@ -149,7 +149,6 @@ template <typename fnT, typename T> struct PositiveTypeMapFactory
     std::enable_if_t<std::is_same<fnT, int>::value, int> get()
     {
         using rT = typename PositiveOutputType<T>::value_type;
-        ;
         return td_ns::GetTypeid<rT>{}.get();
     }
 };
@@ -184,9 +183,7 @@ template <typename fnT, typename T> struct PositiveStridedFactory
 {
     fnT get()
     {
-        if constexpr (std::is_same_v<typename PositiveOutputType<T>::value_type,
-                                     void>)
-        {
+        if constexpr (!PositiveOutputType<T>::is_defined) {
             fnT fn = nullptr;
             return fn;
         }

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/positive.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/positive.hpp
@@ -93,8 +93,7 @@ using PositiveContigFunctor =
 
 template <typename T> struct PositiveOutputType
 {
-    using value_type = typename std::disjunction< // disjunction is C++17
-                                                  // feature, supported by DPC++
+    using value_type = typename std::disjunction<
         td_ns::TypeMapResultEntry<T, std::uint8_t>,
         td_ns::TypeMapResultEntry<T, std::uint16_t>,
         td_ns::TypeMapResultEntry<T, std::uint32_t>,

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/pow.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/pow.hpp
@@ -446,6 +446,52 @@ template <typename argT,
           unsigned int n_vecs>
 class pow_inplace_contig_kernel;
 
+/* @brief Types supported by in-place pow */
+template <typename argTy, typename resTy> struct PowInplaceTypePairSupport
+{
+    /* value if true a kernel for <argTy, resTy> must be instantiated  */
+    static constexpr bool is_defined = std::disjunction< // disjunction is
+                                                         // C++17 feature,
+                                                         // supported by
+                                                         // DPC++ input bool
+        td_ns::TypePairDefinedEntry<argTy, std::int8_t, resTy, std::int8_t>,
+        td_ns::TypePairDefinedEntry<argTy, std::uint8_t, resTy, std::uint8_t>,
+        td_ns::TypePairDefinedEntry<argTy, std::int16_t, resTy, std::int16_t>,
+        td_ns::TypePairDefinedEntry<argTy, std::uint16_t, resTy, std::uint16_t>,
+        td_ns::TypePairDefinedEntry<argTy, std::int32_t, resTy, std::int32_t>,
+        td_ns::TypePairDefinedEntry<argTy, std::uint32_t, resTy, std::uint32_t>,
+        td_ns::TypePairDefinedEntry<argTy, std::int64_t, resTy, std::int64_t>,
+        td_ns::TypePairDefinedEntry<argTy, std::uint64_t, resTy, std::uint64_t>,
+        td_ns::TypePairDefinedEntry<argTy, sycl::half, resTy, sycl::half>,
+        td_ns::TypePairDefinedEntry<argTy, float, resTy, float>,
+        td_ns::TypePairDefinedEntry<argTy, double, resTy, double>,
+        td_ns::TypePairDefinedEntry<argTy,
+                                    std::complex<float>,
+                                    resTy,
+                                    std::complex<float>>,
+        td_ns::TypePairDefinedEntry<argTy,
+                                    std::complex<double>,
+                                    resTy,
+                                    std::complex<double>>,
+        // fall-through
+        td_ns::NotDefinedEntry>::is_defined;
+};
+
+template <typename fnT, typename argT, typename resT>
+struct PowInplaceTypeMapFactory
+{
+    /*! @brief get typeid for output type of x **= y */
+    std::enable_if_t<std::is_same<fnT, int>::value, int> get()
+    {
+        if constexpr (PowInplaceTypePairSupport<argT, resT>::is_defined) {
+            return td_ns::GetTypeid<resT>{}.get();
+        }
+        else {
+            return td_ns::GetTypeid<void>{}.get();
+        }
+    }
+};
+
 template <typename argTy, typename resTy>
 sycl::event
 pow_inplace_contig_impl(sycl::queue &exec_q,
@@ -465,9 +511,7 @@ template <typename fnT, typename T1, typename T2> struct PowInplaceContigFactory
 {
     fnT get()
     {
-        if constexpr (std::is_same_v<typename PowOutputType<T1, T2>::value_type,
-                                     void>)
-        {
+        if constexpr (!PowInplaceTypePairSupport<T1, T2>::is_defined) {
             fnT fn = nullptr;
             return fn;
         }
@@ -505,9 +549,7 @@ struct PowInplaceStridedFactory
 {
     fnT get()
     {
-        if constexpr (std::is_same_v<typename PowOutputType<T1, T2>::value_type,
-                                     void>)
-        {
+        if constexpr (!PowInplaceTypePairSupport<T1, T2>::is_defined) {
             fnT fn = nullptr;
             return fn;
         }

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/pow.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/pow.hpp
@@ -232,6 +232,8 @@ template <typename T1, typename T2> struct PowOutputType
                                         std::complex<double>,
                                         std::complex<double>>,
         td_ns::DefaultResultEntry<void>>::result_type;
+
+    static constexpr bool is_defined = !std::is_same_v<value_type, void>;
 };
 
 template <typename argT1,
@@ -262,9 +264,7 @@ template <typename fnT, typename T1, typename T2> struct PowContigFactory
 {
     fnT get()
     {
-        if constexpr (std::is_same_v<typename PowOutputType<T1, T2>::value_type,
-                                     void>)
-        {
+        if constexpr (!PowOutputType<T1, T2>::is_defined) {
             fnT fn = nullptr;
             return fn;
         }
@@ -281,7 +281,6 @@ template <typename fnT, typename T1, typename T2> struct PowTypeMapFactory
     std::enable_if_t<std::is_same<fnT, int>::value, int> get()
     {
         using rT = typename PowOutputType<T1, T2>::value_type;
-        ;
         return td_ns::GetTypeid<rT>{}.get();
     }
 };
@@ -313,9 +312,7 @@ template <typename fnT, typename T1, typename T2> struct PowStridedFactory
 {
     fnT get()
     {
-        if constexpr (std::is_same_v<typename PowOutputType<T1, T2>::value_type,
-                                     void>)
-        {
+        if constexpr (!PowOutputType<T1, T2>::is_defined) {
             fnT fn = nullptr;
             return fn;
         }

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/pow.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/pow.hpp
@@ -173,8 +173,7 @@ using PowStridedFunctor =
 
 template <typename T1, typename T2> struct PowOutputType
 {
-    using value_type = typename std::disjunction< // disjunction is C++17
-                                                  // feature, supported by DPC++
+    using value_type = typename std::disjunction<
         td_ns::BinaryTypeMapResultEntry<T1,
                                         std::uint8_t,
                                         T2,
@@ -450,10 +449,7 @@ class pow_inplace_contig_kernel;
 template <typename argTy, typename resTy> struct PowInplaceTypePairSupport
 {
     /* value if true a kernel for <argTy, resTy> must be instantiated  */
-    static constexpr bool is_defined = std::disjunction< // disjunction is
-                                                         // C++17 feature,
-                                                         // supported by
-                                                         // DPC++ input bool
+    static constexpr bool is_defined = std::disjunction<
         td_ns::TypePairDefinedEntry<argTy, std::int8_t, resTy, std::int8_t>,
         td_ns::TypePairDefinedEntry<argTy, std::uint8_t, resTy, std::uint8_t>,
         td_ns::TypePairDefinedEntry<argTy, std::int16_t, resTy, std::int16_t>,

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/proj.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/proj.hpp
@@ -108,7 +108,6 @@ using ProjStridedFunctor = elementwise_common::
 
 template <typename T> struct ProjOutputType
 {
-    // disjunction is C++17 feature, supported by DPC++
     using value_type = typename std::disjunction<
         td_ns::TypeMapResultEntry<T, std::complex<float>>,
         td_ns::TypeMapResultEntry<T, std::complex<double>>,

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/proj.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/proj.hpp
@@ -112,6 +112,8 @@ template <typename T> struct ProjOutputType
         td_ns::TypeMapResultEntry<T, std::complex<float>>,
         td_ns::TypeMapResultEntry<T, std::complex<double>>,
         td_ns::DefaultResultEntry<void>>::result_type;
+
+    static constexpr bool is_defined = !std::is_same_v<value_type, void>;
 };
 
 template <typename T1, typename T2, unsigned int vec_sz, unsigned int n_vecs>
@@ -133,9 +135,7 @@ template <typename fnT, typename T> struct ProjContigFactory
 {
     fnT get()
     {
-        if constexpr (std::is_same_v<typename ProjOutputType<T>::value_type,
-                                     void>)
-        {
+        if constexpr (!ProjOutputType<T>::is_defined) {
             fnT fn = nullptr;
             return fn;
         }
@@ -187,9 +187,7 @@ template <typename fnT, typename T> struct ProjStridedFactory
 {
     fnT get()
     {
-        if constexpr (std::is_same_v<typename ProjOutputType<T>::value_type,
-                                     void>)
-        {
+        if constexpr (!ProjOutputType<T>::is_defined) {
             fnT fn = nullptr;
             return fn;
         }

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/real.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/real.hpp
@@ -95,8 +95,7 @@ using RealStridedFunctor = elementwise_common::
 
 template <typename T> struct RealOutputType
 {
-    using value_type = typename std::disjunction< // disjunction is C++17
-                                                  // feature, supported by DPC++
+    using value_type = typename std::disjunction<
         td_ns::TypeMapResultEntry<T, bool>,
         td_ns::TypeMapResultEntry<T, std::uint8_t>,
         td_ns::TypeMapResultEntry<T, std::uint16_t>,

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/real.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/real.hpp
@@ -111,6 +111,8 @@ template <typename T> struct RealOutputType
         td_ns::TypeMapResultEntry<T, std::complex<float>, float>,
         td_ns::TypeMapResultEntry<T, std::complex<double>, double>,
         td_ns::DefaultResultEntry<void>>::result_type;
+
+    static constexpr bool is_defined = !std::is_same_v<value_type, void>;
 };
 
 template <typename T1, typename T2, unsigned int vec_sz, unsigned int n_vecs>
@@ -132,9 +134,7 @@ template <typename fnT, typename T> struct RealContigFactory
 {
     fnT get()
     {
-        if constexpr (std::is_same_v<typename RealOutputType<T>::value_type,
-                                     void>)
-        {
+        if constexpr (!RealOutputType<T>::is_defined) {
             fnT fn = nullptr;
             return fn;
         }
@@ -180,9 +180,7 @@ template <typename fnT, typename T> struct RealStridedFactory
 {
     fnT get()
     {
-        if constexpr (std::is_same_v<typename RealOutputType<T>::value_type,
-                                     void>)
-        {
+        if constexpr (!RealOutputType<T>::is_defined) {
             fnT fn = nullptr;
             return fn;
         }

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/reciprocal.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/reciprocal.hpp
@@ -108,6 +108,8 @@ template <typename T> struct ReciprocalOutputType
         td_ns::TypeMapResultEntry<T, std::complex<float>>,
         td_ns::TypeMapResultEntry<T, std::complex<double>>,
         td_ns::DefaultResultEntry<void>>::result_type;
+
+    static constexpr bool is_defined = !std::is_same_v<value_type, void>;
 };
 
 template <typename T1, typename T2, unsigned int vec_sz, unsigned int n_vecs>
@@ -130,9 +132,7 @@ template <typename fnT, typename T> struct ReciprocalContigFactory
 {
     fnT get()
     {
-        if constexpr (std::is_same_v<
-                          typename ReciprocalOutputType<T>::value_type, void>)
-        {
+        if constexpr (!ReciprocalOutputType<T>::is_defined) {
             fnT fn = nullptr;
             return fn;
         }
@@ -180,9 +180,7 @@ template <typename fnT, typename T> struct ReciprocalStridedFactory
 {
     fnT get()
     {
-        if constexpr (std::is_same_v<
-                          typename ReciprocalOutputType<T>::value_type, void>)
-        {
+        if constexpr (!ReciprocalOutputType<T>::is_defined) {
             fnT fn = nullptr;
             return fn;
         }

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/reciprocal.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/reciprocal.hpp
@@ -101,8 +101,7 @@ using ReciprocalStridedFunctor =
 
 template <typename T> struct ReciprocalOutputType
 {
-    using value_type = typename std::disjunction< // disjunction is C++17
-                                                  // feature, supported by DPC++
+    using value_type = typename std::disjunction<
         td_ns::TypeMapResultEntry<T, sycl::half>,
         td_ns::TypeMapResultEntry<T, float>,
         td_ns::TypeMapResultEntry<T, double>,

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/remainder.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/remainder.hpp
@@ -166,8 +166,7 @@ using RemainderStridedFunctor = elementwise_common::BinaryStridedFunctor<
 
 template <typename T1, typename T2> struct RemainderOutputType
 {
-    using value_type = typename std::disjunction< // disjunction is C++17
-                                                  // feature, supported by DPC++
+    using value_type = typename std::disjunction<
         td_ns::BinaryTypeMapResultEntry<T1,
                                         std::uint8_t,
                                         T2,
@@ -428,10 +427,7 @@ class remainder_inplace_contig_kernel;
 template <typename argTy, typename resTy> struct RemainderInplaceTypePairSupport
 {
     /* value if true a kernel for <argTy, resTy> must be instantiated  */
-    static constexpr bool is_defined = std::disjunction< // disjunction is
-                                                         // C++17 feature,
-                                                         // supported by
-                                                         // DPC++ input
+    static constexpr bool is_defined = std::disjunction<
         td_ns::TypePairDefinedEntry<argTy, std::int8_t, resTy, std::int8_t>,
         td_ns::TypePairDefinedEntry<argTy, std::uint8_t, resTy, std::uint8_t>,
         td_ns::TypePairDefinedEntry<argTy, std::int16_t, resTy, std::int16_t>,

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/remainder.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/remainder.hpp
@@ -424,6 +424,44 @@ template <typename argT,
           unsigned int n_vecs>
 class remainder_inplace_contig_kernel;
 
+/* @brief Types supported by in-place remainder */
+template <typename argTy, typename resTy> struct RemainderInplaceTypePairSupport
+{
+    /* value if true a kernel for <argTy, resTy> must be instantiated  */
+    static constexpr bool is_defined = std::disjunction< // disjunction is
+                                                         // C++17 feature,
+                                                         // supported by
+                                                         // DPC++ input
+        td_ns::TypePairDefinedEntry<argTy, std::int8_t, resTy, std::int8_t>,
+        td_ns::TypePairDefinedEntry<argTy, std::uint8_t, resTy, std::uint8_t>,
+        td_ns::TypePairDefinedEntry<argTy, std::int16_t, resTy, std::int16_t>,
+        td_ns::TypePairDefinedEntry<argTy, std::uint16_t, resTy, std::uint16_t>,
+        td_ns::TypePairDefinedEntry<argTy, std::int32_t, resTy, std::int32_t>,
+        td_ns::TypePairDefinedEntry<argTy, std::uint32_t, resTy, std::uint32_t>,
+        td_ns::TypePairDefinedEntry<argTy, std::int64_t, resTy, std::int64_t>,
+        td_ns::TypePairDefinedEntry<argTy, std::uint64_t, resTy, std::uint64_t>,
+        td_ns::TypePairDefinedEntry<argTy, sycl::half, resTy, sycl::half>,
+        td_ns::TypePairDefinedEntry<argTy, float, resTy, float>,
+        td_ns::TypePairDefinedEntry<argTy, double, resTy, double>,
+        // fall-through
+        td_ns::NotDefinedEntry>::is_defined;
+};
+
+template <typename fnT, typename argT, typename resT>
+struct RemainderInplaceTypeMapFactory
+{
+    /*! @brief get typeid for output type of x %= y */
+    std::enable_if_t<std::is_same<fnT, int>::value, int> get()
+    {
+        if constexpr (RemainderInplaceTypePairSupport<argT, resT>::is_defined) {
+            return td_ns::GetTypeid<resT>{}.get();
+        }
+        else {
+            return td_ns::GetTypeid<void>{}.get();
+        }
+    }
+};
+
 template <typename argTy, typename resTy>
 sycl::event
 remainder_inplace_contig_impl(sycl::queue &exec_q,
@@ -445,10 +483,7 @@ struct RemainderInplaceContigFactory
 {
     fnT get()
     {
-        if constexpr (std::is_same_v<
-                          typename RemainderOutputType<T1, T2>::value_type,
-                          void>)
-        {
+        if constexpr (!RemainderInplaceTypePairSupport<T1, T2>::is_defined) {
             fnT fn = nullptr;
             return fn;
         }
@@ -487,10 +522,7 @@ struct RemainderInplaceStridedFactory
 {
     fnT get()
     {
-        if constexpr (std::is_same_v<
-                          typename RemainderOutputType<T1, T2>::value_type,
-                          void>)
-        {
+        if constexpr (!RemainderInplaceTypePairSupport<T1, T2>::is_defined) {
             fnT fn = nullptr;
             return fn;
         }

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/remainder.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/remainder.hpp
@@ -215,6 +215,8 @@ template <typename T1, typename T2> struct RemainderOutputType
         td_ns::BinaryTypeMapResultEntry<T1, float, T2, float, float>,
         td_ns::BinaryTypeMapResultEntry<T1, double, T2, double, double>,
         td_ns::DefaultResultEntry<void>>::result_type;
+
+    static constexpr bool is_defined = !std::is_same_v<value_type, void>;
 };
 
 template <typename argT1,
@@ -245,10 +247,7 @@ template <typename fnT, typename T1, typename T2> struct RemainderContigFactory
 {
     fnT get()
     {
-        if constexpr (std::is_same_v<
-                          typename RemainderOutputType<T1, T2>::value_type,
-                          void>)
-        {
+        if constexpr (!RemainderOutputType<T1, T2>::is_defined) {
             fnT fn = nullptr;
             return fn;
         }
@@ -298,10 +297,7 @@ template <typename fnT, typename T1, typename T2> struct RemainderStridedFactory
 {
     fnT get()
     {
-        if constexpr (std::is_same_v<
-                          typename RemainderOutputType<T1, T2>::value_type,
-                          void>)
-        {
+        if constexpr (!RemainderOutputType<T1, T2>::is_defined) {
             fnT fn = nullptr;
             return fn;
         }

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/round.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/round.hpp
@@ -119,6 +119,8 @@ template <typename T> struct RoundOutputType
         td_ns::TypeMapResultEntry<T, std::complex<float>>,
         td_ns::TypeMapResultEntry<T, std::complex<double>>,
         td_ns::DefaultResultEntry<void>>::result_type;
+
+    static constexpr bool is_defined = !std::is_same_v<value_type, void>;
 };
 
 template <typename T1, typename T2, unsigned int vec_sz, unsigned int n_vecs>
@@ -140,9 +142,7 @@ template <typename fnT, typename T> struct RoundContigFactory
 {
     fnT get()
     {
-        if constexpr (std::is_same_v<typename RoundOutputType<T>::value_type,
-                                     void>)
-        {
+        if constexpr (!RoundOutputType<T>::is_defined) {
             fnT fn = nullptr;
             return fn;
         }
@@ -188,9 +188,7 @@ template <typename fnT, typename T> struct RoundStridedFactory
 {
     fnT get()
     {
-        if constexpr (std::is_same_v<typename RoundOutputType<T>::value_type,
-                                     void>)
-        {
+        if constexpr (!RoundOutputType<T>::is_defined) {
             fnT fn = nullptr;
             return fn;
         }

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/round.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/round.hpp
@@ -104,8 +104,7 @@ using RoundStridedFunctor = elementwise_common::
 
 template <typename T> struct RoundOutputType
 {
-    using value_type = typename std::disjunction< // disjunction is C++17
-                                                  // feature, supported by DPC++
+    using value_type = typename std::disjunction<
         td_ns::TypeMapResultEntry<T, std::uint8_t>,
         td_ns::TypeMapResultEntry<T, std::uint16_t>,
         td_ns::TypeMapResultEntry<T, std::uint32_t>,

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/rsqrt.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/rsqrt.hpp
@@ -90,6 +90,8 @@ template <typename T> struct RsqrtOutputType
         td_ns::TypeMapResultEntry<T, float, float>,
         td_ns::TypeMapResultEntry<T, double, double>,
         td_ns::DefaultResultEntry<void>>::result_type;
+
+    static constexpr bool is_defined = !std::is_same_v<value_type, void>;
 };
 
 template <typename T1, typename T2, unsigned int vec_sz, unsigned int n_vecs>
@@ -111,9 +113,7 @@ template <typename fnT, typename T> struct RsqrtContigFactory
 {
     fnT get()
     {
-        if constexpr (std::is_same_v<typename RsqrtOutputType<T>::value_type,
-                                     void>)
-        {
+        if constexpr (!RsqrtOutputType<T>::is_defined) {
             fnT fn = nullptr;
             return fn;
         }
@@ -159,9 +159,7 @@ template <typename fnT, typename T> struct RsqrtStridedFactory
 {
     fnT get()
     {
-        if constexpr (std::is_same_v<typename RsqrtOutputType<T>::value_type,
-                                     void>)
-        {
+        if constexpr (!RsqrtOutputType<T>::is_defined) {
             fnT fn = nullptr;
             return fn;
         }

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/rsqrt.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/rsqrt.hpp
@@ -85,8 +85,7 @@ using RsqrtStridedFunctor = elementwise_common::
 
 template <typename T> struct RsqrtOutputType
 {
-    using value_type = typename std::disjunction< // disjunction is C++17
-                                                  // feature, supported by DPC++
+    using value_type = typename std::disjunction<
         td_ns::TypeMapResultEntry<T, sycl::half, sycl::half>,
         td_ns::TypeMapResultEntry<T, float, float>,
         td_ns::TypeMapResultEntry<T, double, double>,

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/sign.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/sign.hpp
@@ -131,6 +131,8 @@ template <typename T> struct SignOutputType
         td_ns::TypeMapResultEntry<T, std::complex<float>>,
         td_ns::TypeMapResultEntry<T, std::complex<double>>,
         td_ns::DefaultResultEntry<void>>::result_type;
+
+    static constexpr bool is_defined = !std::is_same_v<value_type, void>;
 };
 
 template <typename T1, typename T2, unsigned int vec_sz, unsigned int n_vecs>
@@ -152,9 +154,7 @@ template <typename fnT, typename T> struct SignContigFactory
 {
     fnT get()
     {
-        if constexpr (std::is_same_v<typename SignOutputType<T>::value_type,
-                                     void>)
-        {
+        if constexpr (!SignOutputType<T>::is_defined) {
             fnT fn = nullptr;
             return fn;
         }
@@ -171,7 +171,6 @@ template <typename fnT, typename T> struct SignTypeMapFactory
     std::enable_if_t<std::is_same<fnT, int>::value, int> get()
     {
         using rT = typename SignOutputType<T>::value_type;
-        ;
         return td_ns::GetTypeid<rT>{}.get();
     }
 };
@@ -205,9 +204,7 @@ template <typename fnT, typename T> struct SignStridedFactory
 {
     fnT get()
     {
-        if constexpr (std::is_same_v<typename SignOutputType<T>::value_type,
-                                     void>)
-        {
+        if constexpr (!SignOutputType<T>::is_defined) {
             fnT fn = nullptr;
             return fn;
         }

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/sign.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/sign.hpp
@@ -116,8 +116,7 @@ using SignContigFunctor =
 
 template <typename T> struct SignOutputType
 {
-    using value_type = typename std::disjunction< // disjunction is C++17
-                                                  // feature, supported by DPC++
+    using value_type = typename std::disjunction<
         td_ns::TypeMapResultEntry<T, std::uint8_t>,
         td_ns::TypeMapResultEntry<T, std::uint16_t>,
         td_ns::TypeMapResultEntry<T, std::uint32_t>,

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/signbit.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/signbit.hpp
@@ -96,6 +96,8 @@ template <typename argTy> struct SignbitOutputType
         td_ns::TypeMapResultEntry<argTy, float, bool>,
         td_ns::TypeMapResultEntry<argTy, double, bool>,
         td_ns::DefaultResultEntry<void>>::result_type;
+
+    static constexpr bool is_defined = !std::is_same_v<value_type, void>;
 };
 
 template <typename T1, typename T2, unsigned int vec_sz, unsigned int n_vecs>
@@ -117,9 +119,7 @@ template <typename fnT, typename T> struct SignbitContigFactory
 {
     fnT get()
     {
-        if constexpr (std::is_same_v<typename SignbitOutputType<T>::value_type,
-                                     void>)
-        {
+        if constexpr (!SignbitOutputType<T>::is_defined) {
             fnT fn = nullptr;
             return fn;
         }
@@ -166,9 +166,7 @@ template <typename fnT, typename T> struct SignbitStridedFactory
 {
     fnT get()
     {
-        if constexpr (std::is_same_v<typename SignbitOutputType<T>::value_type,
-                                     void>)
-        {
+        if constexpr (!SignbitOutputType<T>::is_defined) {
             fnT fn = nullptr;
             return fn;
         }

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/signbit.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/signbit.hpp
@@ -91,8 +91,7 @@ using SignbitStridedFunctor = elementwise_common::
 
 template <typename argTy> struct SignbitOutputType
 {
-    using value_type = typename std::disjunction< // disjunction is C++17
-                                                  // feature, supported by DPC++
+    using value_type = typename std::disjunction<
         td_ns::TypeMapResultEntry<argTy, sycl::half, bool>,
         td_ns::TypeMapResultEntry<argTy, float, bool>,
         td_ns::TypeMapResultEntry<argTy, double, bool>,

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/sin.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/sin.hpp
@@ -203,8 +203,7 @@ using SinStridedFunctor = elementwise_common::
 
 template <typename T> struct SinOutputType
 {
-    using value_type = typename std::disjunction< // disjunction is C++17
-                                                  // feature, supported by DPC++
+    using value_type = typename std::disjunction<
         td_ns::TypeMapResultEntry<T, sycl::half>,
         td_ns::TypeMapResultEntry<T, float>,
         td_ns::TypeMapResultEntry<T, double>,

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/sin.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/sin.hpp
@@ -210,6 +210,8 @@ template <typename T> struct SinOutputType
         td_ns::TypeMapResultEntry<T, std::complex<float>>,
         td_ns::TypeMapResultEntry<T, std::complex<double>>,
         td_ns::DefaultResultEntry<void>>::result_type;
+
+    static constexpr bool is_defined = !std::is_same_v<value_type, void>;
 };
 
 template <typename T1, typename T2, unsigned int vec_sz, unsigned int n_vecs>
@@ -231,9 +233,7 @@ template <typename fnT, typename T> struct SinContigFactory
 {
     fnT get()
     {
-        if constexpr (std::is_same_v<typename SinOutputType<T>::value_type,
-                                     void>)
-        {
+        if constexpr (!SinOutputType<T>::is_defined) {
             fnT fn = nullptr;
             return fn;
         }
@@ -278,9 +278,7 @@ template <typename fnT, typename T> struct SinStridedFactory
 {
     fnT get()
     {
-        if constexpr (std::is_same_v<typename SinOutputType<T>::value_type,
-                                     void>)
-        {
+        if constexpr (!SinOutputType<T>::is_defined) {
             fnT fn = nullptr;
             return fn;
         }

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/sinh.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/sinh.hpp
@@ -172,8 +172,7 @@ using SinhStridedFunctor = elementwise_common::
 
 template <typename T> struct SinhOutputType
 {
-    using value_type = typename std::disjunction< // disjunction is C++17
-                                                  // feature, supported by DPC++
+    using value_type = typename std::disjunction<
         td_ns::TypeMapResultEntry<T, sycl::half>,
         td_ns::TypeMapResultEntry<T, float>,
         td_ns::TypeMapResultEntry<T, double>,

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/sinh.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/sinh.hpp
@@ -179,6 +179,8 @@ template <typename T> struct SinhOutputType
         td_ns::TypeMapResultEntry<T, std::complex<float>>,
         td_ns::TypeMapResultEntry<T, std::complex<double>>,
         td_ns::DefaultResultEntry<void>>::result_type;
+
+    static constexpr bool is_defined = !std::is_same_v<value_type, void>;
 };
 
 template <typename T1, typename T2, unsigned int vec_sz, unsigned int n_vecs>
@@ -200,9 +202,7 @@ template <typename fnT, typename T> struct SinhContigFactory
 {
     fnT get()
     {
-        if constexpr (std::is_same_v<typename SinhOutputType<T>::value_type,
-                                     void>)
-        {
+        if constexpr (!SinhOutputType<T>::is_defined) {
             fnT fn = nullptr;
             return fn;
         }
@@ -248,9 +248,7 @@ template <typename fnT, typename T> struct SinhStridedFactory
 {
     fnT get()
     {
-        if constexpr (std::is_same_v<typename SinhOutputType<T>::value_type,
-                                     void>)
-        {
+        if constexpr (!SinhOutputType<T>::is_defined) {
             fnT fn = nullptr;
             return fn;
         }

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/sqrt.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/sqrt.hpp
@@ -97,8 +97,7 @@ using SqrtStridedFunctor = elementwise_common::
 
 template <typename T> struct SqrtOutputType
 {
-    using value_type = typename std::disjunction< // disjunction is C++17
-                                                  // feature, supported by DPC++
+    using value_type = typename std::disjunction<
         td_ns::TypeMapResultEntry<T, sycl::half, sycl::half>,
         td_ns::TypeMapResultEntry<T, float, float>,
         td_ns::TypeMapResultEntry<T, double, double>,

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/sqrt.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/sqrt.hpp
@@ -105,6 +105,8 @@ template <typename T> struct SqrtOutputType
         td_ns::
             TypeMapResultEntry<T, std::complex<double>, std::complex<double>>,
         td_ns::DefaultResultEntry<void>>::result_type;
+
+    static constexpr bool is_defined = !std::is_same_v<value_type, void>;
 };
 
 template <typename T1, typename T2, unsigned int vec_sz, unsigned int n_vecs>
@@ -126,9 +128,7 @@ template <typename fnT, typename T> struct SqrtContigFactory
 {
     fnT get()
     {
-        if constexpr (std::is_same_v<typename SqrtOutputType<T>::value_type,
-                                     void>)
-        {
+        if constexpr (!SqrtOutputType<T>::is_defined) {
             fnT fn = nullptr;
             return fn;
         }
@@ -174,9 +174,7 @@ template <typename fnT, typename T> struct SqrtStridedFactory
 {
     fnT get()
     {
-        if constexpr (std::is_same_v<typename SqrtOutputType<T>::value_type,
-                                     void>)
-        {
+        if constexpr (!SqrtOutputType<T>::is_defined) {
             fnT fn = nullptr;
             return fn;
         }

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/square.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/square.hpp
@@ -114,8 +114,7 @@ using SquareStridedFunctor = elementwise_common::
 
 template <typename T> struct SquareOutputType
 {
-    using value_type = typename std::disjunction< // disjunction is C++17
-                                                  // feature, supported by DPC++
+    using value_type = typename std::disjunction<
         td_ns::TypeMapResultEntry<T, bool, std::int8_t>,
         td_ns::TypeMapResultEntry<T, std::uint8_t>,
         td_ns::TypeMapResultEntry<T, std::uint16_t>,

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/square.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/square.hpp
@@ -130,6 +130,8 @@ template <typename T> struct SquareOutputType
         td_ns::TypeMapResultEntry<T, std::complex<float>>,
         td_ns::TypeMapResultEntry<T, std::complex<double>>,
         td_ns::DefaultResultEntry<void>>::result_type;
+
+    static constexpr bool is_defined = !std::is_same_v<value_type, void>;
 };
 
 template <typename T1, typename T2, unsigned int vec_sz, unsigned int n_vecs>
@@ -151,9 +153,7 @@ template <typename fnT, typename T> struct SquareContigFactory
 {
     fnT get()
     {
-        if constexpr (std::is_same_v<typename SquareOutputType<T>::value_type,
-                                     void>)
-        {
+        if constexpr (!SquareOutputType<T>::is_defined) {
             fnT fn = nullptr;
             return fn;
         }
@@ -199,9 +199,7 @@ template <typename fnT, typename T> struct SquareStridedFactory
 {
     fnT get()
     {
-        if constexpr (std::is_same_v<typename SquareOutputType<T>::value_type,
-                                     void>)
-        {
+        if constexpr (!SquareOutputType<T>::is_defined) {
             fnT fn = nullptr;
             return fn;
         }

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/subtract.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/subtract.hpp
@@ -435,6 +435,52 @@ template <typename argT,
           unsigned int n_vecs>
 class subtract_inplace_contig_kernel;
 
+/* @brief Types supported by in-place subtraction */
+template <typename argTy, typename resTy> struct SubtractInplaceTypePairSupport
+{
+    /* value if true a kernel for <argTy, resTy> must be instantiated  */
+    static constexpr bool is_defined = std::disjunction< // disjunction is
+                                                         // C++17 feature,
+                                                         // supported by
+                                                         // DPC++ input
+        td_ns::TypePairDefinedEntry<argTy, std::int8_t, resTy, std::int8_t>,
+        td_ns::TypePairDefinedEntry<argTy, std::uint8_t, resTy, std::uint8_t>,
+        td_ns::TypePairDefinedEntry<argTy, std::int16_t, resTy, std::int16_t>,
+        td_ns::TypePairDefinedEntry<argTy, std::uint16_t, resTy, std::uint16_t>,
+        td_ns::TypePairDefinedEntry<argTy, std::int32_t, resTy, std::int32_t>,
+        td_ns::TypePairDefinedEntry<argTy, std::uint32_t, resTy, std::uint32_t>,
+        td_ns::TypePairDefinedEntry<argTy, std::int64_t, resTy, std::int64_t>,
+        td_ns::TypePairDefinedEntry<argTy, std::uint64_t, resTy, std::uint64_t>,
+        td_ns::TypePairDefinedEntry<argTy, sycl::half, resTy, sycl::half>,
+        td_ns::TypePairDefinedEntry<argTy, float, resTy, float>,
+        td_ns::TypePairDefinedEntry<argTy, double, resTy, double>,
+        td_ns::TypePairDefinedEntry<argTy,
+                                    std::complex<float>,
+                                    resTy,
+                                    std::complex<float>>,
+        td_ns::TypePairDefinedEntry<argTy,
+                                    std::complex<double>,
+                                    resTy,
+                                    std::complex<double>>,
+        // fall-through
+        td_ns::NotDefinedEntry>::is_defined;
+};
+
+template <typename fnT, typename argT, typename resT>
+struct SubtractInplaceTypeMapFactory
+{
+    /*! @brief get typeid for output type of x -= y */
+    std::enable_if_t<std::is_same<fnT, int>::value, int> get()
+    {
+        if constexpr (SubtractInplaceTypePairSupport<argT, resT>::is_defined) {
+            return td_ns::GetTypeid<resT>{}.get();
+        }
+        else {
+            return td_ns::GetTypeid<void>{}.get();
+        }
+    }
+};
+
 template <typename argTy, typename resTy>
 sycl::event
 subtract_inplace_contig_impl(sycl::queue &exec_q,
@@ -456,10 +502,7 @@ struct SubtractInplaceContigFactory
 {
     fnT get()
     {
-        if constexpr (std::is_same_v<
-                          typename SubtractOutputType<T1, T2>::value_type,
-                          void>)
-        {
+        if constexpr (!SubtractInplaceTypePairSupport<T1, T2>::is_defined) {
             fnT fn = nullptr;
             return fn;
         }
@@ -498,10 +541,7 @@ struct SubtractInplaceStridedFactory
 {
     fnT get()
     {
-        if constexpr (std::is_same_v<
-                          typename SubtractOutputType<T1, T2>::value_type,
-                          void>)
-        {
+        if constexpr (!SubtractInplaceTypePairSupport<T1, T2>::is_defined) {
             fnT fn = nullptr;
             return fn;
         }
@@ -546,8 +586,7 @@ struct SubtractInplaceRowMatrixBroadcastFactory
 {
     fnT get()
     {
-        using resT = typename SubtractOutputType<T1, T2>::value_type;
-        if constexpr (!std::is_same_v<resT, T2>) {
+        if constexpr (!SubtractInplaceTypePairSupport<T1, T2>::is_defined) {
             fnT fn = nullptr;
             return fn;
         }

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/subtract.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/subtract.hpp
@@ -166,6 +166,8 @@ template <typename T1, typename T2> struct SubtractOutputType
                                         std::complex<double>,
                                         std::complex<double>>,
         td_ns::DefaultResultEntry<void>>::result_type;
+
+    static constexpr bool is_defined = !std::is_same_v<value_type, void>;
 };
 
 template <typename argT1,
@@ -196,10 +198,7 @@ template <typename fnT, typename T1, typename T2> struct SubtractContigFactory
 {
     fnT get()
     {
-        if constexpr (std::is_same_v<
-                          typename SubtractOutputType<T1, T2>::value_type,
-                          void>)
-        {
+        if constexpr (!SubtractOutputType<T1, T2>::is_defined) {
             fnT fn = nullptr;
             return fn;
         }
@@ -249,10 +248,7 @@ template <typename fnT, typename T1, typename T2> struct SubtractStridedFactory
 {
     fnT get()
     {
-        if constexpr (std::is_same_v<
-                          typename SubtractOutputType<T1, T2>::value_type,
-                          void>)
-        {
+        if constexpr (!SubtractOutputType<T1, T2>::is_defined) {
             fnT fn = nullptr;
             return fn;
         }
@@ -312,10 +308,7 @@ struct SubtractContigMatrixContigRowBroadcastFactory
 {
     fnT get()
     {
-        if constexpr (std::is_same_v<
-                          typename SubtractOutputType<T1, T2>::value_type,
-                          void>)
-        {
+        if constexpr (!SubtractOutputType<T1, T2>::is_defined) {
             fnT fn = nullptr;
             return fn;
         }
@@ -365,12 +358,12 @@ struct SubtractContigRowContigMatrixBroadcastFactory
 {
     fnT get()
     {
-        using resT = typename SubtractOutputType<T1, T2>::value_type;
-        if constexpr (std::is_same_v<resT, void>) {
+        if constexpr (!SubtractOutputType<T1, T2>::is_defined) {
             fnT fn = nullptr;
             return fn;
         }
         else {
+            using resT = typename SubtractOutputType<T1, T2>::value_type;
             if constexpr (dpctl::tensor::type_utils::is_complex<T1>::value ||
                           dpctl::tensor::type_utils::is_complex<T2>::value ||
                           dpctl::tensor::type_utils::is_complex<resT>::value)

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/subtract.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/subtract.hpp
@@ -107,8 +107,7 @@ using SubtractStridedFunctor = elementwise_common::BinaryStridedFunctor<
 
 template <typename T1, typename T2> struct SubtractOutputType
 {
-    using value_type = typename std::disjunction< // disjunction is C++17
-                                                  // feature, supported by DPC++
+    using value_type = typename std::disjunction<
         td_ns::BinaryTypeMapResultEntry<T1,
                                         std::uint8_t,
                                         T2,
@@ -439,10 +438,7 @@ class subtract_inplace_contig_kernel;
 template <typename argTy, typename resTy> struct SubtractInplaceTypePairSupport
 {
     /* value if true a kernel for <argTy, resTy> must be instantiated  */
-    static constexpr bool is_defined = std::disjunction< // disjunction is
-                                                         // C++17 feature,
-                                                         // supported by
-                                                         // DPC++ input
+    static constexpr bool is_defined = std::disjunction<
         td_ns::TypePairDefinedEntry<argTy, std::int8_t, resTy, std::int8_t>,
         td_ns::TypePairDefinedEntry<argTy, std::uint8_t, resTy, std::uint8_t>,
         td_ns::TypePairDefinedEntry<argTy, std::int16_t, resTy, std::int16_t>,

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/tan.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/tan.hpp
@@ -154,6 +154,8 @@ template <typename T> struct TanOutputType
         td_ns::TypeMapResultEntry<T, std::complex<float>>,
         td_ns::TypeMapResultEntry<T, std::complex<double>>,
         td_ns::DefaultResultEntry<void>>::result_type;
+
+    static constexpr bool is_defined = !std::is_same_v<value_type, void>;
 };
 
 template <typename T1, typename T2, unsigned int vec_sz, unsigned int n_vecs>
@@ -175,9 +177,7 @@ template <typename fnT, typename T> struct TanContigFactory
 {
     fnT get()
     {
-        if constexpr (std::is_same_v<typename TanOutputType<T>::value_type,
-                                     void>)
-        {
+        if constexpr (!TanOutputType<T>::is_defined) {
             fnT fn = nullptr;
             return fn;
         }
@@ -222,9 +222,7 @@ template <typename fnT, typename T> struct TanStridedFactory
 {
     fnT get()
     {
-        if constexpr (std::is_same_v<typename TanOutputType<T>::value_type,
-                                     void>)
-        {
+        if constexpr (!TanOutputType<T>::is_defined) {
             fnT fn = nullptr;
             return fn;
         }

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/tan.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/tan.hpp
@@ -147,8 +147,7 @@ using TanStridedFunctor = elementwise_common::
 
 template <typename T> struct TanOutputType
 {
-    using value_type = typename std::disjunction< // disjunction is C++17
-                                                  // feature, supported by DPC++
+    using value_type = typename std::disjunction<
         td_ns::TypeMapResultEntry<T, sycl::half>,
         td_ns::TypeMapResultEntry<T, float>,
         td_ns::TypeMapResultEntry<T, double>,

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/tanh.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/tanh.hpp
@@ -148,6 +148,8 @@ template <typename T> struct TanhOutputType
         td_ns::TypeMapResultEntry<T, std::complex<float>>,
         td_ns::TypeMapResultEntry<T, std::complex<double>>,
         td_ns::DefaultResultEntry<void>>::result_type;
+
+    static constexpr bool is_defined = !std::is_same_v<value_type, void>;
 };
 
 template <typename T1, typename T2, unsigned int vec_sz, unsigned int n_vecs>
@@ -169,9 +171,7 @@ template <typename fnT, typename T> struct TanhContigFactory
 {
     fnT get()
     {
-        if constexpr (std::is_same_v<typename TanhOutputType<T>::value_type,
-                                     void>)
-        {
+        if constexpr (!TanhOutputType<T>::is_defined) {
             fnT fn = nullptr;
             return fn;
         }
@@ -217,9 +217,7 @@ template <typename fnT, typename T> struct TanhStridedFactory
 {
     fnT get()
     {
-        if constexpr (std::is_same_v<typename TanhOutputType<T>::value_type,
-                                     void>)
-        {
+        if constexpr (!TanhOutputType<T>::is_defined) {
             fnT fn = nullptr;
             return fn;
         }

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/tanh.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/tanh.hpp
@@ -141,8 +141,7 @@ using TanhStridedFunctor = elementwise_common::
 
 template <typename T> struct TanhOutputType
 {
-    using value_type = typename std::disjunction< // disjunction is C++17
-                                                  // feature, supported by DPC++
+    using value_type = typename std::disjunction<
         td_ns::TypeMapResultEntry<T, sycl::half>,
         td_ns::TypeMapResultEntry<T, float>,
         td_ns::TypeMapResultEntry<T, double>,

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/true_divide.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/true_divide.hpp
@@ -134,8 +134,7 @@ using TrueDivideStridedFunctor = elementwise_common::BinaryStridedFunctor<
 
 template <typename T1, typename T2> struct TrueDivideOutputType
 {
-    using value_type = typename std::disjunction< // disjunction is C++17
-                                                  // feature, supported by DPC++
+    using value_type = typename std::disjunction<
         td_ns::BinaryTypeMapResultEntry<T1,
                                         sycl::half,
                                         T2,
@@ -445,9 +444,7 @@ struct TrueDivideInplaceTypePairSupport
 {
 
     /* value if true a kernel for <argTy, resTy> must be instantiated  */
-    static constexpr bool is_defined = std::disjunction< // disjunction is C++17
-                                                         // feature, supported
-                                                         // by DPC++ input bool
+    static constexpr bool is_defined = std::disjunction<
         td_ns::TypePairDefinedEntry<argTy, sycl::half, resTy, sycl::half>,
         td_ns::TypePairDefinedEntry<argTy, float, resTy, float>,
         td_ns::TypePairDefinedEntry<argTy, double, resTy, double>,

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/true_divide.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/true_divide.hpp
@@ -173,6 +173,8 @@ template <typename T1, typename T2> struct TrueDivideOutputType
                                         double,
                                         std::complex<double>>,
         td_ns::DefaultResultEntry<void>>::result_type;
+
+    static constexpr bool is_defined = !std::is_same_v<value_type, void>;
 };
 
 template <typename argT1,
@@ -204,10 +206,7 @@ template <typename fnT, typename T1, typename T2> struct TrueDivideContigFactory
 {
     fnT get()
     {
-        if constexpr (std::is_same_v<
-                          typename TrueDivideOutputType<T1, T2>::value_type,
-                          void>)
-        {
+        if constexpr (!TrueDivideOutputType<T1, T2>::is_defined) {
             fnT fn = nullptr;
             return fn;
         }
@@ -259,10 +258,7 @@ struct TrueDivideStridedFactory
 {
     fnT get()
     {
-        if constexpr (std::is_same_v<
-                          typename TrueDivideOutputType<T1, T2>::value_type,
-                          void>)
-        {
+        if constexpr (!TrueDivideOutputType<T1, T2>::is_defined) {
             fnT fn = nullptr;
             return fn;
         }
@@ -322,10 +318,7 @@ struct TrueDivideContigMatrixContigRowBroadcastFactory
 {
     fnT get()
     {
-        if constexpr (std::is_same_v<
-                          typename TrueDivideOutputType<T1, T2>::value_type,
-                          void>)
-        {
+        if constexpr (!TrueDivideOutputType<T1, T2>::is_defined) {
             fnT fn = nullptr;
             return fn;
         }
@@ -375,12 +368,12 @@ struct TrueDivideContigRowContigMatrixBroadcastFactory
 {
     fnT get()
     {
-        using resT = typename TrueDivideOutputType<T1, T2>::value_type;
-        if constexpr (std::is_same_v<resT, void>) {
+        if constexpr (!TrueDivideOutputType<T1, T2>::is_defined) {
             fnT fn = nullptr;
             return fn;
         }
         else {
+            using resT = typename TrueDivideOutputType<T1, T2>::value_type;
             if constexpr (dpctl::tensor::type_utils::is_complex<T1>::value ||
                           dpctl::tensor::type_utils::is_complex<T2>::value ||
                           dpctl::tensor::type_utils::is_complex<resT>::value)

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/trunc.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/trunc.hpp
@@ -105,6 +105,8 @@ template <typename T> struct TruncOutputType
                                   td_ns::TypeMapResultEntry<T, float>,
                                   td_ns::TypeMapResultEntry<T, double>,
                                   td_ns::DefaultResultEntry<void>>::result_type;
+
+    static constexpr bool is_defined = !std::is_same_v<value_type, void>;
 };
 
 template <typename T1, typename T2, unsigned int vec_sz, unsigned int n_vecs>
@@ -126,9 +128,7 @@ template <typename fnT, typename T> struct TruncContigFactory
 {
     fnT get()
     {
-        if constexpr (std::is_same_v<typename TruncOutputType<T>::value_type,
-                                     void>)
-        {
+        if constexpr (!TruncOutputType<T>::is_defined) {
             fnT fn = nullptr;
             return fn;
         }
@@ -174,9 +174,7 @@ template <typename fnT, typename T> struct TruncStridedFactory
 {
     fnT get()
     {
-        if constexpr (std::is_same_v<typename TruncOutputType<T>::value_type,
-                                     void>)
-        {
+        if constexpr (!TruncOutputType<T>::is_defined) {
             fnT fn = nullptr;
             return fn;
         }

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/trunc.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/trunc.hpp
@@ -92,20 +92,19 @@ using TruncStridedFunctor = elementwise_common::
 
 template <typename T> struct TruncOutputType
 {
-    using value_type = typename std::disjunction< // disjunction is C++17
-                                                  // feature, supported by DPC++
-        td_ns::TypeMapResultEntry<T, std::uint8_t>,
-        td_ns::TypeMapResultEntry<T, std::uint16_t>,
-        td_ns::TypeMapResultEntry<T, std::uint32_t>,
-        td_ns::TypeMapResultEntry<T, std::uint64_t>,
-        td_ns::TypeMapResultEntry<T, std::int8_t>,
-        td_ns::TypeMapResultEntry<T, std::int16_t>,
-        td_ns::TypeMapResultEntry<T, std::int32_t>,
-        td_ns::TypeMapResultEntry<T, std::int64_t>,
-        td_ns::TypeMapResultEntry<T, sycl::half>,
-        td_ns::TypeMapResultEntry<T, float>,
-        td_ns::TypeMapResultEntry<T, double>,
-        td_ns::DefaultResultEntry<void>>::result_type;
+    using value_type =
+        typename std::disjunction<td_ns::TypeMapResultEntry<T, std::uint8_t>,
+                                  td_ns::TypeMapResultEntry<T, std::uint16_t>,
+                                  td_ns::TypeMapResultEntry<T, std::uint32_t>,
+                                  td_ns::TypeMapResultEntry<T, std::uint64_t>,
+                                  td_ns::TypeMapResultEntry<T, std::int8_t>,
+                                  td_ns::TypeMapResultEntry<T, std::int16_t>,
+                                  td_ns::TypeMapResultEntry<T, std::int32_t>,
+                                  td_ns::TypeMapResultEntry<T, std::int64_t>,
+                                  td_ns::TypeMapResultEntry<T, sycl::half>,
+                                  td_ns::TypeMapResultEntry<T, float>,
+                                  td_ns::TypeMapResultEntry<T, double>,
+                                  td_ns::DefaultResultEntry<void>>::result_type;
 };
 
 template <typename T1, typename T2, unsigned int vec_sz, unsigned int n_vecs>

--- a/dpctl/tensor/libtensor/source/accumulators/cumulative_logsumexp.cpp
+++ b/dpctl/tensor/libtensor/source/accumulators/cumulative_logsumexp.cpp
@@ -70,7 +70,6 @@ template <typename argTy, typename outTy>
 struct TypePairSupportDataForLogSumExpAccumulation
 {
     static constexpr bool is_defined = std::disjunction<
-        // disjunction is C++17 feature, supported by DPC++ input bool
         td_ns::TypePairDefinedEntry<argTy, bool, outTy, sycl::half>,
         td_ns::TypePairDefinedEntry<argTy, bool, outTy, float>,
         td_ns::TypePairDefinedEntry<argTy, bool, outTy, double>,

--- a/dpctl/tensor/libtensor/source/accumulators/cumulative_prod.cpp
+++ b/dpctl/tensor/libtensor/source/accumulators/cumulative_prod.cpp
@@ -69,8 +69,6 @@ static accumulate_strided_impl_fn_ptr_t
 template <typename argTy, typename outTy>
 struct TypePairSupportDataForProdAccumulation
 {
-
-    // disjunction is C++17 feature, supported by DPC++ input bool
     static constexpr bool is_defined = std::disjunction<
         td_ns::TypePairDefinedEntry<argTy, bool, outTy, std::int32_t>,
         td_ns::TypePairDefinedEntry<argTy, bool, outTy, std::int64_t>,

--- a/dpctl/tensor/libtensor/source/accumulators/cumulative_sum.cpp
+++ b/dpctl/tensor/libtensor/source/accumulators/cumulative_sum.cpp
@@ -69,8 +69,6 @@ static accumulate_strided_impl_fn_ptr_t
 template <typename argTy, typename outTy>
 struct TypePairSupportDataForSumAccumulation
 {
-
-    // disjunction is C++17 feature, supported by DPC++ input bool
     static constexpr bool is_defined = std::disjunction<
         td_ns::TypePairDefinedEntry<argTy, bool, outTy, std::int32_t>,
         td_ns::TypePairDefinedEntry<argTy, bool, outTy, std::int64_t>,

--- a/dpctl/tensor/libtensor/source/elementwise_functions/bitwise_and.cpp
+++ b/dpctl/tensor/libtensor/source/elementwise_functions/bitwise_and.cpp
@@ -66,7 +66,10 @@ namespace bitwise_and_fn_ns = dpctl::tensor::kernels::bitwise_and;
 
 static binary_contig_impl_fn_ptr_t
     bitwise_and_contig_dispatch_table[td_ns::num_types][td_ns::num_types];
+
 static int bitwise_and_output_id_table[td_ns::num_types][td_ns::num_types];
+static int bitwise_and_inplace_output_id_table[td_ns::num_types]
+                                              [td_ns::num_types];
 
 static binary_strided_impl_fn_ptr_t
     bitwise_and_strided_dispatch_table[td_ns::num_types][td_ns::num_types];
@@ -115,6 +118,11 @@ void populate_bitwise_and_dispatch_tables(void)
                          BitwiseAndInplaceContigFactory, num_types>
         dtb5;
     dtb5.populate_dispatch_table(bitwise_and_inplace_contig_dispatch_table);
+
+    // which types are supported by the in-place kernels
+    using fn_ns::BitwiseAndInplaceTypeMapFactory;
+    DispatchTableBuilder<int, BitwiseAndInplaceTypeMapFactory, num_types> dtb6;
+    dtb6.populate_dispatch_table(bitwise_and_inplace_output_id_table);
 };
 
 } // namespace impl
@@ -160,25 +168,27 @@ void init_bitwise_and(py::module_ m)
         m.def("_bitwise_and_result_type", bitwise_and_result_type_pyapi, "");
 
         using impl::bitwise_and_inplace_contig_dispatch_table;
+        using impl::bitwise_and_inplace_output_id_table;
         using impl::bitwise_and_inplace_strided_dispatch_table;
 
-        auto bitwise_and_inplace_pyapi =
-            [&](const arrayT &src, const arrayT &dst, sycl::queue &exec_q,
-                const event_vecT &depends = {}) {
-                return py_binary_inplace_ufunc(
-                    src, dst, exec_q, depends, bitwise_and_output_id_table,
-                    // function pointers to handle inplace operation on
-                    // contiguous arrays (pointers may be nullptr)
-                    bitwise_and_inplace_contig_dispatch_table,
-                    // function pointers to handle inplace operation on strided
-                    // arrays (most general case)
-                    bitwise_and_inplace_strided_dispatch_table,
-                    // function pointers to handle inplace operation on
-                    // c-contig matrix with c-contig row with broadcasting
-                    // (may be nullptr)
-                    td_ns::NullPtrTable<
-                        binary_inplace_row_matrix_broadcast_impl_fn_ptr_t>{});
-            };
+        auto bitwise_and_inplace_pyapi = [&](const arrayT &src,
+                                             const arrayT &dst,
+                                             sycl::queue &exec_q,
+                                             const event_vecT &depends = {}) {
+            return py_binary_inplace_ufunc(
+                src, dst, exec_q, depends, bitwise_and_inplace_output_id_table,
+                // function pointers to handle inplace operation on
+                // contiguous arrays (pointers may be nullptr)
+                bitwise_and_inplace_contig_dispatch_table,
+                // function pointers to handle inplace operation on strided
+                // arrays (most general case)
+                bitwise_and_inplace_strided_dispatch_table,
+                // function pointers to handle inplace operation on
+                // c-contig matrix with c-contig row with broadcasting
+                // (may be nullptr)
+                td_ns::NullPtrTable<
+                    binary_inplace_row_matrix_broadcast_impl_fn_ptr_t>{});
+        };
         m.def("_bitwise_and_inplace", bitwise_and_inplace_pyapi, "",
               py::arg("lhs"), py::arg("rhs"), py::arg("sycl_queue"),
               py::arg("depends") = py::list());

--- a/dpctl/tensor/libtensor/source/elementwise_functions/bitwise_left_shift.cpp
+++ b/dpctl/tensor/libtensor/source/elementwise_functions/bitwise_left_shift.cpp
@@ -67,8 +67,11 @@ namespace bitwise_left_shift_fn_ns = dpctl::tensor::kernels::bitwise_left_shift;
 static binary_contig_impl_fn_ptr_t
     bitwise_left_shift_contig_dispatch_table[td_ns::num_types]
                                             [td_ns::num_types];
+
 static int bitwise_left_shift_output_id_table[td_ns::num_types]
                                              [td_ns::num_types];
+static int bitwise_left_shift_inplace_output_id_table[td_ns::num_types]
+                                                     [td_ns::num_types];
 
 static binary_strided_impl_fn_ptr_t
     bitwise_left_shift_strided_dispatch_table[td_ns::num_types]
@@ -120,6 +123,12 @@ void populate_bitwise_left_shift_dispatch_tables(void)
         dtb5;
     dtb5.populate_dispatch_table(
         bitwise_left_shift_inplace_contig_dispatch_table);
+
+    // which types are supported by the in-place kernels
+    using fn_ns::BitwiseLeftShiftInplaceTypeMapFactory;
+    DispatchTableBuilder<int, BitwiseLeftShiftInplaceTypeMapFactory, num_types>
+        dtb6;
+    dtb6.populate_dispatch_table(bitwise_left_shift_inplace_output_id_table);
 };
 
 } // namespace impl
@@ -169,6 +178,7 @@ void init_bitwise_left_shift(py::module_ m)
               bitwise_left_shift_result_type_pyapi, "");
 
         using impl::bitwise_left_shift_inplace_contig_dispatch_table;
+        using impl::bitwise_left_shift_inplace_output_id_table;
         using impl::bitwise_left_shift_inplace_strided_dispatch_table;
 
         auto bitwise_left_shift_inplace_pyapi =
@@ -176,7 +186,7 @@ void init_bitwise_left_shift(py::module_ m)
                 const event_vecT &depends = {}) {
                 return py_binary_inplace_ufunc(
                     src, dst, exec_q, depends,
-                    bitwise_left_shift_output_id_table,
+                    bitwise_left_shift_inplace_output_id_table,
                     // function pointers to handle inplace operation on
                     // contiguous arrays (pointers may be nullptr)
                     bitwise_left_shift_inplace_contig_dispatch_table,

--- a/dpctl/tensor/libtensor/source/elementwise_functions/bitwise_or.cpp
+++ b/dpctl/tensor/libtensor/source/elementwise_functions/bitwise_or.cpp
@@ -66,7 +66,10 @@ namespace bitwise_or_fn_ns = dpctl::tensor::kernels::bitwise_or;
 
 static binary_contig_impl_fn_ptr_t
     bitwise_or_contig_dispatch_table[td_ns::num_types][td_ns::num_types];
+
 static int bitwise_or_output_id_table[td_ns::num_types][td_ns::num_types];
+static int bitwise_or_inplace_output_id_table[td_ns::num_types]
+                                             [td_ns::num_types];
 
 static binary_strided_impl_fn_ptr_t
     bitwise_or_strided_dispatch_table[td_ns::num_types][td_ns::num_types];
@@ -115,6 +118,11 @@ void populate_bitwise_or_dispatch_tables(void)
                          BitwiseOrInplaceContigFactory, num_types>
         dtb5;
     dtb5.populate_dispatch_table(bitwise_or_inplace_contig_dispatch_table);
+
+    // which types are supported by the in-place kernels
+    using fn_ns::BitwiseOrInplaceTypeMapFactory;
+    DispatchTableBuilder<int, BitwiseOrInplaceTypeMapFactory, num_types> dtb6;
+    dtb6.populate_dispatch_table(bitwise_or_inplace_output_id_table);
 };
 
 } // namespace impl
@@ -160,25 +168,27 @@ void init_bitwise_or(py::module_ m)
         m.def("_bitwise_or_result_type", bitwise_or_result_type_pyapi, "");
 
         using impl::bitwise_or_inplace_contig_dispatch_table;
+        using impl::bitwise_or_inplace_output_id_table;
         using impl::bitwise_or_inplace_strided_dispatch_table;
 
-        auto bitwise_or_inplace_pyapi =
-            [&](const arrayT &src, const arrayT &dst, sycl::queue &exec_q,
-                const event_vecT &depends = {}) {
-                return py_binary_inplace_ufunc(
-                    src, dst, exec_q, depends, bitwise_or_output_id_table,
-                    // function pointers to handle inplace operation on
-                    // contiguous arrays (pointers may be nullptr)
-                    bitwise_or_inplace_contig_dispatch_table,
-                    // function pointers to handle inplace operation on strided
-                    // arrays (most general case)
-                    bitwise_or_inplace_strided_dispatch_table,
-                    // function pointers to handle inplace operation on
-                    // c-contig matrix with c-contig row with broadcasting
-                    // (may be nullptr)
-                    td_ns::NullPtrTable<
-                        binary_inplace_row_matrix_broadcast_impl_fn_ptr_t>{});
-            };
+        auto bitwise_or_inplace_pyapi = [&](const arrayT &src,
+                                            const arrayT &dst,
+                                            sycl::queue &exec_q,
+                                            const event_vecT &depends = {}) {
+            return py_binary_inplace_ufunc(
+                src, dst, exec_q, depends, bitwise_or_inplace_output_id_table,
+                // function pointers to handle inplace operation on
+                // contiguous arrays (pointers may be nullptr)
+                bitwise_or_inplace_contig_dispatch_table,
+                // function pointers to handle inplace operation on strided
+                // arrays (most general case)
+                bitwise_or_inplace_strided_dispatch_table,
+                // function pointers to handle inplace operation on
+                // c-contig matrix with c-contig row with broadcasting
+                // (may be nullptr)
+                td_ns::NullPtrTable<
+                    binary_inplace_row_matrix_broadcast_impl_fn_ptr_t>{});
+        };
         m.def("_bitwise_or_inplace", bitwise_or_inplace_pyapi, "",
               py::arg("lhs"), py::arg("rhs"), py::arg("sycl_queue"),
               py::arg("depends") = py::list());

--- a/dpctl/tensor/libtensor/source/elementwise_functions/bitwise_right_shift.cpp
+++ b/dpctl/tensor/libtensor/source/elementwise_functions/bitwise_right_shift.cpp
@@ -68,8 +68,11 @@ namespace bitwise_right_shift_fn_ns =
 static binary_contig_impl_fn_ptr_t
     bitwise_right_shift_contig_dispatch_table[td_ns::num_types]
                                              [td_ns::num_types];
+
 static int bitwise_right_shift_output_id_table[td_ns::num_types]
                                               [td_ns::num_types];
+static int bitwise_right_shift_inplace_output_id_table[td_ns::num_types]
+                                                      [td_ns::num_types];
 
 static binary_strided_impl_fn_ptr_t
     bitwise_right_shift_strided_dispatch_table[td_ns::num_types]
@@ -121,6 +124,12 @@ void populate_bitwise_right_shift_dispatch_tables(void)
         dtb5;
     dtb5.populate_dispatch_table(
         bitwise_right_shift_inplace_contig_dispatch_table);
+
+    // which types are supported by the in-place kernels
+    using fn_ns::BitwiseRightShiftInplaceTypeMapFactory;
+    DispatchTableBuilder<int, BitwiseRightShiftInplaceTypeMapFactory, num_types>
+        dtb6;
+    dtb6.populate_dispatch_table(bitwise_right_shift_inplace_output_id_table);
 };
 
 } // namespace impl
@@ -170,6 +179,7 @@ void init_bitwise_right_shift(py::module_ m)
               bitwise_right_shift_result_type_pyapi, "");
 
         using impl::bitwise_right_shift_inplace_contig_dispatch_table;
+        using impl::bitwise_right_shift_inplace_output_id_table;
         using impl::bitwise_right_shift_inplace_strided_dispatch_table;
 
         auto bitwise_right_shift_inplace_pyapi =
@@ -177,7 +187,7 @@ void init_bitwise_right_shift(py::module_ m)
                 const event_vecT &depends = {}) {
                 return py_binary_inplace_ufunc(
                     src, dst, exec_q, depends,
-                    bitwise_right_shift_output_id_table,
+                    bitwise_right_shift_inplace_output_id_table,
                     // function pointers to handle inplace operation on
                     // contiguous arrays (pointers may be nullptr)
                     bitwise_right_shift_inplace_contig_dispatch_table,

--- a/dpctl/tensor/libtensor/source/elementwise_functions/true_divide.cpp
+++ b/dpctl/tensor/libtensor/source/elementwise_functions/true_divide.cpp
@@ -137,7 +137,7 @@ void populate_true_divide_dispatch_tables(void)
     dtb5.populate_dispatch_table(
         true_divide_contig_row_contig_matrix_broadcast_dispatch_table);
 
-    // which input types are supported, and what is the type of the result
+    // which types are supported by the in-place kernels
     using fn_ns::TrueDivideInplaceTypeMapFactory;
     DispatchTableBuilder<int, TrueDivideInplaceTypeMapFactory, num_types> dtb6;
     dtb6.populate_dispatch_table(true_divide_inplace_output_id_table);

--- a/dpctl/tensor/libtensor/source/linalg_functions/dot_dispatch.hpp
+++ b/dpctl/tensor/libtensor/source/linalg_functions/dot_dispatch.hpp
@@ -43,8 +43,7 @@ namespace td_ns = dpctl::tensor::type_dispatch;
 
 template <typename T1, typename T2> struct DotAtomicOutputType
 {
-    using value_type = typename std::disjunction< // disjunction is C++17
-                                                  // feature, supported by DPC++
+    using value_type = typename std::disjunction<
         td_ns::BinaryTypeMapResultEntry<T1,
                                         std::uint32_t,
                                         T2,
@@ -85,8 +84,7 @@ template <typename T1, typename T2> struct DotAtomicOutputType
 // gemm, gevm, and dot product share output type struct
 template <typename T1, typename T2> struct DotNoAtomicOutputType
 {
-    using value_type = typename std::disjunction< // disjunction is C++17
-                                                  // feature, supported by DPC++
+    using value_type = typename std::disjunction<
         td_ns::BinaryTypeMapResultEntry<T1, bool, T2, bool, bool>,
         td_ns::BinaryTypeMapResultEntry<T1,
                                         std::uint8_t,

--- a/dpctl/tensor/libtensor/source/linalg_functions/dot_dispatch.hpp
+++ b/dpctl/tensor/libtensor/source/linalg_functions/dot_dispatch.hpp
@@ -78,6 +78,8 @@ template <typename T1, typename T2> struct DotAtomicOutputType
         td_ns::BinaryTypeMapResultEntry<T1, float, T2, float, double>,
         td_ns::BinaryTypeMapResultEntry<T1, double, T2, double, double>,
         td_ns::DefaultResultEntry<void>>::result_type;
+
+    static constexpr bool is_defined = !std::is_same_v<value_type, void>;
 };
 
 // add separate type support lists for atomic vs. temps
@@ -159,6 +161,8 @@ template <typename T1, typename T2> struct DotNoAtomicOutputType
                                         std::complex<double>,
                                         std::complex<double>>,
         td_ns::DefaultResultEntry<void>>::result_type;
+
+    static constexpr bool is_defined = !std::is_same_v<value_type, void>;
 };
 
 template <typename fnT, typename T1, typename T2> struct DotTypeMapFactory
@@ -177,13 +181,13 @@ template <typename fnT, typename T1, typename T2> struct GemmBatchAtomicFactory
 {
     fnT get()
     {
-        using T3 = typename DotAtomicOutputType<T1, T2>::value_type;
-        if constexpr (std::is_same_v<T3, void>) {
+        if constexpr (!DotAtomicOutputType<T1, T2>::is_defined) {
             fnT fn = nullptr;
             return fn;
         }
         else {
             using dpctl::tensor::kernels::gemm_batch_impl;
+            using T3 = typename DotAtomicOutputType<T1, T2>::value_type;
             fnT fn = gemm_batch_impl<T1, T2, T3>;
             return fn;
         }
@@ -195,13 +199,13 @@ struct GemmBatchContigAtomicFactory
 {
     fnT get()
     {
-        using T3 = typename DotAtomicOutputType<T1, T2>::value_type;
-        if constexpr (std::is_same_v<T3, void>) {
+        if constexpr (!DotAtomicOutputType<T1, T2>::is_defined) {
             fnT fn = nullptr;
             return fn;
         }
         else {
             using dpctl::tensor::kernels::gemm_batch_contig_impl;
+            using T3 = typename DotAtomicOutputType<T1, T2>::value_type;
             fnT fn = gemm_batch_contig_impl<T1, T2, T3>;
             return fn;
         }
@@ -212,13 +216,13 @@ template <typename fnT, typename T1, typename T2> struct GemmAtomicFactory
 {
     fnT get()
     {
-        using T3 = typename DotAtomicOutputType<T1, T2>::value_type;
-        if constexpr (std::is_same_v<T3, void>) {
+        if constexpr (!DotAtomicOutputType<T1, T2>::is_defined) {
             fnT fn = nullptr;
             return fn;
         }
         else {
             using dpctl::tensor::kernels::gemm_impl;
+            using T3 = typename DotAtomicOutputType<T1, T2>::value_type;
             fnT fn = gemm_impl<T1, T2, T3>;
             return fn;
         }
@@ -229,13 +233,13 @@ template <typename fnT, typename T1, typename T2> struct GemmContigAtomicFactory
 {
     fnT get()
     {
-        using T3 = typename DotAtomicOutputType<T1, T2>::value_type;
-        if constexpr (std::is_same_v<T3, void>) {
+        if constexpr (!DotAtomicOutputType<T1, T2>::is_defined) {
             fnT fn = nullptr;
             return fn;
         }
         else {
             using dpctl::tensor::kernels::gemm_contig_impl;
+            using T3 = typename DotAtomicOutputType<T1, T2>::value_type;
             fnT fn = gemm_contig_impl<T1, T2, T3>;
             return fn;
         }
@@ -246,13 +250,13 @@ template <typename fnT, typename T1, typename T2> struct GemmTempsFactory
 {
     fnT get()
     {
-        using T3 = typename DotNoAtomicOutputType<T1, T2>::value_type;
-        if constexpr (std::is_same_v<T3, void>) {
+        if constexpr (!DotNoAtomicOutputType<T1, T2>::is_defined) {
             fnT fn = nullptr;
             return fn;
         }
         else {
             using dpctl::tensor::kernels::gemm_tree_impl;
+            using T3 = typename DotNoAtomicOutputType<T1, T2>::value_type;
             fnT fn = gemm_tree_impl<T1, T2, T3>;
             return fn;
         }
@@ -263,13 +267,13 @@ template <typename fnT, typename T1, typename T2> struct GemmContigTempsFactory
 {
     fnT get()
     {
-        using T3 = typename DotNoAtomicOutputType<T1, T2>::value_type;
-        if constexpr (std::is_same_v<T3, void>) {
+        if constexpr (!DotNoAtomicOutputType<T1, T2>::is_defined) {
             fnT fn = nullptr;
             return fn;
         }
         else {
             using dpctl::tensor::kernels::gemm_contig_tree_impl;
+            using T3 = typename DotNoAtomicOutputType<T1, T2>::value_type;
             fnT fn = gemm_contig_tree_impl<T1, T2, T3>;
             return fn;
         }
@@ -280,13 +284,13 @@ template <typename fnT, typename T1, typename T2> struct GemmBatchTempsFactory
 {
     fnT get()
     {
-        using T3 = typename DotNoAtomicOutputType<T1, T2>::value_type;
-        if constexpr (std::is_same_v<T3, void>) {
+        if constexpr (!DotNoAtomicOutputType<T1, T2>::is_defined) {
             fnT fn = nullptr;
             return fn;
         }
         else {
             using dpctl::tensor::kernels::gemm_batch_tree_impl;
+            using T3 = typename DotNoAtomicOutputType<T1, T2>::value_type;
             fnT fn = gemm_batch_tree_impl<T1, T2, T3>;
             return fn;
         }
@@ -298,13 +302,13 @@ struct GemmBatchContigTempsFactory
 {
     fnT get()
     {
-        using T3 = typename DotNoAtomicOutputType<T1, T2>::value_type;
-        if constexpr (std::is_same_v<T3, void>) {
+        if constexpr (!DotNoAtomicOutputType<T1, T2>::is_defined) {
             fnT fn = nullptr;
             return fn;
         }
         else {
             using dpctl::tensor::kernels::gemm_batch_contig_tree_impl;
+            using T3 = typename DotNoAtomicOutputType<T1, T2>::value_type;
             fnT fn = gemm_batch_contig_tree_impl<T1, T2, T3>;
             return fn;
         }
@@ -315,13 +319,13 @@ template <typename fnT, typename T1, typename T2> struct DotProductAtomicFactory
 {
     fnT get()
     {
-        using T3 = typename DotAtomicOutputType<T1, T2>::value_type;
-        if constexpr (std::is_same_v<T3, void>) {
+        if constexpr (!DotAtomicOutputType<T1, T2>::is_defined) {
             fnT fn = nullptr;
             return fn;
         }
         else {
             using dpctl::tensor::kernels::dot_product_impl;
+            using T3 = typename DotAtomicOutputType<T1, T2>::value_type;
             fnT fn = dot_product_impl<T1, T2, T3>;
             return fn;
         }
@@ -333,13 +337,13 @@ struct DotProductNoAtomicFactory
 {
     fnT get()
     {
-        using T3 = typename DotNoAtomicOutputType<T1, T2>::value_type;
-        if constexpr (std::is_same_v<T3, void>) {
+        if constexpr (!DotNoAtomicOutputType<T1, T2>::is_defined) {
             fnT fn = nullptr;
             return fn;
         }
         else {
             using dpctl::tensor::kernels::dot_product_tree_impl;
+            using T3 = typename DotNoAtomicOutputType<T1, T2>::value_type;
             fnT fn = dot_product_tree_impl<T1, T2, T3>;
             return fn;
         }
@@ -351,13 +355,13 @@ struct DotProductContigAtomicFactory
 {
     fnT get()
     {
-        using T3 = typename DotAtomicOutputType<T1, T2>::value_type;
-        if constexpr (std::is_same_v<T3, void>) {
+        if constexpr (!DotAtomicOutputType<T1, T2>::is_defined) {
             fnT fn = nullptr;
             return fn;
         }
         else {
             using dpctl::tensor::kernels::dot_product_contig_impl;
+            using T3 = typename DotAtomicOutputType<T1, T2>::value_type;
             fnT fn = dot_product_contig_impl<T1, T2, T3>;
             return fn;
         }
@@ -369,13 +373,13 @@ struct DotProductContigNoAtomicFactory
 {
     fnT get()
     {
-        using T3 = typename DotNoAtomicOutputType<T1, T2>::value_type;
-        if constexpr (std::is_same_v<T3, void>) {
+        if constexpr (!DotNoAtomicOutputType<T1, T2>::is_defined) {
             fnT fn = nullptr;
             return fn;
         }
         else {
             using dpctl::tensor::kernels::dot_product_contig_tree_impl;
+            using T3 = typename DotNoAtomicOutputType<T1, T2>::value_type;
             fnT fn = dot_product_contig_tree_impl<T1, T2, T3>;
             return fn;
         }

--- a/dpctl/tensor/libtensor/source/reductions/argmax.cpp
+++ b/dpctl/tensor/libtensor/source/reductions/argmax.cpp
@@ -68,9 +68,7 @@ template <typename argTy, typename outTy>
 struct TypePairSupportForArgmaxReductionTemps
 {
 
-    static constexpr bool is_defined = std::disjunction< // disjunction is C++17
-                                                         // feature, supported
-                                                         // by DPC++ input bool
+    static constexpr bool is_defined = std::disjunction<
         td_ns::TypePairDefinedEntry<argTy, bool, outTy, std::int64_t>,
         // input int8_t
         td_ns::TypePairDefinedEntry<argTy, std::int8_t, outTy, std::int64_t>,

--- a/dpctl/tensor/libtensor/source/reductions/argmin.cpp
+++ b/dpctl/tensor/libtensor/source/reductions/argmin.cpp
@@ -69,9 +69,7 @@ template <typename argTy, typename outTy>
 struct TypePairSupportForArgminReductionTemps
 {
 
-    static constexpr bool is_defined = std::disjunction< // disjunction is C++17
-                                                         // feature, supported
-                                                         // by DPC++ input bool
+    static constexpr bool is_defined = std::disjunction<
         td_ns::TypePairDefinedEntry<argTy, bool, outTy, std::int64_t>,
         // input int8_t
         td_ns::TypePairDefinedEntry<argTy, std::int8_t, outTy, std::int64_t>,

--- a/dpctl/tensor/libtensor/source/reductions/logsumexp.cpp
+++ b/dpctl/tensor/libtensor/source/reductions/logsumexp.cpp
@@ -67,9 +67,7 @@ template <typename argTy, typename outTy>
 struct TypePairSupportDataForLogSumExpReductionTemps
 {
 
-    static constexpr bool is_defined = std::disjunction< // disjunction is C++17
-                                                         // feature, supported
-                                                         // by DPC++ input bool
+    static constexpr bool is_defined = std::disjunction<
 #if 1
         td_ns::TypePairDefinedEntry<argTy, bool, outTy, sycl::half>,
         td_ns::TypePairDefinedEntry<argTy, bool, outTy, float>,

--- a/dpctl/tensor/libtensor/source/reductions/max.cpp
+++ b/dpctl/tensor/libtensor/source/reductions/max.cpp
@@ -78,10 +78,8 @@ static reduction_contig_impl_fn_ptr
 template <typename argTy, typename outTy>
 struct TypePairSupportDataForMaxReductionAtomic
 {
-
     /* value is true if a kernel for <argTy, outTy> must be instantiated, false
      * otherwise */
-    // disjunction is C++17 feature, supported by DPC++
     static constexpr bool is_defined = std::disjunction<
         // input int32
         td_ns::TypePairDefinedEntry<argTy, std::int32_t, outTy, std::int32_t>,
@@ -102,8 +100,6 @@ struct TypePairSupportDataForMaxReductionAtomic
 template <typename argTy, typename outTy>
 struct TypePairSupportDataForMaxReductionTemps
 {
-
-    // disjunction is C++17 feature, supported by DPC++
     static constexpr bool is_defined = std::disjunction<
         // input bool
         td_ns::TypePairDefinedEntry<argTy, bool, outTy, bool>,

--- a/dpctl/tensor/libtensor/source/reductions/min.cpp
+++ b/dpctl/tensor/libtensor/source/reductions/min.cpp
@@ -78,10 +78,8 @@ static reduction_contig_impl_fn_ptr
 template <typename argTy, typename outTy>
 struct TypePairSupportDataForMinReductionAtomic
 {
-
     /* value is true if a kernel for <argTy, outTy> must be instantiated, false
      * otherwise */
-    // disjunction is C++17 feature, supported by DPC++
     static constexpr bool is_defined = std::disjunction<
         // input int32
         td_ns::TypePairDefinedEntry<argTy, std::int32_t, outTy, std::int32_t>,
@@ -102,8 +100,6 @@ struct TypePairSupportDataForMinReductionAtomic
 template <typename argTy, typename outTy>
 struct TypePairSupportDataForMinReductionTemps
 {
-
-    // disjunction is C++17 feature, supported by DPC++
     static constexpr bool is_defined = std::disjunction<
         // input bool
         td_ns::TypePairDefinedEntry<argTy, bool, outTy, bool>,

--- a/dpctl/tensor/libtensor/source/reductions/prod.cpp
+++ b/dpctl/tensor/libtensor/source/reductions/prod.cpp
@@ -79,9 +79,7 @@ struct TypePairSupportDataForProductReductionAtomic
 
     /* value if true a kernel for <argTy, outTy> must be instantiated, false
      * otherwise */
-    static constexpr bool is_defined = std::disjunction< // disjunction is C++17
-                                                         // feature, supported
-                                                         // by DPC++ input bool
+    static constexpr bool is_defined = std::disjunction<
         td_ns::TypePairDefinedEntry<argTy, bool, outTy, std::int32_t>,
         td_ns::TypePairDefinedEntry<argTy, bool, outTy, std::uint32_t>,
         td_ns::TypePairDefinedEntry<argTy, bool, outTy, std::int64_t>,
@@ -121,9 +119,7 @@ template <typename argTy, typename outTy>
 struct TypePairSupportDataForProductReductionTemps
 {
 
-    static constexpr bool is_defined = std::disjunction< // disjunction is C++17
-                                                         // feature, supported
-                                                         // by DPC++ input bool
+    static constexpr bool is_defined = std::disjunction<
         td_ns::TypePairDefinedEntry<argTy, bool, outTy, std::int8_t>,
         td_ns::TypePairDefinedEntry<argTy, bool, outTy, std::uint8_t>,
         td_ns::TypePairDefinedEntry<argTy, bool, outTy, std::int16_t>,

--- a/dpctl/tensor/libtensor/source/reductions/reduce_hypot.cpp
+++ b/dpctl/tensor/libtensor/source/reductions/reduce_hypot.cpp
@@ -67,9 +67,7 @@ template <typename argTy, typename outTy>
 struct TypePairSupportDataForHypotReductionTemps
 {
 
-    static constexpr bool is_defined = std::disjunction< // disjunction is C++17
-                                                         // feature, supported
-                                                         // by DPC++ input bool
+    static constexpr bool is_defined = std::disjunction<
         td_ns::TypePairDefinedEntry<argTy, bool, outTy, sycl::half>,
         td_ns::TypePairDefinedEntry<argTy, bool, outTy, float>,
         td_ns::TypePairDefinedEntry<argTy, bool, outTy, double>,

--- a/dpctl/tensor/libtensor/source/reductions/sum.cpp
+++ b/dpctl/tensor/libtensor/source/reductions/sum.cpp
@@ -79,9 +79,7 @@ struct TypePairSupportDataForSumReductionAtomic
 
     /* value if true a kernel for <argTy, outTy> must be instantiated, false
      * otherwise */
-    static constexpr bool is_defined = std::disjunction< // disjunction is C++17
-                                                         // feature, supported
-                                                         // by DPC++ input bool
+    static constexpr bool is_defined = std::disjunction<
         td_ns::TypePairDefinedEntry<argTy, bool, outTy, std::int32_t>,
         td_ns::TypePairDefinedEntry<argTy, bool, outTy, std::uint32_t>,
         td_ns::TypePairDefinedEntry<argTy, bool, outTy, std::int64_t>,
@@ -121,9 +119,7 @@ template <typename argTy, typename outTy>
 struct TypePairSupportDataForSumReductionTemps
 {
 
-    static constexpr bool is_defined = std::disjunction< // disjunction is C++17
-                                                         // feature, supported
-                                                         // by DPC++ input bool
+    static constexpr bool is_defined = std::disjunction<
         td_ns::TypePairDefinedEntry<argTy, bool, outTy, std::int8_t>,
         td_ns::TypePairDefinedEntry<argTy, bool, outTy, std::uint8_t>,
         td_ns::TypePairDefinedEntry<argTy, bool, outTy, std::int16_t>,


### PR DESCRIPTION
This PR fixes some technical debt by introducing dedicated type support matrices for the in-place elementwise operations, making in-place operation code more readable and making it possible to implement dedicated kernels for only in-place or out-of-place operations universally.

Supersedes #1815 

- [X] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
