### PR TITLE
Add dpcpp runtime to project dependencies section of wheel metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ requires = [
   "ninja>=1.11.1; platform_system!='Windows'",
   "cmake>=3.29.0",
   "cython>=3.0.10",
-  "numpy >=1.23",
+  "numpy>=1.23",
   # WARNING: check with doc how to upgrade
   "versioneer[toml]==0.29"
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,9 +40,12 @@ dependencies = [
   # This restrictions are for dependabot, actual restrictions are set with
   # conda.
   # TODO: populate it during build process
-  # TODO: do we have to set sycl runtime dependencies here
-  # "dpcpp-cpp-rt>=0.59.0",
-  # "intel-cmplr-lib-rt>=0.59.0"
+  # TODO: ensure that intel-sycl-rt and intel-cmplr-lib-rt have same version
+  # perhaps by pinning both.
+  # "intel-sycl-rt>=2025.0.0",
+  # "intel-cmplr-lib-rt>=2025.0.0"
+  "intel-cmplr-lib-rt",
+  "intel-sycl-rt",
   "numpy>=1.23.0"
 ]
 description = "A lightweight Python wrapper for a subset of SYCL."


### PR DESCRIPTION
Closes gh-1910.

This PR modifies `"pyproject.toml"` to add DPC++ runtime libraries to `project.dependencies`. 

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [ ] Have you added your changes to the changelog?
- [x] If this PR is a work in progress, are you opening the PR as a draft?
