### PR TITLE
Enable pytest --pyargs dpctl.tests

### DIFF
--- a/dpctl/tests/__init__.py
+++ b/dpctl/tests/__init__.py
@@ -1,0 +1,19 @@
+#                      Data Parallel Control (dpctl)
+#
+# Copyright 2020-2024 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+__doc__ = r"""
+Test suite of `dpctl`. Running test suite requires Cython,
+and a working compiler."""

--- a/dpctl/tests/conftest.py
+++ b/dpctl/tests/conftest.py
@@ -21,13 +21,14 @@ import os
 import sys
 
 import pytest
-from _device_attributes_checks import (
+
+from ._device_attributes_checks import (
     check,
     device_selector,
     invalid_filter,
     valid_filter,
 )
-from _numpy_warnings import suppress_invalid_numpy_warnings
+from ._numpy_warnings import suppress_invalid_numpy_warnings
 
 sys.path.append(os.path.join(os.path.dirname(__file__), "helper"))
 

--- a/dpctl/tests/test_sycl_context.py
+++ b/dpctl/tests/test_sycl_context.py
@@ -18,9 +18,10 @@
 """
 
 import pytest
-from helper import create_invalid_capsule
 
 import dpctl
+
+from .helper import create_invalid_capsule
 
 list_of_valid_filter_selectors = [
     "opencl",

--- a/dpctl/tests/test_sycl_device.py
+++ b/dpctl/tests/test_sycl_device.py
@@ -18,10 +18,11 @@
 """
 
 import pytest
-from helper import get_queue_or_skip
 
 import dpctl
 from dpctl import SyclDeviceCreationError
+
+from .helper import get_queue_or_skip
 
 
 def test_standard_selectors(device_selector, check):

--- a/dpctl/tests/test_sycl_event.py
+++ b/dpctl/tests/test_sycl_event.py
@@ -18,13 +18,14 @@
 """
 
 import pytest
-from helper import create_invalid_capsule
 
 import dpctl
 import dpctl.memory as dpctl_mem
 import dpctl.program as dpctl_prog
 import dpctl.tensor as dpt
 from dpctl import event_status_type as esty
+
+from .helper import create_invalid_capsule
 
 
 def produce_event(profiling=False):

--- a/dpctl/tests/test_sycl_platform.py
+++ b/dpctl/tests/test_sycl_platform.py
@@ -20,9 +20,10 @@
 import sys
 
 import pytest
-from helper import has_sycl_platforms
 
 import dpctl
+
+from .helper import has_sycl_platforms
 
 list_of_valid_filter_selectors = [
     "opencl",

--- a/dpctl/tests/test_sycl_queue.py
+++ b/dpctl/tests/test_sycl_queue.py
@@ -21,9 +21,10 @@ import ctypes
 import sys
 
 import pytest
-from helper import create_invalid_capsule
 
 import dpctl
+
+from .helper import create_invalid_capsule
 
 
 def test_standard_selectors(device_selector, check):

--- a/dpctl/tests/test_tensor_accumulation.py
+++ b/dpctl/tests/test_tensor_accumulation.py
@@ -17,10 +17,11 @@
 from random import randrange
 
 import pytest
-from helper import get_queue_or_skip, skip_if_dtype_not_supported
 
 import dpctl.tensor as dpt
 from dpctl.utils import ExecutionPlacementError
+
+from .helper import get_queue_or_skip, skip_if_dtype_not_supported
 
 sint_types = [
     dpt.int8,

--- a/dpctl/tests/test_tensor_asarray.py
+++ b/dpctl/tests/test_tensor_asarray.py
@@ -16,10 +16,11 @@
 
 import numpy as np
 import pytest
-from helper import get_queue_or_skip
 
 import dpctl
 import dpctl.tensor as dpt
+
+from .helper import get_queue_or_skip
 
 
 @pytest.mark.parametrize(

--- a/dpctl/tests/test_tensor_clip.py
+++ b/dpctl/tests/test_tensor_clip.py
@@ -16,7 +16,6 @@
 
 import numpy as np
 import pytest
-from helper import get_queue_or_skip, skip_if_dtype_not_supported
 from numpy.testing import assert_raises_regex
 
 import dpctl
@@ -28,6 +27,8 @@ from dpctl.tensor._type_utils import (
     _weak_type_num_kind,
 )
 from dpctl.utils import ExecutionPlacementError
+
+from .helper import get_queue_or_skip, skip_if_dtype_not_supported
 
 _all_dtypes = [
     "?",

--- a/dpctl/tests/test_usm_ndarray_ctor.py
+++ b/dpctl/tests/test_usm_ndarray_ctor.py
@@ -20,12 +20,13 @@ from math import prod
 
 import numpy as np
 import pytest
-from helper import get_queue_or_skip, skip_if_dtype_not_supported
 
 import dpctl
 import dpctl.memory as dpm
 import dpctl.tensor as dpt
 from dpctl.tensor import Device
+
+from .helper import get_queue_or_skip, skip_if_dtype_not_supported
 
 
 @pytest.mark.parametrize(

--- a/dpctl/tests/test_usm_ndarray_dlpack.py
+++ b/dpctl/tests/test_usm_ndarray_dlpack.py
@@ -19,12 +19,13 @@ import ctypes
 
 import numpy as np
 import pytest
-from helper import get_queue_or_skip, skip_if_dtype_not_supported
 
 import dpctl
 import dpctl.tensor as dpt
 import dpctl.tensor._dlpack as _dlp
 import dpctl.tensor._usmarray as dpt_arr
+
+from .helper import get_queue_or_skip, skip_if_dtype_not_supported
 
 device_CPU = dpt_arr.DLDeviceType.kDLCPU
 device_oneAPI = dpt_arr.DLDeviceType.kDLOneAPI

--- a/dpctl/tests/test_usm_ndarray_indexing.py
+++ b/dpctl/tests/test_usm_ndarray_indexing.py
@@ -17,13 +17,14 @@
 
 import numpy as np
 import pytest
-from helper import get_queue_or_skip, skip_if_dtype_not_supported
 from numpy.testing import assert_array_equal
 
 import dpctl
 import dpctl.tensor as dpt
 import dpctl.tensor._tensor_impl as ti
 from dpctl.utils import ExecutionPlacementError
+
+from .helper import get_queue_or_skip, skip_if_dtype_not_supported
 
 _all_dtypes = [
     "u1",

--- a/dpctl/tests/test_usm_ndarray_print.py
+++ b/dpctl/tests/test_usm_ndarray_print.py
@@ -16,10 +16,11 @@
 
 import numpy as np
 import pytest
-from helper import get_queue_or_skip, skip_if_dtype_not_supported
 
 import dpctl
 import dpctl.tensor as dpt
+
+from .helper import get_queue_or_skip, skip_if_dtype_not_supported
 
 
 class TestPrint:

--- a/dpctl/tests/test_usm_ndarray_search_functions.py
+++ b/dpctl/tests/test_usm_ndarray_search_functions.py
@@ -19,13 +19,14 @@ import itertools
 
 import numpy as np
 import pytest
-from helper import get_queue_or_skip, skip_if_dtype_not_supported
 from numpy.testing import assert_array_equal
 
 import dpctl.tensor as dpt
 from dpctl.tensor._search_functions import _where_result_type
 from dpctl.tensor._type_utils import _all_data_types
 from dpctl.utils import ExecutionPlacementError
+
+from .helper import get_queue_or_skip, skip_if_dtype_not_supported
 
 _all_dtypes = [
     "?",

--- a/dpctl/tests/test_usm_ndarray_searchsorted.py
+++ b/dpctl/tests/test_usm_ndarray_searchsorted.py
@@ -1,10 +1,11 @@
 import numpy as np
 import pytest
-from helper import get_queue_or_skip, skip_if_dtype_not_supported
 
 import dpctl
 import dpctl.tensor as dpt
 import dpctl.utils as dpu
+
+from .helper import get_queue_or_skip, skip_if_dtype_not_supported
 
 
 def _check(hay_stack, needles, needles_np):


### PR DESCRIPTION
Since dpctl/tests does not contain __init__.py, the standard invocation of pytest failed, rendering it impossible to run test suite without checkout out source tree.

This change should enable the run out of the box

- [x] Have you provided a meaningful PR description?
- [x] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [ ] Have you added your changes to the changelog?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
