### PR TITLE
[MAINT] Fix warnings when building docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Remove unnecessary include in C++ header file [gh-1846](https://github.com/IntelPython/dpctl/pull/1846)
 * Build translation unit "simplify_iteration_space.cpp" compiled multiple times as a static library [gh-1847](https://github.com/IntelPython/dpctl/pull/1847)
 * Fix warning in documentation generation caused by `diff` docstring [gh-1855](https://github.com/IntelPython/dpctl/pull/1855)
+* Fix additional warnings when generating docs [gh-1861](https://github.com/IntelPython/dpctl/pull/1861)
 
 ## [0.18.0] - Sept. XX, 2024
 

--- a/docs/doc_sources/beginners_guides/installation.rst
+++ b/docs/doc_sources/beginners_guides/installation.rst
@@ -59,6 +59,7 @@ Binary wheels of ``dpctl`` and its dependencies are also published on Intel(R) c
 use
 
 .. code-block:: bash
+
     python -m pip install --index-url https://software.repos.intel.com/python/pypi dpctl
 
 .. note::

--- a/dpctl/tensor/_dlpack.pyx
+++ b/dpctl/tensor/_dlpack.pyx
@@ -963,7 +963,7 @@ cdef object _create_device(object device, object dl_device):
 
 
 def from_dlpack(x, /, *, device=None, copy=None):
-    """ from_dlpack(x, /, *, device=None, copy=None)
+    """from_dlpack(x, /, *, device=None, copy=None)
 
     Constructs :class:`dpctl.tensor.usm_ndarray` instance from a Python
     object ``x`` that implements ``__dlpack__`` protocol.
@@ -972,11 +972,7 @@ def from_dlpack(x, /, *, device=None, copy=None):
         x (object):
             A Python object representing an array that supports
             ``__dlpack__`` protocol.
-        device (Optional[str,
-                         :class:`dpctl.SyclDevice`,
-                         :class:`dpctl.SyclQueue`,
-                         :class:`dpctl.tensor.Device`,
-                         tuple([enum.Enum, int])])):
+        device (Optional[str, :class:`dpctl.SyclDevice`, :class:`dpctl.SyclQueue`, :class:`dpctl.tensor.Device`, tuple([:class:`enum.IntEnum`, int])])):
             Array API concept of a device where the output array is to be placed.
             ``device`` can be ``None``, a oneAPI filter selector
             string, an instance of :class:`dpctl.SyclDevice` corresponding to
@@ -986,7 +982,8 @@ def from_dlpack(x, /, *, device=None, copy=None):
             2-tuple matching the format of the output of the ``__dlpack_device__``
             method, an integer enumerator representing the device type followed by
             an integer representing the index of the device. The only supported
-            :enum:`dpctl.tensor.DLDeviceType` types are "kDLCPU" and "kDLOneAPI".
+            :class:`dpctl.tensor.DLDeviceType` types are "kDLCPU" and
+            "kDLOneAPI".
             Default: ``None``.
         copy (bool, optional)
             Boolean indicating whether or not to copy the input.

--- a/dpctl/tensor/_indexing_functions.py
+++ b/dpctl/tensor/_indexing_functions.py
@@ -460,7 +460,7 @@ def take_along_axis(x, indices, /, *, axis=-1, mode="wrap"):
         usm_ndarray:
             an array having the same data type as ``x``. The returned array has
             the same rank (i.e., number of dimensions) as ``x`` and a shape
-            determined according to :ref:`broadcasting`, except for the axis
+            determined according to broadcasting rules, except for the axis
             (dimension) specified by ``axis`` whose size must equal the size
             of the corresponding axis (dimension) in ``indices``.
 

--- a/dpctl/tensor/_usmarray.pyx
+++ b/dpctl/tensor/_usmarray.pyx
@@ -55,8 +55,8 @@ include "_slicing.pxi"
 
 class DLDeviceType(IntEnum):
     """
-    An ``IntEnum`` for the types of DLDevices supported by the DLPack
-    protocol.
+    An :class:`enum.IntEnum` for the types of DLDevices supported by the DLPack protocol.
+
         ``kDLCPU``:
             CPU (host) device
         ``kDLCUDA``:


### PR DESCRIPTION
This PR fixes several warnings raised when buildings docs using `scripts/gen_docs.py`.

- [X] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [X] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [x] Have you added your changes to the changelog?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
