### PR TITLE
Add job explicit, conservative job timeouts

### DIFF
--- a/.github/workflows/conda-package.yml
+++ b/.github/workflows/conda-package.yml
@@ -19,6 +19,7 @@ env:
 jobs:
   build_linux:
     runs-on: ubuntu-22.04
+    timeout-minutes: 90
 
     strategy:
       matrix:
@@ -74,6 +75,7 @@ jobs:
 
   build_windows:
     runs-on: windows-2019
+    timeout-minutes: 150
 
     strategy:
       matrix:
@@ -137,6 +139,7 @@ jobs:
   test_linux:
     needs: build_linux
     runs-on:  ${{ matrix.runner }}
+    timeout-minutes: 30
 
     strategy:
       matrix:
@@ -228,6 +231,7 @@ jobs:
   test_windows:
     needs: build_windows
     runs-on:  ${{ matrix.runner }}
+    timeout-minutes: 60
     defaults:
       run:
         shell: cmd /C CALL {0}
@@ -361,6 +365,7 @@ jobs:
     needs: test_linux
     if: ${{github.ref == 'refs/heads/master' || (startsWith(github.ref, 'refs/heads/release') == true) || github.event_name == 'push' && contains(github.ref, 'refs/tags/')}}
     runs-on: ubuntu-22.04
+    timeout-minutes: 20
     strategy:
       matrix:
         python: ['3.9', '3.10', '3.11', '3.12']
@@ -397,6 +402,7 @@ jobs:
     needs: test_windows
     if: ${{github.ref == 'refs/heads/master' || (startsWith(github.ref, 'refs/heads/release') == true) || github.event_name == 'push' && contains(github.ref, 'refs/tags/')}}
     runs-on: windows-2019
+    timeout-minutes: 20
     strategy:
       matrix:
         python: ['3.9', '3.10', '3.11', '3.12']
@@ -443,6 +449,7 @@ jobs:
         experimental: [false]
         runner: [ubuntu-22.04]
     continue-on-error: ${{ matrix.experimental }}
+    timeout-minutes: 60
     env:
       EXAMPLES_ENV_NAME: examples
       BUILD_ENV_NAME: build_env
@@ -590,6 +597,7 @@ jobs:
   array-api-conformity:
     needs: build_linux
     runs-on:  ${{ matrix.runner }}
+    timeout-minutes: 90
     permissions:
       pull-requests: write
 
@@ -735,6 +743,7 @@ jobs:
     name: Clean up anaconda packages
     needs: [upload_linux, upload_windows]
     runs-on: 'ubuntu-latest'
+    timeout-minutes: 30
     defaults:
       run:
         shell: bash -el {0}

--- a/.github/workflows/cpp_style_checks.yml
+++ b/.github/workflows/cpp_style_checks.yml
@@ -15,6 +15,7 @@ jobs:
   formatting-check:
     name: clang-format
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
     - uses: actions/checkout@v4.1.7
     - name: Run clang-format style check for C/C++ programs.

--- a/.github/workflows/generate-coverage.yaml
+++ b/.github/workflows/generate-coverage.yaml
@@ -10,6 +10,7 @@ jobs:
   generate-coverage:
     name: Generate coverage and push to Coveralls.io
     runs-on: ubuntu-latest
+    timeout-minutes: 150
     permissions:
       pull-requests: write
 
@@ -145,6 +146,7 @@ jobs:
     name: Indicate completion to coveralls.io
     needs: generate-coverage
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     container: python:3-slim
     steps:
     - name: Finished

--- a/.github/workflows/generate-docs.yml
+++ b/.github/workflows/generate-docs.yml
@@ -12,6 +12,7 @@ jobs:
   build-and-deploy:
     name: Build and Deploy Documentation
     runs-on: ubuntu-latest
+    timeout-minutes: 240
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/openssf-scorecard.yml
+++ b/.github/workflows/openssf-scorecard.yml
@@ -22,6 +22,7 @@ jobs:
   analysis:
     name: Scorecard analysis
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       # Needed to upload the results to code-scanning dashboard.
       security-events: write

--- a/.github/workflows/os-llvm-sycl-build.yml
+++ b/.github/workflows/os-llvm-sycl-build.yml
@@ -10,6 +10,7 @@ jobs:
   install-compiler:
     name: Build with nightly build of DPC++ toolchain
     runs-on: ubuntu-22.04
+    timeout-minutes: 90
 
     env:
       DOWNLOAD_URL_PREFIX: https://github.com/intel/llvm/releases/download

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -10,6 +10,7 @@ permissions: read-all
 jobs:
   pre-commit:
     runs-on: ubuntu-24.04
+    timeout-minutes: 30
     steps:
     - uses: actions/checkout@v4.1.7
     - uses: actions/setup-python@v5

--- a/.github/workflows/python_style_checks.yml
+++ b/.github/workflows/python_style_checks.yml
@@ -16,6 +16,7 @@ jobs:
   # The isort job sorts all imports in .py, .pyx, .pxd files
   isort:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4.1.7
       - uses: actions/setup-python@v5
@@ -28,6 +29,7 @@ jobs:
   black:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
+    timeout-minutes: 30
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -47,6 +49,7 @@ jobs:
 
   flake8:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
 
     steps:
     - uses: actions/checkout@v4.1.7


### PR DESCRIPTION
Add `timeout-minutes` property, https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#jobsjob_idtimeout-minutes

This ensures that run-away jobs, like one encountered in gh-1836 would not take extraordinarily long to fail.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [ ] Have you added your changes to the changelog?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
