### PR TITLE
Address CI warnings to not use nodefaults channel

### DIFF
--- a/.github/workflows/conda-package.yml
+++ b/.github/workflows/conda-package.yml
@@ -91,7 +91,8 @@ jobs:
           miniforge-variant: Miniforge3
           miniforge-version: latest
           activate-environment: build
-          channels: conda-forge,nodefaults
+          channels: conda-forge
+          conda-remove-defaults: true
           python-version: ${{ matrix.python }}
 
       - name: Install conda build
@@ -263,7 +264,8 @@ jobs:
       - uses: conda-incubator/setup-miniconda@v3
         with:
           miniforge-version: latest
-          channels: conda-forge,nodefaults
+          channels: conda-forge
+          conda-remove-defaults: true
           activate-environment: ${{ env.TEST_ENV_NAME }}
           python-version: ${{ matrix.python }}
 
@@ -800,7 +802,8 @@ jobs:
         with:
           run-post: false
           channel-priority: "disabled"
-          channels: conda-forge,nodefaults
+          channels: conda-forge
+          conda-remove-defaults: true
           python-version: '3.11'
 
       - name: Install anaconda-client

--- a/.github/workflows/conda-package.yml
+++ b/.github/workflows/conda-package.yml
@@ -459,6 +459,9 @@ jobs:
 
       - uses: conda-incubator/setup-miniconda@v3
         with:
+          miniforge-version: latest
+          channels: conda-forge
+          conda-remove-defaults: true
           auto-activate-base: true
           activate-environment: ""
 


### PR DESCRIPTION
Remove use of nodefaults channel, use conda-remove-defaults: true instead

This change is prompted by CI warning:

```
'nodefaults' channel detected: will remove 'defaults' if added implicitly.
In the future, 'nodefaults' as a way of removing 'defaults' won't be
supported. Please set 'conda-remove-defaults' = 'true' to remove this warning.
```

![image](https://github.com/user-attachments/assets/dad57495-7b2f-40b3-ac13-11311ee384ab)


---

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [ ] Have you added your changes to the changelog?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
