### PR TITLE
Fix documentation warning when rendering `diff` docstring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Use pybind11=2.13.6 [gh-1845](https://github.com/IntelPython/dpctl/pull/1845)
 * Remove unnecessary include in C++ header file [gh-1846](https://github.com/IntelPython/dpctl/pull/1846)
 * Build translation unit "simplify_iteration_space.cpp" compiled multiple times as a static library [gh-1847](https://github.com/IntelPython/dpctl/pull/1847)
+* Fix warning in documentation generation caused by `diff` docstring [gh-1855](https://github.com/IntelPython/dpctl/pull/1855)
 
 ## [0.18.0] - Sept. XX, 2024
 

--- a/dpctl/tensor/_utility_functions.py
+++ b/dpctl/tensor/_utility_functions.py
@@ -104,7 +104,8 @@ def _boolean_reduction(x, axis, keepdims, func):
 
 
 def all(x, /, *, axis=None, keepdims=False):
-    """all(x, axis=None, keepdims=False)
+    """
+    all(x, axis=None, keepdims=False)
 
     Tests whether all input array elements evaluate to True along a given axis.
 
@@ -132,7 +133,8 @@ def all(x, /, *, axis=None, keepdims=False):
 
 
 def any(x, /, *, axis=None, keepdims=False):
-    """any(x, axis=None, keepdims=False)
+    """
+    any(x, axis=None, keepdims=False)
 
     Tests whether any input array elements evaluate to True along a given axis.
 
@@ -176,9 +178,11 @@ def _validate_diff_shape(sh1, sh2, axis):
 
 
 def _concat_diff_input(arr, axis, prepend, append):
-    """Concatenates `arr`, `prepend` and, `append` along `axis`,
+    """
+    Concatenates `arr`, `prepend` and, `append` along `axis`,
     where `arr` is an array and `prepend` and `append` are
-    any mixture of arrays and scalars."""
+    any mixture of arrays and scalars.
+    """
     if prepend is not None and append is not None:
         q1, x_usm_type = arr.sycl_queue, arr.usm_type
         q2, prepend_usm_type = _get_queue_usm_type(prepend)
@@ -441,7 +445,8 @@ def diff(x, /, *, axis=-1, n=1, prepend=None, append=None):
         usm_ndarray:
             an array containing the `n`-th differences. The array will have the
             same shape as `x`, except along `axis`, which will have shape:
-                prepend.shape[axis] + x.shape[axis] + append.shape[axis] - n
+            ``prepend.shape[axis] + x.shape[axis] + append.shape[axis] - n``
+
             The data type of the returned array is determined by the Type
             Promotion Rules.
     """


### PR DESCRIPTION
This PR fixes a warning caused by the docstring for `diff` incorrectly indenting the description of the output shape.

Closes #1849 

- [X] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [x] Have you added your changes to the changelog?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
