### PR TITLE
Update generate-coverage workflow to work with oneAPI 2025

### DIFF
--- a/.github/workflows/conda-package.yml
+++ b/.github/workflows/conda-package.yml
@@ -12,8 +12,9 @@ env:
   PACKAGE_NAME: dpctl
   MODULE_NAME: dpctl
   TEST_ENV_NAME: test_dpctl
-  VER_SCRIPT1: "import json; f = open('ver.json', 'r'); j = json.load(f); f.close(); "
-  VER_SCRIPT2: "d = j['dpctl'][0]; print('='.join((d[s] for s in ('version', 'build'))))"
+  VER_SCRIPT1: "import json; f = open('ver.json', 'r'); j = json.load(f); f.close(); d = j['dpctl'][0];"
+  VER_SCRIPT2: "print('='.join((d[s] for s in ('version', 'build'))))"
+  VER_SCRIPT3: "print(' '.join(d['depends']))"
   INTEL_CHANNEL: "https://software.repos.intel.com/python/conda/"
 
 jobs:
@@ -546,12 +547,14 @@ jobs:
         run: |
           CHANNELS="${{ env.CHANNELS }}"
           . $CONDA/etc/profile.d/conda.sh
-          conda create -n ${{ env.EXAMPLES_ENV_NAME }} -y pytest python=${{ matrix.python }} setuptools"<72.2.0" $CHANNELS
-          conda install -n ${{ env.EXAMPLES_ENV_NAME }} -y cmake $CHANNELS || exit 1
-          conda install -n ${{ env.EXAMPLES_ENV_NAME }} -y ninja $CHANNELS || exit 1
-          conda install -n ${{ env.EXAMPLES_ENV_NAME }} -y pybind11 cython scikit-build $CHANNELS || exit 1
-          conda install -n ${{ env.EXAMPLES_ENV_NAME }} -y mkl-dpcpp mkl-devel-dpcpp dpcpp_cpp_rt $CHANNELS || exit 1
-          conda create -y -n ${{ env.BUILD_ENV_NAME }} $CHANNELS gcc_linux-64 gxx_linux-64 ${{ env.DPCPP_CMPLR }} sysroot_linux-64">=2.28"
+          export DPCTL_DEPENDS=$(python -c "${VER_SCRIPT1} ${VER_SCRIPT3}")
+          echo "Dpctl dependencies: ${DPCTL_DEPENDS}"
+          conda create -n ${{ env.EXAMPLES_ENV_NAME }} -y pytest python=${{ matrix.python }} setuptools"<72.2.0" $DPCTL_DEPENDS $CHANNELS
+          conda install -n ${{ env.EXAMPLES_ENV_NAME }} -y cmake $DPCTL_DEPENDS $CHANNELS || exit 1
+          conda install -n ${{ env.EXAMPLES_ENV_NAME }} -y ninja $DPCTL_DEPENDS $CHANNELS || exit 1
+          conda install -n ${{ env.EXAMPLES_ENV_NAME }} -y pybind11 cython scikit-build $DPCTL_DEPENDS $CHANNELS || exit 1
+          conda install -n ${{ env.EXAMPLES_ENV_NAME }} -y mkl-dpcpp mkl-devel-dpcpp dpcpp_cpp_rt $DPCTL_DEPENDS $CHANNELS || exit 1
+          conda create -y -n ${{ env.BUILD_ENV_NAME }} $CHANNELS gcc_linux-64 gxx_linux-64 ${{ env.DPCPP_CMPLR }} $DPCTL_DEPENDS sysroot_linux-64">=2.28"
       - name: Install dpctl
         shell: bash -l {0}
         run: |

--- a/.github/workflows/conda-package.yml
+++ b/.github/workflows/conda-package.yml
@@ -14,7 +14,7 @@ env:
   TEST_ENV_NAME: test_dpctl
   VER_SCRIPT1: "import json; f = open('ver.json', 'r'); j = json.load(f); f.close(); d = j['dpctl'][0];"
   VER_SCRIPT2: "print('='.join((d[s] for s in ('version', 'build'))))"
-  VER_SCRIPT3: "print(' '.join(d['depends']))"
+  VER_SCRIPT3: "print(' '.join(map(lambda s: chr(34) + s + chr(34), [comp for comp in d['depends'] if 'dpcpp' in comp][1:])))"
   INTEL_CHANNEL: "https://software.repos.intel.com/python/conda/"
 
 jobs:
@@ -364,7 +364,11 @@ jobs:
         shell: pwsh
         run: |
           $script_path="$env:CONDA_PREFIX\Scripts\set-intel-ocl-icd-registry.ps1"
-          &$script_path
+          if (Test-Path $script_path) {
+            &$script_path
+          } else {
+            Write-Warning "File $script_path was NOT found!"
+          }
           # Check the variable assisting OpenCL CPU driver to find TBB DLLs which are not located where it expects them by default
           $cl_cfg="$env:CONDA_PREFIX\Library\lib\cl.cfg"
           Get-Content -Tail 5 -Path $cl_cfg
@@ -541,20 +545,28 @@ jobs:
             ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}-python-${{ matrix.python }}-
             ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}-
       - name: Install example requirements
-        shell: bash -l {0}
+        shell: bash -ex -l {0}
         env:
-          DPCPP_CMPLR: dpcpp_linux-64">=2024.2"
+          DPCPP_CMPLR: "dpcpp_linux-64>=2024.2"
         run: |
           CHANNELS="${{ env.CHANNELS }}"
           . $CONDA/etc/profile.d/conda.sh
-          export DPCTL_DEPENDS=$(python -c "${VER_SCRIPT1} ${VER_SCRIPT3}")
+          DPCTL_DEPENDS="$(python -c "${VER_SCRIPT1} ${VER_SCRIPT3}")"
           echo "Dpctl dependencies: ${DPCTL_DEPENDS}"
-          conda create -n ${{ env.EXAMPLES_ENV_NAME }} -y pytest python=${{ matrix.python }} setuptools"<72.2.0" $DPCTL_DEPENDS $CHANNELS
-          conda install -n ${{ env.EXAMPLES_ENV_NAME }} -y cmake $DPCTL_DEPENDS $CHANNELS || exit 1
-          conda install -n ${{ env.EXAMPLES_ENV_NAME }} -y ninja $DPCTL_DEPENDS $CHANNELS || exit 1
-          conda install -n ${{ env.EXAMPLES_ENV_NAME }} -y pybind11 cython scikit-build $DPCTL_DEPENDS $CHANNELS || exit 1
-          conda install -n ${{ env.EXAMPLES_ENV_NAME }} -y mkl-dpcpp mkl-devel-dpcpp dpcpp_cpp_rt $DPCTL_DEPENDS $CHANNELS || exit 1
-          conda create -y -n ${{ env.BUILD_ENV_NAME }} $CHANNELS gcc_linux-64 gxx_linux-64 ${{ env.DPCPP_CMPLR }} $DPCTL_DEPENDS sysroot_linux-64">=2.28"
+          conda create -n ${{ env.EXAMPLES_ENV_NAME }} -y pytest python=${{ matrix.python }} "setuptools<72.2.0" $CHANNELS
+          echo "Environment created"
+          conda install -n ${{ env.EXAMPLES_ENV_NAME }} -y cmake ninja $CHANNELS || exit 1
+          echo "Cmake and Ninja installed"
+          conda install -n ${{ env.EXAMPLES_ENV_NAME }} -y pybind11 cython scikit-build $CHANNELS || exit 1
+          echo "scikit-build installed"
+          conda install -n ${{ env.EXAMPLES_ENV_NAME }} -y mkl-dpcpp \
+              mkl-devel-dpcpp dpcpp_cpp_rt "${DPCTL_DEPENDS}" \
+              $CHANNELS || exit 1
+          echo "IPL installed"
+          conda create -y -n ${{ env.BUILD_ENV_NAME }} $CHANNELS gcc_linux-64 gxx_linux-64 \
+              ${{ env.DPCPP_CMPLR }} "${DPCTL_DEPENDS}" \
+              "sysroot_linux-64>=2.28"
+          echo "Compiler installed"
       - name: Install dpctl
         shell: bash -l {0}
         run: |

--- a/.github/workflows/generate-coverage.yaml
+++ b/.github/workflows/generate-coverage.yaml
@@ -17,8 +17,6 @@ jobs:
     env:
       ONEAPI_ROOT: /opt/intel/oneapi
       GTEST_ROOT: /home/runner/work/googletest-1.15.2/install
-      # Use oneAPI compiler 2023 to work around an issue
-      USE_2023: 0
 
     steps:
       - name: Cancel Previous Runs
@@ -28,23 +26,23 @@ jobs:
 
       - name: Add Intel repository
         run: |
-          wget https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS-2023.PUB
-          sudo apt-key add GPG-PUB-KEY-INTEL-SW-PRODUCTS-2023.PUB
-          rm GPG-PUB-KEY-INTEL-SW-PRODUCTS-2023.PUB
-          sudo add-apt-repository "deb https://apt.repos.intel.com/oneapi all main"
-          sudo apt-get update
-
-      - name: Install Intel OneAPI 2023
-        if: env.USE_2023 == '1'
-        run: |
-          sudo apt-get install intel-oneapi-compiler-dpcpp-cpp-2023.2.1
-          sudo apt-get install intel-oneapi-tbb-2021.10.0
+          wget https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB
+          cat GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB | gpg --dearmor | sudo tee /usr/share/keyrings/oneapi-archive-keyring.gpg > /dev/null
+          rm GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB
+          echo "deb [signed-by=/usr/share/keyrings/oneapi-archive-keyring.gpg] https://apt.repos.intel.com/oneapi all main" | sudo tee /etc/apt/sources.list.d/oneAPI.list
+          sudo apt update
 
       - name: Install latest Intel OneAPI
-        if: env.USE_2023 != '1'
         run: |
-          sudo apt-get install intel-oneapi-compiler-dpcpp-cpp
-          sudo apt-get install intel-oneapi-tbb
+          sudo apt install intel-oneapi-compiler-dpcpp-cpp
+          sudo apt install intel-oneapi-tbb
+          sudo apt install intel-oneapi-umf
+          sudo apt install hwloc
+
+      - name: Run SYCL list
+        run: |
+          source /opt/intel/oneapi/setvars.sh
+          sycl-ls --verbose
 
       - name: Install CMake and Ninja
         run: |

--- a/.github/workflows/generate-docs.yml
+++ b/.github/workflows/generate-docs.yml
@@ -24,15 +24,18 @@ jobs:
       - name: Add Intel repository
         if: ${{ !github.event.pull_request || github.event.action != 'closed' }}
         run: |
-          wget https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS-2023.PUB
-          sudo apt-key add GPG-PUB-KEY-INTEL-SW-PRODUCTS-2023.PUB
-          rm GPG-PUB-KEY-INTEL-SW-PRODUCTS-2023.PUB
-          sudo add-apt-repository "deb https://apt.repos.intel.com/oneapi all main"
-          sudo apt-get update
+          wget https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB
+          cat GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB | gpg --dearmor | sudo tee /usr/share/keyrings/oneapi-archive-keyring.gpg > /dev/null
+          rm GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB
+          echo "deb [signed-by=/usr/share/keyrings/oneapi-archive-keyring.gpg] https://apt.repos.intel.com/oneapi all main" | sudo tee /etc/apt/sources.list.d/oneAPI.list
+          sudo apt update
       - name: Install Intel OneAPI
         if: ${{ !github.event.pull_request || github.event.action != 'closed' }}
         run: |
-          sudo apt-get install intel-oneapi-compiler-dpcpp-cpp
+          sudo apt install intel-oneapi-compiler-dpcpp-cpp
+          sudo apt install intel-oneapi-tbb
+          sudo apt install intel-oneapi-umf
+          sudo apt install hwloc
       - name: Install Lua
         if: ${{ !github.event.pull_request || github.event.action != 'closed' }}
         run: |


### PR DESCRIPTION
Change to "generate-coverage" workflow to adapt to changes in oneAPI Basekit 2025.0

- Install Unified Memory Framework (UMF) component
- Install `hwloc` utility which is required by UMF

---

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [ ] Have you added your changes to the changelog?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
