### PR TITLE
Fix 1913 empty boolean mask

### DIFF
--- a/dpctl/tensor/_copy_utils.py
+++ b/dpctl/tensor/_copy_utils.py
@@ -924,6 +924,8 @@ def _place_impl(ary, ary_mask, vals, axis=0):
     else:
         rhs = dpt.astype(vals, ary.dtype)
     rhs = dpt.broadcast_to(rhs, expected_vals_shape)
+    if mask_nelems == 0:
+        return
     dep_ev = _manager.submitted_events
     hev, pl_ev = ti._place(
         dst=ary,

--- a/dpctl/tests/test_usm_ndarray_indexing.py
+++ b/dpctl/tests/test_usm_ndarray_indexing.py
@@ -405,6 +405,31 @@ def test_boolean_indexing_validation():
         x[ii[0, :]]
 
 
+def test_boolean_indexing_getitem_empty_mask():
+    get_queue_or_skip()
+    x = dpt.ones((2, 3, 4), dtype="i4")
+    ii = dpt.ones((0,), dtype="?")
+    assert x[ii].size == 0
+    ii1 = dpt.ones((0, 3), dtype="?")
+    assert x[ii1].size == 0
+    ii2 = dpt.ones((0, 3, 4), dtype="?")
+    assert x[ii2].size == 0
+
+
+def test_boolean_indexing_setitem_empty_mask():
+    get_queue_or_skip()
+    x = dpt.ones((2, 3, 4), dtype="i4")
+    ii = dpt.ones((0,), dtype="?")
+    x[ii] = 0
+    assert dpt.all(x == 1)
+    ii1 = dpt.ones((0, 3), dtype="?")
+    x[ii1] = 0
+    assert dpt.all(x == 1)
+    ii2 = dpt.ones((0, 3, 4), dtype="?")
+    x[ii2] = 0
+    assert dpt.all(x == 1)
+
+
 def test_integer_indexing_1d():
     get_queue_or_skip()
     x = dpt.arange(10, dtype="i4")


### PR DESCRIPTION
Closes gh-1913

Add special-casing for empty mask in the implementation of `tensor.place`, which is used by `usm_ndarray.__setitem__` as well.

Added tests.

- [x] Have you provided a meaningful PR description?
- [x] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [x] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [ ] Have you added your changes to the changelog?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
