### PR TITLE
Add support of CV-qualifiers in `is_complex<T>` helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fix warning in documentation generation caused by `diff` docstring [gh-1855](https://github.com/IntelPython/dpctl/pull/1855)
 * Fix additional warnings when generating docs [gh-1861](https://github.com/IntelPython/dpctl/pull/1861)
 * Add missing include of SYCL header to "math_utils.hpp" [gh-1899](https://github.com/IntelPython/dpctl/pull/1899)
+* Add support of cv-qualifiers and sycl::half type in `is_complex<T>` helper [gh-1900](https://github.com/IntelPython/dpctl/pull/1900)
 
 ## [0.18.1] - Oct. 11, 2024
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fix warning in documentation generation caused by `diff` docstring [gh-1855](https://github.com/IntelPython/dpctl/pull/1855)
 * Fix additional warnings when generating docs [gh-1861](https://github.com/IntelPython/dpctl/pull/1861)
 * Add missing include of SYCL header to "math_utils.hpp" [gh-1899](https://github.com/IntelPython/dpctl/pull/1899)
-* Add support of cv-qualifiers and sycl::half type in `is_complex<T>` helper [gh-1900](https://github.com/IntelPython/dpctl/pull/1900)
+* Add support of CV-qualifiers in `is_complex<T>` helper [gh-1900](https://github.com/IntelPython/dpctl/pull/1900)
 
 ## [0.18.1] - Oct. 11, 2024
 

--- a/dpctl/tensor/libtensor/include/utils/type_utils.hpp
+++ b/dpctl/tensor/libtensor/include/utils/type_utils.hpp
@@ -26,6 +26,7 @@
 #include <complex>
 #include <stdexcept>
 #include <sycl/sycl.hpp>
+#include <type_traits>
 #include <utility>
 
 namespace dpctl

--- a/dpctl/tensor/libtensor/include/utils/type_utils.hpp
+++ b/dpctl/tensor/libtensor/include/utils/type_utils.hpp
@@ -43,10 +43,8 @@ struct is_complex : public std::false_type
 template <typename T>
 struct is_complex<
     T,
-    std::enable_if_t<
-        std::is_same_v<std::remove_cv_t<T>, std::complex<sycl::half>> ||
-        std::is_same_v<std::remove_cv_t<T>, std::complex<float>> ||
-        std::is_same_v<std::remove_cv_t<T>, std::complex<double>>>>
+    std::enable_if_t<std::is_same_v<std::remove_cv_t<T>, std::complex<float>> ||
+                     std::is_same_v<std::remove_cv_t<T>, std::complex<double>>>>
     : public std::true_type
 {
 };

--- a/dpctl/tensor/libtensor/include/utils/type_utils.hpp
+++ b/dpctl/tensor/libtensor/include/utils/type_utils.hpp
@@ -35,12 +35,21 @@ namespace tensor
 namespace type_utils
 {
 
-template <class T> struct is_complex : std::false_type
+template <typename T, typename = void>
+struct is_complex : public std::false_type
 {
 };
-template <class T> struct is_complex<std::complex<T>> : std::true_type
+
+template <typename T>
+struct is_complex<T, std::enable_if_t<std::is_same_v<std::remove_cv_t<T>, std::complex<sycl::half>> ||
+                                      std::is_same_v<std::remove_cv_t<T>, std::complex<float>> ||
+                                      std::is_same_v<std::remove_cv_t<T>, std::complex<double>>>>
+    : public std::true_type
 {
 };
+
+template <typename T>
+constexpr bool is_complex_v = is_complex<T>::value;
 
 template <typename dstTy, typename srcTy> dstTy convert_impl(const srcTy &v)
 {

--- a/dpctl/tensor/libtensor/include/utils/type_utils.hpp
+++ b/dpctl/tensor/libtensor/include/utils/type_utils.hpp
@@ -41,15 +41,17 @@ struct is_complex : public std::false_type
 };
 
 template <typename T>
-struct is_complex<T, std::enable_if_t<std::is_same_v<std::remove_cv_t<T>, std::complex<sycl::half>> ||
-                                      std::is_same_v<std::remove_cv_t<T>, std::complex<float>> ||
-                                      std::is_same_v<std::remove_cv_t<T>, std::complex<double>>>>
+struct is_complex<
+    T,
+    std::enable_if_t<
+        std::is_same_v<std::remove_cv_t<T>, std::complex<sycl::half>> ||
+        std::is_same_v<std::remove_cv_t<T>, std::complex<float>> ||
+        std::is_same_v<std::remove_cv_t<T>, std::complex<double>>>>
     : public std::true_type
 {
 };
 
-template <typename T>
-constexpr bool is_complex_v = is_complex<T>::value;
+template <typename T> constexpr bool is_complex_v = is_complex<T>::value;
 
 template <typename dstTy, typename srcTy> dstTy convert_impl(const srcTy &v)
 {


### PR DESCRIPTION
Current implementation of `is_complex<T>` is limited in dpctl tensor headers. It doesn't consider CV-qualifiers for a type.
While STL wrappers of DPC++ has more complete implementation.

The PR proposes to align with the STL wrappers and to add support of CV-qualifiers in `is_complex<T>` implementation. And also it suggests to add `is_complex_v<T>` helper.

The PR would help to simplify implementation of `histogramdd` extension in DPNP.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [x] Have you added your changes to the changelog?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
