### PR TITLE
Lower the threshold to use sequential sort

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Improved performance of copy-and-cast operations from `numpy.ndarray` to `tensor.usm_ndarray` for contiguous inputs [gh-1829](https://github.com/IntelPython/dpctl/pull/1829)
 * Improved performance of copying operation to C-/F-contig array, with optimization for batch of square matrices [gh-1850](https://github.com/IntelPython/dpctl/pull/1850)
 * Improved performance of `tensor.argsort` function for all types [gh-1859](https://github.com/IntelPython/dpctl/pull/1859)
+* Improved performance of `tensor.sort` and `tensor.argsort` for short arrays in the range [16, 64] elements [gh-1866](https://github.com/IntelPython/dpctl/pull/1866)
 
 ### Fixed
 

--- a/dpctl/tensor/libtensor/include/kernels/sorting/sort.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/sorting/sort.hpp
@@ -734,7 +734,7 @@ sycl::event stable_sort_axis1_contig_impl(
 
     auto comp = Comp{};
 
-    constexpr size_t sequential_sorting_threshold = 64;
+    constexpr size_t sequential_sorting_threshold = 16;
 
     if (sort_nelems < sequential_sorting_threshold) {
         // equal work-item sorts entire row

--- a/dpctl/tensor/libtensor/include/kernels/sorting/sort.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/sorting/sort.hpp
@@ -734,6 +734,8 @@ sycl::event stable_sort_axis1_contig_impl(
 
     auto comp = Comp{};
 
+    // constant chosen experimentally to ensure monotonicity of
+    // sorting performance, as measured on GPU Max, and Iris Xe
     constexpr size_t sequential_sorting_threshold = 16;
 
     if (sort_nelems < sequential_sorting_threshold) {


### PR DESCRIPTION
The threshold lowered from 64 elements to sort, to 16 elements. This recovers monotonicity of run-times curve.

When number of array elements along the axis we sort is less than the threshold, a quadratic complexity insertion sort is used. Too high a value of the threshold (64) made for the artifact, where sorting 63 elements took several times longer than sorting 65 elements.

Setting it to 16 recovers monotonicity (sorting 16 elements is not slower than sorting 17 elements).

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [x] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [ ] Have you added your changes to the changelog?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
