### PR TITLE
Additional qualified cpp types

### DIFF
--- a/dpctl/tensor/libtensor/include/kernels/clip.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/clip.hpp
@@ -113,7 +113,7 @@ public:
             const std::uint16_t sgSize =
                 ndit.get_sub_group().get_local_range()[0];
             const std::size_t gid = ndit.get_global_linear_id();
-            const uint16_t nelems_per_sg = sgSize * nelems_per_wi;
+            const std::uint16_t nelems_per_sg = sgSize * nelems_per_wi;
 
             const std::size_t start =
                 (gid / sgSize) * (nelems_per_sg - sgSize) + gid;

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/conj.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/conj.hpp
@@ -103,7 +103,7 @@ using ConjStridedFunctor = elementwise_common::
 template <typename T> struct ConjOutputType
 {
     using value_type = typename std::disjunction<
-        td_ns::TypeMapResultEntry<T, bool, int8_t>,
+        td_ns::TypeMapResultEntry<T, bool, std::int8_t>,
         td_ns::TypeMapResultEntry<T, std::uint8_t>,
         td_ns::TypeMapResultEntry<T, std::uint16_t>,
         td_ns::TypeMapResultEntry<T, std::uint32_t>,

--- a/dpctl/tensor/libtensor/include/utils/sycl_alloc_utils.hpp
+++ b/dpctl/tensor/libtensor/include/utils/sycl_alloc_utils.hpp
@@ -199,7 +199,7 @@ sycl::event async_smart_free(sycl::queue &exec_q,
         cgh.depends_on(depends);
 
         cgh.host_task([ptrs, dels]() {
-            for (size_t i = 0; i < ptrs.size(); ++i) {
+            for (std::size_t i = 0; i < ptrs.size(); ++i) {
                 dels[i](ptrs[i]);
             }
         });

--- a/dpctl/tensor/libtensor/include/utils/type_dispatch_building.hpp
+++ b/dpctl/tensor/libtensor/include/utils/type_dispatch_building.hpp
@@ -26,6 +26,7 @@
 #pragma once
 
 #include <complex>
+#include <cstdint>
 #include <type_traits>
 
 #include <sycl/sycl.hpp>
@@ -69,14 +70,14 @@ private:
     {
         std::vector<funcPtrT> per_dstTy = {
             factory<funcPtrT, dstTy, bool>{}.get(),
-            factory<funcPtrT, dstTy, int8_t>{}.get(),
-            factory<funcPtrT, dstTy, uint8_t>{}.get(),
-            factory<funcPtrT, dstTy, int16_t>{}.get(),
-            factory<funcPtrT, dstTy, uint16_t>{}.get(),
-            factory<funcPtrT, dstTy, int32_t>{}.get(),
-            factory<funcPtrT, dstTy, uint32_t>{}.get(),
-            factory<funcPtrT, dstTy, int64_t>{}.get(),
-            factory<funcPtrT, dstTy, uint64_t>{}.get(),
+            factory<funcPtrT, dstTy, std::int8_t>{}.get(),
+            factory<funcPtrT, dstTy, std::uint8_t>{}.get(),
+            factory<funcPtrT, dstTy, std::int16_t>{}.get(),
+            factory<funcPtrT, dstTy, std::uint16_t>{}.get(),
+            factory<funcPtrT, dstTy, std::int32_t>{}.get(),
+            factory<funcPtrT, dstTy, std::uint32_t>{}.get(),
+            factory<funcPtrT, dstTy, std::int64_t>{}.get(),
+            factory<funcPtrT, dstTy, std::uint64_t>{}.get(),
             factory<funcPtrT, dstTy, sycl::half>{}.get(),
             factory<funcPtrT, dstTy, float>{}.get(),
             factory<funcPtrT, dstTy, double>{}.get(),
@@ -93,14 +94,14 @@ public:
     void populate_dispatch_table(funcPtrT table[][_num_types]) const
     {
         const auto map_by_dst_type = {row_per_dst_type<bool>(),
-                                      row_per_dst_type<int8_t>(),
-                                      row_per_dst_type<uint8_t>(),
-                                      row_per_dst_type<int16_t>(),
-                                      row_per_dst_type<uint16_t>(),
-                                      row_per_dst_type<int32_t>(),
-                                      row_per_dst_type<uint32_t>(),
-                                      row_per_dst_type<int64_t>(),
-                                      row_per_dst_type<uint64_t>(),
+                                      row_per_dst_type<std::int8_t>(),
+                                      row_per_dst_type<std::uint8_t>(),
+                                      row_per_dst_type<std::int16_t>(),
+                                      row_per_dst_type<std::uint16_t>(),
+                                      row_per_dst_type<std::int32_t>(),
+                                      row_per_dst_type<std::uint32_t>(),
+                                      row_per_dst_type<std::int64_t>(),
+                                      row_per_dst_type<std::uint64_t>(),
                                       row_per_dst_type<sycl::half>(),
                                       row_per_dst_type<float>(),
                                       row_per_dst_type<double>(),
@@ -108,9 +109,9 @@ public:
                                       row_per_dst_type<std::complex<double>>()};
         assert(map_by_dst_type.size() == _num_types);
         int dst_id = 0;
-        for (auto &row : map_by_dst_type) {
+        for (const auto &row : map_by_dst_type) {
             int src_id = 0;
-            for (auto &fn_ptr : row) {
+            for (const auto &fn_ptr : row) {
                 table[dst_id][src_id] = fn_ptr;
                 ++src_id;
             }
@@ -139,14 +140,14 @@ public:
     void populate_dispatch_vector(funcPtrT vector[]) const
     {
         const auto fn_map_by_type = {func_per_type<bool>(),
-                                     func_per_type<int8_t>(),
-                                     func_per_type<uint8_t>(),
-                                     func_per_type<int16_t>(),
-                                     func_per_type<uint16_t>(),
-                                     func_per_type<int32_t>(),
-                                     func_per_type<uint32_t>(),
-                                     func_per_type<int64_t>(),
-                                     func_per_type<uint64_t>(),
+                                     func_per_type<std::int8_t>(),
+                                     func_per_type<std::uint8_t>(),
+                                     func_per_type<std::int16_t>(),
+                                     func_per_type<std::uint16_t>(),
+                                     func_per_type<std::int32_t>(),
+                                     func_per_type<std::uint32_t>(),
+                                     func_per_type<std::int64_t>(),
+                                     func_per_type<std::uint64_t>(),
                                      func_per_type<sycl::half>(),
                                      func_per_type<float>(),
                                      func_per_type<double>(),
@@ -154,7 +155,7 @@ public:
                                      func_per_type<std::complex<double>>()};
         assert(fn_map_by_type.size() == _num_types);
         int ty_id = 0;
-        for (auto &fn : fn_map_by_type) {
+        for (const auto &fn : fn_map_by_type) {
             vector[ty_id] = fn;
             ++ty_id;
         }

--- a/dpctl/tensor/libtensor/source/integer_advanced_indexing.cpp
+++ b/dpctl/tensor/libtensor/source/integer_advanced_indexing.cpp
@@ -245,7 +245,7 @@ usm_ndarray_take(const dpctl::tensor::usm_ndarray &src,
                  const py::object &py_ind,
                  const dpctl::tensor::usm_ndarray &dst,
                  int axis_start,
-                 uint8_t mode,
+                 std::uint8_t mode,
                  sycl::queue &exec_q,
                  const std::vector<sycl::event> &depends)
 {
@@ -560,7 +560,7 @@ usm_ndarray_put(const dpctl::tensor::usm_ndarray &dst,
                 const py::object &py_ind,
                 const dpctl::tensor::usm_ndarray &val,
                 int axis_start,
-                uint8_t mode,
+                std::uint8_t mode,
                 sycl::queue &exec_q,
                 const std::vector<sycl::event> &depends)
 {

--- a/dpctl/tensor/libtensor/source/integer_advanced_indexing.hpp
+++ b/dpctl/tensor/libtensor/source/integer_advanced_indexing.hpp
@@ -43,7 +43,7 @@ usm_ndarray_take(const dpctl::tensor::usm_ndarray &,
                  const py::object &,
                  const dpctl::tensor::usm_ndarray &,
                  int,
-                 uint8_t,
+                 std::uint8_t,
                  sycl::queue &,
                  const std::vector<sycl::event> & = {});
 
@@ -52,7 +52,7 @@ usm_ndarray_put(const dpctl::tensor::usm_ndarray &,
                 const py::object &,
                 const dpctl::tensor::usm_ndarray &,
                 int,
-                uint8_t,
+                std::uint8_t,
                 sycl::queue &,
                 const std::vector<sycl::event> & = {});
 

--- a/libsyclinterface/source/dpctl_sycl_queue_interface.cpp
+++ b/libsyclinterface/source/dpctl_sycl_queue_interface.cpp
@@ -31,9 +31,13 @@
 #include "dpctl_sycl_device_interface.h"
 #include "dpctl_sycl_device_manager.h"
 #include "dpctl_sycl_type_casters.hpp"
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include <cstdint>
 #include <exception>
 #include <sstream>
-#include <stddef.h>
 #include <stdexcept>
 #include <sycl/sycl.hpp> /* SYCL headers   */
 #include <utility>
@@ -45,49 +49,49 @@ using namespace sycl;
         switch ((ARGTY)) {                                                     \
         case DPCTL_INT8_T:                                                     \
         {                                                                      \
-            auto la = local_accessor<int8_t, NDIM>(R, CGH);                    \
+            auto la = local_accessor<std::int8_t, NDIM>(R, CGH);               \
             CGH.set_arg(IDX, la);                                              \
             return true;                                                       \
         }                                                                      \
         case DPCTL_UINT8_T:                                                    \
         {                                                                      \
-            auto la = local_accessor<uint8_t, NDIM>(R, CGH);                   \
+            auto la = local_accessor<std::uint8_t, NDIM>(R, CGH);              \
             CGH.set_arg(IDX, la);                                              \
             return true;                                                       \
         }                                                                      \
         case DPCTL_INT16_T:                                                    \
         {                                                                      \
-            auto la = local_accessor<int16_t, NDIM>(R, CGH);                   \
+            auto la = local_accessor<std::int16_t, NDIM>(R, CGH);              \
             CGH.set_arg(IDX, la);                                              \
             return true;                                                       \
         }                                                                      \
         case DPCTL_UINT16_T:                                                   \
         {                                                                      \
-            auto la = local_accessor<uint16_t, NDIM>(R, CGH);                  \
+            auto la = local_accessor<std::uint16_t, NDIM>(R, CGH);             \
             CGH.set_arg(IDX, la);                                              \
             return true;                                                       \
         }                                                                      \
         case DPCTL_INT32_T:                                                    \
         {                                                                      \
-            auto la = local_accessor<int32_t, NDIM>(R, CGH);                   \
+            auto la = local_accessor<std::int32_t, NDIM>(R, CGH);              \
             CGH.set_arg(IDX, la);                                              \
             return true;                                                       \
         }                                                                      \
         case DPCTL_UINT32_T:                                                   \
         {                                                                      \
-            auto la = local_accessor<uint32_t, NDIM>(R, CGH);                  \
+            auto la = local_accessor<std::uint32_t, NDIM>(R, CGH);             \
             CGH.set_arg(IDX, la);                                              \
             return true;                                                       \
         }                                                                      \
         case DPCTL_INT64_T:                                                    \
         {                                                                      \
-            auto la = local_accessor<int64_t, NDIM>(R, CGH);                   \
+            auto la = local_accessor<std::int64_t, NDIM>(R, CGH);              \
             CGH.set_arg(IDX, la);                                              \
             return true;                                                       \
         }                                                                      \
         case DPCTL_UINT64_T:                                                   \
         {                                                                      \
-            auto la = local_accessor<uint64_t, NDIM>(R, CGH);                  \
+            auto la = local_accessor<std::uint64_t, NDIM>(R, CGH);             \
             CGH.set_arg(IDX, la);                                              \
             return true;                                                       \
         }                                                                      \
@@ -119,8 +123,8 @@ using namespace dpctl::syclinterface;
 
 typedef struct complex
 {
-    uint64_t real;
-    uint64_t imag;
+    std::uint64_t real;
+    std::uint64_t imag;
 } complexNumber;
 
 void set_dependent_events(handler &cgh,
@@ -177,28 +181,28 @@ bool set_kernel_arg(handler &cgh,
 
     switch (ArgTy) {
     case DPCTL_INT8_T:
-        cgh.set_arg(idx, *(int8_t *)Arg);
+        cgh.set_arg(idx, *(std::int8_t *)Arg);
         break;
     case DPCTL_UINT8_T:
-        cgh.set_arg(idx, *(uint8_t *)Arg);
+        cgh.set_arg(idx, *(std::uint8_t *)Arg);
         break;
     case DPCTL_INT16_T:
-        cgh.set_arg(idx, *(int16_t *)Arg);
+        cgh.set_arg(idx, *(std::int16_t *)Arg);
         break;
     case DPCTL_UINT16_T:
-        cgh.set_arg(idx, *(uint16_t *)Arg);
+        cgh.set_arg(idx, *(std::uint16_t *)Arg);
         break;
     case DPCTL_INT32_T:
-        cgh.set_arg(idx, *(int32_t *)Arg);
+        cgh.set_arg(idx, *(std::int32_t *)Arg);
         break;
     case DPCTL_UINT32_T:
-        cgh.set_arg(idx, *(uint32_t *)Arg);
+        cgh.set_arg(idx, *(std::uint32_t *)Arg);
         break;
     case DPCTL_INT64_T:
-        cgh.set_arg(idx, *(int64_t *)Arg);
+        cgh.set_arg(idx, *(std::int64_t *)Arg);
         break;
     case DPCTL_UINT64_T:
-        cgh.set_arg(idx, *(uint64_t *)Arg);
+        cgh.set_arg(idx, *(std::uint64_t *)Arg);
         break;
     case DPCTL_FLOAT32_T:
         cgh.set_arg(idx, *(float *)Arg);

--- a/libsyclinterface/tests/test_sycl_context_interface.cpp
+++ b/libsyclinterface/tests/test_sycl_context_interface.cpp
@@ -29,8 +29,10 @@
 #include "dpctl_sycl_device_interface.h"
 #include "dpctl_sycl_device_selector_interface.h"
 #include "dpctl_sycl_types.h"
-#include <gtest/gtest.h>
+
 #include <stddef.h>
+
+#include <gtest/gtest.h>
 #include <sycl/sycl.hpp>
 #include <vector>
 

--- a/libsyclinterface/tests/test_sycl_device_aspects.cpp
+++ b/libsyclinterface/tests/test_sycl_device_aspects.cpp
@@ -30,8 +30,10 @@
 #include "dpctl_sycl_enum_types.h"
 #include "dpctl_sycl_type_casters.hpp"
 #include "dpctl_utils_helper.h"
-#include <gtest/gtest.h>
+
 #include <stddef.h>
+
+#include <gtest/gtest.h>
 #include <sycl/sycl.hpp>
 #include <utility>
 

--- a/libsyclinterface/tests/test_sycl_device_interface.cpp
+++ b/libsyclinterface/tests/test_sycl_device_interface.cpp
@@ -29,8 +29,10 @@
 #include "dpctl_sycl_platform_interface.h"
 #include "dpctl_utils.h"
 #include "dpctl_utils_helper.h"
-#include <gtest/gtest.h>
+
 #include <stddef.h>
+
+#include <gtest/gtest.h>
 #include <sycl/sycl.hpp>
 
 using namespace sycl;

--- a/libsyclinterface/tests/test_sycl_device_manager.cpp
+++ b/libsyclinterface/tests/test_sycl_device_manager.cpp
@@ -30,8 +30,10 @@
 #include "dpctl_sycl_device_selector_interface.h"
 #include "dpctl_utils.h"
 #include "dpctl_utils_helper.h"
-#include <gtest/gtest.h>
+
 #include <stddef.h>
+
+#include <gtest/gtest.h>
 #include <string>
 
 using dpctl::syclinterface::dpctl_default_selector;

--- a/libsyclinterface/tests/test_sycl_device_subdevices.cpp
+++ b/libsyclinterface/tests/test_sycl_device_subdevices.cpp
@@ -1,4 +1,3 @@
-
 //===--- test_sycl_device_interface.cpp - Test cases for device interface  ===//
 //
 //                      Data Parallel Control (dpCtl)
@@ -32,8 +31,10 @@
 #include "dpctl_sycl_type_casters.hpp"
 #include "dpctl_utils.h"
 #include "dpctl_utils_helper.h"
-#include <gtest/gtest.h>
+
 #include <stddef.h>
+
+#include <gtest/gtest.h>
 #include <sycl/sycl.hpp>
 
 using namespace sycl;

--- a/libsyclinterface/tests/test_sycl_kernel_bundle_interface.cpp
+++ b/libsyclinterface/tests/test_sycl_kernel_bundle_interface.cpp
@@ -33,11 +33,13 @@
 #include "dpctl_sycl_kernel_bundle_interface.h"
 #include "dpctl_sycl_kernel_interface.h"
 #include "dpctl_sycl_queue_interface.h"
+
+#include <stddef.h>
+
 #include <array>
 #include <filesystem>
 #include <fstream>
 #include <gtest/gtest.h>
-#include <stddef.h>
 #include <sycl/sycl.hpp>
 
 using namespace sycl;

--- a/libsyclinterface/tests/test_sycl_kernel_interface.cpp
+++ b/libsyclinterface/tests/test_sycl_kernel_interface.cpp
@@ -32,9 +32,11 @@
 #include "dpctl_sycl_kernel_interface.h"
 #include "dpctl_sycl_queue_interface.h"
 #include "dpctl_utils.h"
+
+#include <stddef.h>
+
 #include <array>
 #include <gtest/gtest.h>
-#include <stddef.h>
 #include <sycl/sycl.hpp>
 
 using namespace sycl;

--- a/libsyclinterface/tests/test_sycl_queue_interface.cpp
+++ b/libsyclinterface/tests/test_sycl_queue_interface.cpp
@@ -33,8 +33,10 @@
 #include "dpctl_sycl_queue_interface.h"
 #include "dpctl_sycl_type_casters.hpp"
 #include "dpctl_sycl_usm_interface.h"
-#include <gtest/gtest.h>
+
 #include <stddef.h>
+
+#include <gtest/gtest.h>
 #include <sycl/sycl.hpp>
 
 using namespace sycl;

--- a/libsyclinterface/tests/test_sycl_queue_submit.cpp
+++ b/libsyclinterface/tests/test_sycl_queue_submit.cpp
@@ -32,17 +32,20 @@
 #include "dpctl_sycl_queue_interface.h"
 #include "dpctl_sycl_type_casters.hpp"
 #include "dpctl_sycl_usm_interface.h"
+
+#include <stddef.h>
+
+#include <cstdint>
 #include <filesystem>
 #include <fstream>
 #include <gtest/gtest.h>
 #include <iostream>
-#include <stddef.h>
 #include <sycl/sycl.hpp>
 #include <utility>
 
 namespace
 {
-constexpr size_t SIZE = 1024;
+constexpr std::size_t SIZE = 1024;
 static_assert(SIZE % 8 == 0);
 
 using namespace dpctl::syclinterface;
@@ -51,15 +54,15 @@ template <typename T>
 void submit_kernel(DPCTLSyclQueueRef QRef,
                    DPCTLSyclKernelBundleRef KBRef,
                    std::vector<char> spirvBuffer,
-                   size_t spirvFileSize,
+                   std::size_t spirvFileSize,
                    DPCTLKernelArgType kernelArgTy,
                    std::string kernelName)
 {
     T scalarVal = 3;
-    constexpr size_t NARGS = 4;
-    constexpr size_t RANGE_NDIMS_1 = 1;
-    constexpr size_t RANGE_NDIMS_2 = 2;
-    constexpr size_t RANGE_NDIMS_3 = 3;
+    constexpr std::size_t NARGS = 4;
+    constexpr std::size_t RANGE_NDIMS_1 = 1;
+    constexpr std::size_t RANGE_NDIMS_2 = 2;
+    constexpr std::size_t RANGE_NDIMS_3 = 3;
 
     ASSERT_TRUE(DPCTLKernelBundle_HasKernel(KBRef, kernelName.c_str()));
     auto kernel = DPCTLKernelBundle_GetKernel(KBRef, kernelName.c_str());
@@ -73,7 +76,7 @@ void submit_kernel(DPCTLSyclQueueRef QRef,
     ASSERT_TRUE(c != nullptr);
 
     // Create kernel args for vector_add
-    size_t Range[] = {SIZE};
+    std::size_t Range[] = {SIZE};
     void *args[NARGS] = {unwrap<void>(a), unwrap<void>(b), unwrap<void>(c),
                          (void *)&scalarVal};
     DPCTLKernelArgType addKernelArgTypes[] = {DPCTL_VOID_PTR, DPCTL_VOID_PTR,
@@ -84,7 +87,7 @@ void submit_kernel(DPCTLSyclQueueRef QRef,
     ASSERT_TRUE(E1Ref != nullptr);
 
     // Create kernel args for vector_add
-    size_t Range2D[] = {SIZE, 1};
+    std::size_t Range2D[] = {SIZE, 1};
     DPCTLSyclEventRef DepEvs[] = {E1Ref};
     auto E2Ref =
         DPCTLQueue_SubmitRange(kernel, QRef, args, addKernelArgTypes, NARGS,
@@ -92,7 +95,7 @@ void submit_kernel(DPCTLSyclQueueRef QRef,
     ASSERT_TRUE(E2Ref != nullptr);
 
     // Create kernel args for vector_add
-    size_t Range3D[] = {SIZE, 1, 1};
+    std::size_t Range3D[] = {SIZE, 1, 1};
     DPCTLSyclEventRef DepEvs2[] = {E1Ref, E2Ref};
     auto E3Ref =
         DPCTLQueue_SubmitRange(kernel, QRef, args, addKernelArgTypes, NARGS,
@@ -174,7 +177,7 @@ void submit_kernel(
 }
 
 template <typename T>
-void driver(size_t N)
+void driver(std::size_t N)
 {
     sycl::queue q;
     auto *a = sycl::malloc_shared<T>(N, q);
@@ -191,19 +194,19 @@ void driver(size_t N)
 
 int main(int argc, const char **argv)
 {
-    size_t N = 0;
+    std::size_t N = 0;
     std::cout << "Enter problem size in N:\n";
     std::cin >> N;
     std::cout << "Executing with N = " << N << std::endl;
 
-    driver<int8_t>(N);
-    driver<uint8_t>(N);
-    driver<int16_t>(N);
-    driver<uint16_t>(N);
-    driver<int32_t>(N);
-    driver<uint32_t>(N);
-    driver<int64_t>(N);
-    driver<uint64_t>(N);
+    driver<std::int8_t>(N);
+    driver<std::uint8_t>(N);
+    driver<std::int16_t>(N);
+    driver<std::uint16_t>(N);
+    driver<std::int32_t>(N);
+    driver<std::uint32_t>(N);
+    driver<std::int64_t>(N);
+    driver<std::uint64_t>(N);
     driver<float>(N);
     driver<double>(N);
 
@@ -214,7 +217,7 @@ int main(int argc, const char **argv)
 struct TestQueueSubmit : public ::testing::Test
 {
     std::ifstream spirvFile;
-    size_t spirvFileSize_;
+    std::size_t spirvFileSize_;
     std::vector<char> spirvBuffer_;
     DPCTLSyclQueueRef QRef = nullptr;
     DPCTLSyclKernelBundleRef KBRef = nullptr;
@@ -255,7 +258,7 @@ struct TestQueueSubmit : public ::testing::Test
 struct TestQueueSubmitFP64 : public ::testing::Test
 {
     std::ifstream spirvFile;
-    size_t spirvFileSize_;
+    std::size_t spirvFileSize_;
     std::vector<char> spirvBuffer_;
     DPCTLSyclDeviceRef DRef = nullptr;
     DPCTLSyclQueueRef QRef = nullptr;
@@ -294,58 +297,58 @@ struct TestQueueSubmitFP64 : public ::testing::Test
 
 TEST_F(TestQueueSubmit, CheckForInt8)
 {
-    submit_kernel<int8_t>(QRef, KBRef, spirvBuffer_, spirvFileSize_,
-                          DPCTLKernelArgType::DPCTL_INT8_T,
-                          "_ZTS11RangeKernelIaE");
+    submit_kernel<std::int8_t>(QRef, KBRef, spirvBuffer_, spirvFileSize_,
+                               DPCTLKernelArgType::DPCTL_INT8_T,
+                               "_ZTS11RangeKernelIaE");
 }
 
 TEST_F(TestQueueSubmit, CheckForUInt8)
 {
-    submit_kernel<uint8_t>(QRef, KBRef, spirvBuffer_, spirvFileSize_,
-                           DPCTLKernelArgType::DPCTL_UINT8_T,
-                           "_ZTS11RangeKernelIhE");
+    submit_kernel<std::uint8_t>(QRef, KBRef, spirvBuffer_, spirvFileSize_,
+                                DPCTLKernelArgType::DPCTL_UINT8_T,
+                                "_ZTS11RangeKernelIhE");
 }
 
 TEST_F(TestQueueSubmit, CheckForInt16)
 {
-    submit_kernel<int16_t>(QRef, KBRef, spirvBuffer_, spirvFileSize_,
-                           DPCTLKernelArgType::DPCTL_INT16_T,
-                           "_ZTS11RangeKernelIsE");
+    submit_kernel<std::int16_t>(QRef, KBRef, spirvBuffer_, spirvFileSize_,
+                                DPCTLKernelArgType::DPCTL_INT16_T,
+                                "_ZTS11RangeKernelIsE");
 }
 
 TEST_F(TestQueueSubmit, CheckForUInt16)
 {
-    submit_kernel<uint16_t>(QRef, KBRef, spirvBuffer_, spirvFileSize_,
-                            DPCTLKernelArgType::DPCTL_UINT16_T,
-                            "_ZTS11RangeKernelItE");
+    submit_kernel<std::uint16_t>(QRef, KBRef, spirvBuffer_, spirvFileSize_,
+                                 DPCTLKernelArgType::DPCTL_UINT16_T,
+                                 "_ZTS11RangeKernelItE");
 }
 
 TEST_F(TestQueueSubmit, CheckForInt32)
 {
-    submit_kernel<int32_t>(QRef, KBRef, spirvBuffer_, spirvFileSize_,
-                           DPCTLKernelArgType::DPCTL_INT32_T,
-                           "_ZTS11RangeKernelIiE");
+    submit_kernel<std::int32_t>(QRef, KBRef, spirvBuffer_, spirvFileSize_,
+                                DPCTLKernelArgType::DPCTL_INT32_T,
+                                "_ZTS11RangeKernelIiE");
 }
 
 TEST_F(TestQueueSubmit, CheckForUInt32)
 {
-    submit_kernel<uint32_t>(QRef, KBRef, spirvBuffer_, spirvFileSize_,
-                            DPCTLKernelArgType::DPCTL_UINT32_T,
-                            "_ZTS11RangeKernelIjE");
+    submit_kernel<std::uint32_t>(QRef, KBRef, spirvBuffer_, spirvFileSize_,
+                                 DPCTLKernelArgType::DPCTL_UINT32_T,
+                                 "_ZTS11RangeKernelIjE");
 }
 
 TEST_F(TestQueueSubmit, CheckForInt64)
 {
-    submit_kernel<int64_t>(QRef, KBRef, spirvBuffer_, spirvFileSize_,
-                           DPCTLKernelArgType::DPCTL_INT64_T,
-                           "_ZTS11RangeKernelIlE");
+    submit_kernel<std::int64_t>(QRef, KBRef, spirvBuffer_, spirvFileSize_,
+                                DPCTLKernelArgType::DPCTL_INT64_T,
+                                "_ZTS11RangeKernelIlE");
 }
 
 TEST_F(TestQueueSubmit, CheckForUInt64)
 {
-    submit_kernel<uint64_t>(QRef, KBRef, spirvBuffer_, spirvFileSize_,
-                            DPCTLKernelArgType::DPCTL_UINT64_T,
-                            "_ZTS11RangeKernelImE");
+    submit_kernel<std::uint64_t>(QRef, KBRef, spirvBuffer_, spirvFileSize_,
+                                 DPCTLKernelArgType::DPCTL_UINT64_T,
+                                 "_ZTS11RangeKernelImE");
 }
 
 TEST_F(TestQueueSubmit, CheckForFloat)
@@ -368,9 +371,9 @@ TEST_F(TestQueueSubmit, CheckForUnsupportedArgTy)
 {
 
     int scalarVal = 3;
-    size_t Range[] = {SIZE};
-    size_t RANGE_NDIMS = 1;
-    constexpr size_t NARGS = 4;
+    std::size_t Range[] = {SIZE};
+    std::size_t RANGE_NDIMS = 1;
+    constexpr std::size_t NARGS = 4;
 
     auto kernel = DPCTLKernelBundle_GetKernel(KBRef, "_ZTS11RangeKernelIdE");
     void *args[NARGS] = {unwrap<void>(nullptr), unwrap<void>(nullptr),

--- a/libsyclinterface/tests/test_sycl_queue_submit_local_accessor_arg.cpp
+++ b/libsyclinterface/tests/test_sycl_queue_submit_local_accessor_arg.cpp
@@ -41,7 +41,7 @@
 
 namespace
 {
-constexpr size_t SIZE = 100;
+constexpr std::size_t SIZE = 100;
 
 using namespace dpctl::syclinterface;
 
@@ -49,12 +49,12 @@ template <typename T>
 void submit_kernel(DPCTLSyclQueueRef QRef,
                    DPCTLSyclKernelBundleRef KBRef,
                    std::vector<char> spirvBuffer,
-                   size_t spirvFileSize,
+                   std::size_t spirvFileSize,
                    DPCTLKernelArgType kernelArgTy,
                    std::string kernelName)
 {
-    constexpr size_t NARGS = 2;
-    constexpr size_t RANGE_NDIMS = 1;
+    constexpr std::size_t NARGS = 2;
+    constexpr std::size_t RANGE_NDIMS = 1;
 
     ASSERT_TRUE(DPCTLKernelBundle_HasKernel(KBRef, kernelName.c_str()));
     auto kernel = DPCTLKernelBundle_GetKernel(KBRef, kernelName.c_str());
@@ -70,8 +70,8 @@ void submit_kernel(DPCTLSyclQueueRef QRef,
     auto la1 = MDLocalAccessor{1, kernelArgTy, SIZE / 10, 1, 1};
 
     // Create kernel args for vector_add
-    size_t gRange[] = {SIZE};
-    size_t lRange[] = {SIZE / 10};
+    std::size_t gRange[] = {SIZE};
+    std::size_t lRange[] = {SIZE / 10};
     void *args_1d[NARGS] = {unwrap<void>(a), (void *)&la1};
     DPCTLKernelArgType addKernelArgTypes[] = {DPCTL_VOID_PTR,
                                               DPCTL_LOCAL_ACCESSOR};
@@ -174,7 +174,7 @@ void submit_kernel(sycl::queue q, const unsigned long N, T *a)
 }
 
 template <typename T>
-void driver(size_t N)
+void driver(std::size_t N)
 {
     sycl::queue q;
     auto *a = sycl::malloc_shared<T>(N, q);
@@ -185,7 +185,7 @@ void driver(size_t N)
 
 int main(int argc, const char **argv)
 {
-    size_t N = 0;
+    std::size_t N = 0;
     std::cout << "Enter problem size in N:\n";
     std::cin >> N;
     std::cout << "Executing with N = " << N << std::endl;
@@ -209,7 +209,7 @@ int main(int argc, const char **argv)
 struct TestQueueSubmitWithLocalAccessor : public ::testing::Test
 {
     std::ifstream spirvFile;
-    size_t spirvFileSize_;
+    std::size_t spirvFileSize_;
     std::vector<char> spirvBuffer_;
     DPCTLSyclQueueRef QRef = nullptr;
     DPCTLSyclKernelBundleRef KBRef = nullptr;
@@ -250,7 +250,7 @@ struct TestQueueSubmitWithLocalAccessor : public ::testing::Test
 struct TestQueueSubmitWithLocalAccessorFP64 : public ::testing::Test
 {
     std::ifstream spirvFile;
-    size_t spirvFileSize_;
+    std::size_t spirvFileSize_;
     std::vector<char> spirvBuffer_;
     DPCTLSyclDeviceRef DRef = nullptr;
     DPCTLSyclQueueRef QRef = nullptr;
@@ -289,58 +289,58 @@ struct TestQueueSubmitWithLocalAccessorFP64 : public ::testing::Test
 
 TEST_F(TestQueueSubmitWithLocalAccessor, CheckForInt8)
 {
-    submit_kernel<int8_t>(QRef, KBRef, spirvBuffer_, spirvFileSize_,
-                          DPCTLKernelArgType::DPCTL_INT8_T,
-                          "_ZTS14SyclKernel_SLMIaE");
+    submit_kernel<std::int8_t>(QRef, KBRef, spirvBuffer_, spirvFileSize_,
+                               DPCTLKernelArgType::DPCTL_INT8_T,
+                               "_ZTS14SyclKernel_SLMIaE");
 }
 
 TEST_F(TestQueueSubmitWithLocalAccessor, CheckForUInt8)
 {
-    submit_kernel<uint8_t>(QRef, KBRef, spirvBuffer_, spirvFileSize_,
-                           DPCTLKernelArgType::DPCTL_UINT8_T,
-                           "_ZTS14SyclKernel_SLMIhE");
+    submit_kernel<std::uint8_t>(QRef, KBRef, spirvBuffer_, spirvFileSize_,
+                                DPCTLKernelArgType::DPCTL_UINT8_T,
+                                "_ZTS14SyclKernel_SLMIhE");
 }
 
 TEST_F(TestQueueSubmitWithLocalAccessor, CheckForInt16)
 {
-    submit_kernel<int16_t>(QRef, KBRef, spirvBuffer_, spirvFileSize_,
-                           DPCTLKernelArgType::DPCTL_INT16_T,
-                           "_ZTS14SyclKernel_SLMIsE");
+    submit_kernel<std::int16_t>(QRef, KBRef, spirvBuffer_, spirvFileSize_,
+                                DPCTLKernelArgType::DPCTL_INT16_T,
+                                "_ZTS14SyclKernel_SLMIsE");
 }
 
 TEST_F(TestQueueSubmitWithLocalAccessor, CheckForUInt16)
 {
-    submit_kernel<uint16_t>(QRef, KBRef, spirvBuffer_, spirvFileSize_,
-                            DPCTLKernelArgType::DPCTL_UINT16_T,
-                            "_ZTS14SyclKernel_SLMItE");
+    submit_kernel<std::uint16_t>(QRef, KBRef, spirvBuffer_, spirvFileSize_,
+                                 DPCTLKernelArgType::DPCTL_UINT16_T,
+                                 "_ZTS14SyclKernel_SLMItE");
 }
 
 TEST_F(TestQueueSubmitWithLocalAccessor, CheckForInt32)
 {
-    submit_kernel<int32_t>(QRef, KBRef, spirvBuffer_, spirvFileSize_,
-                           DPCTLKernelArgType::DPCTL_INT32_T,
-                           "_ZTS14SyclKernel_SLMIiE");
+    submit_kernel<std::int32_t>(QRef, KBRef, spirvBuffer_, spirvFileSize_,
+                                DPCTLKernelArgType::DPCTL_INT32_T,
+                                "_ZTS14SyclKernel_SLMIiE");
 }
 
 TEST_F(TestQueueSubmitWithLocalAccessor, CheckForUInt32)
 {
-    submit_kernel<uint32_t>(QRef, KBRef, spirvBuffer_, spirvFileSize_,
-                            DPCTLKernelArgType::DPCTL_UINT32_T,
-                            "_ZTS14SyclKernel_SLMIjE");
+    submit_kernel<std::uint32_t>(QRef, KBRef, spirvBuffer_, spirvFileSize_,
+                                 DPCTLKernelArgType::DPCTL_UINT32_T,
+                                 "_ZTS14SyclKernel_SLMIjE");
 }
 
 TEST_F(TestQueueSubmitWithLocalAccessor, CheckForInt64)
 {
-    submit_kernel<int64_t>(QRef, KBRef, spirvBuffer_, spirvFileSize_,
-                           DPCTLKernelArgType::DPCTL_INT64_T,
-                           "_ZTS14SyclKernel_SLMIlE");
+    submit_kernel<std::int64_t>(QRef, KBRef, spirvBuffer_, spirvFileSize_,
+                                DPCTLKernelArgType::DPCTL_INT64_T,
+                                "_ZTS14SyclKernel_SLMIlE");
 }
 
 TEST_F(TestQueueSubmitWithLocalAccessor, CheckForUInt64)
 {
-    submit_kernel<uint64_t>(QRef, KBRef, spirvBuffer_, spirvFileSize_,
-                            DPCTLKernelArgType::DPCTL_UINT64_T,
-                            "_ZTS14SyclKernel_SLMImE");
+    submit_kernel<std::uint64_t>(QRef, KBRef, spirvBuffer_, spirvFileSize_,
+                                 DPCTLKernelArgType::DPCTL_UINT64_T,
+                                 "_ZTS14SyclKernel_SLMImE");
 }
 
 TEST_F(TestQueueSubmitWithLocalAccessor, CheckForFloat)
@@ -361,10 +361,10 @@ TEST_F(TestQueueSubmitWithLocalAccessorFP64, CheckForDouble)
 
 TEST_F(TestQueueSubmitWithLocalAccessor, CheckForUnsupportedArgTy)
 {
-    size_t gRange[] = {SIZE};
-    size_t lRange[] = {SIZE / 10};
-    size_t RANGE_NDIMS = 1;
-    constexpr size_t NARGS = 2;
+    std::size_t gRange[] = {SIZE};
+    std::size_t lRange[] = {SIZE / 10};
+    std::size_t RANGE_NDIMS = 1;
+    constexpr std::size_t NARGS = 2;
 
     auto la = MDLocalAccessor{1, DPCTL_UNSUPPORTED_KERNEL_ARG, SIZE / 10, 1, 1};
     auto kernel = DPCTLKernelBundle_GetKernel(KBRef, "_ZTS14SyclKernel_SLMImE");

--- a/libsyclinterface/tests/test_sycl_queue_submit_local_accessor_arg.cpp
+++ b/libsyclinterface/tests/test_sycl_queue_submit_local_accessor_arg.cpp
@@ -32,10 +32,12 @@
 #include "dpctl_sycl_queue_interface.h"
 #include "dpctl_sycl_type_casters.hpp"
 #include "dpctl_sycl_usm_interface.h"
+
+#include <stddef.h>
+
 #include <filesystem>
 #include <fstream>
 #include <gtest/gtest.h>
-#include <stddef.h>
 #include <sycl/sycl.hpp>
 #include <utility>
 

--- a/libsyclinterface/tests/test_sycl_usm_interface.cpp
+++ b/libsyclinterface/tests/test_sycl_usm_interface.cpp
@@ -31,9 +31,11 @@
 #include "dpctl_sycl_queue_interface.h"
 #include "dpctl_sycl_type_casters.hpp"
 #include "dpctl_sycl_usm_interface.h"
+
+#include <stddef.h>
+
 #include <cstring>
 #include <gtest/gtest.h>
-#include <stddef.h>
 #include <sycl/sycl.hpp>
 
 using namespace sycl;


### PR DESCRIPTION
Fixed a single instance of unqualified `size_t` picked up after rebasing.

Also fixed unqualified `uint8_t`, `uint16_t`, etc. in `dpctl/tensor/libtensor`.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [ ] Have you added your changes to the changelog?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
