### PR TITLE
Remove #include <exception> line from offset_utils.hpp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fixed CI/CD workflow for building conda packages on Windows [gh-1831](https://github.com/IntelPython/dpctl/pull/1831)
 * Do not use Mambaforge variant of miniforge as deprecated [gh-1844](https://github.com/IntelPython/dpctl/pull/1844)
 * Use pybind11=2.13.6 [gh-1845](https://github.com/IntelPython/dpctl/pull/1845)
-
+* Remove unnecessary include in C++ header file [gh-1846](https://github.com/IntelPython/dpctl/pull/1846)
 
 ## [0.18.0] - Sept. XX, 2024
 

--- a/dpctl/tensor/libtensor/include/utils/offset_utils.hpp
+++ b/dpctl/tensor/libtensor/include/utils/offset_utils.hpp
@@ -27,7 +27,6 @@
 #pragma once
 
 #include <algorithm>
-#include <exception>
 #include <sycl/sycl.hpp>
 #include <tuple>
 #include <vector>


### PR DESCRIPTION
Removed `#include <exception>` line from "offset_utils.hpp".

The file uses none of the functionality defined in that header.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [ ] Have you added your changes to the changelog?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
