### PR TITLE
Revert work-around for problem in MKL 2024.2.0, fixed in 2024.2.1

### DIFF
--- a/dpctl/tests/test_sycl_kernel_submit.py
+++ b/dpctl/tests/test_sycl_kernel_submit.py
@@ -18,7 +18,6 @@
 """
 
 import ctypes
-import sys
 
 import numpy as np
 import pytest
@@ -80,14 +79,6 @@ def test_create_program_from_source(ctype_str, dtype, ctypes_ctor):
 
     b_np = dpt.asnumpy(b)
     a_np = dpt.asnumpy(a)
-
-    if "mkl_umath" in sys.modules:
-        mod = sys.modules["mkl_umath"]
-        if hasattr(mod, "restore"):
-            # undo numpy umath patching to work around
-            # incorrect reference result on
-            # AMD EPYC 7763 64-Core Processor as observed in GH CI
-            mod.restore()
 
     for r in (
         [


### PR DESCRIPTION
This PR reverts work-around added to "test_sycl_kernel_submit.py" to fix test due to issue with MKL 2024.2.0, as used by `mkl_umath`. The issue is fixed in MKL 2024.2.1

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [ ] Have you added your changes to the changelog?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
