### PR TITLE
Permit `"same_kind"` casting for `usm_ndarray` element-wise in-place operators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+* `"same_kind"`-style casting for `tensor.usm_ndarray` in-place mathematical operators[gh-1827](https://github.com/IntelPython/dpctl/pull/1827)
+
 ### Change
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-* `"same_kind"`-style casting for `tensor.usm_ndarray` in-place mathematical operators[gh-1827](https://github.com/IntelPython/dpctl/pull/1827)
+* `"same_kind"`-style casting for `tensor.usm_ndarray` in-place mathematical operators [gh-1827](https://github.com/IntelPython/dpctl/pull/1827)
 
 ### Change
 

--- a/dpctl/tensor/_elementwise_common.py
+++ b/dpctl/tensor/_elementwise_common.py
@@ -976,8 +976,14 @@ class BinaryElementwiseFunc:
                     "operands could not be broadcast together with shapes "
                     f"{o1_shape} and {o2_shape}"
                 )
+
             if res_shape != o1_shape:
-                raise ValueError("")
+                raise ValueError(
+                    "The shape of the non-broadcastable left-hand "
+                    f"side {o1_shape} is inconsistent with the "
+                    f"broadcast shape {res_shape}."
+                )
+
             sycl_dev = exec_q.sycl_device
             o1_dtype = o1.dtype
             o2_dtype = _get_dtype(o2, sycl_dev)

--- a/dpctl/tensor/_elementwise_common.py
+++ b/dpctl/tensor/_elementwise_common.py
@@ -37,6 +37,7 @@ from ._type_utils import (
     _all_data_types,
     _find_buf_dtype,
     _find_buf_dtype2,
+    _find_buf_dtype_in_place_op,
     _resolve_weak_types,
     _to_device_supported_dtype,
 )
@@ -213,7 +214,7 @@ class UnaryElementwiseFunc:
 
             if res_dt != out.dtype:
                 raise ValueError(
-                    f"Output array of type {res_dt} is needed,"
+                    f"Output array of type {res_dt} is needed, "
                     f" got {out.dtype}"
                 )
 
@@ -650,7 +651,7 @@ class BinaryElementwiseFunc:
 
             if res_dt != out.dtype:
                 raise ValueError(
-                    f"Output array of type {res_dt} is needed,"
+                    f"Output array of type {res_dt} is needed, "
                     f"got {out.dtype}"
                 )
 
@@ -927,3 +928,128 @@ class BinaryElementwiseFunc:
         )
         _manager.add_event_pair(ht_, bf_ev)
         return out
+
+    def _inplace_op(self, o1, o2):
+        if not isinstance(o1, dpt.usm_ndarray):
+            raise TypeError(
+                "Expected first argument to be "
+                f"dpctl.tensor.usm_ndarray, got {type(o1)}"
+            )
+        if not o1.flags.writable:
+            raise ValueError("provided left-hand side array is read-only")
+        q1, o1_usm_type = o1.sycl_queue, o1.usm_type
+        q2, o2_usm_type = _get_queue_usm_type(o2)
+        if q2 is None:
+            exec_q = q1
+            res_usm_type = o1_usm_type
+        else:
+            exec_q = dpctl.utils.get_execution_queue((q1, q2))
+            if exec_q is None:
+                raise ExecutionPlacementError(
+                    "Execution placement can not be unambiguously inferred "
+                    "from input arguments."
+                )
+            res_usm_type = dpctl.utils.get_coerced_usm_type(
+                (
+                    o1_usm_type,
+                    o2_usm_type,
+                )
+            )
+        dpctl.utils.validate_usm_type(res_usm_type, allow_none=False)
+        o1_shape = o1.shape
+        o2_shape = _get_shape(o2)
+        if not isinstance(o2_shape, (tuple, list)):
+            raise TypeError(
+                "Shape of second argument can not be inferred. "
+                "Expected list or tuple."
+            )
+        try:
+            res_shape = _broadcast_shape_impl(
+                [
+                    o1_shape,
+                    o2_shape,
+                ]
+            )
+        except ValueError:
+            raise ValueError(
+                "operands could not be broadcast together with shapes "
+                f"{o1_shape} and {o2_shape}"
+            )
+        if res_shape != o1_shape:
+            raise ValueError("")
+        sycl_dev = exec_q.sycl_device
+        o1_dtype = o1.dtype
+        o2_dtype = _get_dtype(o2, sycl_dev)
+        if not _validate_dtype(o2_dtype):
+            raise ValueError("Operand has an unsupported data type")
+
+        o1_dtype, o2_dtype = self.weak_type_resolver_(
+            o1_dtype, o2_dtype, sycl_dev
+        )
+
+        buf_dt, res_dt = _find_buf_dtype_in_place_op(
+            o1_dtype,
+            o2_dtype,
+            self.result_type_resolver_fn_,
+            sycl_dev,
+        )
+
+        if res_dt is None:
+            raise ValueError(
+                f"function '{self.name_}' does not support input types "
+                f"({o1_dtype}, {o2_dtype}), "
+                "and the inputs could not be safely coerced to any "
+                "supported types according to the casting rule ''same_kind''."
+            )
+
+        if res_dt != o1_dtype:
+            raise ValueError(
+                f"Output array of type {res_dt} is needed, " f"got {o1_dtype}"
+            )
+
+        _manager = SequentialOrderManager[exec_q]
+        if isinstance(o2, dpt.usm_ndarray):
+            src2 = o2
+            if (
+                ti._array_overlap(o2, o1)
+                and not ti._same_logical_tensors(o2, o1)
+                and buf_dt is None
+            ):
+                buf_dt = o2_dtype
+        else:
+            src2 = dpt.asarray(o2, dtype=o2_dtype, sycl_queue=exec_q)
+        if buf_dt is None:
+            if src2.shape != res_shape:
+                src2 = dpt.broadcast_to(src2, res_shape)
+            dep_evs = _manager.submitted_events
+            ht_, comp_ev = self.binary_inplace_fn_(
+                lhs=o1,
+                rhs=src2,
+                sycl_queue=exec_q,
+                depends=dep_evs,
+            )
+            _manager.add_event_pair(ht_, comp_ev)
+        else:
+            buf = dpt.empty_like(src2, dtype=buf_dt)
+            dep_evs = _manager.submitted_events
+            (
+                ht_copy_ev,
+                copy_ev,
+            ) = ti._copy_usm_ndarray_into_usm_ndarray(
+                src=src2,
+                dst=buf,
+                sycl_queue=exec_q,
+                depends=dep_evs,
+            )
+            _manager.add_event_pair(ht_copy_ev, copy_ev)
+
+            buf = dpt.broadcast_to(buf, res_shape)
+            ht_, bf_ev = self.binary_inplace_fn_(
+                lhs=o1,
+                rhs=buf,
+                sycl_queue=exec_q,
+                depends=[copy_ev],
+            )
+            _manager.add_event_pair(ht_, bf_ev)
+
+        return o1

--- a/dpctl/tensor/_elementwise_common.py
+++ b/dpctl/tensor/_elementwise_common.py
@@ -215,7 +215,7 @@ class UnaryElementwiseFunc:
             if res_dt != out.dtype:
                 raise ValueError(
                     f"Output array of type {res_dt} is needed, "
-                    f" got {out.dtype}"
+                    f"got {out.dtype}"
                 )
 
             if (

--- a/dpctl/tensor/_elementwise_common.py
+++ b/dpctl/tensor/_elementwise_common.py
@@ -930,140 +930,138 @@ class BinaryElementwiseFunc:
         return out
 
     def _inplace_op(self, o1, o2):
-        if self.binary_inplace_fn_ is not None:
-            if not isinstance(o1, dpt.usm_ndarray):
-                raise TypeError(
-                    "Expected first argument to be "
-                    f"dpctl.tensor.usm_ndarray, got {type(o1)}"
-                )
-            if not o1.flags.writable:
-                raise ValueError("provided left-hand side array is read-only")
-            q1, o1_usm_type = o1.sycl_queue, o1.usm_type
-            q2, o2_usm_type = _get_queue_usm_type(o2)
-            if q2 is None:
-                exec_q = q1
-                res_usm_type = o1_usm_type
-            else:
-                exec_q = dpctl.utils.get_execution_queue((q1, q2))
-                if exec_q is None:
-                    raise ExecutionPlacementError(
-                        "Execution placement can not be unambiguously inferred "
-                        "from input arguments."
-                    )
-                res_usm_type = dpctl.utils.get_coerced_usm_type(
-                    (
-                        o1_usm_type,
-                        o2_usm_type,
-                    )
-                )
-            dpctl.utils.validate_usm_type(res_usm_type, allow_none=False)
-            o1_shape = o1.shape
-            o2_shape = _get_shape(o2)
-            if not isinstance(o2_shape, (tuple, list)):
-                raise TypeError(
-                    "Shape of second argument can not be inferred. "
-                    "Expected list or tuple."
-                )
-            try:
-                res_shape = _broadcast_shape_impl(
-                    [
-                        o1_shape,
-                        o2_shape,
-                    ]
-                )
-            except ValueError:
-                raise ValueError(
-                    "operands could not be broadcast together with shapes "
-                    f"{o1_shape} and {o2_shape}"
-                )
-
-            if res_shape != o1_shape:
-                raise ValueError(
-                    "The shape of the non-broadcastable left-hand "
-                    f"side {o1_shape} is inconsistent with the "
-                    f"broadcast shape {res_shape}."
-                )
-
-            sycl_dev = exec_q.sycl_device
-            o1_dtype = o1.dtype
-            o2_dtype = _get_dtype(o2, sycl_dev)
-            if not _validate_dtype(o2_dtype):
-                raise ValueError("Operand has an unsupported data type")
-
-            o1_dtype, o2_dtype = self.weak_type_resolver_(
-                o1_dtype, o2_dtype, sycl_dev
-            )
-
-            buf_dt, res_dt = _find_buf_dtype_in_place_op(
-                o1_dtype,
-                o2_dtype,
-                self.result_type_resolver_fn_,
-                sycl_dev,
-            )
-
-            if res_dt is None:
-                raise ValueError(
-                    f"function '{self.name_}' does not support input types "
-                    f"({o1_dtype}, {o2_dtype}), "
-                    "and the inputs could not be safely coerced to any "
-                    "supported types according to the casting rule "
-                    "''same_kind''."
-                )
-
-            if res_dt != o1_dtype:
-                raise ValueError(
-                    f"Output array of type {res_dt} is needed, "
-                    f"got {o1_dtype}"
-                )
-
-            _manager = SequentialOrderManager[exec_q]
-            if isinstance(o2, dpt.usm_ndarray):
-                src2 = o2
-                if (
-                    ti._array_overlap(o2, o1)
-                    and not ti._same_logical_tensors(o2, o1)
-                    and buf_dt is None
-                ):
-                    buf_dt = o2_dtype
-            else:
-                src2 = dpt.asarray(o2, dtype=o2_dtype, sycl_queue=exec_q)
-            if buf_dt is None:
-                if src2.shape != res_shape:
-                    src2 = dpt.broadcast_to(src2, res_shape)
-                dep_evs = _manager.submitted_events
-                ht_, comp_ev = self.binary_inplace_fn_(
-                    lhs=o1,
-                    rhs=src2,
-                    sycl_queue=exec_q,
-                    depends=dep_evs,
-                )
-                _manager.add_event_pair(ht_, comp_ev)
-            else:
-                buf = dpt.empty_like(src2, dtype=buf_dt)
-                dep_evs = _manager.submitted_events
-                (
-                    ht_copy_ev,
-                    copy_ev,
-                ) = ti._copy_usm_ndarray_into_usm_ndarray(
-                    src=src2,
-                    dst=buf,
-                    sycl_queue=exec_q,
-                    depends=dep_evs,
-                )
-                _manager.add_event_pair(ht_copy_ev, copy_ev)
-
-                buf = dpt.broadcast_to(buf, res_shape)
-                ht_, bf_ev = self.binary_inplace_fn_(
-                    lhs=o1,
-                    rhs=buf,
-                    sycl_queue=exec_q,
-                    depends=[copy_ev],
-                )
-                _manager.add_event_pair(ht_, bf_ev)
-
-            return o1
-        else:
+        if self.binary_inplace_fn_ is None:
             raise ValueError(
                 "binary function does not have a dedicated in-place "
                 "implementation"
             )
+        if not isinstance(o1, dpt.usm_ndarray):
+            raise TypeError(
+                "Expected first argument to be "
+                f"dpctl.tensor.usm_ndarray, got {type(o1)}"
+            )
+        if not o1.flags.writable:
+            raise ValueError("provided left-hand side array is read-only")
+        q1, o1_usm_type = o1.sycl_queue, o1.usm_type
+        q2, o2_usm_type = _get_queue_usm_type(o2)
+        if q2 is None:
+            exec_q = q1
+            res_usm_type = o1_usm_type
+        else:
+            exec_q = dpctl.utils.get_execution_queue((q1, q2))
+            if exec_q is None:
+                raise ExecutionPlacementError(
+                    "Execution placement can not be unambiguously inferred "
+                    "from input arguments."
+                )
+            res_usm_type = dpctl.utils.get_coerced_usm_type(
+                (
+                    o1_usm_type,
+                    o2_usm_type,
+                )
+            )
+        dpctl.utils.validate_usm_type(res_usm_type, allow_none=False)
+        o1_shape = o1.shape
+        o2_shape = _get_shape(o2)
+        if not isinstance(o2_shape, (tuple, list)):
+            raise TypeError(
+                "Shape of second argument can not be inferred. "
+                "Expected list or tuple."
+            )
+        try:
+            res_shape = _broadcast_shape_impl(
+                [
+                    o1_shape,
+                    o2_shape,
+                ]
+            )
+        except ValueError:
+            raise ValueError(
+                "operands could not be broadcast together with shapes "
+                f"{o1_shape} and {o2_shape}"
+            )
+
+        if res_shape != o1_shape:
+            raise ValueError(
+                "The shape of the non-broadcastable left-hand "
+                f"side {o1_shape} is inconsistent with the "
+                f"broadcast shape {res_shape}."
+            )
+
+        sycl_dev = exec_q.sycl_device
+        o1_dtype = o1.dtype
+        o2_dtype = _get_dtype(o2, sycl_dev)
+        if not _validate_dtype(o2_dtype):
+            raise ValueError("Operand has an unsupported data type")
+
+        o1_dtype, o2_dtype = self.weak_type_resolver_(
+            o1_dtype, o2_dtype, sycl_dev
+        )
+
+        buf_dt, res_dt = _find_buf_dtype_in_place_op(
+            o1_dtype,
+            o2_dtype,
+            self.result_type_resolver_fn_,
+            sycl_dev,
+        )
+
+        if res_dt is None:
+            raise ValueError(
+                f"function '{self.name_}' does not support input types "
+                f"({o1_dtype}, {o2_dtype}), "
+                "and the inputs could not be safely coerced to any "
+                "supported types according to the casting rule "
+                "''same_kind''."
+            )
+
+        if res_dt != o1_dtype:
+            raise ValueError(
+                f"Output array of type {res_dt} is needed, " f"got {o1_dtype}"
+            )
+
+        _manager = SequentialOrderManager[exec_q]
+        if isinstance(o2, dpt.usm_ndarray):
+            src2 = o2
+            if (
+                ti._array_overlap(o2, o1)
+                and not ti._same_logical_tensors(o2, o1)
+                and buf_dt is None
+            ):
+                buf_dt = o2_dtype
+        else:
+            src2 = dpt.asarray(o2, dtype=o2_dtype, sycl_queue=exec_q)
+        if buf_dt is None:
+            if src2.shape != res_shape:
+                src2 = dpt.broadcast_to(src2, res_shape)
+            dep_evs = _manager.submitted_events
+            ht_, comp_ev = self.binary_inplace_fn_(
+                lhs=o1,
+                rhs=src2,
+                sycl_queue=exec_q,
+                depends=dep_evs,
+            )
+            _manager.add_event_pair(ht_, comp_ev)
+        else:
+            buf = dpt.empty_like(src2, dtype=buf_dt)
+            dep_evs = _manager.submitted_events
+            (
+                ht_copy_ev,
+                copy_ev,
+            ) = ti._copy_usm_ndarray_into_usm_ndarray(
+                src=src2,
+                dst=buf,
+                sycl_queue=exec_q,
+                depends=dep_evs,
+            )
+            _manager.add_event_pair(ht_copy_ev, copy_ev)
+
+            buf = dpt.broadcast_to(buf, res_shape)
+            ht_, bf_ev = self.binary_inplace_fn_(
+                lhs=o1,
+                rhs=buf,
+                sycl_queue=exec_q,
+                depends=[copy_ev],
+            )
+            _manager.add_event_pair(ht_, bf_ev)
+
+        return o1

--- a/dpctl/tensor/_type_utils.py
+++ b/dpctl/tensor/_type_utils.py
@@ -277,6 +277,21 @@ def _find_buf_dtype2(arg1_dtype, arg2_dtype, query_fn, sycl_dev, acceptance_fn):
     return None, None, None
 
 
+def _find_buf_dtype_in_place_op(arg1_dtype, arg2_dtype, query_fn, sycl_dev):
+    res_dt = query_fn(arg1_dtype, arg2_dtype)
+    if res_dt:
+        return None, res_dt
+
+    _fp16 = sycl_dev.has_aspect_fp16
+    _fp64 = sycl_dev.has_aspect_fp64
+    if _can_cast(arg2_dtype, arg1_dtype, _fp16, _fp64, casting="same_kind"):
+        res_dt = query_fn(arg1_dtype, arg1_dtype)
+        if res_dt:
+            return arg1_dtype, res_dt
+
+    return None, None
+
+
 class WeakBooleanType:
     "Python type representing type of Python boolean objects"
 
@@ -959,4 +974,5 @@ __all__ = [
     "WeakComplexType",
     "_default_accumulation_dtype",
     "_default_accumulation_dtype_fp_types",
+    "_find_buf_dtype_in_place_op",
 ]

--- a/dpctl/tensor/_usmarray.pyx
+++ b/dpctl/tensor/_usmarray.pyx
@@ -1508,43 +1508,43 @@ cdef class usm_ndarray:
         return dpctl.tensor.bitwise_xor(other, self)
 
     def __iadd__(self, other):
-        return dpctl.tensor.add(self, other, out=self)
+        return dpctl.tensor.add._inplace_op(self, other)
 
     def __iand__(self, other):
-        return dpctl.tensor.bitwise_and(self, other, out=self)
+        return dpctl.tensor.bitwise_and._inplace_op(self, other)
 
     def __ifloordiv__(self, other):
-        return dpctl.tensor.floor_divide(self, other, out=self)
+        return dpctl.tensor.floor_divide._inplace_op(self, other)
 
     def __ilshift__(self, other):
-        return dpctl.tensor.bitwise_left_shift(self, other, out=self)
+        return dpctl.tensor.bitwise_left_shift._inplace_op(self, other)
 
     def __imatmul__(self, other):
-        return dpctl.tensor.matmul(self, other, out=self)
+        return dpctl.tensor.matmul(self, other, out=self, dtype=self.dtype)
 
     def __imod__(self, other):
-        return dpctl.tensor.remainder(self, other, out=self)
+        return dpctl.tensor.remainder._inplace_op(self, other)
 
     def __imul__(self, other):
-        return dpctl.tensor.multiply(self, other, out=self)
+        return dpctl.tensor.multiply._inplace_op(self, other)
 
     def __ior__(self, other):
-        return dpctl.tensor.bitwise_or(self, other, out=self)
+        return dpctl.tensor.bitwise_or._inplace_op(self, other)
 
     def __ipow__(self, other):
-        return dpctl.tensor.pow(self, other, out=self)
+        return dpctl.tensor.pow._inplace_op(self, other)
 
     def __irshift__(self, other):
-        return dpctl.tensor.bitwise_right_shift(self, other, out=self)
+        return dpctl.tensor.bitwise_right_shift._inplace_op(self, other)
 
     def __isub__(self, other):
-        return dpctl.tensor.subtract(self, other, out=self)
+        return dpctl.tensor.subtract._inplace_op(self, other)
 
     def __itruediv__(self, other):
-        return dpctl.tensor.divide(self, other, out=self)
+        return dpctl.tensor.divide._inplace_op(self, other)
 
     def __ixor__(self, other):
-        return dpctl.tensor.bitwise_xor(self, other, out=self)
+        return dpctl.tensor.bitwise_xor._inplace_op(self, other)
 
     def __str__(self):
         return usm_ndarray_str(self)

--- a/dpctl/tests/elementwise/test_add.py
+++ b/dpctl/tests/elementwise/test_add.py
@@ -358,7 +358,7 @@ def test_add_inplace_dtype_matrix(op1_dtype, op2_dtype):
     dev = q.sycl_device
     _fp16 = dev.has_aspect_fp16
     _fp64 = dev.has_aspect_fp64
-    if _can_cast(ar2.dtype, ar1.dtype, _fp16, _fp64):
+    if _can_cast(ar2.dtype, ar1.dtype, _fp16, _fp64, casting="same_kind"):
         ar1 += ar2
         assert (
             dpt.asnumpy(ar1) == np.full(ar1.shape, 2, dtype=ar1.dtype)

--- a/dpctl/tests/elementwise/test_add.py
+++ b/dpctl/tests/elementwise/test_add.py
@@ -358,6 +358,8 @@ def test_add_inplace_dtype_matrix(op1_dtype, op2_dtype):
     dev = q.sycl_device
     _fp16 = dev.has_aspect_fp16
     _fp64 = dev.has_aspect_fp64
+    # operators use a different Python implementation which permits
+    # same kind style casting
     if _can_cast(ar2.dtype, ar1.dtype, _fp16, _fp64, casting="same_kind"):
         ar1 += ar2
         assert (
@@ -374,6 +376,9 @@ def test_add_inplace_dtype_matrix(op1_dtype, op2_dtype):
         with pytest.raises(ValueError):
             ar1 += ar2
 
+    # here, test the special case where out is the first argument
+    # so an in-place kernel is used for efficiency
+    # this covers a specific branch in the BinaryElementwiseFunc logic
     ar1 = dpt.ones(sz, dtype=op1_dtype)
     ar2 = dpt.ones_like(ar1, dtype=op2_dtype)
     if _can_cast(ar2.dtype, ar1.dtype, _fp16, _fp64):

--- a/dpctl/tests/elementwise/test_bitwise_and.py
+++ b/dpctl/tests/elementwise/test_bitwise_and.py
@@ -114,7 +114,7 @@ def test_bitwise_and_inplace_dtype_matrix(op1_dtype, op2_dtype):
     dev = q.sycl_device
     _fp16 = dev.has_aspect_fp16
     _fp64 = dev.has_aspect_fp64
-    if _can_cast(ar2.dtype, ar1.dtype, _fp16, _fp64):
+    if _can_cast(ar2.dtype, ar1.dtype, _fp16, _fp64, casting="same_kind"):
         ar1 &= ar2
         assert dpt.all(ar1 == 1)
 

--- a/dpctl/tests/elementwise/test_bitwise_and.py
+++ b/dpctl/tests/elementwise/test_bitwise_and.py
@@ -125,19 +125,3 @@ def test_bitwise_and_inplace_dtype_matrix(op1_dtype, op2_dtype):
     else:
         with pytest.raises(ValueError):
             ar1 &= ar2
-            dpt.bitwise_and(ar1, ar2, out=ar1)
-
-    # out is second arg
-    ar1 = dpt.ones(sz, dtype=op1_dtype, sycl_queue=q)
-    ar2 = dpt.ones_like(ar1, dtype=op2_dtype, sycl_queue=q)
-    if _can_cast(ar1.dtype, ar2.dtype, _fp16, _fp64):
-        dpt.bitwise_and(ar1, ar2, out=ar2)
-        assert dpt.all(ar2 == 1)
-
-        ar3 = dpt.ones(sz, dtype=op1_dtype, sycl_queue=q)[::-1]
-        ar4 = dpt.ones(2 * sz, dtype=op2_dtype, sycl_queue=q)[::2]
-        dpt.bitwise_and(ar3, ar4, out=ar4)
-        dpt.all(ar4 == 1)
-    else:
-        with pytest.raises(ValueError):
-            dpt.bitwise_and(ar1, ar2, out=ar2)

--- a/dpctl/tests/elementwise/test_bitwise_left_shift.py
+++ b/dpctl/tests/elementwise/test_bitwise_left_shift.py
@@ -122,7 +122,7 @@ def test_bitwise_left_shift_inplace_dtype_matrix(op1_dtype, op2_dtype):
     dev = q.sycl_device
     _fp16 = dev.has_aspect_fp16
     _fp64 = dev.has_aspect_fp64
-    if _can_cast(ar2.dtype, ar1.dtype, _fp16, _fp64):
+    if _can_cast(ar2.dtype, ar1.dtype, _fp16, _fp64, casting="same_kind"):
         ar1 <<= ar2
         assert dpt.all(ar1 == 2)
 

--- a/dpctl/tests/elementwise/test_bitwise_left_shift.py
+++ b/dpctl/tests/elementwise/test_bitwise_left_shift.py
@@ -133,19 +133,3 @@ def test_bitwise_left_shift_inplace_dtype_matrix(op1_dtype, op2_dtype):
     else:
         with pytest.raises(ValueError):
             ar1 <<= ar2
-            dpt.bitwise_left_shift(ar1, ar2, out=ar1)
-
-    # out is second arg
-    ar1 = dpt.ones(sz, dtype=op1_dtype, sycl_queue=q)
-    ar2 = dpt.ones_like(ar1, dtype=op2_dtype, sycl_queue=q)
-    if _can_cast(ar1.dtype, ar2.dtype, _fp16, _fp64):
-        dpt.bitwise_left_shift(ar1, ar2, out=ar2)
-        assert dpt.all(ar2 == 2)
-
-        ar3 = dpt.ones(sz, dtype=op1_dtype, sycl_queue=q)[::-1]
-        ar4 = dpt.ones(2 * sz, dtype=op2_dtype, sycl_queue=q)[::2]
-        dpt.bitwise_left_shift(ar3, ar4, out=ar4)
-        dpt.all(ar4 == 2)
-    else:
-        with pytest.raises(ValueError):
-            dpt.bitwise_left_shift(ar1, ar2, out=ar2)

--- a/dpctl/tests/elementwise/test_bitwise_or.py
+++ b/dpctl/tests/elementwise/test_bitwise_or.py
@@ -114,7 +114,7 @@ def test_bitwise_or_inplace_dtype_matrix(op1_dtype, op2_dtype):
     dev = q.sycl_device
     _fp16 = dev.has_aspect_fp16
     _fp64 = dev.has_aspect_fp64
-    if _can_cast(ar2.dtype, ar1.dtype, _fp16, _fp64):
+    if _can_cast(ar2.dtype, ar1.dtype, _fp16, _fp64, casting="same_kind"):
         ar1 |= ar2
         assert dpt.all(ar1 == 1)
 

--- a/dpctl/tests/elementwise/test_bitwise_xor.py
+++ b/dpctl/tests/elementwise/test_bitwise_xor.py
@@ -114,7 +114,7 @@ def test_bitwise_xor_inplace_dtype_matrix(op1_dtype, op2_dtype):
     dev = q.sycl_device
     _fp16 = dev.has_aspect_fp16
     _fp64 = dev.has_aspect_fp64
-    if _can_cast(ar2.dtype, ar1.dtype, _fp16, _fp64):
+    if _can_cast(ar2.dtype, ar1.dtype, _fp16, _fp64, casting="same_kind"):
         ar1 ^= ar2
         assert dpt.all(ar1 == 0)
 

--- a/dpctl/tests/elementwise/test_divide.py
+++ b/dpctl/tests/elementwise/test_divide.py
@@ -226,7 +226,7 @@ def test_divide_inplace_dtype_matrix(op1_dtype, op2_dtype):
     _fp64 = dev.has_aspect_fp64
     # out array only valid if it is inexact
     if (
-        _can_cast(ar2.dtype, ar1.dtype, _fp16, _fp64)
+        _can_cast(ar2.dtype, ar1.dtype, _fp16, _fp64, casting="same_kind")
         and dpt.dtype(op1_dtype).kind in "fc"
     ):
         ar1 /= ar2
@@ -276,7 +276,7 @@ def test_divide_gh_1711():
 
 
 # don't test for overflowing double as Python won't cast
-# an Python integer of that size to a Python float
+# a Python integer of that size to a Python float
 @pytest.mark.parametrize("fp_dt", [dpt.float16, dpt.float32])
 def test_divide_by_scalar_overflow(fp_dt):
     q = get_queue_or_skip()

--- a/dpctl/tests/elementwise/test_elementwise_classes.py
+++ b/dpctl/tests/elementwise/test_elementwise_classes.py
@@ -118,7 +118,7 @@ def test_binary_class_nout():
     assert nout == 1
 
 
-def test_biary_read_only_out():
+def test_binary_read_only_out():
     get_queue_or_skip()
     x1 = dpt.ones(32, dtype=dpt.float32)
     x2 = dpt.ones_like(x1)
@@ -126,3 +126,12 @@ def test_biary_read_only_out():
     r.flags["W"] = False
     with pytest.raises(ValueError):
         binary_fn(x1, x2, out=r)
+
+
+def test_binary_no_inplace_op():
+    get_queue_or_skip()
+    x1 = dpt.ones(10, dtype="i4")
+    x2 = dpt.ones_like(x1)
+
+    with pytest.raises(ValueError):
+        dpt.logaddexp._inplace_op(x1, x2)

--- a/dpctl/tests/elementwise/test_floor_divide.py
+++ b/dpctl/tests/elementwise/test_floor_divide.py
@@ -290,7 +290,7 @@ def test_floor_divide_inplace_dtype_matrix(op1_dtype, op2_dtype):
     _fp16 = dev.has_aspect_fp16
     _fp64 = dev.has_aspect_fp64
     # out array only valid if it is inexact
-    if _can_cast(ar2.dtype, ar1.dtype, _fp16, _fp64):
+    if _can_cast(ar2.dtype, ar1.dtype, _fp16, _fp64, casting="same_kind"):
         ar1 //= ar2
         assert dpt.all(ar1 == 1)
 

--- a/dpctl/tests/elementwise/test_floor_divide.py
+++ b/dpctl/tests/elementwise/test_floor_divide.py
@@ -302,18 +302,3 @@ def test_floor_divide_inplace_dtype_matrix(op1_dtype, op2_dtype):
         with pytest.raises(ValueError):
             ar1 //= ar2
             dpt.floor_divide(ar1, ar2, out=ar1)
-
-    # out is second arg
-    ar1 = dpt.ones(sz, dtype=op1_dtype, sycl_queue=q)
-    ar2 = dpt.ones_like(ar1, dtype=op2_dtype, sycl_queue=q)
-    if _can_cast(ar1.dtype, ar2.dtype, _fp16, _fp64):
-        dpt.floor_divide(ar1, ar2, out=ar2)
-        assert dpt.all(ar2 == 1)
-
-        ar3 = dpt.ones(sz, dtype=op1_dtype, sycl_queue=q)[::-1]
-        ar4 = dpt.ones(2 * sz, dtype=op2_dtype, sycl_queue=q)[::2]
-        dpt.floor_divide(ar3, ar4, out=ar4)
-        dpt.all(ar4 == 1)
-    else:
-        with pytest.raises(ValueError):
-            dpt.floor_divide(ar1, ar2, out=ar2)

--- a/dpctl/tests/elementwise/test_multiply.py
+++ b/dpctl/tests/elementwise/test_multiply.py
@@ -205,7 +205,7 @@ def test_multiply_inplace_dtype_matrix(op1_dtype, op2_dtype):
     dev = q.sycl_device
     _fp16 = dev.has_aspect_fp16
     _fp64 = dev.has_aspect_fp64
-    if _can_cast(ar2.dtype, ar1.dtype, _fp16, _fp64):
+    if _can_cast(ar2.dtype, ar1.dtype, _fp16, _fp64, casting="same_kind"):
         ar1 *= ar2
         assert (
             dpt.asnumpy(ar1) == np.full(ar1.shape, 1, dtype=ar1.dtype)

--- a/dpctl/tests/elementwise/test_pow.py
+++ b/dpctl/tests/elementwise/test_pow.py
@@ -183,7 +183,7 @@ def test_pow_inplace_dtype_matrix(op1_dtype, op2_dtype):
     dev = q.sycl_device
     _fp16 = dev.has_aspect_fp16
     _fp64 = dev.has_aspect_fp64
-    if _can_cast(ar2.dtype, ar1.dtype, _fp16, _fp64):
+    if _can_cast(ar2.dtype, ar1.dtype, _fp16, _fp64, casting="same_kind"):
         ar1 **= ar2
         assert (
             dpt.asnumpy(ar1) == np.full(ar1.shape, 1, dtype=ar1.dtype)

--- a/dpctl/tests/elementwise/test_remainder.py
+++ b/dpctl/tests/elementwise/test_remainder.py
@@ -235,7 +235,7 @@ def test_remainder_inplace_dtype_matrix(op1_dtype, op2_dtype):
     dev = q.sycl_device
     _fp16 = dev.has_aspect_fp16
     _fp64 = dev.has_aspect_fp64
-    if _can_cast(ar2.dtype, ar1.dtype, _fp16, _fp64):
+    if _can_cast(ar2.dtype, ar1.dtype, _fp16, _fp64, casting="same_kind"):
         ar1 %= ar2
         assert dpt.all(ar1 == dpt.zeros(ar1.shape, dtype=ar1.dtype))
 

--- a/dpctl/tests/elementwise/test_subtract.py
+++ b/dpctl/tests/elementwise/test_subtract.py
@@ -208,7 +208,7 @@ def test_subtract_inplace_dtype_matrix(op1_dtype, op2_dtype):
     dev = q.sycl_device
     _fp16 = dev.has_aspect_fp16
     _fp64 = dev.has_aspect_fp64
-    if _can_cast(ar2.dtype, ar1.dtype, _fp16, _fp64):
+    if _can_cast(ar2.dtype, ar1.dtype, _fp16, _fp64, casting="same_kind"):
         ar1 -= ar2
         assert (dpt.asnumpy(ar1) == np.zeros(ar1.shape, dtype=ar1.dtype)).all()
 


### PR DESCRIPTION
This pull request proposes a new implementation for in-place element-wise operators which permits casting equivalent to `"same_kind"`

This allows such operations as
```
In [1]: import dpctl.tensor as dpt, dpctl, numpy as np

In [2]: x = dpt.ones((10, 10), dtype="i4")

In [3]: y = dpt.ones((10, 10), dtype="i8")

In [4]: x += y

In [5]: x
Out[5]:
usm_ndarray([[2, 2, 2, 2, 2, 2, 2, 2, 2, 2],
             [2, 2, 2, 2, 2, 2, 2, 2, 2, 2],
             [2, 2, 2, 2, 2, 2, 2, 2, 2, 2],
             [2, 2, 2, 2, 2, 2, 2, 2, 2, 2],
             [2, 2, 2, 2, 2, 2, 2, 2, 2, 2],
             [2, 2, 2, 2, 2, 2, 2, 2, 2, 2],
             [2, 2, 2, 2, 2, 2, 2, 2, 2, 2],
             [2, 2, 2, 2, 2, 2, 2, 2, 2, 2],
             [2, 2, 2, 2, 2, 2, 2, 2, 2, 2],
             [2, 2, 2, 2, 2, 2, 2, 2, 2, 2]], dtype=int32)
```

This PR maintains the inclusion of (conditionally used) in-place kernels in element-wise operators when `dpt.bin_op(x, y, out=x)` for some `bin_op` which has an in-place implementation.

Resolves #1757 

- [x] Have you provided a meaningful PR description?
- [x] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [x] Have you added your changes to the changelog?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
