### PR TITLE
Remove the wheels installation with anaconda from the instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,11 +72,11 @@ conda install dpctl -c https://software.repos.intel.com/python/conda/ -c conda-f
 
 ## Pip
 
-The `dpctl` can be installed using `pip` obtaining wheel packages either from PyPi or from Intel(R) channel on Anaconda.
-To install `dpctl` wheel package from Intel(R) channel on Anaconda, run the following command:
+The `dpctl` can be installed using `pip` obtaining wheel packages from PyPi.
+To install `dpctl` wheel package, run the following command:
 
 ```bash
-python -m pip install --index-url https://pypi.anaconda.org/intel/simple dpctl
+python -m pip install dpctl
 ```
 
 Installing the bleeding edge

--- a/docs/doc_sources/beginners_guides/installation.rst
+++ b/docs/doc_sources/beginners_guides/installation.rst
@@ -54,14 +54,6 @@ Binary wheels are published with Python Package Index (https://pypi.org/project/
 
     python -m pip install dpctl
 
-Binary wheels of ``dpctl`` and its dependencies are also published on
-http://anaconda.org/intel. To install from this non-default package index,
-use
-
-.. code-block:: bash
-
-    python -m pip install --index-url https://pypi.anaconda.org/intel/simple dpctl
-
 .. note::
     As of April 2024, installation using ``pip`` on Linux* requires
     that host operating system had ``libstdc++.so`` library version 6.0.29


### PR DESCRIPTION
This PR removes the wheels installation with Anaconda from the instruction, since we will no longer be able to upload packages to Anaconda. And so far,  wheels can only be uploaded on Pypi

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
