### PR TITLE
Align recipe's meta yaml with conda-forge

### DIFF
--- a/conda-recipe/conda_build_config.yaml
+++ b/conda-recipe/conda_build_config.yaml
@@ -1,2 +1,18 @@
 numpy:
     - 1.23
+c_compiler:                   # [linux]
+    - gcc                     # [linux]
+cxx_compiler:                 # [linux]
+    - gxx                     # [linux]
+cxx_compiler_version:         # [linux]
+    - '14'                    # [linux]
+c_stdlib:                     # [linux]
+    - sysroot                 # [linux]
+c_stdlib_version:             # [linux]
+    - 2.28                    # [linux]
+c_stdlib:                     # [win]
+    - vs                      # [win]
+cxx_compiler:                 # [win]
+    - vs2019                  # [win]
+c_compiler:                   # [win]
+    - vs2019                  # [win]

--- a/conda-recipe/conda_build_config.yaml
+++ b/conda-recipe/conda_build_config.yaml
@@ -1,5 +1,5 @@
 numpy:
-    - 1.23
+    - '1.23'
 c_compiler:                   # [linux]
     - gcc                     # [linux]
 cxx_compiler:                 # [linux]
@@ -9,7 +9,7 @@ cxx_compiler_version:         # [linux]
 c_stdlib:                     # [linux]
     - sysroot                 # [linux]
 c_stdlib_version:             # [linux]
-    - 2.28                    # [linux]
+    - '2.28'                  # [linux]
 c_stdlib:                     # [win]
     - vs                      # [win]
 cxx_compiler:                 # [win]

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -24,7 +24,6 @@ requirements:
         - {{ compiler('cxx') }}
         - {{ stdlib('c') }}
         - {{ compiler('dpcpp') }} >={{ required_compiler_version }}
-        - sysroot_linux-64 >=2.28  # [linux]
     host:
         - python
         - pip >=24.0

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -22,6 +22,7 @@ requirements:
     # TODO: keep in sync with /pyproject.toml
     build:
         - {{ compiler('cxx') }}
+        - {{ stdlib('c') }}
         - {{ compiler('dpcpp') }} >={{ required_compiler_version }}
         - sysroot_linux-64 >=2.28  # [linux]
     host:
@@ -57,6 +58,7 @@ test:
     requires:
         - {{ compiler('c') }}
         - {{ compiler('cxx') }}
+        - {{ stdlib('c') }}
         - cython
         - setuptools
         - pytest


### PR DESCRIPTION
Install `{{ stdlib('c') }}` into build environment. 

This requires adding `conda_build_config.yaml` where the version of the compiler as well as standard libraries be specified.

@ekomarova @xaleryb These changes break internal CI. Is there a way to align with conda-forge?

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [ ] Have you added your changes to the changelog?
- [x] If this PR is a work in progress, are you opening the PR as a draft?
