### PR TITLE
Support dpctl in vritual environment out of the box

### DIFF
--- a/dpctl/__init__.py
+++ b/dpctl/__init__.py
@@ -26,6 +26,7 @@ __author__ = "Intel Corp."
 import os
 import os.path
 
+from . import _init_helper
 from ._device_selection import select_device_with_aspects
 from ._sycl_context import SyclContext, SyclContextCreationError
 from ._sycl_device import (
@@ -137,3 +138,4 @@ def get_include():
 
 __version__ = get_versions()["version"]
 del get_versions
+del _init_helper

--- a/dpctl/_init_helper.py
+++ b/dpctl/_init_helper.py
@@ -1,0 +1,27 @@
+#                      Data Parallel Control (dpctl)
+#
+# Copyright 2020-2024 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import os.path
+
+if hasattr(os, "add_dll_directory"):
+    # For virtual environments on Windows, add folder
+    # with DPC++ libraries to the DLL search path gh-1745
+    if "VIRTUAL_ENV" in os.environ:
+        venv_dir = os.environ["VIRTUAL_ENV"]
+        expected_dir = os.path.join(venv_dir, "Library", "bin")
+        if os.exists(expected_dir):
+            os.add_dll_directory(expected_dir)


### PR DESCRIPTION
Since location of "Library\bin" in the virtual environment is not on the default search path, importing of `dpctl` fails due to unmet dependencies for native extensions of `dpctl` submodules.

This change introduces `"_init_helper.py"` file which implements the following logic using built-in `os` Python module:

1. If `os.add_dll_directory` attribute exists, and `VIRTUAL_ENV` environment variable is set, and ``os.path.join(os.environ["VIRTUAL_ENV"], "Library", "bin")`` folder exists, call ``os.add_dll_directory`` with that directory.

With this change the gh-1745 is fixed, and ``python -m dpctl -f`` works out of the box.

Only GPU devices are visible, and to enable CPU device two additional steps must be performed:

  1. Edit ``%VIRUAL_ENV%\Library\bin\cl.cfg`` and set `CL_CONFIG_TBB_DLL_PATH` variable at the bottom of the configuration file to the **expanded value** of ``%VIRUAL_ENV%\Library\bin\tbb12.dll`` but use **forward** slashes, instead of native **backward** slashes.
  2. Append ``%VIRUAL_ENV%\Library\bin`` to the ``PATH`` using ``set "PATH=%PATH%:%VIRTUAL_ENV%\Library\bin"``

After these changes `python -m dpctl -f` should see CPU device.

@icfaust

---

- [x] Have you provided a meaningful PR description?
- [x] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [x] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [ ] Have you added your changes to the changelog?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
