### PR TITLE
Updated from_dlpack docstring

### DIFF
--- a/dpctl/tensor/_dlpack.pyx
+++ b/dpctl/tensor/_dlpack.pyx
@@ -976,10 +976,7 @@ def from_dlpack(x, /, *, device=None, copy=None):
             Device where the output array is to be placed. ``device`` keyword values can be:
 
             * ``None``
-                The data remains on the same device. If the data backing up
-                input object ``x`` resides on ``"kDLCPU"`` device, the return
-                type would be :class:`numpy.ndarray`, otherwise the return
-                type would be :class:`dpctl.tensor.usm_ndarray`.
+                The data remains on the same device.
             * oneAPI filter selector string
                 SYCL device selected by :ref:`filter selector string <filter_selector_string>`.
             * :class:`dpctl.SyclDevice`
@@ -995,20 +992,9 @@ def from_dlpack(x, /, *, device=None, copy=None):
                method: an integer enumerator representing the device type followed by
                an integer representing the index of the device.
                The only supported :class:`dpctl.tensor.DLDeviceType` device types
-               are ``"kDLCPU"`` and ``"kDLOneAPI"``. If ``"kDLCPU"`` requested, the
-               output type is :class:`numpy.ndarray`, otherwise it is
-               :class:`dpctl.tensor.usm_ndarray`.
+               are ``"kDLCPU"`` and ``"kDLOneAPI"``.
 
             Default: ``None``.
-
-            .. note::
-
-                If the return type if :class:`dpctl.tensor.usm_ndarray`, the associated
-                SYCL queue is derived from the ``device`` keyword. When ``device``
-                keyword value has type :class:`dpctl.SyclQueue`, the explicit queue
-                instance is used, when ``device`` keyword value has type :class:`dpctl.tensor.Device`,
-                the ``device.sycl_queue`` is used. In all other cases, the cached
-                SYCL queue corresponding the implied SYCL device is used.
 
         copy (bool, optional)
             Boolean indicating whether or not to copy the input.
@@ -1028,6 +1014,22 @@ def from_dlpack(x, /, *, device=None, copy=None):
             An array containing the data in ``x``. When ``copy`` is
             ``None`` or ``False``, this may be a view into the original
             memory.
+
+            The type of the returned object
+            depends on where the data backing up input object ``x`` resides.
+            If it resides in a USM allocation on a SYCL device, the
+            type :class:`dpctl.tensor.usm_ndarray` is returned, otherwise if it resides
+            on ``"kDLCPU"`` device the type is :class:`numpy.ndarray`, and otherwise
+            an exception is raised.
+
+            .. note::
+
+                If the return type is :class:`dpctl.tensor.usm_ndarray`, the associated
+                SYCL queue is derived from the ``device`` keyword. When ``device``
+                keyword value has type :class:`dpctl.SyclQueue`, the explicit queue
+                instance is used, when ``device`` keyword value has type :class:`dpctl.tensor.Device`,
+                the ``device.sycl_queue`` is used. In all other cases, the cached
+                SYCL queue corresponding to the implied SYCL device is used.
 
     Raises:
         TypeError:


### PR DESCRIPTION
Closes gh-1917.

The change to docstring documents that `tensor.from_dlpack` may return ``numpy.ndarray`` or ``tensor.usm_ndarray`` and stipulates when that may happen.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [ ] Have you added your changes to the changelog?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
