### PR TITLE
Add missing include to `math_utils.hpp`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Build translation unit "simplify_iteration_space.cpp" compiled multiple times as a static library [gh-1847](https://github.com/IntelPython/dpctl/pull/1847)
 * Fix warning in documentation generation caused by `diff` docstring [gh-1855](https://github.com/IntelPython/dpctl/pull/1855)
 * Fix additional warnings when generating docs [gh-1861](https://github.com/IntelPython/dpctl/pull/1861)
+* Add missing include of SYCL header to "math_utils.hpp" [gh-1899](https://github.com/IntelPython/dpctl/pull/1899)
 
 ## [0.18.1] - Oct. 11, 2024
 

--- a/dpctl/tensor/libtensor/include/utils/math_utils.hpp
+++ b/dpctl/tensor/libtensor/include/utils/math_utils.hpp
@@ -25,6 +25,7 @@
 #pragma once
 #include <cmath>
 #include <complex>
+#include <sycl/sycl.hpp>
 
 namespace dpctl
 {


### PR DESCRIPTION
The PR proposes to add missing `sycl/sycl.hpp` include to `math_utils.hpp` header file, because `sycl::half` type and functions from `sycl` namespace are used there.
Otherwise the isolated include, like
```cpp
#pragma once

#include <complex>
#include <pybind11/numpy.h>
#include <pybind11/pybind11.h>

#include "utils/math_utils.hpp"

// ... some code
```
used by an extension code will produce compilation errors:
```bash
math_utils.hpp:121:24: error: no member named 'log' in namespace 'sycl'; did you mean simply 'log'?
math_utils.hpp:130:31: error: no member named 'log1p' in namespace 'sycl'; did you mean simply 'log1p'?
...
```

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [x] Have you added your changes to the changelog?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
