### PR TITLE
Add missing #include <exception>

### DIFF
--- a/dpctl/_host_task_util.hpp
+++ b/dpctl/_host_task_util.hpp
@@ -30,10 +30,13 @@
 //===----------------------------------------------------------------------===//
 
 #pragma once
+#include <exception>
+#include <sycl/sycl.hpp>
+
 #include "Python.h"
+
 #include "syclinterface/dpctl_data_types.h"
 #include "syclinterface/dpctl_sycl_type_casters.hpp"
-#include <sycl/sycl.hpp>
 
 DPCTLSyclEventRef async_dec_ref(DPCTLSyclQueueRef QRef,
                                 PyObject **obj_array,

--- a/dpctl/tensor/libtensor/source/accumulators/accumulate_over_axis.hpp
+++ b/dpctl/tensor/libtensor/source/accumulators/accumulate_over_axis.hpp
@@ -25,6 +25,7 @@
 #pragma once
 
 #include <cstdint>
+#include <exception>
 #include <limits>
 #include <stdexcept>
 #include <sycl/sycl.hpp>

--- a/dpctl/tensor/libtensor/source/elementwise_functions/elementwise_functions.hpp
+++ b/dpctl/tensor/libtensor/source/elementwise_functions/elementwise_functions.hpp
@@ -24,6 +24,7 @@
 //===----------------------------------------------------------------------===//
 #pragma once
 
+#include <exception>
 #include <stdexcept>
 #include <sycl/sycl.hpp>
 #include <utility>

--- a/dpctl/tensor/libtensor/source/linalg_functions/dot.cpp
+++ b/dpctl/tensor/libtensor/source/linalg_functions/dot.cpp
@@ -23,6 +23,7 @@
 //===--------------------------------------------------------------------===//
 
 #include <cstdint>
+#include <exception>
 #include <stdexcept>
 #include <sycl/sycl.hpp>
 #include <utility>

--- a/dpctl/tensor/libtensor/source/reductions/reduction_over_axis.hpp
+++ b/dpctl/tensor/libtensor/source/reductions/reduction_over_axis.hpp
@@ -27,6 +27,7 @@
 
 #include <algorithm>
 #include <cstdint>
+#include <exception>
 #include <stdexcept>
 #include <sycl/sycl.hpp>
 #include <type_traits>


### PR DESCRIPTION
Use of std::exception type (in `catch(const std::exception &e) {`), requires `#include <exception>`.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [ ] Have you added your changes to the changelog?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
