### PR TITLE
Use Ubuntu 24.04 to run the OS-LLVM workflow to build dpctl with nightly SYCL bundle DPC++ compiler

### DIFF
--- a/.github/workflows/os-llvm-sycl-build.yml
+++ b/.github/workflows/os-llvm-sycl-build.yml
@@ -9,7 +9,7 @@ permissions: read-all
 jobs:
   install-compiler:
     name: Build with nightly build of DPC++ toolchain
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 90
 
     env:

--- a/.github/workflows/os-llvm-sycl-build.yml
+++ b/.github/workflows/os-llvm-sycl-build.yml
@@ -93,11 +93,6 @@ jobs:
               cp oclcpuexp/x64/libOpenCL.so* dpcpp_compiler/lib/
           fi
 
-      - name: Install system components
-        shell: bash -l {0}
-        run: |
-          sudo apt-get install libtinfo5
-
       - name: Setup Python
         uses: actions/setup-python@v5
         with:


### PR DESCRIPTION
Use Ubuntu 24.04 to run the OS-LLVM workflow to build dpctl with nightly SYCL bundle DPC++ compiler, attempting to fix execution failure of clang++ due to old system `glibc` library.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [ ] Have you added your changes to the changelog?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
