### PR TITLE
Throw exception in py_sort if inputs are not C-contiguous

### DIFF
--- a/dpctl/tensor/libtensor/source/sorting/argsort.cpp
+++ b/dpctl/tensor/libtensor/source/sorting/argsort.cpp
@@ -125,7 +125,6 @@ py_argsort(const dpctl::tensor::usm_ndarray &src,
             "Output index array must have data type int32 or int64");
     }
 
-    // handle special case when both reduction and iteration are 1D contiguous
     bool is_src_c_contig = src.is_c_contiguous();
     bool is_dst_c_contig = dst.is_c_contiguous();
 
@@ -150,7 +149,8 @@ py_argsort(const dpctl::tensor::usm_ndarray &src,
         return std::make_pair(keep_args_alive_ev, comp_ev);
     }
 
-    return std::make_pair(sycl::event(), sycl::event());
+    throw py::value_error(
+        "Both source and destination arrays must be C-contiguous");
 }
 
 using dpctl::tensor::kernels::sort_contig_fn_ptr_t;

--- a/dpctl/tensor/libtensor/source/sorting/sort.cpp
+++ b/dpctl/tensor/libtensor/source/sorting/sort.cpp
@@ -123,7 +123,6 @@ py_sort(const dpctl::tensor::usm_ndarray &src,
                               "the same value data type");
     }
 
-    // handle special case when both reduction and iteration are 1D contiguous
     bool is_src_c_contig = src.is_c_contiguous();
     bool is_dst_c_contig = dst.is_c_contiguous();
 

--- a/dpctl/tensor/libtensor/source/sorting/sort.cpp
+++ b/dpctl/tensor/libtensor/source/sorting/sort.cpp
@@ -144,7 +144,8 @@ py_sort(const dpctl::tensor::usm_ndarray &src,
         return std::make_pair(keep_args_alive_ev, comp_ev);
     }
 
-    return std::make_pair(sycl::event(), sycl::event());
+    throw py::value_error(
+        "Both source and destination arrays must be C-contiguous");
 }
 
 using dpctl::tensor::kernels::sort_contig_fn_ptr_t;


### PR DESCRIPTION
This changes behavior of `py_sort` C++ function to throw `py::value_error` exception should either input array be not C-contiguous.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [ ] Have you added your changes to the changelog?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
