### PR TITLE
Check pointer alignment when copying from strided array to C-contiguous array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 * Fix for `tensor.result_type` when all inputs are Python built-in scalars [gh-1877](https://github.com/IntelPython/dpctl/pull/1877)
-
 * Improved error in constructors `tensor.full` and `tensor.full_like` when provided a non-numeric fill value [gh-1878](https://github.com/IntelPython/dpctl/pull/1878)
+* Added a check for pointer alignment when copying to C-contiguous memory [gh-1890](https://github.com/IntelPython/dpctl/pull/1890)
 
 ### Maintenance
 

--- a/dpctl/tensor/libtensor/include/kernels/copy_as_contiguous.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/copy_as_contiguous.hpp
@@ -148,41 +148,92 @@ as_c_contiguous_array_generic_impl(sycl::queue &exec_q,
     constexpr std::size_t preferred_lws = 256;
     constexpr std::uint32_t n_vecs = 2;
     constexpr std::uint32_t vec_sz = 4;
-    constexpr bool enable_sg_load = true;
-    using KernelName =
-        as_contig_krn<T, IndexerT, vec_sz, n_vecs, enable_sg_load>;
 
-    const auto &kernel_id = sycl::get_kernel_id<KernelName>();
+    using dpctl::tensor::kernels::alignment_utils::
+        disabled_sg_loadstore_wrapper_krn;
+    using dpctl::tensor::kernels::alignment_utils::is_aligned;
+    using dpctl::tensor::kernels::alignment_utils::required_alignment;
 
-    auto const &ctx = exec_q.get_context();
-    auto const &dev = exec_q.get_device();
-    auto kb = sycl::get_kernel_bundle<sycl::bundle_state::executable>(
-        ctx, {dev}, {kernel_id});
+    sycl::event copy_ev;
+    if (is_aligned<required_alignment>(src_p) &&
+        is_aligned<required_alignment>(dst_p))
+    {
+        constexpr bool enable_sg_load = true;
+        using KernelName =
+            as_contig_krn<T, IndexerT, vec_sz, n_vecs, enable_sg_load>;
 
-    auto krn = kb.get_kernel(kernel_id);
+        const auto &kernel_id = sycl::get_kernel_id<KernelName>();
 
-    const std::uint32_t max_sg_size = krn.template get_info<
-        sycl::info::kernel_device_specific::max_sub_group_size>(dev);
+        auto const &ctx = exec_q.get_context();
+        auto const &dev = exec_q.get_device();
+        auto kb = sycl::get_kernel_bundle<sycl::bundle_state::executable>(
+            ctx, {dev}, {kernel_id});
 
-    const std::size_t lws =
-        ((preferred_lws + max_sg_size - 1) / max_sg_size) * max_sg_size;
+        auto krn = kb.get_kernel(kernel_id);
 
-    constexpr std::uint32_t nelems_per_wi = n_vecs * vec_sz;
-    size_t n_groups =
-        (nelems + nelems_per_wi * lws - 1) / (nelems_per_wi * lws);
+        const std::uint32_t max_sg_size = krn.template get_info<
+            sycl::info::kernel_device_specific::max_sub_group_size>(dev);
 
-    sycl::event copy_ev = exec_q.submit([&](sycl::handler &cgh) {
-        cgh.depends_on(depends);
-        cgh.use_kernel_bundle(kb);
+        const std::size_t lws =
+            ((preferred_lws + max_sg_size - 1) / max_sg_size) * max_sg_size;
 
-        const sycl::range<1> gRange{n_groups * lws};
-        const sycl::range<1> lRange{lws};
+        constexpr std::uint32_t nelems_per_wi = n_vecs * vec_sz;
+        size_t n_groups =
+            (nelems + nelems_per_wi * lws - 1) / (nelems_per_wi * lws);
 
-        cgh.parallel_for<KernelName>(
-            sycl::nd_range<1>(gRange, lRange),
-            CopyAsCContigFunctor<T, IndexerT, vec_sz, n_vecs, enable_sg_load>(
-                nelems, src_tp, dst_tp, src_indexer));
-    });
+        copy_ev = exec_q.submit([&](sycl::handler &cgh) {
+            cgh.depends_on(depends);
+            cgh.use_kernel_bundle(kb);
+
+            const sycl::range<1> gRange{n_groups * lws};
+            const sycl::range<1> lRange{lws};
+
+            cgh.parallel_for<KernelName>(
+                sycl::nd_range<1>(gRange, lRange),
+                CopyAsCContigFunctor<T, IndexerT, vec_sz, n_vecs,
+                                     enable_sg_load>(nelems, src_tp, dst_tp,
+                                                     src_indexer));
+        });
+    }
+    else {
+        constexpr bool disable_sg_load = false;
+        using InnerKernelName =
+            as_contig_krn<T, IndexerT, vec_sz, n_vecs, disable_sg_load>;
+        using KernelName = disabled_sg_loadstore_wrapper_krn<InnerKernelName>;
+
+        const auto &kernel_id = sycl::get_kernel_id<KernelName>();
+
+        auto const &ctx = exec_q.get_context();
+        auto const &dev = exec_q.get_device();
+        auto kb = sycl::get_kernel_bundle<sycl::bundle_state::executable>(
+            ctx, {dev}, {kernel_id});
+
+        auto krn = kb.get_kernel(kernel_id);
+
+        const std::uint32_t max_sg_size = krn.template get_info<
+            sycl::info::kernel_device_specific::max_sub_group_size>(dev);
+
+        const std::size_t lws =
+            ((preferred_lws + max_sg_size - 1) / max_sg_size) * max_sg_size;
+
+        constexpr std::uint32_t nelems_per_wi = n_vecs * vec_sz;
+        size_t n_groups =
+            (nelems + nelems_per_wi * lws - 1) / (nelems_per_wi * lws);
+
+        copy_ev = exec_q.submit([&](sycl::handler &cgh) {
+            cgh.depends_on(depends);
+            cgh.use_kernel_bundle(kb);
+
+            const sycl::range<1> gRange{n_groups * lws};
+            const sycl::range<1> lRange{lws};
+
+            cgh.parallel_for<KernelName>(
+                sycl::nd_range<1>(gRange, lRange),
+                CopyAsCContigFunctor<T, IndexerT, vec_sz, n_vecs,
+                                     disable_sg_load>(nelems, src_tp, dst_tp,
+                                                      src_indexer));
+        });
+    }
 
     return copy_ev;
 }

--- a/dpctl/tests/test_usm_ndarray_ctor.py
+++ b/dpctl/tests/test_usm_ndarray_ctor.py
@@ -2632,3 +2632,19 @@ def test_full_functions_raise_type_error():
     x = dpt.ones(1, dtype="i4")
     with pytest.raises(TypeError):
         dpt.full_like(x, "0")
+
+
+@pytest.mark.parametrize("dt", _all_dtypes)
+def test_setitem_copy_as_contig_alignment(dt):
+    q = get_queue_or_skip()
+    skip_if_dtype_not_supported(dt, q)
+
+    dtype_ = dpt.dtype(dt)
+    n0, n1 = 8, 23
+
+    x = dpt.zeros((n0, n1), dtype=dtype_, sycl_queue=q)
+
+    vals = dpt.ones(n1, dtype=dtype_, sycl_queue=q)[dpt.newaxis, :]
+    x[1:, ...] = vals
+    assert dpt.all(x[0] == 0)
+    assert dpt.all(x[1:, :] == vals)


### PR DESCRIPTION
This PR resolves https://github.com/IntelPython/dpctl/issues/1887

When using sub-group loads and stores, certain alignment of pointers is required. Copies to C-contiguous memory were not properly checking alignment, which would lead to incorrect results.

Before, using the example in #1887:
```
import dpctl.tensor as dpt

padded = dpt.zeros((8, 23), dtype=dpt.int64)
value = dpt.asarray([[0, 4, 5, 6, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]])
right_slice = (slice(1, None, None), Ellipsis)
padded[right_slice] = value
print(padded)
#usm_ndarray([[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
#             [4, 5, 6, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
#             [4, 5, 6, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
#             [4, 5, 6, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
#             [4, 5, 6, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
#             [4, 5, 6, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
#             [4, 5, 6, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
#             [0, 4, 5, 6, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]])
```

with this change:
```
import dpctl.tensor as dpt

padded = dpt.zeros((8, 23), dtype=dpt.int64)
value = dpt.asarray([[0, 4, 5, 6, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]])
right_slice = (slice(1, None, None), Ellipsis)
padded[right_slice] = value
print(padded)
# expected result
#usm_ndarray([[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
#             [0, 4, 5, 6, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
#             [0, 4, 5, 6, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
#             [0, 4, 5, 6, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
#             [0, 4, 5, 6, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
#             [0, 4, 5, 6, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
#             [0, 4, 5, 6, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
#             [0, 4, 5, 6, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]])
```

- [X] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [X] Have you tested your changes locally for CPU and GPU devices?
- [X] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [ ] Have you added your changes to the changelog?
- [X] If this PR is a work in progress, are you opening the PR as a draft?
