### PR TITLE
Add Intel channel for installing wheels

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,11 +72,11 @@ conda install dpctl -c https://software.repos.intel.com/python/conda/ -c conda-f
 
 ## Pip
 
-The `dpctl` can be installed using `pip` obtaining wheel packages from PyPi.
-To install `dpctl` wheel package, run the following command:
+The `dpctl` can be installed using `pip` obtaining wheel packages either from PyPi or from Intel(R) channel.
+To install `dpctl` wheel package from Intel(R) channel, run the following command:
 
 ```bash
-python -m pip install dpctl
+python -m pip install --index-url https://software.repos.intel.com/python/pypi dpctl
 ```
 
 Installing the bleeding edge

--- a/docs/doc_sources/beginners_guides/installation.rst
+++ b/docs/doc_sources/beginners_guides/installation.rst
@@ -54,6 +54,13 @@ Binary wheels are published with Python Package Index (https://pypi.org/project/
 
     python -m pip install dpctl
 
+
+Binary wheels of ``dpctl`` and its dependencies are also published on Intel(R) channel. To install from this non-default package index,
+use
+
+.. code-block:: bash
+    python -m pip install --index-url https://software.repos.intel.com/python/pypi dpctl
+
 .. note::
     As of April 2024, installation using ``pip`` on Linux* requires
     that host operating system had ``libstdc++.so`` library version 6.0.29


### PR DESCRIPTION
TDO team has deployed pypi channel, which will be used starting from the 2025 release. This PR updates the instructions by adding the installation from Intel pypi channel

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [ ] Have you added your changes to the changelog?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
