### PR TITLE
Fix deprecation warnings in example/ sources

### DIFF
--- a/examples/cython/sycl_buffer/src/use_sycl_buffer.hpp
+++ b/examples/cython/sycl_buffer/src/use_sycl_buffer.hpp
@@ -29,8 +29,11 @@
 
 #pragma once
 
-#include <CL/sycl.hpp>
 #include <algorithm>
+#include <cstddef>
+#include <sycl/sycl.hpp>
+
+using std::size_t;
 
 inline size_t upper_multiple(size_t n, size_t wg)
 {

--- a/examples/cython/sycl_buffer/syclbuffer/_buffer_example.pyx
+++ b/examples/cython/sycl_buffer/syclbuffer/_buffer_example.pyx
@@ -35,7 +35,7 @@ cdef extern from "use_sycl_buffer.hpp":
         size_t,         # number of columns of the input matrix
         const T *,      # data pointer of the input matrix
         T *             # pointer for the resulting vector
-    ) nogil except+
+    ) except+ nogil
 
 
 def columnwise_total(cython.floating[:, ::1] mat, queue=None):
@@ -83,7 +83,7 @@ def columnwise_total(cython.floating[:, ::1] mat, queue=None):
         q = c_dpctl.SyclQueue(queue)
     exec_queue_ptr = unwrap_queue(q.get_queue_ref())
 
-    with nogil:
+    with nogil, cython.boundscheck(False):
         native_columnwise_total(
             exec_queue_ptr[0], n_rows, n_cols, &mat[0,0], &res_memslice[0]
         )

--- a/examples/cython/use_dpctl_sycl/use_dpctl_sycl/utils.hpp
+++ b/examples/cython/use_dpctl_sycl/use_dpctl_sycl/utils.hpp
@@ -16,8 +16,8 @@
 
 #pragma once
 
-#include <CL/sycl.hpp>
 #include <string>
+#include <sycl/sycl.hpp>
 
 std::string get_device_name(sycl::device d)
 {

--- a/examples/cython/usm_memory/src/sycl_blackscholes.hpp
+++ b/examples/cython/usm_memory/src/sycl_blackscholes.hpp
@@ -28,9 +28,9 @@
 
 #pragma once
 
-#include <CL/sycl.hpp>
 #include <oneapi/mkl.hpp>
 #include <oneapi/mkl/rng/device.hpp>
+#include <sycl/sycl.hpp>
 
 template <typename T> class black_scholes_kernel;
 

--- a/examples/pybind11/onemkl_gemv/cpp/main.cpp
+++ b/examples/pybind11/onemkl_gemv/cpp/main.cpp
@@ -25,10 +25,10 @@
 //===----------------------------------------------------------------------===//
 
 #include "cg_solver.hpp"
-#include <CL/sycl.hpp>
 #include <chrono>
 #include <iostream>
 #include <oneapi/mkl.hpp>
+#include <sycl/sycl.hpp>
 
 using T = double;
 

--- a/examples/pybind11/onemkl_gemv/sycl_gemm/_onemkl.cpp
+++ b/examples/pybind11/onemkl_gemv/sycl_gemm/_onemkl.cpp
@@ -27,7 +27,7 @@
 //===----------------------------------------------------------------------===//
 
 // clang-format off
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <oneapi/mkl.hpp>
 #include "cg_solver.hpp"
 #include <pybind11/pybind11.h>

--- a/examples/pybind11/onemkl_gemv/sycl_gemm/cg_solver.hpp
+++ b/examples/pybind11/onemkl_gemv/sycl_gemm/cg_solver.hpp
@@ -27,8 +27,8 @@
 
 #pragma once
 
-#include <CL/sycl.hpp>
 #include <oneapi/mkl.hpp>
+#include <sycl/sycl.hpp>
 
 namespace cg_solver
 {

--- a/examples/pybind11/use_dpctl_sycl_kernel/use_kernel/_example.cpp
+++ b/examples/pybind11/use_dpctl_sycl_kernel/use_kernel/_example.cpp
@@ -27,10 +27,10 @@
 //===----------------------------------------------------------------------===//
 
 #include "dpctl4pybind11.hpp"
-#include <CL/sycl.hpp>
 #include <cstdint>
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
+#include <sycl/sycl.hpp>
 #include <vector>
 
 namespace py = pybind11;

--- a/examples/pybind11/use_dpctl_sycl_queue/use_queue_device/_example.cpp
+++ b/examples/pybind11/use_dpctl_sycl_queue/use_queue_device/_example.cpp
@@ -27,11 +27,11 @@
 //===----------------------------------------------------------------------===//
 
 #include "dpctl4pybind11.hpp"
-#include <CL/sycl.hpp>
 #include <cstdint>
 #include <pybind11/numpy.h>
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
+#include <sycl/sycl.hpp>
 
 namespace py = pybind11;
 


### PR DESCRIPTION
Replace ``#include <CL/sycl.hpp>`` with ``#include <sycl/sycl.hpp>`` per deprecation warning

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [ ] Have you added your changes to the changelog?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
