### PR TITLE
Correct docstring of Container helper class

### DIFF
--- a/dpctl/tests/test_usm_ndarray_dlpack.py
+++ b/dpctl/tests/test_usm_ndarray_dlpack.py
@@ -750,7 +750,7 @@ class LegacyContainer:
 
 
 class Container:
-    "Helper class implementing legacy `__dlpack__` protocol"
+    "Helper class implementing `__dlpack__` protocol version 1.0"
 
     def __init__(self, array):
         self._array = array


### PR DESCRIPTION
The docstring stated that this container implemented legacy DLPack protocol, while it implements DLPack 1.0

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [ ] Have you added your changes to the changelog?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
