### PR TITLE
Add alternative implementation of device timer to SyclTimer class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,13 +8,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-### Change
+### Changed
 
 * Improved performance of copy-and-cast operations from `numpy.ndarray` to `tensor.usm_ndarray` for contiguous inputs [gh-1829](https://github.com/IntelPython/dpctl/pull/1829)
 * Improved performance of copying operation to C-/F-contig array, with optimization for batch of square matrices [gh-1850](https://github.com/IntelPython/dpctl/pull/1850)
 * Improved performance of `tensor.argsort` function for all types [gh-1859](https://github.com/IntelPython/dpctl/pull/1859)
 * Improved performance of `tensor.sort` and `tensor.argsort` for short arrays in the range [16, 64] elements [gh-1866](https://github.com/IntelPython/dpctl/pull/1866)
 * Implement radix sort algorithm to be used in `dpt.sort` and `dpt.argsort` [gh-1867](https://github.com/IntelPython/dpctl/pull/1867)
+* Extended `dpctl.SyclTimer` with `device_timer` keyword, implementing different methods of collecting device times [gh-1872](https://github.com/IntelPython/dpctl/pull/1872)
 
 ### Fixed
 * Fix for `tensor.result_type` when all inputs are Python built-in scalars [gh-1877](https://github.com/IntelPython/dpctl/pull/1877)

--- a/dpctl/tests/test_sycl_timer.py
+++ b/dpctl/tests/test_sycl_timer.py
@@ -1,0 +1,108 @@
+#                      Data Parallel Control (dpctl)
+#
+# Copyright 2020-2024 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import time
+
+import pytest
+
+import dpctl
+import dpctl.tensor as dpt
+
+
+@pytest.fixture
+def profiling_queue():
+    try:
+        q = dpctl.SyclQueue(property="enable_profiling")
+    except dpctl.SyclQueueCreationError:
+        pytest.skip(
+            "Could not created profiling queue " "for default-selected device"
+        )
+    return q
+
+
+@pytest.mark.parametrize(
+    "device_timer", [None, "queue_barrier", "order_manager"]
+)
+def test_sycl_timer_queue_barrier(profiling_queue, device_timer):
+    dev = dpt.Device.create_device(profiling_queue)
+
+    timer = dpctl.SyclTimer(
+        host_timer=time.perf_counter, device_timer=device_timer, time_scale=1e3
+    )
+
+    with timer(dev.sycl_queue):
+        x = dpt.linspace(0, 1, num=10**6, device=dev)
+        y = 3.0 - dpt.square(x - 0.5)
+        z = dpt.sort(y)
+        res1 = z[-1]
+        res2 = dpt.max(y)
+
+    host_dt, device_dt = timer.dt
+
+    assert dpt.all(res1 == res2)
+    assert host_dt > 0
+    assert device_dt > 0
+
+
+def test_sycl_timer_accumulation(profiling_queue):
+    q = profiling_queue
+
+    timer = dpctl.SyclTimer(
+        host_timer=time.perf_counter,
+        device_timer="order_manager",
+        time_scale=1e3,
+    )
+
+    # initial condition
+    x = dpt.linspace(0, 1, num=10**6, sycl_queue=q)
+
+    aitkens_data = [
+        x,
+    ]
+
+    # 16 iterations of Aitken's accelerated Newton's method
+    # x <- x - f(x)/f'(x) for f(x) = x - cos(x)
+    for _ in range(16):
+        # only time Newton step
+        with timer(q):
+            s = dpt.sin(x)
+            x = (dpt.cos(x) + x * s) / (1 + s)
+        aitkens_data.append(x)
+        aitkens_data = aitkens_data[-3:]
+        if len(aitkens_data) == 3:
+            # apply Aitkens acceleration
+            d1 = aitkens_data[-1] - aitkens_data[-2]
+            d2 = aitkens_data[-2] - aitkens_data[-3]
+            if not dpt.any(d1 == d2):
+                x = aitkens_data[-1] - dpt.square(d1) / (d1 - d2)
+
+    # Total time for 16 iterations
+    dev_dt = timer.dt.device_dt
+    assert dev_dt > 0
+
+    # check convergence
+    assert dpt.max(x) - dpt.min(x) < 1e-5
+
+
+def test_sycl_timer_validation():
+    with pytest.raises(ValueError):
+        dpctl.SyclTimer(device_timer="invalid")
+
+    timer = dpctl.SyclTimer()
+    mock_queue = Ellipsis
+
+    with pytest.raises(TypeError):
+        timer(mock_queue)

--- a/dpctl/utils/src/order_keeper.cpp
+++ b/dpctl/utils/src/order_keeper.cpp
@@ -26,4 +26,17 @@ PYBIND11_MODULE(_seq_order_keeper, m)
              &SequentialOrder::add_to_submitted_events)
         .def("wait", &SequentialOrder::wait,
              py::call_guard<py::gil_scoped_release>());
+
+    auto submit_empty_task_fn =
+        [](sycl::queue &exec_q,
+           const std::vector<sycl::event> &depends) -> sycl::event {
+        return exec_q.submit([&](sycl::handler &cgh) {
+            cgh.depends_on(depends);
+            cgh.single_task([]() {
+                // empty body
+            });
+        });
+    };
+    m.def("_submit_empty_task", submit_empty_task_fn, py::arg("sycl_queue"),
+          py::arg("depends") = py::list());
 }


### PR DESCRIPTION
This PR adds Python API to submit empty body single task to a queue. `dpctl.SyclTimer` is modified to acquire `device_timer` keyword argument with supported values being `"queue_barrier"` (legacy behavior, a default), and `"order_manager"`.

With `"order_manager"`, timer submits the empty body single tasks (fence tasks) to the queue, using order manager to order them so as to fence timed submissions. For example, execution of the following snippet:

```python
   prior_ops
   with timer(profiling_queue):
        compute_using_the_queue
   subsequent_ops
```

results in a task graph `[prior_tasks] -> [fence_start_task] -> [ compute_tasks] -> [fence_end_task] -> [subsequent_tasks]`.

Timer uses profiling data from events associated with fence tasks to estimate execution time of compute tasks as measured by the device's timer.

The `device_timer="order_manager"` is useful to time `dpctl.tensor` operations which leverage order manager.


- [x] Have you provided a meaningful PR description?
- [x] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [x] Have you checked performance impact of proposed changes?
- [x] Have you added documentation for your changes, if necessary?
- [ ] Have you added your changes to the changelog?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
