### PR TITLE
result_type to raise unless at least one argument is usm_ndarray

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+* Change to `tensor.result_type` to raise `ValueError` unless at least one argument is a `tensor.usm_ndarray` instance [gh-1876](https://github.com/IntelPython/dpctl/pull/1876)
+
 ### Maintenance
 
 * Update black version used in Python code style workflow [gh-1828](https://github.com/IntelPython/dpctl/pull/1828)

--- a/dpctl/tensor/_search_functions.py
+++ b/dpctl/tensor/_search_functions.py
@@ -35,6 +35,7 @@ from ._type_utils import (
     _all_data_types,
     _can_cast,
     _is_weak_dtype,
+    _result_type_fn_impl,
     _strong_dtype_num_kind,
     _to_device_supported_dtype,
     _weak_type_num_kind,
@@ -95,7 +96,13 @@ def _resolve_two_weak_types(o1_dtype, o2_dtype, dev):
 
 
 def _where_result_type(dt1, dt2, dev):
-    res_dtype = dpt.result_type(dt1, dt2)
+    res_dtype = _result_type_fn_impl(
+        (
+            dt1,
+            dt2,
+        ),
+        sycl_device=dev,
+    )
     fp16 = dev.has_aspect_fp16
     fp64 = dev.has_aspect_fp64
 

--- a/dpctl/tensor/_type_utils.py
+++ b/dpctl/tensor/_type_utils.py
@@ -760,7 +760,7 @@ def _result_type_fn_impl(arrays_and_dtypes_tuple, sycl_device=None):
                 inspected = True
     else:
         raise ValueError(
-            "At least only argument must have type `dpctl.tensor.usm_ndarray`"
+            "At least one argument must have type `dpctl.tensor.usm_ndarray`"
         )
 
     if not (has_fp16 and has_fp64):

--- a/dpctl/tests/helper/_helper.py
+++ b/dpctl/tests/helper/_helper.py
@@ -55,11 +55,14 @@ def skip_if_dtype_not_supported(dt, q_or_dev):
     import dpctl.tensor as dpt
 
     dt = dpt.dtype(dt)
-    if type(q_or_dev) is dpctl.SyclQueue:
+    if isinstance(q_or_dev, dpctl.SyclQueue):
         dev = q_or_dev.sycl_device
-    elif type(q_or_dev) is dpctl.SyclDevice:
-        dev = q_or_dev
     else:
+        dev = q_or_dev
+
+    if not hasattr(dev, "has_aspect_fp16") or not hasattr(
+        dev, "has_aspect_fp64"
+    ):
         raise TypeError(
             "Expected dpctl.SyclQueue or dpctl.SyclDevice, "
             f"got {type(q_or_dev)}"

--- a/dpctl/tests/test_usm_ndarray_manipulation.py
+++ b/dpctl/tests/test_usm_ndarray_manipulation.py
@@ -998,11 +998,6 @@ def test_result_type():
 
     assert dpt.result_type(*X) == np.result_type(*X_np)
 
-    X = [dpt.int32, "int64", 2]
-    X_np = [np.int32, "int64", 2]
-
-    assert dpt.result_type(*X) == np.result_type(*X_np)
-
     X = [usm_ar, dpt.int32, "int64", 2.0]
     X_np = [np_ar, np.int32, "int64", 2.0]
 
@@ -1012,6 +1007,10 @@ def test_result_type():
     X_np = [np_ar, np.int32, "int64", 2.0 + 1j]
 
     assert dpt.result_type(*X).kind == np.result_type(*X_np).kind
+
+    X = [dpt.int32, "int64", 2]
+    with pytest.raises(ValueError):
+        dpt.result_type(*X)
 
 
 def test_swapaxes_1d():

--- a/dpctl/tests/test_usm_ndarray_search_functions.py
+++ b/dpctl/tests/test_usm_ndarray_search_functions.py
@@ -48,6 +48,7 @@ _all_dtypes = [
 
 class mock_device:
     def __init__(self, fp16, fp64):
+        self.name = "Mock device"
         self.has_aspect_fp16 = fp16
         self.has_aspect_fp64 = fp64
 
@@ -101,14 +102,17 @@ def test_where_result_types(dt1, dt2, fp16, fp64):
     dev = mock_device(fp16, fp64)
 
     dt1 = dpt.dtype(dt1)
+    skip_if_dtype_not_supported(dt1, dev)
     dt2 = dpt.dtype(dt2)
+    skip_if_dtype_not_supported(dt2, dev)
+
     res_t = _where_result_type(dt1, dt2, dev)
 
     if fp16 and fp64:
-        assert res_t == dpt.result_type(dt1, dt2)
+        assert res_t == np.result_type(dt1, dt2)
     else:
         if res_t:
-            assert res_t.kind == dpt.result_type(dt1, dt2).kind
+            assert res_t.kind == np.result_type(dt1, dt2).kind
         else:
             # some illegal cases are covered above, but
             # this guarantees that _where_result_type


### PR DESCRIPTION
`dpt.result_type` is being changed to raise unless at least one argument is `dpt.usm_ndarray`.

Implementation of `dpt.where` was calling `dpt.result_type` with just dtypes, although it has the device available. Implementation of `result_type` was factored out into a helper function which can accommodate know device, and reused by `dpt.result_type` and `_where_result_type` function.

Test files were tweaked to avoid calling `dpt.result_type` with just dtypes.

Closes gh-1874 and supersedes gh-1875

- [x] Have you provided a meaningful PR description?
- [x] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [x] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [ ] Have you added your changes to the changelog?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
