### PR TITLE
No need to pin cmake used on Windows to 3.26

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -35,10 +35,7 @@ requirements:
         {% if dep.startswith('ninja') %}
         - {{ dep.split(';')[0] }} # [not win]
         {% elif dep.startswith('cmake') %}
-        # We need to pin cmake version on Windows, because we are patching
-        # cmake files distributed with it.
-        - cmake=3.26 # [win]
-        - {{ dep }} # [not win]
+        - {{ dep }}
         {% elif dep.startswith('build>=') %}
         - {{ 'python-' ~ dep }}
         {% else %}


### PR DESCRIPTION
We only patched cmake to work around a problem with IntelSYCL and cmake 3.26, it works out of the box with newer versions of cmake.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
