### PR TITLE
Bugfix/gh 1926 astype

### DIFF
--- a/dpctl/tensor/_copy_utils.py
+++ b/dpctl/tensor/_copy_utils.py
@@ -672,6 +672,10 @@ def astype(
     f_contig = usm_ary.flags.f_contiguous
     needs_copy = copy or not ary_dtype == target_dtype
     if not needs_copy and (order != "K"):
+        # ensure that order="F" for C-contig input triggers copy,
+        # and order="C" for F-contig input triggers copy too.
+        # 1D arrays which are both C- and F- contig should not
+        # force copying for neither order="F", nor order="C", see gh-1926
         needs_copy = (
             c_contig and not f_contig and order not in ["A", "C"]
         ) or (not c_contig and f_contig and order not in ["A", "F"])

--- a/dpctl/tensor/_copy_utils.py
+++ b/dpctl/tensor/_copy_utils.py
@@ -672,9 +672,9 @@ def astype(
     f_contig = usm_ary.flags.f_contiguous
     needs_copy = copy or not ary_dtype == target_dtype
     if not needs_copy and (order != "K"):
-        needs_copy = (c_contig and order not in ["A", "C"]) or (
-            f_contig and order not in ["A", "F"]
-        )
+        needs_copy = (
+            c_contig and not f_contig and order not in ["A", "C"]
+        ) or (not c_contig and f_contig and order not in ["A", "F"])
     if not needs_copy:
         return usm_ary
     copy_order = "C"

--- a/dpctl/tests/test_usm_ndarray_ctor.py
+++ b/dpctl/tests/test_usm_ndarray_ctor.py
@@ -1435,6 +1435,17 @@ def test_astype_device():
     assert r.sycl_queue == q2
 
 
+def test_astype_gh_1926():
+    get_queue_or_skip()
+
+    x = dpt.ones(10_000)
+    x_ = dpt.astype(x, x.dtype, copy=False, order="C")
+    assert x is x_
+
+    x__ = dpt.astype(x, x.dtype, copy=False, order="F")
+    assert x is x__
+
+
 def test_copy():
     try:
         X = dpt.usm_ndarray((5, 5), "i4")[2:4, 1:4]

--- a/dpctl/tests/test_usm_ndarray_ctor.py
+++ b/dpctl/tests/test_usm_ndarray_ctor.py
@@ -1438,7 +1438,7 @@ def test_astype_device():
 def test_astype_gh_1926():
     get_queue_or_skip()
 
-    x = dpt.ones(10_000)
+    x = dpt.ones(64)
     x_ = dpt.astype(x, x.dtype, copy=False, order="C")
     assert x is x_
 


### PR DESCRIPTION
This PR closes gh-1926

Faulty checks modified `c_contig` -> `c_contig and not f_contig` and `f_contig` -> `f_contig and not c_contig`. 

When the input array is 1d, it is both C- and F-contig, and if prior checking indicated no copy is needed, no correct is necessary.

- [x] Have you provided a meaningful PR description?
- [x] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [x] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [ ] Have you added your changes to the changelog?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
