### PR TITLE
Fix undefined behavior in integer advanced indexing and indexing functions

### DIFF
--- a/dpctl/tensor/libtensor/include/kernels/integer_advanced_indexing.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/integer_advanced_indexing.hpp
@@ -30,6 +30,7 @@
 #include <type_traits>
 
 #include "dpctl_tensor_types.hpp"
+#include "utils/indexing_utils.hpp"
 #include "utils/offset_utils.hpp"
 #include "utils/type_utils.hpp"
 
@@ -42,54 +43,10 @@ namespace kernels
 namespace indexing
 {
 
-using namespace dpctl::tensor::offset_utils;
-
 template <typename ProjectorT,
-          typename OrthogStrider,
-          typename IndicesStrider,
-          typename AxesStrider,
-          typename T,
-          typename indT>
-class take_kernel;
-template <typename ProjectorT,
-          typename OrthogStrider,
-          typename IndicesStrider,
-          typename AxesStrider,
-          typename T,
-          typename indT>
-class put_kernel;
-
-class WrapIndex
-{
-public:
-    WrapIndex() = default;
-
-    void operator()(ssize_t max_item, ssize_t &ind) const
-    {
-        max_item = std::max<ssize_t>(max_item, 1);
-        ind = sycl::clamp<ssize_t>(ind, -max_item, max_item - 1);
-        ind = (ind < 0) ? ind + max_item : ind;
-        return;
-    }
-};
-
-class ClipIndex
-{
-public:
-    ClipIndex() = default;
-
-    void operator()(ssize_t max_item, ssize_t &ind) const
-    {
-        max_item = std::max<ssize_t>(max_item, 1);
-        ind = sycl::clamp<ssize_t>(ind, ssize_t(0), max_item - 1);
-        return;
-    }
-};
-
-template <typename ProjectorT,
-          typename OrthogStrider,
-          typename IndicesStrider,
-          typename AxesStrider,
+          typename OrthogIndexer,
+          typename IndicesIndexer,
+          typename AxesIndexer,
           typename T,
           typename indT>
 class TakeFunctor
@@ -101,9 +58,9 @@ private:
     int k_ = 0;
     size_t ind_nelems_ = 0;
     const ssize_t *axes_shape_and_strides_ = nullptr;
-    const OrthogStrider orthog_strider;
-    const IndicesStrider ind_strider;
-    const AxesStrider axes_strider;
+    const OrthogIndexer orthog_strider;
+    const IndicesIndexer ind_strider;
+    const AxesIndexer axes_strider;
 
 public:
     TakeFunctor(const char *src_cp,
@@ -112,9 +69,9 @@ public:
                 int k,
                 size_t ind_nelems,
                 const ssize_t *axes_shape_and_strides,
-                const OrthogStrider &orthog_strider_,
-                const IndicesStrider &ind_strider_,
-                const AxesStrider &axes_strider_)
+                const OrthogIndexer &orthog_strider_,
+                const IndicesIndexer &ind_strider_,
+                const AxesIndexer &axes_strider_)
         : src_(src_cp), dst_(dst_cp), ind_(ind_cp), k_(k),
           ind_nelems_(ind_nelems),
           axes_shape_and_strides_(axes_shape_and_strides),
@@ -141,11 +98,11 @@ public:
             indT *ind_data = reinterpret_cast<indT *>(ind_[axis_idx]);
 
             ssize_t ind_offset = ind_strider(i_along, axis_idx);
-            ssize_t i = static_cast<ssize_t>(ind_data[ind_offset]);
-
-            proj(axes_shape_and_strides_[axis_idx], i);
-
-            src_offset += i * axes_shape_and_strides_[k_ + axis_idx];
+            // proj produces an index in the range of the given axis
+            ssize_t projected_idx =
+                proj(axes_shape_and_strides_[axis_idx], ind_data[ind_offset]);
+            src_offset +=
+                projected_idx * axes_shape_and_strides_[k_ + axis_idx];
         }
 
         dst_offset += axes_strider(i_along);
@@ -153,6 +110,14 @@ public:
         dst[dst_offset] = src[src_offset];
     }
 };
+
+template <typename ProjectorT,
+          typename OrthogIndexer,
+          typename IndicesIndexer,
+          typename AxesIndexer,
+          typename T,
+          typename indT>
+class take_kernel;
 
 typedef sycl::event (*take_fn_ptr_t)(sycl::queue &,
                                      size_t,
@@ -194,21 +159,29 @@ sycl::event take_impl(sycl::queue &q,
     sycl::event take_ev = q.submit([&](sycl::handler &cgh) {
         cgh.depends_on(depends);
 
-        const TwoOffsets_StridedIndexer orthog_indexer{
-            nd, src_offset, dst_offset, orthog_shape_and_strides};
-        const NthStrideOffset indices_indexer{ind_nd, ind_offsets,
-                                              ind_shape_and_strides};
-        const StridedIndexer axes_indexer{ind_nd, 0,
-                                          axes_shape_and_strides + (2 * k)};
+        using OrthogIndexerT =
+            dpctl::tensor::offset_utils::TwoOffsets_StridedIndexer;
+        const OrthogIndexerT orthog_indexer{nd, src_offset, dst_offset,
+                                            orthog_shape_and_strides};
+
+        using NthStrideIndexerT = dpctl::tensor::offset_utils::NthStrideOffset;
+        const NthStrideIndexerT indices_indexer{ind_nd, ind_offsets,
+                                                ind_shape_and_strides};
+
+        using AxesIndexerT = dpctl::tensor::offset_utils::StridedIndexer;
+        const AxesIndexerT axes_indexer{ind_nd, 0,
+                                        axes_shape_and_strides + (2 * k)};
+
+        using KernelName =
+            take_kernel<ProjectorT, OrthogIndexerT, NthStrideIndexerT,
+                        AxesIndexerT, Ty, indT>;
 
         const size_t gws = orthog_nelems * ind_nelems;
 
-        cgh.parallel_for<
-            take_kernel<ProjectorT, TwoOffsets_StridedIndexer, NthStrideOffset,
-                        StridedIndexer, Ty, indT>>(
+        cgh.parallel_for<KernelName>(
             sycl::range<1>(gws),
-            TakeFunctor<ProjectorT, TwoOffsets_StridedIndexer, NthStrideOffset,
-                        StridedIndexer, Ty, indT>(
+            TakeFunctor<ProjectorT, OrthogIndexerT, NthStrideIndexerT,
+                        AxesIndexerT, Ty, indT>(
                 src_p, dst_p, ind_p, k, ind_nelems, axes_shape_and_strides,
                 orthog_indexer, indices_indexer, axes_indexer));
     });
@@ -217,9 +190,9 @@ sycl::event take_impl(sycl::queue &q,
 }
 
 template <typename ProjectorT,
-          typename OrthogStrider,
-          typename IndicesStrider,
-          typename AxesStrider,
+          typename OrthogIndexer,
+          typename IndicesIndexer,
+          typename AxesIndexer,
           typename T,
           typename indT>
 class PutFunctor
@@ -231,9 +204,9 @@ private:
     int k_ = 0;
     size_t ind_nelems_ = 0;
     const ssize_t *axes_shape_and_strides_ = nullptr;
-    const OrthogStrider orthog_strider;
-    const IndicesStrider ind_strider;
-    const AxesStrider axes_strider;
+    const OrthogIndexer orthog_strider;
+    const IndicesIndexer ind_strider;
+    const AxesIndexer axes_strider;
 
 public:
     PutFunctor(char *dst_cp,
@@ -242,9 +215,9 @@ public:
                int k,
                size_t ind_nelems,
                const ssize_t *axes_shape_and_strides,
-               const OrthogStrider &orthog_strider_,
-               const IndicesStrider &ind_strider_,
-               const AxesStrider &axes_strider_)
+               const OrthogIndexer &orthog_strider_,
+               const IndicesIndexer &ind_strider_,
+               const AxesIndexer &axes_strider_)
         : dst_(dst_cp), val_(val_cp), ind_(ind_cp), k_(k),
           ind_nelems_(ind_nelems),
           axes_shape_and_strides_(axes_shape_and_strides),
@@ -271,11 +244,12 @@ public:
             indT *ind_data = reinterpret_cast<indT *>(ind_[axis_idx]);
 
             ssize_t ind_offset = ind_strider(i_along, axis_idx);
-            ssize_t i = static_cast<ssize_t>(ind_data[ind_offset]);
 
-            proj(axes_shape_and_strides_[axis_idx], i);
-
-            dst_offset += i * axes_shape_and_strides_[k_ + axis_idx];
+            // proj produces an index in the range of the given axis
+            ssize_t projected_idx =
+                proj(axes_shape_and_strides_[axis_idx], ind_data[ind_offset]);
+            dst_offset +=
+                projected_idx * axes_shape_and_strides_[k_ + axis_idx];
         }
 
         val_offset += axes_strider(i_along);
@@ -283,6 +257,14 @@ public:
         dst[dst_offset] = val[val_offset];
     }
 };
+
+template <typename ProjectorT,
+          typename OrthogIndexer,
+          typename IndicesIndexer,
+          typename AxesIndexer,
+          typename T,
+          typename indT>
+class put_kernel;
 
 typedef sycl::event (*put_fn_ptr_t)(sycl::queue &,
                                     size_t,
@@ -324,20 +306,29 @@ sycl::event put_impl(sycl::queue &q,
     sycl::event put_ev = q.submit([&](sycl::handler &cgh) {
         cgh.depends_on(depends);
 
-        const TwoOffsets_StridedIndexer orthog_indexer{
-            nd, dst_offset, val_offset, orthog_shape_and_strides};
-        const NthStrideOffset indices_indexer{ind_nd, ind_offsets,
-                                              ind_shape_and_strides};
-        const StridedIndexer axes_indexer{ind_nd, 0,
-                                          axes_shape_and_strides + (2 * k)};
+        using OrthogIndexerT =
+            dpctl::tensor::offset_utils::TwoOffsets_StridedIndexer;
+        const OrthogIndexerT orthog_indexer{nd, dst_offset, val_offset,
+                                            orthog_shape_and_strides};
+
+        using NthStrideIndexerT = dpctl::tensor::offset_utils::NthStrideOffset;
+        const NthStrideIndexerT indices_indexer{ind_nd, ind_offsets,
+                                                ind_shape_and_strides};
+
+        using AxesIndexerT = dpctl::tensor::offset_utils::StridedIndexer;
+        const AxesIndexerT axes_indexer{ind_nd, 0,
+                                        axes_shape_and_strides + (2 * k)};
+
+        using KernelName =
+            put_kernel<ProjectorT, OrthogIndexerT, NthStrideIndexerT,
+                       AxesIndexerT, Ty, indT>;
 
         const size_t gws = orthog_nelems * ind_nelems;
 
-        cgh.parallel_for<put_kernel<ProjectorT, TwoOffsets_StridedIndexer,
-                                    NthStrideOffset, StridedIndexer, Ty, indT>>(
+        cgh.parallel_for<KernelName>(
             sycl::range<1>(gws),
-            PutFunctor<ProjectorT, TwoOffsets_StridedIndexer, NthStrideOffset,
-                       StridedIndexer, Ty, indT>(
+            PutFunctor<ProjectorT, OrthogIndexerT, NthStrideIndexerT,
+                       AxesIndexerT, Ty, indT>(
                 dst_p, val_p, ind_p, k, ind_nelems, axes_shape_and_strides,
                 orthog_indexer, indices_indexer, axes_indexer));
     });
@@ -352,7 +343,8 @@ template <typename fnT, typename T, typename indT> struct TakeWrapFactory
         if constexpr (std::is_integral<indT>::value &&
                       !std::is_same<indT, bool>::value)
         {
-            fnT fn = take_impl<WrapIndex, T, indT>;
+            using dpctl::tensor::indexing_utils::WrapIndex;
+            fnT fn = take_impl<WrapIndex<indT>, T, indT>;
             return fn;
         }
         else {
@@ -369,7 +361,8 @@ template <typename fnT, typename T, typename indT> struct TakeClipFactory
         if constexpr (std::is_integral<indT>::value &&
                       !std::is_same<indT, bool>::value)
         {
-            fnT fn = take_impl<ClipIndex, T, indT>;
+            using dpctl::tensor::indexing_utils::ClipIndex;
+            fnT fn = take_impl<ClipIndex<indT>, T, indT>;
             return fn;
         }
         else {
@@ -386,7 +379,8 @@ template <typename fnT, typename T, typename indT> struct PutWrapFactory
         if constexpr (std::is_integral<indT>::value &&
                       !std::is_same<indT, bool>::value)
         {
-            fnT fn = put_impl<WrapIndex, T, indT>;
+            using dpctl::tensor::indexing_utils::WrapIndex;
+            fnT fn = put_impl<WrapIndex<indT>, T, indT>;
             return fn;
         }
         else {
@@ -403,7 +397,8 @@ template <typename fnT, typename T, typename indT> struct PutClipFactory
         if constexpr (std::is_integral<indT>::value &&
                       !std::is_same<indT, bool>::value)
         {
-            fnT fn = put_impl<ClipIndex, T, indT>;
+            using dpctl::tensor::indexing_utils::ClipIndex;
+            fnT fn = put_impl<ClipIndex<indT>, T, indT>;
             return fn;
         }
         else {

--- a/dpctl/tensor/libtensor/include/utils/indexing_utils.hpp
+++ b/dpctl/tensor/libtensor/include/utils/indexing_utils.hpp
@@ -1,0 +1,140 @@
+//===----- indexing_utils.hpp - Utilities for indexing modes  -----*-C++-*/===//
+//
+//                      Data Parallel Control (dpctl)
+//
+// Copyright 2020-2024 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// This file defines utilities for handling out-of-bounds integer indices in
+/// kernels that involve indexing operations, such as take, put, or advanced
+/// tensor integer indexing.
+//===----------------------------------------------------------------------===//
+
+#pragma once
+#include <cstdint>
+#include <limits>
+#include <sycl/sycl.hpp>
+
+#include "kernels/dpctl_tensor_types.hpp"
+
+namespace dpctl
+{
+namespace tensor
+{
+namespace indexing_utils
+{
+
+/*
+ * ssize_t for indices is a design choice, dpctl::tensor::usm_ndarray
+ * uses py::ssize_t for shapes and strides internally and Python uses
+ * py_ssize_t for sizes of e.g. lists.
+ */
+
+template <typename IndT> struct WrapIndex
+{
+    ssize_t operator()(ssize_t max_item, IndT ind) const
+    {
+        ssize_t projected;
+        max_item = sycl::max<ssize_t>(max_item, 1);
+
+        if constexpr (std::is_signed_v<IndT>) {
+            static constexpr std::uintmax_t ind_max =
+                std::numeric_limits<IndT>::max();
+            static constexpr std::uintmax_t ssize_max =
+                std::numeric_limits<ssize_t>::max();
+            static constexpr std::intmax_t ind_min =
+                std::numeric_limits<IndT>::min();
+            static constexpr std::intmax_t ssize_min =
+                std::numeric_limits<ssize_t>::min();
+
+            if constexpr (ind_max <= ssize_max && ind_min >= ssize_min) {
+                projected = sycl::clamp<ssize_t>(static_cast<ssize_t>(ind),
+                                                 -max_item, max_item - 1);
+            }
+            else {
+                projected = sycl::clamp<IndT>(ind, static_cast<IndT>(-max_item),
+                                              static_cast<IndT>(max_item - 1));
+            }
+            return (projected < 0) ? projected + max_item : projected;
+        }
+        else {
+            static constexpr std::uintmax_t ind_max =
+                std::numeric_limits<IndT>::max();
+            static constexpr std::uintmax_t ssize_max =
+                std::numeric_limits<ssize_t>::max();
+
+            if constexpr (ind_max <= ssize_max) {
+                projected =
+                    sycl::min<ssize_t>(static_cast<ssize_t>(ind), max_item - 1);
+            }
+            else {
+                projected =
+                    sycl::min<IndT>(ind, static_cast<IndT>(max_item - 1));
+            }
+            return projected;
+        }
+    }
+};
+
+template <typename IndT> struct ClipIndex
+{
+    ssize_t operator()(ssize_t max_item, IndT ind) const
+    {
+        ssize_t projected;
+        max_item = sycl::max<ssize_t>(max_item, 1);
+
+        if constexpr (std::is_signed_v<IndT>) {
+            static constexpr std::uintmax_t ind_max =
+                std::numeric_limits<IndT>::max();
+            static constexpr std::uintmax_t ssize_max =
+                std::numeric_limits<ssize_t>::max();
+            static constexpr std::intmax_t ind_min =
+                std::numeric_limits<IndT>::min();
+            static constexpr std::intmax_t ssize_min =
+                std::numeric_limits<ssize_t>::min();
+
+            if constexpr (ind_max <= ssize_max && ind_min >= ssize_min) {
+                projected = sycl::clamp<ssize_t>(static_cast<ssize_t>(ind),
+                                                 ssize_t(0), max_item - 1);
+            }
+            else {
+                projected = sycl::clamp<IndT>(ind, IndT(0),
+                                              static_cast<IndT>(max_item - 1));
+            }
+        }
+        else {
+            static constexpr std::uintmax_t ind_max =
+                std::numeric_limits<IndT>::max();
+            static constexpr std::uintmax_t ssize_max =
+                std::numeric_limits<ssize_t>::max();
+
+            if constexpr (ind_max <= ssize_max) {
+                projected =
+                    sycl::min<ssize_t>(static_cast<ssize_t>(ind), max_item - 1);
+            }
+            else {
+                projected =
+                    sycl::min<IndT>(ind, static_cast<IndT>(max_item - 1));
+            }
+        }
+        return projected;
+    }
+};
+
+} // namespace indexing_utils
+} // namespace tensor
+} // namespace dpctl


### PR DESCRIPTION
This PR proposes a solution to undefined behavior that could occur in some edge cases with integer advanced indexing, where indices OOB for `ssize_t` (aka `std::ptrdiff_t`) would be cast directly to `ssize_t` and overflow or underflow.

As `ssize_t`/`std::ptrdiff_t` is defined to be a signed type with the same size as `size_t`, this means that on 32-bit systems, overflow/underflow could occur for even smaller values.

This PR also re-organizes `integer_advanced_indexing.hpp` by reducing namespace clutter, and moves the rewritten `ClipIndex` and `WrapIndex` structs into a separate header file. This enables them to be re-used more easily in extensions.

- [X] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [X] Have you tested your changes locally for CPU and GPU devices?
- [X] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [ ] Have you added your changes to the changelog?
- [X] If this PR is a work in progress, are you opening the PR as a draft?
