### PR TITLE
Delete remove defaults channel step from test_windows job

### DIFF
--- a/.github/workflows/conda-package.yml
+++ b/.github/workflows/conda-package.yml
@@ -267,9 +267,6 @@ jobs:
           activate-environment: ${{ env.TEST_ENV_NAME }}
           python-version: ${{ matrix.python }}
 
-      - name: Remove defaults channel
-        run: conda config --remove channels defaults
-
       - name: Install conda-index
         run: |
           conda install -n base conda-index

--- a/.github/workflows/conda-package.yml
+++ b/.github/workflows/conda-package.yml
@@ -91,7 +91,7 @@ jobs:
           miniforge-variant: Miniforge3
           miniforge-version: latest
           activate-environment: build
-          channels: conda-forge
+          channels: conda-forge,nodefaults
           python-version: ${{ matrix.python }}
 
       - name: Install conda build
@@ -800,7 +800,7 @@ jobs:
         with:
           run-post: false
           channel-priority: "disabled"
-          channels: conda-forge
+          channels: conda-forge,nodefaults
           python-version: '3.11'
 
       - name: Install anaconda-client


### PR DESCRIPTION
The setup-miniconda action is removing 'defaults' channels now, and attempt at repeated removal trips an error.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [ ] Have you added your changes to the changelog?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
