### PR TITLE
Support python 3.13

### DIFF
--- a/.github/workflows/conda-package.yml
+++ b/.github/workflows/conda-package.yml
@@ -24,7 +24,7 @@ jobs:
 
     strategy:
       matrix:
-        python: ['3.9', '3.10', '3.11', '3.12']
+        python: ['3.9', '3.10', '3.11', '3.12', '3.13']
     steps:
       - uses: actions/checkout@v4.2.2
         with:
@@ -80,7 +80,7 @@ jobs:
 
     strategy:
       matrix:
-        python: ['3.9', '3.10', '3.11', '3.12']
+        python: ['3.9', '3.10', '3.11', '3.12', '3.13']
     steps:
       - uses: actions/checkout@v4.2.2
         with:
@@ -145,7 +145,7 @@ jobs:
 
     strategy:
       matrix:
-        python: ['3.9', '3.10', '3.11', '3.12']
+        python: ['3.9', '3.10', '3.11', '3.12', '3.13']
         experimental: [false]
         runner: [ubuntu-22.04]
     continue-on-error: ${{ matrix.experimental }}
@@ -239,7 +239,7 @@ jobs:
         shell: cmd /C CALL {0}
     strategy:
       matrix:
-        python: ['3.9', '3.10', '3.11', '3.12']
+        python: ['3.9', '3.10', '3.11', '3.12', '3.13']
         experimental: [false]
         runner: [windows-2019]
     continue-on-error: ${{ matrix.experimental }}
@@ -408,7 +408,7 @@ jobs:
     timeout-minutes: 20
     strategy:
       matrix:
-        python: ['3.9', '3.10', '3.11', '3.12']
+        python: ['3.9', '3.10', '3.11', '3.12', '3.13']
     steps:
       - name: Download conda artifact
         uses: actions/download-artifact@v4
@@ -445,7 +445,7 @@ jobs:
     timeout-minutes: 20
     strategy:
       matrix:
-        python: ['3.9', '3.10', '3.11', '3.12']
+        python: ['3.9', '3.10', '3.11', '3.12', '3.13']
     steps:
       - name: Download artifact
         uses: actions/download-artifact@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Add missing include of SYCL header to "math_utils.hpp" [gh-1899](https://github.com/IntelPython/dpctl/pull/1899)
 * Add support of CV-qualifiers in `is_complex<T>` helper [gh-1900](https://github.com/IntelPython/dpctl/pull/1900)
 * Tuning work for elementwise functions with modest performance gains (under 10%) [gh-1889](https://github.com/IntelPython/dpctl/pull/1889)
+* Support for Python 3.13 for `dpctl` [gh-1941](https://github.com/IntelPython/dpctl/pull/1941)
 
 ## [0.18.3] - Dec. 07, 2024
 

--- a/dpctl/_host_task_util.hpp
+++ b/dpctl/_host_task_util.hpp
@@ -58,8 +58,14 @@ DPCTLSyclEventRef async_dec_ref(DPCTLSyclQueueRef QRef,
                 cgh.depends_on(*(unwrap<sycl::event>(depERefs[ev_id])));
             }
             cgh.host_task([obj_array_size, obj_vec]() {
+                const bool initialized = Py_IsInitialized();
+#if PY_VERSION_HEX < 0x30d0000
+                const bool finalizing = _Py_IsFinalizing();
+#else
+                const bool finalizing = Py_IsFinalizing();
+#endif
                 // if the main thread has not finilized the interpreter yet
-                if (Py_IsInitialized() && !_Py_IsFinalizing()) {
+                if (initialized && !finalizing) {
                     PyGILState_STATE gstate;
                     gstate = PyGILState_Ensure();
                     for (size_t i = 0; i < obj_array_size; ++i) {

--- a/dpctl/apis/include/dpctl4pybind11.hpp
+++ b/dpctl/apis/include/dpctl4pybind11.hpp
@@ -198,7 +198,13 @@ private:
     {
         void operator()(py::object *p) const
         {
-            bool guard = (Py_IsInitialized() && !_Py_IsFinalizing());
+            const bool initialized = Py_IsInitialized();
+#if PY_VERSION_HEX < 0x30d0000
+            const bool finilizing = _Py_IsFinalizing();
+#else
+            const bool finilizing = Py_IsFinalizing();
+#endif
+            const bool guard = initialized && !finilizing;
 
             if (guard) {
                 delete p;


### PR DESCRIPTION
Fix native extension code for Python 3.13 (account to removal of `_Py_IsFinilizing()` as it is replaced by `Py_IsFinilizing()`).

Build and test with Python 3.13 in conda package workflow.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [ ] Have you added your changes to the changelog?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
