### PR TITLE
Improve `dpctl.tensor.full` error for invalid `fill_value`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+* Improved error in constructors `tensor.full` and `tensor.full_like` when provided a non-numeric fill value [gh-1878](https://github.com/IntelPython/dpctl/pull/1878)
+
 ### Maintenance
 
 * Update black version used in Python code style workflow [gh-1828](https://github.com/IntelPython/dpctl/pull/1828)

--- a/dpctl/tensor/_ctors.py
+++ b/dpctl/tensor/_ctors.py
@@ -1111,14 +1111,14 @@ def full(
             sycl_queue=sycl_queue,
         )
         return dpt.copy(dpt.broadcast_to(X, shape), order=order)
-
-    sycl_queue = normalize_queue_device(sycl_queue=sycl_queue, device=device)
-    usm_type = usm_type if usm_type is not None else "device"
-    if not isinstance(fill_value, Number):
+    elif not isinstance(fill_value, Number):
         raise TypeError(
             "`full` array cannot be constructed with value of type "
             f"{type(fill_value)}"
         )
+
+    sycl_queue = normalize_queue_device(sycl_queue=sycl_queue, device=device)
+    usm_type = usm_type if usm_type is not None else "device"
     dtype = _get_dtype(dtype, sycl_queue, ref_type=type(fill_value))
     res = dpt.usm_ndarray(
         shape,
@@ -1486,6 +1486,11 @@ def full_like(
             )
             _manager.add_event_pair(hev, copy_ev)
             return res
+        elif not isinstance(fill_value, Number):
+            raise TypeError(
+                "`full` array cannot be constructed with value of type "
+                f"{type(fill_value)}"
+            )
 
         dtype = _get_dtype(dtype, sycl_queue, ref_type=type(fill_value))
         res = _empty_like_orderK(x, dtype, usm_type, sycl_queue)

--- a/dpctl/tensor/_ctors.py
+++ b/dpctl/tensor/_ctors.py
@@ -1111,7 +1111,12 @@ def full(
             sycl_queue=sycl_queue,
         )
         return dpt.copy(dpt.broadcast_to(X, shape), order=order)
-    elif not isinstance(fill_value, Number):
+    # TODO: verify if `np.True_` and `np.False_` should be instances of
+    # Number in NumPy, like other NumPy scalars and like Python bools
+    # check for `np.bool_` separately as NumPy<2 has no `np.bool`
+    elif not isinstance(fill_value, Number) and not isinstance(
+        fill_value, np.bool_
+    ):
         raise TypeError(
             "`full` array cannot be constructed with value of type "
             f"{type(fill_value)}"
@@ -1486,7 +1491,12 @@ def full_like(
             )
             _manager.add_event_pair(hev, copy_ev)
             return res
-        elif not isinstance(fill_value, Number):
+        # TODO: verify if `np.True_` and `np.False_` should be instances of
+        # Number in NumPy, like other NumPy scalars and like Python bools
+        # check for `np.bool_` separately as NumPy<2 has no `np.bool`
+        elif not isinstance(fill_value, Number) and not isinstance(
+            fill_value, np.bool_
+        ):
             raise TypeError(
                 "`full` array cannot be constructed with value of type "
                 f"{type(fill_value)}"

--- a/dpctl/tensor/_ctors.py
+++ b/dpctl/tensor/_ctors.py
@@ -15,6 +15,7 @@
 #  limitations under the License.
 
 import operator
+from numbers import Number
 
 import numpy as np
 
@@ -1113,6 +1114,11 @@ def full(
 
     sycl_queue = normalize_queue_device(sycl_queue=sycl_queue, device=device)
     usm_type = usm_type if usm_type is not None else "device"
+    if not isinstance(fill_value, Number):
+        raise TypeError(
+            "`full` array cannot be constructed with value of type "
+            f"{type(fill_value)}"
+        )
     dtype = _get_dtype(dtype, sycl_queue, ref_type=type(fill_value))
     res = dpt.usm_ndarray(
         shape,

--- a/dpctl/tests/test_usm_ndarray_ctor.py
+++ b/dpctl/tests/test_usm_ndarray_ctor.py
@@ -2623,8 +2623,12 @@ def test_setitem_from_numpy_contig():
     assert dpt.all(dpt.flip(Xdpt, axis=-1) == expected)
 
 
-def test_full_raises_type_error():
+def test_full_functions_raise_type_error():
     get_queue_or_skip()
 
     with pytest.raises(TypeError):
         dpt.full(1, "0")
+
+    x = dpt.ones(1, dtype="i4")
+    with pytest.raises(TypeError):
+        dpt.full_like(x, "0")

--- a/dpctl/tests/test_usm_ndarray_ctor.py
+++ b/dpctl/tests/test_usm_ndarray_ctor.py
@@ -2621,3 +2621,10 @@ def test_setitem_from_numpy_contig():
 
     expected = dpt.reshape(dpt.arange(-10, 10, dtype=fp_dt), (4, 5))
     assert dpt.all(dpt.flip(Xdpt, axis=-1) == expected)
+
+
+def test_full_raises_type_error():
+    get_queue_or_skip()
+
+    with pytest.raises(TypeError):
+        dpt.full(1, "0")


### PR DESCRIPTION
This PR proposes adding a check to `full` when the value to construct the array with is not a scalar value, i.e., some type of object or a string.

Previously these cases would fail, but pybind11 would throw RuntimeError. Now, a TypeError is thrown from Python, and the result array is never allocated, preventing wasted memory allocation.

- [X] Have you provided a meaningful PR description?
- [X] Have you added a test, reproducer or referred to an issue with a reproducer?
- [X] Have you tested your changes locally for CPU and GPU devices?
- [X] Have you made sure that new changes do not introduce compiler warnings?
- [X] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [ ] Have you added your changes to the changelog?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
