### PR TITLE
Add iota kernel

### DIFF
--- a/dpctl/tensor/libtensor/include/kernels/sorting/radix_sort.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/sorting/radix_sort.hpp
@@ -75,6 +75,8 @@ std::uint32_t ceil_log2(SizeT n)
 
     std::uint32_t exp{1};
     --n;
+    // if n > 2^b, n = q * 2^b + r for q > 0 and 0 <= r < 2^b
+    // ceil_log2(q * 2^b + r) == ceil_log2(q * 2^b) == q + ceil_log2(n1)
     if (n >= (SizeT{1} << 32)) {
         n >>= 32;
         exp += 32;

--- a/dpctl/tensor/libtensor/include/kernels/sorting/sort_utils.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/sorting/sort_utils.hpp
@@ -1,0 +1,103 @@
+//=== sorting.hpp -  Implementation of sorting kernels       ---*-C++-*--/===//
+//
+//                      Data Parallel Control (dpctl)
+//
+// Copyright 2020-2024 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// This file defines kernels for tensor sort/argsort operations.
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <vector>
+
+#include <sycl/sycl.hpp>
+
+namespace dpctl
+{
+namespace tensor
+{
+namespace kernels
+{
+namespace sort_utils_detail
+{
+
+namespace syclexp = sycl::ext::oneapi::experimental;
+
+template <class KernelName, typename T>
+sycl::event iota_impl(sycl::queue &exec_q,
+                      T *data,
+                      std::size_t nelems,
+                      const std::vector<sycl::event> &dependent_events)
+{
+    constexpr std::uint32_t lws = 256;
+    constexpr std::uint32_t n_wi = 4;
+    const std::size_t n_groups = (nelems + n_wi * lws - 1) / (n_wi * lws);
+
+    sycl::range<1> gRange{n_groups * lws};
+    sycl::range<1> lRange{lws};
+    sycl::nd_range<1> ndRange{gRange, lRange};
+
+    sycl::event e = exec_q.submit([&](sycl::handler &cgh) {
+        cgh.depends_on(dependent_events);
+        cgh.parallel_for<KernelName>(ndRange, [=](sycl::nd_item<1> it) {
+            const std::size_t gid = it.get_global_id();
+            const auto &sg = it.get_sub_group();
+            const std::uint32_t lane_id = sg.get_local_id()[0];
+
+            const std::size_t offset = (gid - lane_id) * n_wi;
+            const std::uint32_t max_sgSize = sg.get_max_local_range()[0];
+
+            std::array<T, n_wi> stripe{};
+#pragma unroll
+            for (std::uint32_t i = 0; i < n_wi; ++i) {
+                stripe[i] = T(offset + lane_id + i * max_sgSize);
+            }
+
+            if (offset + n_wi * max_sgSize < nelems) {
+                constexpr auto group_ls_props = syclexp::properties{
+                    syclexp::data_placement_striped
+                    // , syclexp::full_group
+                };
+
+                auto out_multi_ptr = sycl::address_space_cast<
+                    sycl::access::address_space::global_space,
+                    sycl::access::decorated::yes>(&data[offset]);
+
+                syclexp::group_store(sg, sycl::span<T, n_wi>{&stripe[0], n_wi},
+                                     out_multi_ptr, group_ls_props);
+            }
+            else {
+                for (std::size_t idx = offset + lane_id; idx < nelems;
+                     idx += max_sgSize)
+                {
+                    data[idx] = T(idx);
+                }
+            }
+        });
+    });
+
+    return e;
+}
+
+} // end of namespace sort_utils_detail
+} // end of namespace kernels
+} // end of namespace tensor
+} // end of namespace dpctl

--- a/dpctl/tensor/libtensor/include/kernels/sorting/topk.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/sorting/topk.hpp
@@ -145,8 +145,9 @@ topk_full_merge_sort_impl(sycl::queue &exec_q,
             std::size_t src_idx = iter_gid * axis_nelems + axis_gid;
             std::size_t dst_idx = iter_gid * k + axis_gid;
 
-            auto res_ind = index_data[src_idx];
-            vals_tp[dst_idx] = arg_tp[res_ind];
+            const IndexTy res_ind = index_data[src_idx];
+            const argTy v = arg_tp[res_ind];
+            vals_tp[dst_idx] = v;
             inds_tp[dst_idx] = res_ind % axis_nelems;
         });
     });
@@ -418,8 +419,9 @@ sycl::event topk_merge_impl(
                 const std::size_t src_idx = iter_gid * alloc_len + axis_gid;
                 const std::size_t dst_idx = gid;
 
-                const auto res_ind = index_data[src_idx];
-                vals_tp[dst_idx] = arg_tp[res_ind];
+                const IndexTy res_ind = index_data[src_idx];
+                const argTy v = arg_tp[res_ind];
+                vals_tp[dst_idx] = v;
                 inds_tp[dst_idx] = (res_ind % axis_nelems);
             });
         });
@@ -528,7 +530,8 @@ sycl::event topk_radix_impl(sycl::queue &exec_q,
             const std::size_t dst_idx = gid;
 
             const IndexTy res_ind = tmp_tp[src_idx];
-            vals_tp[dst_idx] = arg_tp[res_ind];
+            const argTy v = arg_tp[res_ind];
+            vals_tp[dst_idx] = v;
             inds_tp[dst_idx] = (res_ind % axis_nelems);
         });
     });

--- a/dpctl/tensor/libtensor/include/kernels/sorting/topk.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/sorting/topk.hpp
@@ -410,17 +410,17 @@ sycl::event topk_merge_impl(
                 topk_partial_merge_map_back_krn<argTy, IndexTy, ValueComp>;
 
             cgh.parallel_for<KernelName>(iter_nelems * k, [=](sycl::id<1> id) {
-                std::size_t gid = id[0];
+                const std::size_t gid = id[0];
 
-                std::size_t iter_gid = gid / k;
-                std::size_t axis_gid = gid - (iter_gid * k);
+                const std::size_t iter_gid = gid / k;
+                const std::size_t axis_gid = gid - (iter_gid * k);
 
-                std::size_t src_idx = iter_gid * alloc_len + axis_gid;
-                std::size_t dst_idx = iter_gid * k + axis_gid;
+                const std::size_t src_idx = iter_gid * alloc_len + axis_gid;
+                const std::size_t dst_idx = gid;
 
-                auto res_ind = index_data[src_idx];
+                const auto res_ind = index_data[src_idx];
                 vals_tp[dst_idx] = arg_tp[res_ind];
-                inds_tp[dst_idx] = res_ind % axis_nelems;
+                inds_tp[dst_idx] = (res_ind % axis_nelems);
             });
         });
 
@@ -519,17 +519,17 @@ sycl::event topk_radix_impl(sycl::queue &exec_q,
         using KernelName = topk_radix_map_back_krn<argTy, IndexTy>;
 
         cgh.parallel_for<KernelName>(iter_nelems * k, [=](sycl::id<1> id) {
-            std::size_t gid = id[0];
+            const std::size_t gid = id[0];
 
-            std::size_t iter_gid = gid / k;
-            std::size_t axis_gid = gid - (iter_gid * k);
+            const std::size_t iter_gid = gid / k;
+            const std::size_t axis_gid = gid - (iter_gid * k);
 
-            std::size_t src_idx = iter_gid * axis_nelems + axis_gid;
-            std::size_t dst_idx = iter_gid * k + axis_gid;
+            const std::size_t src_idx = iter_gid * axis_nelems + axis_gid;
+            const std::size_t dst_idx = gid;
 
-            IndexTy res_ind = tmp_tp[src_idx];
+            const IndexTy res_ind = tmp_tp[src_idx];
             vals_tp[dst_idx] = arg_tp[res_ind];
-            inds_tp[dst_idx] = res_ind % axis_nelems;
+            inds_tp[dst_idx] = (res_ind % axis_nelems);
         });
     });
 

--- a/dpctl/tensor/libtensor/include/utils/sycl_alloc_utils.hpp
+++ b/dpctl/tensor/libtensor/include/utils/sycl_alloc_utils.hpp
@@ -133,7 +133,7 @@ smart_malloc_shared(std::size_t count,
 
 template <typename T>
 std::unique_ptr<T, USMDeleter>
-smart_malloc_jost(std::size_t count,
+smart_malloc_host(std::size_t count,
                   const sycl::queue &q,
                   const sycl::property_list &propList = {})
 {

--- a/dpctl/tests/test_usm_ndarray_top_k.py
+++ b/dpctl/tests/test_usm_ndarray_top_k.py
@@ -20,6 +20,38 @@ import dpctl.tensor as dpt
 from dpctl.tests.helper import get_queue_or_skip, skip_if_dtype_not_supported
 
 
+def _expected_largest_inds(inp, n, shift, k):
+    "Computed expected top_k indices for mode='largest'"
+    assert k < n
+    ones_start_id = shift % (2 * n)
+
+    alloc_dev = inp.device
+
+    if ones_start_id < n:
+        expected_inds = dpt.arange(
+            ones_start_id, ones_start_id + k, dtype="i8", device=alloc_dev
+        )
+    else:
+        # wrap-around
+        ones_end_id = (ones_start_id + n) % (2 * n)
+        if ones_end_id >= k:
+            expected_inds = dpt.arange(k, dtype="i8", device=alloc_dev)
+        else:
+            expected_inds = dpt.concat(
+                (
+                    dpt.arange(ones_end_id, dtype="i8", device=alloc_dev),
+                    dpt.arange(
+                        ones_start_id,
+                        ones_start_id + k - ones_end_id,
+                        dtype="i8",
+                        device=alloc_dev,
+                    ),
+                )
+            )
+
+    return expected_inds
+
+
 @pytest.mark.parametrize(
     "dtype",
     [
@@ -38,23 +70,57 @@ from dpctl.tests.helper import get_queue_or_skip, skip_if_dtype_not_supported
         "c16",
     ],
 )
-@pytest.mark.parametrize("n", [33, 255, 511, 1021, 8193])
-def test_topk_1d_largest(dtype, n):
+@pytest.mark.parametrize("n", [33, 43, 255, 511, 1021, 8193])
+def test_top_k_1d_largest(dtype, n):
     q = get_queue_or_skip()
     skip_if_dtype_not_supported(dtype, q)
 
+    shift, k = 734, 5
     o = dpt.ones(n, dtype=dtype)
     z = dpt.zeros(n, dtype=dtype)
-    zo = dpt.concat((o, z))
-    inp = dpt.roll(zo, 734)
-    k = 5
+    oz = dpt.concat((o, z))
+    inp = dpt.roll(oz, shift)
+
+    expected_inds = _expected_largest_inds(oz, n, shift, k)
 
     s = dpt.top_k(inp, k, mode="largest")
     assert s.values.shape == (k,)
     assert s.values.dtype == inp.dtype
     assert s.indices.shape == (k,)
-    assert dpt.all(s.values == dpt.ones(k, dtype=dtype))
-    assert dpt.all(s.values == inp[s.indices])
+    assert dpt.all(s.indices == expected_inds)
+    assert dpt.all(s.values == dpt.ones(k, dtype=dtype)), s.values
+    assert dpt.all(s.values == inp[s.indices]), s.indices
+
+
+def _expected_smallest_inds(inp, n, shift, k):
+    "Computed expected top_k indices for mode='smallest'"
+    assert k < n
+    zeros_start_id = (n + shift) % (2 * n)
+    zeros_end_id = (shift) % (2 * n)
+
+    alloc_dev = inp.device
+
+    if zeros_start_id < zeros_end_id:
+        expected_inds = dpt.arange(
+            zeros_start_id, zeros_start_id + k, dtype="i8", device=alloc_dev
+        )
+    else:
+        if zeros_end_id >= k:
+            expected_inds = dpt.arange(k, dtype="i8", device=alloc_dev)
+        else:
+            expected_inds = dpt.concat(
+                (
+                    dpt.arange(zeros_end_id, dtype="i8", device=alloc_dev),
+                    dpt.arange(
+                        zeros_start_id,
+                        zeros_start_id + k - zeros_end_id,
+                        dtype="i8",
+                        device=alloc_dev,
+                    ),
+                )
+            )
+
+    return expected_inds
 
 
 @pytest.mark.parametrize(
@@ -75,41 +141,80 @@ def test_topk_1d_largest(dtype, n):
         "c16",
     ],
 )
-@pytest.mark.parametrize("n", [33, 255, 257, 513, 1021, 8193])
-def test_topk_1d_smallest(dtype, n):
+@pytest.mark.parametrize("n", [37, 39, 61, 255, 257, 513, 1021, 8193])
+def test_top_k_1d_smallest(dtype, n):
     q = get_queue_or_skip()
     skip_if_dtype_not_supported(dtype, q)
 
+    shift, k = 734, 5
     o = dpt.ones(n, dtype=dtype)
     z = dpt.zeros(n, dtype=dtype)
-    zo = dpt.concat((o, z))
-    inp = dpt.roll(zo, 734)
-    k = 5
+    oz = dpt.concat((o, z))
+    inp = dpt.roll(oz, shift)
+
+    expected_inds = _expected_smallest_inds(oz, n, shift, k)
 
     s = dpt.top_k(inp, k, mode="smallest")
     assert s.values.shape == (k,)
     assert s.values.dtype == inp.dtype
     assert s.indices.shape == (k,)
-    assert dpt.all(s.values == dpt.zeros(k, dtype=dtype))
-    assert dpt.all(s.values == inp[s.indices])
+    assert dpt.all(s.indices == expected_inds)
+    assert dpt.all(s.values == dpt.zeros(k, dtype=dtype)), s.values
+    assert dpt.all(s.values == inp[s.indices]), s.indices
 
 
 # triage failing top k radix implementation on CPU
 # replicates from Python behavior of radix sort topk implementation
-@pytest.mark.parametrize("n", [33, 255, 511, 1021, 8193])
-def test_topk_largest_1d_radix_i1_255(n):
+@pytest.mark.parametrize(
+    "n",
+    [
+        33,
+        34,
+        35,
+        36,
+        37,
+        38,
+        39,
+        40,
+        41,
+        42,
+        43,
+        44,
+        45,
+        46,
+        47,
+        48,
+        49,
+        50,
+        61,
+        137,
+        255,
+        511,
+        1021,
+        8193,
+    ],
+)
+def test_top_k_largest_1d_radix_i1(n):
     get_queue_or_skip()
     dt = "i1"
 
+    shift, k = 734, 5
     o = dpt.ones(n, dtype=dt)
     z = dpt.zeros(n, dtype=dt)
-    zo = dpt.concat((o, z))
-    inp = dpt.roll(zo, 734)
-    k = 5
+    oz = dpt.concat((o, z))
+    inp = dpt.roll(oz, shift)
 
-    sorted = dpt.copy(dpt.sort(inp, descending=True, kind="radixsort")[:k])
-    argsorted = dpt.copy(
-        dpt.argsort(inp, descending=True, kind="radixsort")[:k]
-    )
-    assert dpt.all(sorted == dpt.ones(k, dtype=dt))
-    assert dpt.all(sorted == inp[argsorted])
+    expected_inds = _expected_largest_inds(oz, n, shift, k)
+
+    sorted_v = dpt.sort(inp, descending=True, kind="radixsort")
+    argsorted = dpt.argsort(inp, descending=True, kind="radixsort")
+
+    assert dpt.all(sorted_v == inp[argsorted])
+
+    topk_vals = dpt.copy(sorted_v[:k])
+    topk_inds = dpt.copy(argsorted[:k])
+
+    assert dpt.all(topk_vals == dpt.ones(k, dtype=dt))
+    assert dpt.all(topk_inds == expected_inds)
+
+    assert dpt.all(topk_vals == inp[topk_inds]), topk_inds

--- a/dpctl/tests/test_usm_ndarray_top_k.py
+++ b/dpctl/tests/test_usm_ndarray_top_k.py
@@ -96,9 +96,9 @@ def test_topk_1d_smallest(dtype, n):
 
 # triage failing top k radix implementation on CPU
 # replicates from Python behavior of radix sort topk implementation
-def test_topk_largest_1d_radix_i1_255():
+@pytest.mark.parametrize("n", [33, 255, 511, 1021, 8193])
+def test_topk_largest_1d_radix_i1_255(n):
     get_queue_or_skip()
-    n = 255
     dt = "i1"
 
     o = dpt.ones(n, dtype=dt)

--- a/dpctl/tests/test_usm_ndarray_top_k.py
+++ b/dpctl/tests/test_usm_ndarray_top_k.py
@@ -1,0 +1,94 @@
+#                      Data Parallel Control (dpctl)
+#
+# Copyright 2020-2024 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+import dpctl.tensor as dpt
+from dpctl.tests.helper import get_queue_or_skip, skip_if_dtype_not_supported
+
+
+@pytest.mark.parametrize(
+    "dtype",
+    [
+        "i1",
+        "u1",
+        "i2",
+        "u2",
+        "i4",
+        "u4",
+        "i8",
+        "u8",
+        "f2",
+        "f4",
+        "f8",
+        "c8",
+        "c16",
+    ],
+)
+@pytest.mark.parametrize("n", [33, 255, 511, 1021, 8193])
+def test_topk_1d_largest(dtype, n):
+    q = get_queue_or_skip()
+    skip_if_dtype_not_supported(dtype, q)
+
+    o = dpt.ones(n, dtype=dtype)
+    z = dpt.zeros(n, dtype=dtype)
+    zo = dpt.concat((o, z))
+    inp = dpt.roll(zo, 734)
+    k = 5
+
+    s = dpt.top_k(inp, k, mode="largest")
+    assert s.values.shape == (k,)
+    assert s.values.dtype == inp.dtype
+    assert s.indices.shape == (k,)
+    assert dpt.all(s.values == dpt.ones(k, dtype=dtype))
+    assert dpt.all(s.values == inp[s.indices])
+
+
+@pytest.mark.parametrize(
+    "dtype",
+    [
+        "i1",
+        "u1",
+        "i2",
+        "u2",
+        "i4",
+        "u4",
+        "i8",
+        "u8",
+        "f2",
+        "f4",
+        "f8",
+        "c8",
+        "c16",
+    ],
+)
+@pytest.mark.parametrize("n", [33, 255, 257, 513, 1021, 8193])
+def test_topk_1d_smallest(dtype, n):
+    q = get_queue_or_skip()
+    skip_if_dtype_not_supported(dtype, q)
+
+    o = dpt.ones(n, dtype=dtype)
+    z = dpt.zeros(n, dtype=dtype)
+    zo = dpt.concat((o, z))
+    inp = dpt.roll(zo, 734)
+    k = 5
+
+    s = dpt.top_k(inp, k, mode="smallest")
+    assert s.values.shape == (k,)
+    assert s.values.dtype == inp.dtype
+    assert s.indices.shape == (k,)
+    assert dpt.all(s.values == dpt.zeros(k, dtype=dtype))
+    assert dpt.all(s.values == inp[s.indices])

--- a/dpctl/tests/test_usm_ndarray_top_k.py
+++ b/dpctl/tests/test_usm_ndarray_top_k.py
@@ -92,3 +92,24 @@ def test_topk_1d_smallest(dtype, n):
     assert s.indices.shape == (k,)
     assert dpt.all(s.values == dpt.zeros(k, dtype=dtype))
     assert dpt.all(s.values == inp[s.indices])
+
+
+# triage failing top k radix implementation on CPU
+# replicates from Python behavior of radix sort topk implementation
+def test_topk_largest_1d_radix_i1_255():
+    get_queue_or_skip()
+    n = 255
+    dt = "i1"
+
+    o = dpt.ones(n, dtype=dt)
+    z = dpt.zeros(n, dtype=dt)
+    zo = dpt.concat((o, z))
+    inp = dpt.roll(zo, 734)
+    k = 5
+
+    sorted = dpt.copy(dpt.sort(inp, descending=True, kind="radixsort")[:k])
+    argsorted = dpt.copy(
+        dpt.argsort(inp, descending=True, kind="radixsort")[:k]
+    )
+    assert dpt.all(sorted == dpt.ones(k, dtype=dt))
+    assert dpt.all(sorted == inp[argsorted])


### PR DESCRIPTION
This PR builds on top of feature/topk branch. 

It adds `iota_impl` in new `sort_utils.hpp` file, and uses it in `merge_sort.hpp`, `radix_sort.hpp` and `topk.hpp`.

It also fixes possible USM allocation leak in exception handling.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [ ] Have you added your changes to the changelog?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
