### PR TITLE
Ignore run export on level-zero

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,7 +78,7 @@ The full list of changes that went into this release are:
 * Clean-up uses of `Strided1DIndexer` class [gh-1805](https://github.com/IntelPython/dpctl/pull/1805)
 * Tweak to readability of C++ code implementing matrix-matrix multiplication [gh-1810](https://github.com/IntelPython/dpctl/pull/1810)
 * Do not add `sycl::event` associated with compute task to vector of events representing execution of `host_task` [gh-1807](https://github.com/IntelPython/dpctl/pull/1807)
-* Remove 'level-zero' conda package from run-time dependencies of 'dpctl' since Intel GPU driver stack now explicitly depends on `libze1` package which provides Level-Zero loader library [gh-1801](https://github.com/IntelPython/dpctl/pull/1801)
+* Remove 'level-zero' conda package from run-time dependencies of 'dpctl' since Intel GPU driver stack now explicitly depends on `libze1` package which provides Level-Zero loader library [gh-1801](https://github.com/IntelPython/dpctl/pull/1801), [gh-1840](https://github.com/IntelPython/dpctl/pull/1840)
 * Use dedicated type-support matrices for in-place element-wise binary operations [gh-1816](https://github.com/IntelPython/dpctl/pull/1816)
 * Remove recommendation to install wheels from Anaconda PyPI index [gh-1819](https://github.com/IntelPython/dpctl/pull/1819)
 * Removed use of post-link and pre-unlink conda scripts in `dpctl` [gh-1821](https://github.com/IntelPython/dpctl/pull/1821)

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -15,6 +15,8 @@ build:
     script_env:
         - WHEELS_OUTPUT_FOLDER
         - OVERRIDE_INTEL_IPO  # [win]
+    ignore_run_export:
+        - level-zero
 
 requirements:
     # TODO: keep in sync with /pyproject.toml

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -15,7 +15,7 @@ build:
     script_env:
         - WHEELS_OUTPUT_FOLDER
         - OVERRIDE_INTEL_IPO  # [win]
-    ignore_run_export:
+    ignore_run_exports:
         - level-zero
 
 requirements:


### PR DESCRIPTION
dpctl was still specifying run-time dependency on level-zero though run_export of level-zero-devel.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [ ] Have you added your changes to the changelog?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
