### PR TITLE
Improve interoperability between `SyclDevice` and DLPack devices

### DIFF
--- a/dpctl/_sycl_device.pyx
+++ b/dpctl/_sycl_device.pyx
@@ -2044,6 +2044,23 @@ cdef class SyclDevice(_SyclDevice):
                     return str(relId)
 
     def get_device_id(self):
+        """ get_device_id()
+        For a parent device, returns the canonical index of this device in the
+        list of devices visible to dpctl.
+        Returns:
+            int:
+                The index of the device.
+        Raises:
+            ValueError:
+                If the device is a sub-device.
+        :Example:
+            .. code-block:: python
+                import dpctl
+                gpu_dev = dpctl.SyclDevice("gpu")
+                i = gpu_dev.get_device_id
+                devs = dpctl.get_devices()
+                assert devs[i] == gpu_dev
+        """
         cdef int dev_id = -1
 
         if self.parent_device:

--- a/dpctl/_sycl_device.pyx
+++ b/dpctl/_sycl_device.pyx
@@ -1950,9 +1950,7 @@ cdef class SyclDevice(_SyclDevice):
 
     cdef int get_overall_ordinal(self):
         """ If this device is a root ``sycl::device``, returns the ordinal
-        position of this device in the vector ``sycl::device::get_devices()``
-        filtered to contain only devices with the same backend as this
-        device.
+        position of this device in the vector ``sycl::device::get_devices()``.
 
         Returns -1 if the device is a sub-device, or the device could not
         be found in the vector.
@@ -2044,6 +2042,18 @@ cdef class SyclDevice(_SyclDevice):
                     return ":".join((dt_str, str(relId)))
                 else:
                     return str(relId)
+
+    def get_device_id(self):
+        cdef int dev_id = -1
+
+        if self.parent_device:
+            raise TypeError("This SyclDevice is not a root device")
+
+        dev_id = self.get_overall_ordinal()
+        if dev_id < 0:
+            raise ValueError
+        return dev_id
+
 
 cdef api DPCTLSyclDeviceRef SyclDevice_GetDeviceRef(SyclDevice dev):
     """

--- a/dpctl/_sycl_device.pyx
+++ b/dpctl/_sycl_device.pyx
@@ -292,7 +292,7 @@ cdef class SyclDevice(_SyclDevice):
             temporary memory.
         SyclDeviceCreationError:
             If the :class:`dpctl.SyclDevice` object creation failed.
-        TypeError:
+        ValueError:
             If the list of :class:`dpctl.SyclDevice` objects was empty,
             or the input capsule contained a null pointer or could not
             be renamed.
@@ -363,7 +363,7 @@ cdef class SyclDevice(_SyclDevice):
                     "Could not create a SyclDevice from default selector"
                 )
         else:
-            raise ValueError(
+            raise TypeError(
                 "Invalid argument. Argument should be a str object specifying "
                 "a SYCL filter selector string."
             )
@@ -1557,7 +1557,7 @@ cdef class SyclDevice(_SyclDevice):
         cdef int i
 
         if ncounts == 0:
-            raise TypeError(
+            raise ValueError(
                 "Non-empty object representing list of counts is expected."
             )
         counts_buff = <size_t *> malloc((<size_t> ncounts) * sizeof(size_t))
@@ -1659,7 +1659,7 @@ cdef class SyclDevice(_SyclDevice):
                 Created sub-devices.
 
         Raises:
-            TypeError:
+            ValueError:
                 If the ``partition`` keyword argument is not specified or
                 the affinity domain string is not legal or is not one of the
                 three supported options.
@@ -1695,7 +1695,7 @@ cdef class SyclDevice(_SyclDevice):
                     _partition_affinity_domain_type._next_partitionable
                 )
             else:
-                raise TypeError(
+                raise ValueError(
                     "Partition affinity domain {} is not understood.".format(
                         partition
                     )
@@ -1708,11 +1708,11 @@ cdef class SyclDevice(_SyclDevice):
         else:
             try:
                 partition = int(partition)
-                return self.create_sub_devices_equally(partition)
             except Exception as e:
                 raise TypeError(
                     "Unsupported type of sub-device argument"
                 ) from e
+            return self.create_sub_devices_equally(partition)
 
     @property
     def parent_device(self):
@@ -1877,7 +1877,7 @@ cdef class SyclDevice(_SyclDevice):
                 A Python string representing a filter selector string.
 
         Raises:
-            TypeError:
+            ValueError:
                 If the device is a sub-device.
 
         :Example:
@@ -1902,7 +1902,7 @@ cdef class SyclDevice(_SyclDevice):
         else:
             # this a sub-device, free it, and raise an exception
             DPCTLDevice_Delete(pDRef)
-            raise TypeError("This SyclDevice is not a root device")
+            raise ValueError("This SyclDevice is not a root device")
 
     cdef int get_backend_and_device_type_ordinal(self):
         """ If this device is a root ``sycl::device``, returns the ordinal
@@ -1983,9 +1983,9 @@ cdef class SyclDevice(_SyclDevice):
                 A Python string representing a filter selector string.
 
         Raises:
-            TypeError:
-                If the device is a sub-device.
             ValueError:
+                If the device is a sub-device.
+
                 If no match for the device was found in the vector
                 returned by ``sycl::device::get_devices()``
 
@@ -2024,7 +2024,7 @@ cdef class SyclDevice(_SyclDevice):
             else:
                 # this a sub-device, free it, and raise an exception
                 DPCTLDevice_Delete(pDRef)
-                raise TypeError("This SyclDevice is not a root device")
+                raise ValueError("This SyclDevice is not a root device")
         else:
             if include_backend:
                 BTy = DPCTLDevice_GetBackend(self._device_ref)
@@ -2047,7 +2047,7 @@ cdef class SyclDevice(_SyclDevice):
         cdef int dev_id = -1
 
         if self.parent_device:
-            raise TypeError("This SyclDevice is not a root device")
+            raise ValueError("This SyclDevice is not a root device")
 
         dev_id = self.get_overall_ordinal()
         if dev_id < 0:

--- a/dpctl/_sycl_device.pyx
+++ b/dpctl/_sycl_device.pyx
@@ -2042,6 +2042,30 @@ cdef class SyclDevice(_SyclDevice):
                 else:
                     return str(relId)
 
+    def get_unpartitioned_parent_device(self):
+        """ get_unpartitioned_parent_device(self)
+
+        Returns the unpartitioned parent device of this device, or None for a
+        root device.
+
+        Returns:
+            dpctl.SyclDevice:
+                A parent, unpartitioned :class:`dpctl.SyclDevice` instance if
+                the device is a sub-device, ``None`` otherwise.
+        """
+        cdef DPCTLSyclDeviceRef pDRef = NULL
+        cdef DPCTLSyclDeviceRef tDRef = NULL
+        pDRef = DPCTLDevice_GetParentDevice(self._device_ref)
+        if pDRef is NULL:
+            return None
+        else:
+            tDRef = DPCTLDevice_GetParentDevice(pDRef)
+            while tDRef is not NULL:
+                DPCTLDevice_Delete(pDRef)
+                pDRef = tDRef
+                tDRef = DPCTLDevice_GetParentDevice(pDRef)
+            return SyclDevice._create(pDRef)
+
     def get_device_id(self):
         """ get_device_id()
         For an unpartitioned device, returns the canonical index of this device

--- a/dpctl/_sycl_device.pyx
+++ b/dpctl/_sycl_device.pyx
@@ -283,7 +283,8 @@ cdef class SyclDevice(_SyclDevice):
 
     Args:
         arg (str, optional):
-            The argument can be a selector string or ``None``.
+            The argument can be a selector string, another
+            :class:`dpctl.SyclDevice`, or ``None``.
             Defaults to ``None``.
 
     Raises:
@@ -292,10 +293,8 @@ cdef class SyclDevice(_SyclDevice):
             temporary memory.
         SyclDeviceCreationError:
             If the :class:`dpctl.SyclDevice` object creation failed.
-        ValueError:
-            If the list of :class:`dpctl.SyclDevice` objects was empty,
-            or the input capsule contained a null pointer or could not
-            be renamed.
+        TypeError:
+            If the argument is not a :class:`dpctl.SyclDevice` or string.
     """
     @staticmethod
     cdef SyclDevice _create(DPCTLSyclDeviceRef dref):
@@ -365,7 +364,7 @@ cdef class SyclDevice(_SyclDevice):
         else:
             raise TypeError(
                 "Invalid argument. Argument should be a str object specifying "
-                "a SYCL filter selector string."
+                "a SYCL filter selector string or another SyclDevice."
             )
 
     def print_device_info(self):

--- a/dpctl/_sycl_device.pyx
+++ b/dpctl/_sycl_device.pyx
@@ -2044,14 +2044,17 @@ cdef class SyclDevice(_SyclDevice):
 
     def get_device_id(self):
         """ get_device_id()
-        For a parent device, returns the canonical index of this device in the
-        list of devices visible to dpctl.
+        For an unpartitioned device, returns the canonical index of this device
+        in the list of devices visible to dpctl.
+
         Returns:
             int:
                 The index of the device.
+
         Raises:
             ValueError:
                 If the device is a sub-device.
+
         :Example:
             .. code-block:: python
                 import dpctl

--- a/dpctl/_sycl_device.pyx
+++ b/dpctl/_sycl_device.pyx
@@ -2057,6 +2057,7 @@ cdef class SyclDevice(_SyclDevice):
 
         :Example:
             .. code-block:: python
+
                 import dpctl
                 gpu_dev = dpctl.SyclDevice("gpu")
                 i = gpu_dev.get_device_id

--- a/dpctl/tensor/__init__.py
+++ b/dpctl/tensor/__init__.py
@@ -59,6 +59,10 @@ from dpctl.tensor._data_types import (
     uint64,
 )
 from dpctl.tensor._device import Device
+from dpctl.tensor._dldevice_conversions import (
+    dldevice_to_sycldevice,
+    sycldevice_to_dldevice,
+)
 from dpctl.tensor._dlpack import from_dlpack
 from dpctl.tensor._indexing_functions import (
     extract,
@@ -388,4 +392,6 @@ __all__ = [
     "take_along_axis",
     "put_along_axis",
     "top_k",
+    "dldevice_to_sycldevice",
+    "sycldevice_to_dldevice",
 ]

--- a/dpctl/tensor/__init__.py
+++ b/dpctl/tensor/__init__.py
@@ -60,8 +60,8 @@ from dpctl.tensor._data_types import (
 )
 from dpctl.tensor._device import Device
 from dpctl.tensor._dldevice_conversions import (
-    dldevice_to_sycldevice,
-    sycldevice_to_dldevice,
+    dldevice_to_sycl_device,
+    sycl_device_to_dldevice,
 )
 from dpctl.tensor._dlpack import from_dlpack
 from dpctl.tensor._indexing_functions import (
@@ -392,6 +392,6 @@ __all__ = [
     "take_along_axis",
     "put_along_axis",
     "top_k",
-    "dldevice_to_sycldevice",
-    "sycldevice_to_dldevice",
+    "dldevice_to_sycl_device",
+    "sycl_device_to_dldevice",
 ]

--- a/dpctl/tensor/_dldevice_conversions.py
+++ b/dpctl/tensor/_dldevice_conversions.py
@@ -1,0 +1,40 @@
+#                       Data Parallel Control (dpctl)
+#
+#  Copyright 2020-2025 Intel Corporation
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import dpctl
+
+from ._usmarray import DLDeviceType
+
+
+def dldevice_to_sycldevice(dl_dev: tuple):
+    if isinstance(dl_dev, tuple):
+        if len(dl_dev) != 2:
+            raise ValueError("dldevice tuple must have length 2")
+    else:
+        raise TypeError(
+            f"dl_dev is expected to be a 2-tuple, got " f"{type(dl_dev)}"
+        )
+    if dl_dev[0] != DLDeviceType.kDLOneAPI:
+        raise ValueError("dldevice type must be kDLOneAPI")
+    return dpctl.SyclDevice(str(dl_dev[1]))
+
+
+def sycldevice_to_dldevice(dev: dpctl.SyclDevice):
+    if not isinstance(dev, dpctl.SyclDevice):
+        raise TypeError(
+            "dev is expected to be a dpctl.SyclDevice, got " f"{type(dev)}"
+        )
+    return (DLDeviceType.kDLOneAPI, dev.get_device_id())

--- a/dpctl/tensor/_dldevice_conversions.py
+++ b/dpctl/tensor/_dldevice_conversions.py
@@ -18,7 +18,7 @@ from .._sycl_device import SyclDevice
 from ._usmarray import DLDeviceType
 
 
-def dldevice_to_sycldevice(dl_dev: tuple):
+def dldevice_to_sycl_device(dl_dev: tuple):
     if isinstance(dl_dev, tuple):
         if len(dl_dev) != 2:
             raise ValueError("dldevice tuple must have length 2")
@@ -31,7 +31,7 @@ def dldevice_to_sycldevice(dl_dev: tuple):
     return SyclDevice(str(dl_dev[1]))
 
 
-def sycldevice_to_dldevice(dev: SyclDevice):
+def sycl_device_to_dldevice(dev: SyclDevice):
     if not isinstance(dev, SyclDevice):
         raise TypeError(
             "dev is expected to be a SyclDevice, got " f"{type(dev)}"

--- a/dpctl/tensor/_dldevice_conversions.py
+++ b/dpctl/tensor/_dldevice_conversions.py
@@ -14,8 +14,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-import dpctl
-
+from .._sycl_device import SyclDevice
 from ._usmarray import DLDeviceType
 
 
@@ -29,12 +28,12 @@ def dldevice_to_sycldevice(dl_dev: tuple):
         )
     if dl_dev[0] != DLDeviceType.kDLOneAPI:
         raise ValueError("dldevice type must be kDLOneAPI")
-    return dpctl.SyclDevice(str(dl_dev[1]))
+    return SyclDevice(str(dl_dev[1]))
 
 
-def sycldevice_to_dldevice(dev: dpctl.SyclDevice):
-    if not isinstance(dev, dpctl.SyclDevice):
+def sycldevice_to_dldevice(dev: SyclDevice):
+    if not isinstance(dev, SyclDevice):
         raise TypeError(
-            "dev is expected to be a dpctl.SyclDevice, got " f"{type(dev)}"
+            "dev is expected to be a SyclDevice, got " f"{type(dev)}"
         )
     return (DLDeviceType.kDLOneAPI, dev.get_device_id())

--- a/dpctl/tensor/_dlpack.pxd
+++ b/dpctl/tensor/_dlpack.pxd
@@ -47,8 +47,6 @@ cpdef object to_dlpack_versioned_capsule(usm_ndarray array, bint copied) except 
 cpdef object numpy_to_dlpack_versioned_capsule(ndarray array, bint copied) except +
 cpdef object from_dlpack_capsule(object dltensor) except +
 
-cdef int get_parent_device_ordinal_id(SyclDevice dev) except *
-
 cdef class DLPackCreationError(Exception):
     """
     A DLPackCreateError exception is raised when constructing

--- a/dpctl/tensor/_usmarray.pyx
+++ b/dpctl/tensor/_usmarray.pyx
@@ -1304,16 +1304,16 @@ cdef class usm_ndarray:
             DLPackCreationError:
                 when the ``device_id`` could not be determined.
         """
-        cdef int dev_id = c_dlpack.get_parent_device_ordinal_id(<c_dpctl.SyclDevice>self.sycl_device)
-        if dev_id < 0:
+        try:
+            dev_id = self.sycl_device.get_device_id()
+        except ValueError as e:
             raise c_dlpack.DLPackCreationError(
                 "Could not determine id of the device where array was allocated."
             )
-        else:
-            return (
-                DLDeviceType.kDLOneAPI,
-                dev_id,
-            )
+        return (
+            DLDeviceType.kDLOneAPI,
+            dev_id,
+        )
 
     def __eq__(self, other):
         return dpctl.tensor.equal(self, other)

--- a/dpctl/tests/test_sycl_context.py
+++ b/dpctl/tests/test_sycl_context.py
@@ -263,7 +263,7 @@ def test_cpython_api_SyclContext_Make():
 
 def test_invalid_capsule():
     cap = create_invalid_capsule()
-    with pytest.raises(ValueError):
+    with pytest.raises(TypeError):
         dpctl.SyclContext(cap)
 
 

--- a/dpctl/tests/test_sycl_device.py
+++ b/dpctl/tests/test_sycl_device.py
@@ -280,7 +280,21 @@ def test_get_device_id_method():
         assert hash(d) == hash(d_r)
 
 
-def test_sub_devices_disallow_device_id():
+def test_get_unpartitioned_parent_device_method():
+    """
+    Test that the get_unpartitioned_parent method returns self for root
+    devices.
+    """
+    devices = dpctl.get_devices()
+    for d in devices:
+        assert d == d.get_unpartitioned_parent_device()
+
+
+def test_get_unpartitioned_parent_device_from_sub_device():
+    """
+    Test that the get_unpartitioned_parent method returns the parent device
+    from the sub-device.
+    """
     try:
         dev = dpctl.SyclDevice()
     except dpctl.SyclDeviceCreationError:
@@ -295,5 +309,4 @@ def test_sub_devices_disallow_device_id():
     except dpctl.SyclSubDeviceCreationError:
         pytest.skip("Default device can not be partitioned")
     assert isinstance(sdevs, list) and len(sdevs) > 0
-    with pytest.raises(ValueError):
-        sdevs[0].get_device_id()
+    assert dev == sdevs[0].get_unpartitioned_parent_device()

--- a/dpctl/tests/test_sycl_device.py
+++ b/dpctl/tests/test_sycl_device.py
@@ -61,12 +61,12 @@ def test_valid_filter_selectors(valid_filter, check):
 
 def test_invalid_filter_selectors(invalid_filter):
     """
-    An invalid filter string should always be caught and a ValueError raised.
+    An invalid filter string should always be caught and a TypeError raised.
     """
     exc = (
         SyclDeviceCreationError
         if isinstance(invalid_filter, str)
-        else ValueError
+        else TypeError
     )
     with pytest.raises(exc):
         dpctl.SyclDevice(invalid_filter)
@@ -295,5 +295,5 @@ def test_sub_devices_disallow_device_id():
     except dpctl.SyclSubDeviceCreationError:
         pytest.skip("Default device can not be partitioned")
     assert isinstance(sdevs, list) and len(sdevs) > 0
-    with pytest.raises(TypeError):
+    with pytest.raises(ValueError):
         sdevs[0].get_device_id()

--- a/dpctl/tests/test_usm_ndarray_dlpack.py
+++ b/dpctl/tests/test_usm_ndarray_dlpack.py
@@ -826,3 +826,38 @@ def test_generic_container():
     assert isinstance(Z, dpt.usm_ndarray)
     assert Z._pointer == X._pointer
     assert Z.device == X.device
+
+
+def test_sycldevice_to_dldevice(all_root_devices):
+    for sycl_dev in all_root_devices:
+        dev = dpt.sycldevice_to_dldevice(sycl_dev)
+        assert type(dev) is tuple
+        assert len(dev) == 2
+        assert dev[0] == device_oneAPI
+        assert dev[1] == all_root_devices.index(sycl_dev)
+
+
+def test_dldevice_to_sycldevice(all_root_devices):
+    for sycl_dev in all_root_devices:
+        dldev = dpt.empty(0, device=sycl_dev).__dlpack_device__()
+        dev = dpt.dldevice_to_sycldevice(dldev)
+        assert type(dev) is dpctl.SyclDevice
+        assert dev == all_root_devices[dldev[1]]
+
+
+def test_dldevice_conversion_arg_validation():
+    bad_dldevice_type = (dpt.DLDeviceType.kDLCPU, 0)
+    with pytest.raises(ValueError):
+        dpt.dldevice_to_sycldevice(bad_dldevice_type)
+
+    bad_dldevice_len = bad_dldevice_type + (0,)
+    with pytest.raises(ValueError):
+        dpt.dldevice_to_sycldevice(bad_dldevice_len)
+
+    bad_dldevice = dict()
+    with pytest.raises(TypeError):
+        dpt.dldevice_to_sycldevice(bad_dldevice)
+
+    bad_sycldevice = dict()
+    with pytest.raises(TypeError):
+        dpt.sycldevice_to_dldevice(bad_sycldevice)

--- a/dpctl/tests/test_usm_ndarray_dlpack.py
+++ b/dpctl/tests/test_usm_ndarray_dlpack.py
@@ -828,19 +828,19 @@ def test_generic_container():
     assert Z.device == X.device
 
 
-def test_sycldevice_to_dldevice(all_root_devices):
+def test_sycl_device_to_dldevice(all_root_devices):
     for sycl_dev in all_root_devices:
-        dev = dpt.sycldevice_to_dldevice(sycl_dev)
+        dev = dpt.sycl_device_to_dldevice(sycl_dev)
         assert type(dev) is tuple
         assert len(dev) == 2
         assert dev[0] == device_oneAPI
         assert dev[1] == all_root_devices.index(sycl_dev)
 
 
-def test_dldevice_to_sycldevice(all_root_devices):
+def test_dldevice_to_sycl_device(all_root_devices):
     for sycl_dev in all_root_devices:
         dldev = dpt.empty(0, device=sycl_dev).__dlpack_device__()
-        dev = dpt.dldevice_to_sycldevice(dldev)
+        dev = dpt.dldevice_to_sycl_device(dldev)
         assert type(dev) is dpctl.SyclDevice
         assert dev == all_root_devices[dldev[1]]
 
@@ -848,16 +848,16 @@ def test_dldevice_to_sycldevice(all_root_devices):
 def test_dldevice_conversion_arg_validation():
     bad_dldevice_type = (dpt.DLDeviceType.kDLCPU, 0)
     with pytest.raises(ValueError):
-        dpt.dldevice_to_sycldevice(bad_dldevice_type)
+        dpt.dldevice_to_sycl_device(bad_dldevice_type)
 
     bad_dldevice_len = bad_dldevice_type + (0,)
     with pytest.raises(ValueError):
-        dpt.dldevice_to_sycldevice(bad_dldevice_len)
+        dpt.dldevice_to_sycl_device(bad_dldevice_len)
 
     bad_dldevice = dict()
     with pytest.raises(TypeError):
-        dpt.dldevice_to_sycldevice(bad_dldevice)
+        dpt.dldevice_to_sycl_device(bad_dldevice)
 
     bad_sycldevice = dict()
     with pytest.raises(TypeError):
-        dpt.sycldevice_to_dldevice(bad_sycldevice)
+        dpt.sycl_device_to_dldevice(bad_sycldevice)


### PR DESCRIPTION
This PR proposes improving dpctl's interoperability with DLPack by

- Adding a new method `get_device_id` to `dpctl.SyclDevice` which returns the ordinal ID of a root device
- Adding new functions `dpctl.tensor.dldevice_to_sycldevice` and its converse `dpctl.tensor.sycldevice_to_dldevice` which function as conversions between `dpctl.SyclDevices` and the DLPack device tuples returned by `arr.__dlpack_device__()` for some array `arr` from an arbitrary array library

Closes #1929 

- [X] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [X] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [ ] Have you added your changes to the changelog?
- [X] If this PR is a work in progress, are you opening the PR as a draft?
