### PR TITLE
Technical debt changes

### DIFF
--- a/dpctl/tensor/CMakeLists.txt
+++ b/dpctl/tensor/CMakeLists.txt
@@ -114,12 +114,10 @@ set(_reduction_sources
 set(_sorting_sources
     ${CMAKE_CURRENT_SOURCE_DIR}/libtensor/source/sorting/merge_sort.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/libtensor/source/sorting/merge_argsort.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/libtensor/source/sorting/searchsorted.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/libtensor/source/sorting/topk.cpp
-)
-set(_sorting_radix_sources
     ${CMAKE_CURRENT_SOURCE_DIR}/libtensor/source/sorting/radix_sort.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/libtensor/source/sorting/radix_argsort.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/libtensor/source/sorting/searchsorted.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/libtensor/source/sorting/topk.cpp
 )
 set(_static_lib_sources
     ${CMAKE_CURRENT_SOURCE_DIR}/libtensor/source/simplify_iteration_space.cpp
@@ -155,10 +153,6 @@ set(_tensor_reductions_impl_sources
 set(_tensor_sorting_impl_sources
     ${CMAKE_CURRENT_SOURCE_DIR}/libtensor/source/tensor_sorting.cpp
     ${_sorting_sources}
-)
-set(_tensor_sorting_radix_impl_sources
-    ${CMAKE_CURRENT_SOURCE_DIR}/libtensor/source/tensor_sorting_radix.cpp
-    ${_sorting_radix_sources}
 )
 set(_linalg_sources
     ${CMAKE_CURRENT_SOURCE_DIR}/libtensor/source/elementwise_functions/elementwise_functions_type_utils.cpp
@@ -211,12 +205,6 @@ list(APPEND _py_trgts ${python_module_name})
 set(python_module_name _tensor_sorting_impl)
 pybind11_add_module(${python_module_name} MODULE ${_tensor_sorting_impl_sources})
 add_sycl_to_target(TARGET ${python_module_name} SOURCES ${_tensor_sorting_impl_sources})
-target_link_libraries(${python_module_name} PRIVATE ${_static_lib_trgt})
-list(APPEND _py_trgts ${python_module_name})
-
-set(python_module_name _tensor_sorting_radix_impl)
-pybind11_add_module(${python_module_name} MODULE ${_tensor_sorting_radix_impl_sources})
-add_sycl_to_target(TARGET ${python_module_name} SOURCES ${_tensor_sorting_radix_impl_sources})
 target_link_libraries(${python_module_name} PRIVATE ${_static_lib_trgt})
 list(APPEND _py_trgts ${python_module_name})
 

--- a/dpctl/tensor/_sorting.py
+++ b/dpctl/tensor/_sorting.py
@@ -25,16 +25,14 @@ from ._numpy_helper import normalize_axis_index
 from ._tensor_sorting_impl import (
     _argsort_ascending,
     _argsort_descending,
-    _sort_ascending,
-    _sort_descending,
-    _topk,
-)
-from ._tensor_sorting_radix_impl import (
     _radix_argsort_ascending,
     _radix_argsort_descending,
     _radix_sort_ascending,
     _radix_sort_descending,
     _radix_sort_dtype_supported,
+    _sort_ascending,
+    _sort_descending,
+    _topk,
 )
 
 __all__ = ["sort", "argsort"]

--- a/dpctl/tensor/libtensor/include/kernels/accumulators.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/accumulators.hpp
@@ -90,7 +90,7 @@ template <typename BinOpT, typename T> struct can_use_inclusive_scan_over_group
     static constexpr bool value = sycl::has_known_identity<BinOpT, T>::value;
 };
 
-namespace
+namespace detail
 {
 template <typename T> class stack_t
 {
@@ -141,7 +141,7 @@ public:
     std::size_t get_local_stride() const { return local_stride_; }
 };
 
-} // end of anonymous namespace
+} // end of namespace detail
 
 // Iterative cumulative summation
 
@@ -627,7 +627,7 @@ sycl::event inclusive_scan_iter_1d(sycl::queue &exec_q,
             throw std::bad_alloc();
         }
 
-        std::vector<stack_t<outputT>> stack{};
+        std::vector<detail::stack_t<outputT>> stack{};
 
         // inclusive scans over blocks
         n_groups_ = n_groups;
@@ -867,7 +867,7 @@ sycl::event inclusive_scan_iter(sycl::queue &exec_q,
             throw std::bad_alloc();
         }
 
-        std::vector<stack_strided_t<outputT>> stack{};
+        std::vector<detail::stack_strided_t<outputT>> stack{};
 
         // inclusive scans over blocks
         acc_groups_ = acc_groups;

--- a/dpctl/tensor/libtensor/include/kernels/accumulators.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/accumulators.hpp
@@ -1233,7 +1233,8 @@ std::size_t cumsum_val_contig_impl(sycl::queue &q,
     copy_e.wait();
     std::size_t return_val = static_cast<std::size_t>(*last_elem_host_usm);
 
-    // free USM host allocation
+    // explicitly free USM host allocation, by envoking deleter of
+    // the unique_ptr
     host_usm_owner.reset(nullptr);
 
     return return_val;
@@ -1347,7 +1348,8 @@ cumsum_val_strided_impl(sycl::queue &q,
     copy_e.wait();
     std::size_t return_val = static_cast<std::size_t>(*last_elem_host_usm);
 
-    // free USM-host temporary
+    // explicitly free USM-host temporary, by envoking deleter of
+    // the unique_ptr
     host_usm_owner.reset(nullptr);
 
     return return_val;

--- a/dpctl/tensor/libtensor/include/kernels/boolean_advanced_indexing.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/boolean_advanced_indexing.hpp
@@ -212,7 +212,7 @@ private:
 
 // ======= Masked extraction ================================
 
-namespace
+namespace detail
 {
 
 template <std::size_t I, std::size_t... IR>
@@ -234,7 +234,7 @@ std::size_t get_lws(std::size_t n)
     return _get_lws_impl<lws0, lws1, lws2>(n);
 }
 
-} // end of anonymous namespace
+} // end of namespace detail
 
 template <typename MaskedDstIndexerT, typename dataT, typename indT>
 class masked_extract_all_slices_contig_impl_krn;
@@ -278,7 +278,7 @@ sycl::event masked_extract_all_slices_contig_impl(
 
     const std::size_t masked_extent = iteration_size;
 
-    const std::size_t lws = get_lws(masked_extent);
+    const std::size_t lws = detail::get_lws(masked_extent);
 
     const std::size_t n_groups = (iteration_size + lws - 1) / lws;
 
@@ -357,7 +357,7 @@ sycl::event masked_extract_all_slices_strided_impl(
 
     const std::size_t masked_nelems = iteration_size;
 
-    const std::size_t lws = get_lws(masked_nelems);
+    const std::size_t lws = detail::get_lws(masked_nelems);
 
     const std::size_t n_groups = (masked_nelems + lws - 1) / lws;
 
@@ -452,7 +452,7 @@ sycl::event masked_extract_some_slices_strided_impl(
 
     const std::size_t masked_extent = masked_nelems;
 
-    const std::size_t lws = get_lws(masked_extent);
+    const std::size_t lws = detail::get_lws(masked_extent);
 
     const std::size_t n_groups = ((masked_extent + lws - 1) / lws);
     const std::size_t orthog_extent = static_cast<std::size_t>(orthog_nelems);

--- a/dpctl/tensor/libtensor/include/kernels/copy_and_cast.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/copy_and_cast.hpp
@@ -551,7 +551,7 @@ typedef void (*copy_and_cast_from_host_blocking_fn_ptr_t)(
     sycl::queue &,
     std::size_t,
     int,
-    ssize_t *,
+    const ssize_t *,
     const char *,
     ssize_t,
     ssize_t,
@@ -604,7 +604,7 @@ void copy_and_cast_from_host_impl(
     sycl::queue &q,
     std::size_t nelems,
     int nd,
-    ssize_t *shape_and_strides,
+    const ssize_t *shape_and_strides,
     const char *host_src_p,
     ssize_t src_offset,
     ssize_t src_min_nelem_offset,
@@ -797,12 +797,12 @@ public:
 // define function type
 typedef sycl::event (*copy_for_reshape_fn_ptr_t)(
     sycl::queue &,
-    std::size_t,  // num_elements
-    int,          // src_nd
-    int,          // dst_nd
-    ssize_t *,    // packed shapes and strides
-    const char *, // src_data_ptr
-    char *,       // dst_data_ptr
+    std::size_t,     // num_elements
+    int,             // src_nd
+    int,             // dst_nd
+    const ssize_t *, // packed shapes and strides
+    const char *,    // src_data_ptr
+    char *,          // dst_data_ptr
     const std::vector<sycl::event> &);
 
 /*!
@@ -832,7 +832,7 @@ copy_for_reshape_generic_impl(sycl::queue &q,
                               std::size_t nelems,
                               int src_nd,
                               int dst_nd,
-                              ssize_t *packed_shapes_and_strides,
+                              const ssize_t *packed_shapes_and_strides,
                               const char *src_p,
                               char *dst_p,
                               const std::vector<sycl::event> &depends)

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/abs.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/abs.hpp
@@ -125,7 +125,7 @@ template <typename T> struct AbsOutputType
     static constexpr bool is_defined = !std::is_same_v<value_type, void>;
 };
 
-namespace
+namespace hyperparam_detail
 {
 
 namespace vsu_ns = dpctl::tensor::kernels::vec_size_utils;
@@ -141,7 +141,7 @@ template <typename argTy> struct AbsContigHyperparameterSet
     constexpr static auto n_vecs = value_type::n_vecs;
 };
 
-} // namespace
+} // namespace hyperparam_detail
 
 template <typename T1, typename T2, std::uint8_t vec_sz, std::uint8_t n_vecs>
 class abs_contig_kernel;
@@ -153,8 +153,9 @@ sycl::event abs_contig_impl(sycl::queue &exec_q,
                             char *res_p,
                             const std::vector<sycl::event> &depends = {})
 {
-    constexpr std::uint8_t vec_sz = AbsContigHyperparameterSet<argTy>::vec_sz;
-    constexpr std::uint8_t n_vec = AbsContigHyperparameterSet<argTy>::n_vecs;
+    using AbsHS = hyperparam_detail::AbsContigHyperparameterSet<argTy>;
+    constexpr std::uint8_t vec_sz = AbsHS::vec_sz;
+    constexpr std::uint8_t n_vec = AbsHS::n_vecs;
 
     return elementwise_common::unary_contig_impl<
         argTy, AbsOutputType, AbsContigFunctor, abs_contig_kernel, vec_sz,

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/acos.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/acos.hpp
@@ -159,7 +159,7 @@ template <typename T> struct AcosOutputType
     static constexpr bool is_defined = !std::is_same_v<value_type, void>;
 };
 
-namespace
+namespace hyperparam_detail
 {
 
 namespace vsu_ns = dpctl::tensor::kernels::vec_size_utils;
@@ -175,7 +175,7 @@ template <typename argTy> struct AcosContigHyperparameterSet
     constexpr static auto n_vecs = value_type::n_vecs;
 };
 
-} // namespace
+} // end of namespace hyperparam_detail
 
 template <typename T1, typename T2, std::uint8_t vec_sz, std::uint8_t n_vecs>
 class acos_contig_kernel;
@@ -187,8 +187,9 @@ sycl::event acos_contig_impl(sycl::queue &exec_q,
                              char *res_p,
                              const std::vector<sycl::event> &depends = {})
 {
-    constexpr std::uint8_t vec_sz = AcosContigHyperparameterSet<argTy>::vec_sz;
-    constexpr std::uint8_t n_vec = AcosContigHyperparameterSet<argTy>::n_vecs;
+    using AcosHS = hyperparam_detail::AcosContigHyperparameterSet<argTy>;
+    constexpr std::uint8_t vec_sz = AcosHS::vec_sz;
+    constexpr std::uint8_t n_vec = AcosHS::n_vecs;
 
     return elementwise_common::unary_contig_impl<
         argTy, AcosOutputType, AcosContigFunctor, acos_contig_kernel, vec_sz,

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/acosh.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/acosh.hpp
@@ -186,7 +186,7 @@ template <typename T> struct AcoshOutputType
     static constexpr bool is_defined = !std::is_same_v<value_type, void>;
 };
 
-namespace
+namespace hyperparam_detail
 {
 
 namespace vsu_ns = dpctl::tensor::kernels::vec_size_utils;
@@ -203,7 +203,7 @@ template <typename argTy> struct AcoshContigHyperparameterSet
     constexpr static auto n_vecs = value_type::n_vecs;
 };
 
-} // namespace
+} // end of namespace hyperparam_detail
 
 template <typename T1, typename T2, std::uint8_t vec_sz, std::uint8_t n_vecs>
 class acosh_contig_kernel;
@@ -215,8 +215,9 @@ sycl::event acosh_contig_impl(sycl::queue &exec_q,
                               char *res_p,
                               const std::vector<sycl::event> &depends = {})
 {
-    constexpr std::uint8_t vec_sz = AcoshContigHyperparameterSet<argTy>::vec_sz;
-    constexpr std::uint8_t n_vec = AcoshContigHyperparameterSet<argTy>::n_vecs;
+    using AcoshHS = hyperparam_detail::AcoshContigHyperparameterSet<argTy>;
+    constexpr std::uint8_t vec_sz = AcoshHS::vec_sz;
+    constexpr std::uint8_t n_vec = AcoshHS::n_vecs;
 
     return elementwise_common::unary_contig_impl<
         argTy, AcoshOutputType, AcoshContigFunctor, acosh_contig_kernel, vec_sz,

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/add.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/add.hpp
@@ -199,7 +199,7 @@ template <typename T1, typename T2> struct AddOutputType
     static constexpr bool is_defined = !std::is_same_v<value_type, void>;
 };
 
-namespace
+namespace hyperparam_detail
 {
 
 namespace vsu_ns = dpctl::tensor::kernels::vec_size_utils;
@@ -252,7 +252,7 @@ template <typename argTy1, typename argTy2> struct AddContigHyperparameterSet
     constexpr static auto n_vecs = value_type::n_vecs;
 };
 
-} // end of anonymous namespace
+} // end of namespace hyperparam_detail
 
 template <typename argT1,
           typename argT2,
@@ -272,8 +272,9 @@ sycl::event add_contig_impl(sycl::queue &exec_q,
                             ssize_t res_offset,
                             const std::vector<sycl::event> &depends = {})
 {
-    constexpr auto vec_sz = AddContigHyperparameterSet<argTy1, argTy2>::vec_sz;
-    constexpr auto n_vecs = AddContigHyperparameterSet<argTy1, argTy2>::n_vecs;
+    using AddHS = hyperparam_detail::AddContigHyperparameterSet<argTy1, argTy2>;
+    constexpr auto vec_sz = AddHS::vec_sz;
+    constexpr auto n_vecs = AddHS::n_vecs;
 
     return elementwise_common::binary_contig_impl<
         argTy1, argTy2, AddOutputType, AddContigFunctor, add_contig_kernel,
@@ -550,8 +551,10 @@ add_inplace_contig_impl(sycl::queue &exec_q,
                         ssize_t res_offset,
                         const std::vector<sycl::event> &depends = {})
 {
-    constexpr auto vec_sz = AddContigHyperparameterSet<resTy, argTy>::vec_sz;
-    constexpr auto n_vecs = AddContigHyperparameterSet<resTy, argTy>::n_vecs;
+    constexpr auto vec_sz =
+        hyperparam_detail::AddContigHyperparameterSet<resTy, argTy>::vec_sz;
+    constexpr auto n_vecs =
+        hyperparam_detail::AddContigHyperparameterSet<resTy, argTy>::n_vecs;
 
     return elementwise_common::binary_inplace_contig_impl<
         argTy, resTy, AddInplaceContigFunctor, add_inplace_contig_kernel,

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/angle.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/angle.hpp
@@ -102,7 +102,7 @@ template <typename T> struct AngleOutputType
     static constexpr bool is_defined = !std::is_same_v<value_type, void>;
 };
 
-namespace
+namespace hyperparam_detail
 {
 
 namespace vsu_ns = dpctl::tensor::kernels::vec_size_utils;
@@ -119,7 +119,7 @@ template <typename argTy> struct AngleContigHyperparameterSet
     constexpr static auto n_vecs = value_type::n_vecs;
 };
 
-} // end of anonymous namespace
+} // end of namespace hyperparam_detail
 
 template <typename T1, typename T2, std::uint8_t vec_sz, std::uint8_t n_vecs>
 class angle_contig_kernel;
@@ -131,8 +131,9 @@ sycl::event angle_contig_impl(sycl::queue &exec_q,
                               char *res_p,
                               const std::vector<sycl::event> &depends = {})
 {
-    constexpr std::uint8_t vec_sz = AngleContigHyperparameterSet<argTy>::vec_sz;
-    constexpr std::uint8_t n_vec = AngleContigHyperparameterSet<argTy>::n_vecs;
+    using AngleHS = hyperparam_detail::AngleContigHyperparameterSet<argTy>;
+    constexpr std::uint8_t vec_sz = AngleHS::vec_sz;
+    constexpr std::uint8_t n_vec = AngleHS::n_vecs;
 
     return elementwise_common::unary_contig_impl<
         argTy, AngleOutputType, AngleContigFunctor, angle_contig_kernel, vec_sz,

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/asin.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/asin.hpp
@@ -179,7 +179,7 @@ template <typename T> struct AsinOutputType
     static constexpr bool is_defined = !std::is_same_v<value_type, void>;
 };
 
-namespace
+namespace hyperparam_detail
 {
 
 namespace vsu_ns = dpctl::tensor::kernels::vec_size_utils;
@@ -196,7 +196,7 @@ template <typename argTy> struct AsinContigHyperparameterSet
     constexpr static auto n_vecs = value_type::n_vecs;
 };
 
-} // end of anonymous namespace
+} // end of namespace hyperparam_detail
 
 template <typename T1, typename T2, std::uint8_t vec_sz, std::uint8_t n_vecs>
 class asin_contig_kernel;
@@ -208,8 +208,9 @@ sycl::event asin_contig_impl(sycl::queue &exec_q,
                              char *res_p,
                              const std::vector<sycl::event> &depends = {})
 {
-    constexpr std::uint8_t vec_sz = AsinContigHyperparameterSet<argTy>::vec_sz;
-    constexpr std::uint8_t n_vec = AsinContigHyperparameterSet<argTy>::n_vecs;
+    using AddHS = hyperparam_detail::AsinContigHyperparameterSet<argTy>;
+    constexpr std::uint8_t vec_sz = AddHS::vec_sz;
+    constexpr std::uint8_t n_vec = AddHS::n_vecs;
 
     return elementwise_common::unary_contig_impl<
         argTy, AsinOutputType, AsinContigFunctor, asin_contig_kernel, vec_sz,

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/asinh.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/asinh.hpp
@@ -162,7 +162,7 @@ template <typename T> struct AsinhOutputType
     static constexpr bool is_defined = !std::is_same_v<value_type, void>;
 };
 
-namespace
+namespace hyperparam_detail
 {
 
 namespace vsu_ns = dpctl::tensor::kernels::vec_size_utils;
@@ -179,7 +179,7 @@ template <typename argTy> struct AsinhContigHyperparameterSet
     constexpr static auto n_vecs = value_type::n_vecs;
 };
 
-} // end of anonymous namespace
+} // end of namespace hyperparam_detail
 
 template <typename T1, typename T2, std::uint8_t vec_sz, std::uint8_t n_vecs>
 class asinh_contig_kernel;
@@ -191,8 +191,9 @@ sycl::event asinh_contig_impl(sycl::queue &exec_q,
                               char *res_p,
                               const std::vector<sycl::event> &depends = {})
 {
-    constexpr std::uint8_t vec_sz = AsinhContigHyperparameterSet<argTy>::vec_sz;
-    constexpr std::uint8_t n_vec = AsinhContigHyperparameterSet<argTy>::n_vecs;
+    using AsinhHS = hyperparam_detail::AsinhContigHyperparameterSet<argTy>;
+    constexpr std::uint8_t vec_sz = AsinhHS::vec_sz;
+    constexpr std::uint8_t n_vec = AsinhHS::n_vecs;
 
     return elementwise_common::unary_contig_impl<
         argTy, AsinhOutputType, AsinhContigFunctor, asinh_contig_kernel, vec_sz,

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/atan.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/atan.hpp
@@ -172,7 +172,7 @@ template <typename T> struct AtanOutputType
     static constexpr bool is_defined = !std::is_same_v<value_type, void>;
 };
 
-namespace
+namespace hyperparam_detail
 {
 
 namespace vsu_ns = dpctl::tensor::kernels::vec_size_utils;
@@ -189,7 +189,7 @@ template <typename argTy> struct AtanContigHyperparameterSet
     constexpr static auto n_vecs = value_type::n_vecs;
 };
 
-} // end of anonymous namespace
+} // end of namespace hyperparam_detail
 
 template <typename T1, typename T2, std::uint8_t vec_sz, std::uint8_t n_vecs>
 class atan_contig_kernel;
@@ -201,8 +201,9 @@ sycl::event atan_contig_impl(sycl::queue &exec_q,
                              char *res_p,
                              const std::vector<sycl::event> &depends = {})
 {
-    constexpr std::uint8_t vec_sz = AtanContigHyperparameterSet<argTy>::vec_sz;
-    constexpr std::uint8_t n_vec = AtanContigHyperparameterSet<argTy>::n_vecs;
+    using AtanHS = hyperparam_detail::AtanContigHyperparameterSet<argTy>;
+    constexpr std::uint8_t vec_sz = AtanHS::vec_sz;
+    constexpr std::uint8_t n_vec = AtanHS::n_vecs;
 
     return elementwise_common::unary_contig_impl<
         argTy, AtanOutputType, AtanContigFunctor, atan_contig_kernel, vec_sz,

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/atan2.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/atan2.hpp
@@ -106,7 +106,7 @@ template <typename T1, typename T2> struct Atan2OutputType
     static constexpr bool is_defined = !std::is_same_v<value_type, void>;
 };
 
-namespace
+namespace hyperparam_detail
 {
 
 namespace vsu_ns = dpctl::tensor::kernels::vec_size_utils;
@@ -123,7 +123,7 @@ template <typename argTy1, typename argTy2> struct Atan2ContigHyperparameterSet
     constexpr static auto n_vecs = value_type::n_vecs;
 };
 
-} // end of anonymous namespace
+} // end of namespace hyperparam_detail
 
 template <typename argT1,
           typename argT2,
@@ -143,10 +143,10 @@ sycl::event atan2_contig_impl(sycl::queue &exec_q,
                               ssize_t res_offset,
                               const std::vector<sycl::event> &depends = {})
 {
-    constexpr std::uint8_t vec_sz =
-        Atan2ContigHyperparameterSet<argTy1, argTy2>::vec_sz;
-    constexpr std::uint8_t n_vecs =
-        Atan2ContigHyperparameterSet<argTy1, argTy2>::n_vecs;
+    using Atan2HS =
+        hyperparam_detail::Atan2ContigHyperparameterSet<argTy1, argTy2>;
+    constexpr std::uint8_t vec_sz = Atan2HS::vec_sz;
+    constexpr std::uint8_t n_vecs = Atan2HS::n_vecs;
 
     return elementwise_common::binary_contig_impl<
         argTy1, argTy2, Atan2OutputType, Atan2ContigFunctor,

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/atanh.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/atanh.hpp
@@ -163,7 +163,7 @@ template <typename T> struct AtanhOutputType
     static constexpr bool is_defined = !std::is_same_v<value_type, void>;
 };
 
-namespace
+namespace hyperparam_detail
 {
 
 namespace vsu_ns = dpctl::tensor::kernels::vec_size_utils;
@@ -180,7 +180,7 @@ template <typename argTy> struct AtanhContigHyperparameterSet
     constexpr static auto n_vecs = value_type::n_vecs;
 };
 
-} // end of anonymous namespace
+} // end of namespace hyperparam_detail
 
 template <typename T1, typename T2, std::uint8_t vec_sz, std::uint8_t n_vecs>
 class atanh_contig_kernel;
@@ -192,8 +192,9 @@ sycl::event atanh_contig_impl(sycl::queue &exec_q,
                               char *res_p,
                               const std::vector<sycl::event> &depends = {})
 {
-    constexpr std::uint8_t vec_sz = AtanhContigHyperparameterSet<argTy>::vec_sz;
-    constexpr std::uint8_t n_vec = AtanhContigHyperparameterSet<argTy>::n_vecs;
+    using AtanhHS = hyperparam_detail::AtanhContigHyperparameterSet<argTy>;
+    constexpr std::uint8_t vec_sz = AtanhHS::vec_sz;
+    constexpr std::uint8_t n_vec = AtanhHS::n_vecs;
 
     return elementwise_common::unary_contig_impl<
         argTy, AtanhOutputType, AtanhContigFunctor, atanh_contig_kernel, vec_sz,

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/bitwise_and.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/bitwise_and.hpp
@@ -163,7 +163,7 @@ template <typename T1, typename T2> struct BitwiseAndOutputType
     static constexpr bool is_defined = !std::is_same_v<value_type, void>;
 };
 
-namespace
+namespace hyperparam_detail
 {
 
 namespace vsu_ns = dpctl::tensor::kernels::vec_size_utils;
@@ -180,7 +180,7 @@ struct BitwiseAndContigHyperparameterSet
     constexpr static auto vec_sz = value_type::vec_sz;
     constexpr static auto n_vecs = value_type::n_vecs;
 };
-} // namespace
+} // end of namespace hyperparam_detail
 
 template <typename argT1,
           typename argT2,
@@ -201,10 +201,10 @@ bitwise_and_contig_impl(sycl::queue &exec_q,
                         ssize_t res_offset,
                         const std::vector<sycl::event> &depends = {})
 {
-    constexpr std::uint8_t vec_sz =
-        BitwiseAndContigHyperparameterSet<argTy1, argTy2>::vec_sz;
-    constexpr std::uint8_t n_vec =
-        BitwiseAndContigHyperparameterSet<argTy1, argTy2>::n_vecs;
+    using BitwiseAndHS =
+        hyperparam_detail::BitwiseAndContigHyperparameterSet<argTy1, argTy2>;
+    constexpr std::uint8_t vec_sz = BitwiseAndHS::vec_sz;
+    constexpr std::uint8_t n_vec = BitwiseAndHS::n_vecs;
 
     return elementwise_common::binary_contig_impl<
         argTy1, argTy2, BitwiseAndOutputType, BitwiseAndContigFunctor,
@@ -389,10 +389,10 @@ bitwise_and_inplace_contig_impl(sycl::queue &exec_q,
                                 ssize_t res_offset,
                                 const std::vector<sycl::event> &depends = {})
 {
-    constexpr std::uint8_t vec_sz =
-        BitwiseAndContigHyperparameterSet<resTy, argTy>::vec_sz;
-    constexpr std::uint8_t n_vecs =
-        BitwiseAndContigHyperparameterSet<resTy, argTy>::n_vecs;
+    using BitwiseAndHS =
+        hyperparam_detail::BitwiseAndContigHyperparameterSet<resTy, argTy>;
+    constexpr std::uint8_t vec_sz = BitwiseAndHS::vec_sz;
+    constexpr std::uint8_t n_vecs = BitwiseAndHS::n_vecs;
 
     return elementwise_common::binary_inplace_contig_impl<
         argTy, resTy, BitwiseAndInplaceContigFunctor,

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/bitwise_invert.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/bitwise_invert.hpp
@@ -118,7 +118,7 @@ template <typename argTy> struct BitwiseInvertOutputType
     static constexpr bool is_defined = !std::is_same_v<value_type, void>;
 };
 
-namespace
+namespace hyperparam_detail
 {
 
 namespace vsu_ns = dpctl::tensor::kernels::vec_size_utils;
@@ -135,7 +135,7 @@ template <typename argTy> struct BitwiseInvertContigHyperparameterSet
     constexpr static auto n_vecs = value_type::n_vecs;
 };
 
-} // end of anonymous namespace
+} // end of namespace hyperparam_detail
 
 template <typename T1, typename T2, std::uint8_t vec_sz, std::uint8_t n_vecs>
 class bitwise_invert_contig_kernel;
@@ -148,10 +148,10 @@ bitwise_invert_contig_impl(sycl::queue &exec_q,
                            char *res_p,
                            const std::vector<sycl::event> &depends = {})
 {
-    constexpr std::uint8_t vec_sz =
-        BitwiseInvertContigHyperparameterSet<argTy>::vec_sz;
-    constexpr std::uint8_t n_vec =
-        BitwiseInvertContigHyperparameterSet<argTy>::n_vecs;
+    using BitwiseInvertHS =
+        hyperparam_detail::BitwiseInvertContigHyperparameterSet<argTy>;
+    constexpr std::uint8_t vec_sz = BitwiseInvertHS::vec_sz;
+    constexpr std::uint8_t n_vec = BitwiseInvertHS::n_vecs;
 
     return elementwise_common::unary_contig_impl<
         argTy, BitwiseInvertOutputType, BitwiseInvertContigFunctor,

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/bitwise_left_shift.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/bitwise_left_shift.hpp
@@ -172,7 +172,7 @@ template <typename T1, typename T2> struct BitwiseLeftShiftOutputType
     static constexpr bool is_defined = !std::is_same_v<value_type, void>;
 };
 
-namespace
+namespace hyperparam_detail
 {
 
 namespace vsu_ns = dpctl::tensor::kernels::vec_size_utils;
@@ -190,7 +190,7 @@ struct BitwiseLeftShiftContigHyperparameterSet
     constexpr static auto n_vecs = value_type::n_vecs;
 };
 
-} // end of anonymous namespace
+} // end of namespace hyperparam_detail
 
 template <typename argT1,
           typename argT2,
@@ -211,10 +211,11 @@ bitwise_left_shift_contig_impl(sycl::queue &exec_q,
                                ssize_t res_offset,
                                const std::vector<sycl::event> &depends = {})
 {
-    constexpr std::uint8_t vec_sz =
-        BitwiseLeftShiftContigHyperparameterSet<argTy1, argTy2>::vec_sz;
-    constexpr std::uint8_t n_vecs =
-        BitwiseLeftShiftContigHyperparameterSet<argTy1, argTy2>::n_vecs;
+    using BitwiseLSHS =
+        hyperparam_detail::BitwiseLeftShiftContigHyperparameterSet<argTy1,
+                                                                   argTy2>;
+    constexpr std::uint8_t vec_sz = BitwiseLSHS::vec_sz;
+    constexpr std::uint8_t n_vecs = BitwiseLSHS::n_vecs;
 
     return elementwise_common::binary_contig_impl<
         argTy1, argTy2, BitwiseLeftShiftOutputType,
@@ -403,10 +404,11 @@ sycl::event bitwise_left_shift_inplace_contig_impl(
     ssize_t res_offset,
     const std::vector<sycl::event> &depends = {})
 {
-    constexpr std::uint8_t vec_sz =
-        BitwiseLeftShiftContigHyperparameterSet<resTy, argTy>::vec_sz;
-    constexpr std::uint8_t n_vecs =
-        BitwiseLeftShiftContigHyperparameterSet<resTy, argTy>::n_vecs;
+    using BitwiseLSHS =
+        hyperparam_detail::BitwiseLeftShiftContigHyperparameterSet<resTy,
+                                                                   argTy>;
+    constexpr std::uint8_t vec_sz = BitwiseLSHS::vec_sz;
+    constexpr std::uint8_t n_vecs = BitwiseLSHS::n_vecs;
 
     return elementwise_common::binary_inplace_contig_impl<
         argTy, resTy, BitwiseLeftShiftInplaceContigFunctor,

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/bitwise_or.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/bitwise_or.hpp
@@ -162,7 +162,7 @@ template <typename T1, typename T2> struct BitwiseOrOutputType
     static constexpr bool is_defined = !std::is_same_v<value_type, void>;
 };
 
-namespace
+namespace hyperparam_detail
 {
 
 namespace vsu_ns = dpctl::tensor::kernels::vec_size_utils;
@@ -180,7 +180,7 @@ struct BitwiseOrContigHyperparameterSet
     constexpr static auto n_vecs = value_type::n_vecs;
 };
 
-} // end of anonymous namespace
+} // end of namespace hyperparam_detail
 
 template <typename argT1,
           typename argT2,
@@ -200,10 +200,10 @@ sycl::event bitwise_or_contig_impl(sycl::queue &exec_q,
                                    ssize_t res_offset,
                                    const std::vector<sycl::event> &depends = {})
 {
-    constexpr std::uint8_t vec_sz =
-        BitwiseOrContigHyperparameterSet<argTy1, argTy2>::vec_sz;
-    constexpr std::uint8_t n_vecs =
-        BitwiseOrContigHyperparameterSet<argTy1, argTy2>::n_vecs;
+    using BitwiseOrHS =
+        hyperparam_detail::BitwiseOrContigHyperparameterSet<argTy1, argTy2>;
+    constexpr std::uint8_t vec_sz = BitwiseOrHS::vec_sz;
+    constexpr std::uint8_t n_vecs = BitwiseOrHS::n_vecs;
 
     return elementwise_common::binary_contig_impl<
         argTy1, argTy2, BitwiseOrOutputType, BitwiseOrContigFunctor,
@@ -384,10 +384,11 @@ bitwise_or_inplace_contig_impl(sycl::queue &exec_q,
                                ssize_t res_offset,
                                const std::vector<sycl::event> &depends = {})
 {
-    constexpr std::uint8_t vec_sz =
-        BitwiseOrContigHyperparameterSet<resTy, argTy>::vec_sz;
-    constexpr std::uint8_t n_vecs =
-        BitwiseOrContigHyperparameterSet<resTy, argTy>::n_vecs;
+    using BitwiseOrHS =
+        hyperparam_detail::BitwiseOrContigHyperparameterSet<resTy, argTy>;
+
+    constexpr std::uint8_t vec_sz = BitwiseOrHS::vec_sz;
+    constexpr std::uint8_t n_vecs = BitwiseOrHS::n_vecs;
 
     return elementwise_common::binary_inplace_contig_impl<
         argTy, resTy, BitwiseOrInplaceContigFunctor,

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/bitwise_right_shift.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/bitwise_right_shift.hpp
@@ -174,7 +174,7 @@ template <typename T1, typename T2> struct BitwiseRightShiftOutputType
     static constexpr bool is_defined = !std::is_same_v<value_type, void>;
 };
 
-namespace
+namespace hyperparam_detail
 {
 
 namespace vsu_ns = dpctl::tensor::kernels::vec_size_utils;
@@ -192,7 +192,7 @@ struct BitwiseRightShiftContigHyperparameterSet
     constexpr static auto n_vecs = value_type::n_vecs;
 };
 
-} // end of anonymous namespace
+} // namespace hyperparam_detail
 
 template <typename argT1,
           typename argT2,
@@ -213,10 +213,11 @@ bitwise_right_shift_contig_impl(sycl::queue &exec_q,
                                 ssize_t res_offset,
                                 const std::vector<sycl::event> &depends = {})
 {
-    constexpr std::uint8_t vec_sz =
-        BitwiseRightShiftContigHyperparameterSet<argTy1, argTy2>::vec_sz;
-    constexpr std::uint8_t n_vecs =
-        BitwiseRightShiftContigHyperparameterSet<argTy1, argTy2>::n_vecs;
+    using BitwiseRSHS =
+        hyperparam_detail::BitwiseRightShiftContigHyperparameterSet<argTy1,
+                                                                    argTy2>;
+    constexpr std::uint8_t vec_sz = BitwiseRSHS::vec_sz;
+    constexpr std::uint8_t n_vecs = BitwiseRSHS::n_vecs;
 
     return elementwise_common::binary_contig_impl<
         argTy1, argTy2, BitwiseRightShiftOutputType,
@@ -407,11 +408,13 @@ sycl::event bitwise_right_shift_inplace_contig_impl(
     ssize_t res_offset,
     const std::vector<sycl::event> &depends = {})
 {
+    using BitwiseRSHS =
+        hyperparam_detail::BitwiseRightShiftContigHyperparameterSet<resTy,
+                                                                    argTy>;
+
     // res = OP(res, arg)
-    constexpr std::uint8_t vec_sz =
-        BitwiseRightShiftContigHyperparameterSet<resTy, argTy>::vec_sz;
-    constexpr std::uint8_t n_vecs =
-        BitwiseRightShiftContigHyperparameterSet<resTy, argTy>::n_vecs;
+    constexpr std::uint8_t vec_sz = BitwiseRSHS::vec_sz;
+    constexpr std::uint8_t n_vecs = BitwiseRSHS::n_vecs;
 
     return elementwise_common::binary_inplace_contig_impl<
         argTy, resTy, BitwiseRightShiftInplaceContigFunctor,

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/bitwise_xor.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/bitwise_xor.hpp
@@ -163,7 +163,7 @@ template <typename T1, typename T2> struct BitwiseXorOutputType
     static constexpr bool is_defined = !std::is_same_v<value_type, void>;
 };
 
-namespace
+namespace hyperparam_detail
 {
 
 namespace vsu_ns = dpctl::tensor::kernels::vec_size_utils;
@@ -181,7 +181,7 @@ struct BitwiseXorContigHyperparameterSet
     constexpr static auto n_vecs = value_type::n_vecs;
 };
 
-} // end of anonymous namespace
+} // end of namespace hyperparam_detail
 
 template <typename argT1,
           typename argT2,
@@ -202,10 +202,10 @@ bitwise_xor_contig_impl(sycl::queue &exec_q,
                         ssize_t res_offset,
                         const std::vector<sycl::event> &depends = {})
 {
-    constexpr std::uint8_t vec_sz =
-        BitwiseXorContigHyperparameterSet<argTy1, argTy2>::vec_sz;
-    constexpr std::uint8_t n_vecs =
-        BitwiseXorContigHyperparameterSet<argTy1, argTy2>::n_vecs;
+    using BitwiseXorHS =
+        hyperparam_detail::BitwiseXorContigHyperparameterSet<argTy1, argTy2>;
+    constexpr std::uint8_t vec_sz = BitwiseXorHS::vec_sz;
+    constexpr std::uint8_t n_vecs = BitwiseXorHS::n_vecs;
 
     return elementwise_common::binary_contig_impl<
         argTy1, argTy2, BitwiseXorOutputType, BitwiseXorContigFunctor,
@@ -390,10 +390,11 @@ bitwise_xor_inplace_contig_impl(sycl::queue &exec_q,
                                 ssize_t res_offset,
                                 const std::vector<sycl::event> &depends = {})
 {
-    constexpr std::uint8_t vec_sz =
-        BitwiseXorContigHyperparameterSet<resTy, argTy>::vec_sz;
-    constexpr std::uint8_t n_vecs =
-        BitwiseXorContigHyperparameterSet<resTy, argTy>::n_vecs;
+    using BitwiseXorHS =
+        hyperparam_detail::BitwiseXorContigHyperparameterSet<resTy, argTy>;
+
+    constexpr std::uint8_t vec_sz = BitwiseXorHS::vec_sz;
+    constexpr std::uint8_t n_vecs = BitwiseXorHS::n_vecs;
 
     return elementwise_common::binary_inplace_contig_impl<
         argTy, resTy, BitwiseXorInplaceContigFunctor,

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/cbrt.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/cbrt.hpp
@@ -94,7 +94,7 @@ template <typename T> struct CbrtOutputType
     static constexpr bool is_defined = !std::is_same_v<value_type, void>;
 };
 
-namespace
+namespace hyperparam_detail
 {
 
 namespace vsu_ns = dpctl::tensor::kernels::vec_size_utils;
@@ -111,7 +111,7 @@ template <typename argTy> struct CbrtContigHyperparameterSet
     constexpr static auto n_vecs = value_type::n_vecs;
 };
 
-} // end of anonymous namespace
+} // end of namespace hyperparam_detail
 
 template <typename T1, typename T2, std::uint8_t vec_sz, std::uint8_t n_vecs>
 class cbrt_contig_kernel;
@@ -123,8 +123,9 @@ sycl::event cbrt_contig_impl(sycl::queue &exec_q,
                              char *res_p,
                              const std::vector<sycl::event> &depends = {})
 {
-    constexpr std::uint8_t vec_sz = CbrtContigHyperparameterSet<argTy>::vec_sz;
-    constexpr std::uint8_t n_vecs = CbrtContigHyperparameterSet<argTy>::n_vecs;
+    using CbrtHS = hyperparam_detail::CbrtContigHyperparameterSet<argTy>;
+    constexpr std::uint8_t vec_sz = CbrtHS::vec_sz;
+    constexpr std::uint8_t n_vecs = CbrtHS::n_vecs;
 
     return elementwise_common::unary_contig_impl<
         argTy, CbrtOutputType, CbrtContigFunctor, cbrt_contig_kernel, vec_sz,

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/ceil.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/ceil.hpp
@@ -115,7 +115,7 @@ template <typename T> struct CeilOutputType
     static constexpr bool is_defined = !std::is_same_v<value_type, void>;
 };
 
-namespace
+namespace hyperparam_detail
 {
 
 namespace vsu_ns = dpctl::tensor::kernels::vec_size_utils;
@@ -132,7 +132,7 @@ template <typename argTy> struct CeilContigHyperparameterSet
     constexpr static auto n_vecs = value_type::n_vecs;
 };
 
-} // end of anonymous namespace
+} // end of namespace hyperparam_detail
 
 template <typename T1, typename T2, std::uint8_t vec_sz, std::uint8_t n_vecs>
 class ceil_contig_kernel;
@@ -144,8 +144,9 @@ sycl::event ceil_contig_impl(sycl::queue &exec_q,
                              char *res_p,
                              const std::vector<sycl::event> &depends = {})
 {
-    constexpr std::uint8_t vec_sz = CeilContigHyperparameterSet<argTy>::vec_sz;
-    constexpr std::uint8_t n_vecs = CeilContigHyperparameterSet<argTy>::n_vecs;
+    using CeilHS = hyperparam_detail::CeilContigHyperparameterSet<argTy>;
+    constexpr std::uint8_t vec_sz = CeilHS::vec_sz;
+    constexpr std::uint8_t n_vecs = CeilHS::n_vecs;
 
     return elementwise_common::unary_contig_impl<
         argTy, CeilOutputType, CeilContigFunctor, ceil_contig_kernel, vec_sz,

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/common.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/common.hpp
@@ -912,11 +912,11 @@ sycl::event binary_contig_matrix_contig_row_broadcast_impl(
         *(std::max_element(std::begin(sg_sizes), std::end(sg_sizes)));
 
     std::size_t n1_padded = n1 + max_sgSize;
-    argT2 *padded_vec = sycl::malloc_device<argT2>(n1_padded, exec_q);
+    auto padded_vec_owner =
+        dpctl::tensor::alloc_utils::smart_malloc_device<argT2>(n1_padded,
+                                                               exec_q);
+    argT2 *padded_vec = padded_vec_owner.get();
 
-    if (padded_vec == nullptr) {
-        throw std::runtime_error("Could not allocate memory on the device");
-    }
     sycl::event make_padded_vec_ev = exec_q.submit([&](sycl::handler &cgh) {
         cgh.depends_on(depends); // ensure vec contains actual data
         cgh.parallel_for({n1_padded}, [=](sycl::id<1> id) {
@@ -948,13 +948,9 @@ sycl::event binary_contig_matrix_contig_row_broadcast_impl(
                 mat, padded_vec, res, n_elems, n1));
     });
 
-    sycl::event tmp_cleanup_ev = exec_q.submit([&](sycl::handler &cgh) {
-        cgh.depends_on(comp_ev);
-        const sycl::context &ctx = exec_q.get_context();
-        using dpctl::tensor::alloc_utils::sycl_free_noexcept;
-        cgh.host_task(
-            [ctx, padded_vec]() { sycl_free_noexcept(padded_vec, ctx); });
-    });
+    sycl::event tmp_cleanup_ev = dpctl::tensor::alloc_utils::async_smart_free(
+        exec_q, {comp_ev}, padded_vec_owner);
+
     host_tasks.push_back(tmp_cleanup_ev);
 
     return comp_ev;
@@ -992,11 +988,10 @@ sycl::event binary_contig_row_contig_matrix_broadcast_impl(
         *(std::max_element(std::begin(sg_sizes), std::end(sg_sizes)));
 
     std::size_t n1_padded = n1 + max_sgSize;
-    argT2 *padded_vec = sycl::malloc_device<argT2>(n1_padded, exec_q);
-
-    if (padded_vec == nullptr) {
-        throw std::runtime_error("Could not allocate memory on the device");
-    }
+    auto padded_vec_owner =
+        dpctl::tensor::alloc_utils::smart_malloc_device<argT2>(n1_padded,
+                                                               exec_q);
+    argT2 *padded_vec = padded_vec_owner.get();
 
     sycl::event make_padded_vec_ev = exec_q.submit([&](sycl::handler &cgh) {
         cgh.depends_on(depends); // ensure vec contains actual data
@@ -1029,13 +1024,9 @@ sycl::event binary_contig_row_contig_matrix_broadcast_impl(
                 padded_vec, mat, res, n_elems, n1));
     });
 
-    sycl::event tmp_cleanup_ev = exec_q.submit([&](sycl::handler &cgh) {
-        cgh.depends_on(comp_ev);
-        const sycl::context &ctx = exec_q.get_context();
-        using dpctl::tensor::alloc_utils::sycl_free_noexcept;
-        cgh.host_task(
-            [ctx, padded_vec]() { sycl_free_noexcept(padded_vec, ctx); });
-    });
+    sycl::event tmp_cleanup_ev = dpctl::tensor::alloc_utils::async_smart_free(
+        exec_q, {comp_ev}, padded_vec_owner);
+
     host_tasks.push_back(tmp_cleanup_ev);
 
     return comp_ev;

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/conj.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/conj.hpp
@@ -122,7 +122,7 @@ template <typename T> struct ConjOutputType
     static constexpr bool is_defined = !std::is_same_v<value_type, void>;
 };
 
-namespace
+namespace hyperparam_detail
 {
 
 namespace vsu_ns = dpctl::tensor::kernels::vec_size_utils;
@@ -139,7 +139,7 @@ template <typename argTy> struct ConjContigHyperparameterSet
     constexpr static auto n_vecs = value_type::n_vecs;
 };
 
-} // end of anonymous namespace
+} // end of namespace hyperparam_detail
 
 template <typename T1, typename T2, std::uint8_t vec_sz, std::uint8_t n_vecs>
 class conj_contig_kernel;
@@ -151,8 +151,9 @@ sycl::event conj_contig_impl(sycl::queue &exec_q,
                              char *res_p,
                              const std::vector<sycl::event> &depends = {})
 {
-    constexpr std::uint8_t vec_sz = ConjContigHyperparameterSet<argTy>::vec_sz;
-    constexpr std::uint8_t n_vecs = ConjContigHyperparameterSet<argTy>::n_vecs;
+    using ConjHS = hyperparam_detail::ConjContigHyperparameterSet<argTy>;
+    constexpr std::uint8_t vec_sz = ConjHS::vec_sz;
+    constexpr std::uint8_t n_vecs = ConjHS::n_vecs;
 
     return elementwise_common::unary_contig_impl<
         argTy, ConjOutputType, ConjContigFunctor, conj_contig_kernel, vec_sz,

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/copysign.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/copysign.hpp
@@ -120,7 +120,7 @@ template <typename T1, typename T2> struct CopysignOutputType
     static constexpr bool is_defined = !std::is_same_v<value_type, void>;
 };
 
-namespace
+namespace hyperparam_detail
 {
 
 namespace vsu_ns = dpctl::tensor::kernels::vec_size_utils;
@@ -138,7 +138,7 @@ struct CopysignContigHyperparameterSet
     constexpr static auto n_vecs = value_type::n_vecs;
 };
 
-} // end of anonymous namespace
+} // end of namespace hyperparam_detail
 
 template <typename argT1,
           typename argT2,
@@ -158,10 +158,10 @@ sycl::event copysign_contig_impl(sycl::queue &exec_q,
                                  ssize_t res_offset,
                                  const std::vector<sycl::event> &depends = {})
 {
-    constexpr std::uint8_t vec_sz =
-        CopysignContigHyperparameterSet<argTy1, argTy2>::vec_sz;
-    constexpr std::uint8_t n_vecs =
-        CopysignContigHyperparameterSet<argTy1, argTy2>::n_vecs;
+    using CopySignHS =
+        hyperparam_detail::CopysignContigHyperparameterSet<argTy1, argTy2>;
+    constexpr std::uint8_t vec_sz = CopySignHS::vec_sz;
+    constexpr std::uint8_t n_vecs = CopySignHS::n_vecs;
 
     return elementwise_common::binary_contig_impl<
         argTy1, argTy2, CopysignOutputType, CopysignContigFunctor,

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/cos.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/cos.hpp
@@ -195,7 +195,7 @@ template <typename T> struct CosOutputType
     static constexpr bool is_defined = !std::is_same_v<value_type, void>;
 };
 
-namespace
+namespace hyperparam_detail
 {
 
 namespace vsu_ns = dpctl::tensor::kernels::vec_size_utils;
@@ -212,7 +212,7 @@ template <typename argTy> struct CosContigHyperparameterSet
     constexpr static auto n_vecs = value_type::n_vecs;
 };
 
-} // end of anonymous namespace
+} // end of namespace hyperparam_detail
 
 template <typename T1, typename T2, std::uint8_t vec_sz, std::uint8_t n_vecs>
 class cos_contig_kernel;
@@ -224,8 +224,9 @@ sycl::event cos_contig_impl(sycl::queue &exec_q,
                             char *res_p,
                             const std::vector<sycl::event> &depends = {})
 {
-    constexpr std::uint8_t vec_sz = CosContigHyperparameterSet<argTy>::vec_sz;
-    constexpr std::uint8_t n_vecs = CosContigHyperparameterSet<argTy>::n_vecs;
+    using CosHS = hyperparam_detail::CosContigHyperparameterSet<argTy>;
+    constexpr std::uint8_t vec_sz = CosHS::vec_sz;
+    constexpr std::uint8_t n_vecs = CosHS::n_vecs;
 
     return elementwise_common::unary_contig_impl<
         argTy, CosOutputType, CosContigFunctor, cos_contig_kernel, vec_sz,

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/cosh.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/cosh.hpp
@@ -184,7 +184,7 @@ template <typename T> struct CoshOutputType
     static constexpr bool is_defined = !std::is_same_v<value_type, void>;
 };
 
-namespace
+namespace hyperparam_detail
 {
 
 namespace vsu_ns = dpctl::tensor::kernels::vec_size_utils;
@@ -201,7 +201,7 @@ template <typename argTy> struct CoshContigHyperparameterSet
     constexpr static auto n_vecs = value_type::n_vecs;
 };
 
-} // end of anonymous namespace
+} // namespace hyperparam_detail
 
 template <typename T1, typename T2, std::uint8_t vec_sz, std::uint8_t n_vecs>
 class cosh_contig_kernel;
@@ -213,8 +213,9 @@ sycl::event cosh_contig_impl(sycl::queue &exec_q,
                              char *res_p,
                              const std::vector<sycl::event> &depends = {})
 {
-    constexpr std::uint8_t vec_sz = CoshContigHyperparameterSet<argTy>::vec_sz;
-    constexpr std::uint8_t n_vecs = CoshContigHyperparameterSet<argTy>::n_vecs;
+    using CoshHS = hyperparam_detail::CoshContigHyperparameterSet<argTy>;
+    constexpr std::uint8_t vec_sz = CoshHS::vec_sz;
+    constexpr std::uint8_t n_vecs = CoshHS::n_vecs;
 
     return elementwise_common::unary_contig_impl<
         argTy, CoshOutputType, CoshContigFunctor, cosh_contig_kernel, vec_sz,

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/equal.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/equal.hpp
@@ -192,7 +192,7 @@ template <typename T1, typename T2> struct EqualOutputType
     static constexpr bool is_defined = !std::is_same_v<value_type, void>;
 };
 
-namespace
+namespace hyperparam_detail
 {
 
 namespace vsu_ns = dpctl::tensor::kernels::vec_size_utils;
@@ -209,7 +209,7 @@ template <typename argTy1, typename argTy2> struct EqualContigHyperparameterSet
     constexpr static auto n_vecs = value_type::n_vecs;
 };
 
-} // end of anonymous namespace
+} // end of namespace hyperparam_detail
 
 template <typename argT1,
           typename argT2,
@@ -229,10 +229,10 @@ sycl::event equal_contig_impl(sycl::queue &exec_q,
                               ssize_t res_offset,
                               const std::vector<sycl::event> &depends = {})
 {
-    constexpr std::uint8_t vec_sz =
-        EqualContigHyperparameterSet<argTy1, argTy2>::vec_sz;
-    constexpr std::uint8_t n_vecs =
-        EqualContigHyperparameterSet<argTy1, argTy2>::n_vecs;
+    using EqualHS =
+        hyperparam_detail::EqualContigHyperparameterSet<argTy1, argTy2>;
+    constexpr std::uint8_t vec_sz = EqualHS::vec_sz;
+    constexpr std::uint8_t n_vecs = EqualHS::n_vecs;
 
     return elementwise_common::binary_contig_impl<
         argTy1, argTy2, EqualOutputType, EqualContigFunctor,

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/exp.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/exp.hpp
@@ -153,7 +153,7 @@ template <typename T> struct ExpOutputType
     static constexpr bool is_defined = !std::is_same_v<value_type, void>;
 };
 
-namespace
+namespace hyperparam_detail
 {
 
 namespace vsu_ns = dpctl::tensor::kernels::vec_size_utils;
@@ -170,7 +170,7 @@ template <typename argTy> struct ExpContigHyperparameterSet
     constexpr static auto n_vecs = value_type::n_vecs;
 };
 
-} // end of anonymous namespace
+} // end of namespace hyperparam_detail
 
 template <typename T1, typename T2, std::uint8_t vec_sz, std::uint8_t n_vecs>
 class exp_contig_kernel;
@@ -182,8 +182,9 @@ sycl::event exp_contig_impl(sycl::queue &exec_q,
                             char *res_p,
                             const std::vector<sycl::event> &depends = {})
 {
-    constexpr std::uint8_t vec_sz = ExpContigHyperparameterSet<argTy>::vec_sz;
-    constexpr std::uint8_t n_vecs = ExpContigHyperparameterSet<argTy>::n_vecs;
+    using ExpHS = hyperparam_detail::ExpContigHyperparameterSet<argTy>;
+    constexpr std::uint8_t vec_sz = ExpHS::vec_sz;
+    constexpr std::uint8_t n_vecs = ExpHS::n_vecs;
 
     return elementwise_common::unary_contig_impl<
         argTy, ExpOutputType, ExpContigFunctor, exp_contig_kernel, vec_sz,

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/exp2.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/exp2.hpp
@@ -155,7 +155,7 @@ template <typename T> struct Exp2OutputType
     static constexpr bool is_defined = !std::is_same_v<value_type, void>;
 };
 
-namespace
+namespace hyperparam_detail
 {
 
 namespace vsu_ns = dpctl::tensor::kernels::vec_size_utils;
@@ -172,7 +172,7 @@ template <typename argTy> struct Exp2ContigHyperparameterSet
     constexpr static auto n_vecs = value_type::n_vecs;
 };
 
-} // end of anonymous namespace
+} // end of namespace hyperparam_detail
 
 template <typename T1, typename T2, std::uint8_t vec_sz, std::uint8_t n_vecs>
 class exp2_contig_kernel;
@@ -184,8 +184,10 @@ sycl::event exp2_contig_impl(sycl::queue &exec_q,
                              char *res_p,
                              const std::vector<sycl::event> &depends = {})
 {
-    constexpr std::uint8_t vec_sz = Exp2ContigHyperparameterSet<argTy>::vec_sz;
-    constexpr std::uint8_t n_vecs = Exp2ContigHyperparameterSet<argTy>::n_vecs;
+    using Exp2HS = hyperparam_detail::Exp2ContigHyperparameterSet<argTy>;
+
+    constexpr std::uint8_t vec_sz = Exp2HS::vec_sz;
+    constexpr std::uint8_t n_vecs = Exp2HS::n_vecs;
 
     return elementwise_common::unary_contig_impl<
         argTy, Exp2OutputType, Exp2ContigFunctor, exp2_contig_kernel, vec_sz,

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/expm1.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/expm1.hpp
@@ -168,7 +168,7 @@ template <typename T> struct Expm1OutputType
     static constexpr bool is_defined = !std::is_same_v<value_type, void>;
 };
 
-namespace
+namespace hyperparam_detail
 {
 
 namespace vsu_ns = dpctl::tensor::kernels::vec_size_utils;
@@ -185,7 +185,7 @@ template <typename argTy> struct Expm1ContigHyperparameterSet
     constexpr static auto n_vecs = value_type::n_vecs;
 };
 
-} // end of anonymous namespace
+} // end of namespace hyperparam_detail
 
 template <typename T1, typename T2, std::uint8_t vec_sz, std::uint8_t n_vecs>
 class expm1_contig_kernel;
@@ -197,8 +197,9 @@ sycl::event expm1_contig_impl(sycl::queue &exec_q,
                               char *res_p,
                               const std::vector<sycl::event> &depends = {})
 {
-    constexpr std::uint8_t vec_sz = Expm1ContigHyperparameterSet<argTy>::vec_sz;
-    constexpr std::uint8_t n_vecs = Expm1ContigHyperparameterSet<argTy>::n_vecs;
+    using Expm1HS = hyperparam_detail::Expm1ContigHyperparameterSet<argTy>;
+    constexpr std::uint8_t vec_sz = Expm1HS::vec_sz;
+    constexpr std::uint8_t n_vecs = Expm1HS::n_vecs;
 
     return elementwise_common::unary_contig_impl<
         argTy, Expm1OutputType, Expm1ContigFunctor, expm1_contig_kernel, vec_sz,

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/floor.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/floor.hpp
@@ -115,7 +115,7 @@ template <typename T> struct FloorOutputType
     static constexpr bool is_defined = !std::is_same_v<value_type, void>;
 };
 
-namespace
+namespace hyperparam_detail
 {
 
 namespace vsu_ns = dpctl::tensor::kernels::vec_size_utils;
@@ -132,7 +132,7 @@ template <typename argTy> struct FloorContigHyperparameterSet
     constexpr static auto n_vecs = value_type::n_vecs;
 };
 
-} // end of anonymous namespace
+} // end of namespace hyperparam_detail
 
 template <typename T1, typename T2, std::uint8_t vec_sz, std::uint8_t n_vecs>
 class floor_contig_kernel;
@@ -144,8 +144,9 @@ sycl::event floor_contig_impl(sycl::queue &exec_q,
                               char *res_p,
                               const std::vector<sycl::event> &depends = {})
 {
-    constexpr std::uint8_t vec_sz = FloorContigHyperparameterSet<argTy>::vec_sz;
-    constexpr std::uint8_t n_vecs = FloorContigHyperparameterSet<argTy>::n_vecs;
+    using FloorHS = hyperparam_detail::FloorContigHyperparameterSet<argTy>;
+    constexpr std::uint8_t vec_sz = FloorHS::vec_sz;
+    constexpr std::uint8_t n_vecs = FloorHS::n_vecs;
 
     return elementwise_common::unary_contig_impl<
         argTy, FloorOutputType, FloorContigFunctor, floor_contig_kernel, vec_sz,

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/floor_divide.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/floor_divide.hpp
@@ -204,7 +204,7 @@ template <typename T1, typename T2> struct FloorDivideOutputType
     static constexpr bool is_defined = !std::is_same_v<value_type, void>;
 };
 
-namespace
+namespace hyperparam_detail
 {
 
 namespace vsu_ns = dpctl::tensor::kernels::vec_size_utils;
@@ -222,7 +222,7 @@ struct FloorDivideContigHyperparameterSet
     constexpr static auto n_vecs = value_type::n_vecs;
 };
 
-} // end of anonymous namespace
+} // end of namespace hyperparam_detail
 
 template <typename argT1,
           typename argT2,
@@ -243,10 +243,10 @@ floor_divide_contig_impl(sycl::queue &exec_q,
                          ssize_t res_offset,
                          const std::vector<sycl::event> &depends = {})
 {
-    constexpr std::uint8_t vec_sz =
-        FloorDivideContigHyperparameterSet<argTy1, argTy2>::vec_sz;
-    constexpr std::uint8_t n_vecs =
-        FloorDivideContigHyperparameterSet<argTy1, argTy2>::n_vecs;
+    using FloorDivideHS =
+        hyperparam_detail::FloorDivideContigHyperparameterSet<argTy1, argTy2>;
+    constexpr std::uint8_t vec_sz = FloorDivideHS::vec_sz;
+    constexpr std::uint8_t n_vecs = FloorDivideHS::n_vecs;
 
     return elementwise_common::binary_contig_impl<
         argTy1, argTy2, FloorDivideOutputType, FloorDivideContigFunctor,
@@ -469,10 +469,11 @@ floor_divide_inplace_contig_impl(sycl::queue &exec_q,
                                  ssize_t res_offset,
                                  const std::vector<sycl::event> &depends = {})
 {
-    constexpr std::uint8_t vec_sz =
-        FloorDivideContigHyperparameterSet<resTy, argTy>::vec_sz;
-    constexpr std::uint8_t n_vecs =
-        FloorDivideContigHyperparameterSet<resTy, argTy>::n_vecs;
+    using FloorDivideHS =
+        hyperparam_detail::FloorDivideContigHyperparameterSet<resTy, argTy>;
+
+    constexpr std::uint8_t vec_sz = FloorDivideHS::vec_sz;
+    constexpr std::uint8_t n_vecs = FloorDivideHS::n_vecs;
 
     return elementwise_common::binary_inplace_contig_impl<
         argTy, resTy, FloorDivideInplaceContigFunctor,

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/greater.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/greater.hpp
@@ -193,7 +193,7 @@ template <typename T1, typename T2> struct GreaterOutputType
     static constexpr bool is_defined = !std::is_same_v<value_type, void>;
 };
 
-namespace
+namespace hyperparam_detail
 {
 
 namespace vsu_ns = dpctl::tensor::kernels::vec_size_utils;
@@ -211,7 +211,7 @@ struct GreaterContigHyperparameterSet
     constexpr static auto n_vecs = value_type::n_vecs;
 };
 
-} // end of anonymous namespace
+} // end of namespace hyperparam_detail
 
 template <typename argT1,
           typename argT2,
@@ -231,10 +231,11 @@ sycl::event greater_contig_impl(sycl::queue &exec_q,
                                 ssize_t res_offset,
                                 const std::vector<sycl::event> &depends = {})
 {
-    constexpr std::uint8_t vec_sz =
-        GreaterContigHyperparameterSet<argTy1, argTy2>::vec_sz;
-    constexpr std::uint8_t n_vecs =
-        GreaterContigHyperparameterSet<argTy1, argTy2>::n_vecs;
+    using GreaterHS =
+        hyperparam_detail::GreaterContigHyperparameterSet<argTy1, argTy2>;
+
+    constexpr std::uint8_t vec_sz = GreaterHS::vec_sz;
+    constexpr std::uint8_t n_vecs = GreaterHS::n_vecs;
 
     return elementwise_common::binary_contig_impl<
         argTy1, argTy2, GreaterOutputType, GreaterContigFunctor,

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/greater_equal.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/greater_equal.hpp
@@ -194,7 +194,7 @@ template <typename T1, typename T2> struct GreaterEqualOutputType
     static constexpr bool is_defined = !std::is_same_v<value_type, void>;
 };
 
-namespace
+namespace hyperparam_detail
 {
 
 namespace vsu_ns = dpctl::tensor::kernels::vec_size_utils;
@@ -212,7 +212,7 @@ struct GreaterEqualContigHyperparameterSet
     constexpr static auto n_vecs = value_type::n_vecs;
 };
 
-} // end of anonymous namespace
+} // end of namespace hyperparam_detail
 
 template <typename argT1,
           typename argT2,
@@ -233,10 +233,10 @@ greater_equal_contig_impl(sycl::queue &exec_q,
                           ssize_t res_offset,
                           const std::vector<sycl::event> &depends = {})
 {
-    constexpr std::uint8_t vec_sz =
-        GreaterEqualContigHyperparameterSet<argTy1, argTy2>::vec_sz;
-    constexpr std::uint8_t n_vecs =
-        GreaterEqualContigHyperparameterSet<argTy1, argTy2>::n_vecs;
+    using GreaterEqHS =
+        hyperparam_detail::GreaterEqualContigHyperparameterSet<argTy1, argTy2>;
+    constexpr std::uint8_t vec_sz = GreaterEqHS::vec_sz;
+    constexpr std::uint8_t n_vecs = GreaterEqHS::n_vecs;
 
     return elementwise_common::binary_contig_impl<
         argTy1, argTy2, GreaterEqualOutputType, GreaterEqualContigFunctor,

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/hypot.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/hypot.hpp
@@ -122,7 +122,7 @@ template <typename T1, typename T2> struct HypotOutputType
     static constexpr bool is_defined = !std::is_same_v<value_type, void>;
 };
 
-namespace
+namespace hyperparam_detail
 {
 
 namespace vsu_ns = dpctl::tensor::kernels::vec_size_utils;
@@ -139,7 +139,7 @@ template <typename argTy1, typename argTy2> struct HypotContigHyperparameterSet
     constexpr static auto n_vecs = value_type::n_vecs;
 };
 
-} // end of anonymous namespace
+} // end of namespace hyperparam_detail
 
 template <typename argT1,
           typename argT2,
@@ -159,10 +159,10 @@ sycl::event hypot_contig_impl(sycl::queue &exec_q,
                               ssize_t res_offset,
                               const std::vector<sycl::event> &depends = {})
 {
-    constexpr std::uint8_t vec_sz =
-        HypotContigHyperparameterSet<argTy1, argTy2>::vec_sz;
-    constexpr std::uint8_t n_vecs =
-        HypotContigHyperparameterSet<argTy1, argTy2>::n_vecs;
+    using HypotHS =
+        hyperparam_detail::HypotContigHyperparameterSet<argTy1, argTy2>;
+    constexpr std::uint8_t vec_sz = HypotHS::vec_sz;
+    constexpr std::uint8_t n_vecs = HypotHS::n_vecs;
 
     return elementwise_common::binary_contig_impl<
         argTy1, argTy2, HypotOutputType, HypotContigFunctor,

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/imag.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/imag.hpp
@@ -118,7 +118,7 @@ template <typename T> struct ImagOutputType
     static constexpr bool is_defined = !std::is_same_v<value_type, void>;
 };
 
-namespace
+namespace hyperparam_detail
 {
 
 namespace vsu_ns = dpctl::tensor::kernels::vec_size_utils;
@@ -135,7 +135,7 @@ template <typename argTy> struct ImagContigHyperparameterSet
     constexpr static auto n_vecs = value_type::n_vecs;
 };
 
-} // end of anonymous namespace
+} // end of namespace hyperparam_detail
 
 template <typename T1, typename T2, std::uint8_t vec_sz, std::uint8_t n_vecs>
 class imag_contig_kernel;
@@ -147,8 +147,9 @@ sycl::event imag_contig_impl(sycl::queue &exec_q,
                              char *res_p,
                              const std::vector<sycl::event> &depends = {})
 {
-    constexpr std::uint8_t vec_sz = ImagContigHyperparameterSet<argTy>::vec_sz;
-    constexpr std::uint8_t n_vecs = ImagContigHyperparameterSet<argTy>::n_vecs;
+    using ImagHS = hyperparam_detail::ImagContigHyperparameterSet<argTy>;
+    constexpr std::uint8_t vec_sz = ImagHS::vec_sz;
+    constexpr std::uint8_t n_vecs = ImagHS::n_vecs;
 
     return elementwise_common::unary_contig_impl<
         argTy, ImagOutputType, ImagContigFunctor, imag_contig_kernel, vec_sz,

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/isfinite.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/isfinite.hpp
@@ -120,7 +120,7 @@ template <typename argTy> struct IsFiniteOutputType
     using value_type = bool;
 };
 
-namespace
+namespace hyperparam_detail
 {
 
 namespace vsu_ns = dpctl::tensor::kernels::vec_size_utils;
@@ -137,7 +137,7 @@ template <typename argTy> struct IsFiniteContigHyperparameterSet
     constexpr static auto n_vecs = value_type::n_vecs;
 };
 
-} // end of anonymous namespace
+} // end of namespace hyperparam_detail
 
 template <typename T1, typename T2, std::uint8_t vec_sz, std::uint8_t n_vecs>
 class isfinite_contig_kernel;
@@ -149,10 +149,10 @@ sycl::event isfinite_contig_impl(sycl::queue &exec_q,
                                  char *res_p,
                                  const std::vector<sycl::event> &depends = {})
 {
-    constexpr std::uint8_t vec_sz =
-        IsFiniteContigHyperparameterSet<argTy>::vec_sz;
-    constexpr std::uint8_t n_vecs =
-        IsFiniteContigHyperparameterSet<argTy>::n_vecs;
+    using IsFiniteHS =
+        hyperparam_detail::IsFiniteContigHyperparameterSet<argTy>;
+    constexpr std::uint8_t vec_sz = IsFiniteHS::vec_sz;
+    constexpr std::uint8_t n_vecs = IsFiniteHS::n_vecs;
 
     return elementwise_common::unary_contig_impl<
         argTy, IsFiniteOutputType, IsFiniteContigFunctor,

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/isinf.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/isinf.hpp
@@ -120,7 +120,7 @@ template <typename argTy> struct IsInfOutputType
     using value_type = bool;
 };
 
-namespace
+namespace hyperparam_detail
 {
 
 namespace vsu_ns = dpctl::tensor::kernels::vec_size_utils;
@@ -137,7 +137,7 @@ template <typename argTy> struct IsInfContigHyperparameterSet
     constexpr static auto n_vecs = value_type::n_vecs;
 };
 
-} // end of anonymous namespace
+} // namespace hyperparam_detail
 
 template <typename T1, typename T2, std::uint8_t vec_sz, std::uint8_t n_vecs>
 class isinf_contig_kernel;
@@ -149,8 +149,9 @@ sycl::event isinf_contig_impl(sycl::queue &exec_q,
                               char *res_p,
                               const std::vector<sycl::event> &depends = {})
 {
-    constexpr std::uint8_t vec_sz = IsInfContigHyperparameterSet<argTy>::vec_sz;
-    constexpr std::uint8_t n_vecs = IsInfContigHyperparameterSet<argTy>::n_vecs;
+    using IsInfHS = hyperparam_detail::IsInfContigHyperparameterSet<argTy>;
+    constexpr std::uint8_t vec_sz = IsInfHS::vec_sz;
+    constexpr std::uint8_t n_vecs = IsInfHS::n_vecs;
 
     return elementwise_common::unary_contig_impl<
         argTy, IsInfOutputType, IsInfContigFunctor, isinf_contig_kernel, vec_sz,

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/isnan.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/isnan.hpp
@@ -118,7 +118,7 @@ template <typename argTy> struct IsNanOutputType
     using value_type = bool;
 };
 
-namespace
+namespace hyperparam_detail
 {
 
 namespace vsu_ns = dpctl::tensor::kernels::vec_size_utils;
@@ -135,7 +135,7 @@ template <typename argTy> struct IsNanContigHyperparameterSet
     constexpr static auto n_vecs = value_type::n_vecs;
 };
 
-} // end of anonymous namespace
+} // end of namespace hyperparam_detail
 
 template <typename T1, typename T2, std::uint8_t vec_sz, std::uint8_t n_vecs>
 class isnan_contig_kernel;
@@ -147,8 +147,9 @@ sycl::event isnan_contig_impl(sycl::queue &exec_q,
                               char *res_p,
                               const std::vector<sycl::event> &depends = {})
 {
-    constexpr std::uint8_t vec_sz = IsNanContigHyperparameterSet<argTy>::vec_sz;
-    constexpr std::uint8_t n_vecs = IsNanContigHyperparameterSet<argTy>::n_vecs;
+    using IsNanHS = hyperparam_detail::IsNanContigHyperparameterSet<argTy>;
+    constexpr std::uint8_t vec_sz = IsNanHS::vec_sz;
+    constexpr std::uint8_t n_vecs = IsNanHS::n_vecs;
 
     return elementwise_common::unary_contig_impl<
         argTy, IsNanOutputType, IsNanContigFunctor, isnan_contig_kernel, vec_sz,

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/less.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/less.hpp
@@ -191,7 +191,7 @@ template <typename T1, typename T2> struct LessOutputType
     static constexpr bool is_defined = !std::is_same_v<value_type, void>;
 };
 
-namespace
+namespace hyperparam_detail
 {
 
 namespace vsu_ns = dpctl::tensor::kernels::vec_size_utils;
@@ -208,7 +208,7 @@ template <typename argTy1, typename argTy2> struct LessContigHyperparameterSet
     constexpr static auto n_vecs = value_type::n_vecs;
 };
 
-} // end of anonymous namespace
+} // end of namespace hyperparam_detail
 
 template <typename argT1,
           typename argT2,
@@ -228,10 +228,10 @@ sycl::event less_contig_impl(sycl::queue &exec_q,
                              ssize_t res_offset,
                              const std::vector<sycl::event> &depends = {})
 {
-    constexpr std::uint8_t vec_sz =
-        LessContigHyperparameterSet<argTy1, argTy2>::vec_sz;
-    constexpr std::uint8_t n_vecs =
-        LessContigHyperparameterSet<argTy1, argTy2>::n_vecs;
+    using LessHS =
+        hyperparam_detail::LessContigHyperparameterSet<argTy1, argTy2>;
+    constexpr std::uint8_t vec_sz = LessHS::vec_sz;
+    constexpr std::uint8_t n_vecs = LessHS::n_vecs;
 
     return elementwise_common::binary_contig_impl<
         argTy1, argTy2, LessOutputType, LessContigFunctor, less_contig_kernel,

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/less_equal.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/less_equal.hpp
@@ -192,7 +192,7 @@ template <typename T1, typename T2> struct LessEqualOutputType
     static constexpr bool is_defined = !std::is_same_v<value_type, void>;
 };
 
-namespace
+namespace hyperparam_detail
 {
 
 namespace vsu_ns = dpctl::tensor::kernels::vec_size_utils;
@@ -210,7 +210,7 @@ struct LessEqualContigHyperparameterSet
     constexpr static auto n_vecs = value_type::n_vecs;
 };
 
-} // end of anonymous namespace
+} // end of namespace hyperparam_detail
 
 template <typename argT1,
           typename argT2,
@@ -230,10 +230,10 @@ sycl::event less_equal_contig_impl(sycl::queue &exec_q,
                                    ssize_t res_offset,
                                    const std::vector<sycl::event> &depends = {})
 {
-    constexpr std::uint8_t vec_sz =
-        LessEqualContigHyperparameterSet<argTy1, argTy2>::vec_sz;
-    constexpr std::uint8_t n_vecs =
-        LessEqualContigHyperparameterSet<argTy1, argTy2>::n_vecs;
+    using LessEqHS =
+        hyperparam_detail::LessEqualContigHyperparameterSet<argTy1, argTy2>;
+    constexpr std::uint8_t vec_sz = LessEqHS::vec_sz;
+    constexpr std::uint8_t n_vecs = LessEqHS::n_vecs;
 
     return elementwise_common::binary_contig_impl<
         argTy1, argTy2, LessEqualOutputType, LessEqualContigFunctor,

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/log.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/log.hpp
@@ -110,7 +110,7 @@ template <typename T> struct LogOutputType
     static constexpr bool is_defined = !std::is_same_v<value_type, void>;
 };
 
-namespace
+namespace hyperparam_detail
 {
 
 namespace vsu_ns = dpctl::tensor::kernels::vec_size_utils;
@@ -127,7 +127,7 @@ template <typename argTy> struct LogContigHyperparameterSet
     constexpr static auto n_vecs = value_type::n_vecs;
 };
 
-} // end of anonymous namespace
+} // end of namespace hyperparam_detail
 
 template <typename T1, typename T2, std::uint8_t vec_sz, std::uint8_t n_vecs>
 class log_contig_kernel;
@@ -139,8 +139,9 @@ sycl::event log_contig_impl(sycl::queue &exec_q,
                             char *res_p,
                             const std::vector<sycl::event> &depends = {})
 {
-    constexpr std::uint8_t vec_sz = LogContigHyperparameterSet<argTy>::vec_sz;
-    constexpr std::uint8_t n_vecs = LogContigHyperparameterSet<argTy>::n_vecs;
+    using LogHS = hyperparam_detail::LogContigHyperparameterSet<argTy>;
+    constexpr std::uint8_t vec_sz = LogHS::vec_sz;
+    constexpr std::uint8_t n_vecs = LogHS::n_vecs;
 
     return elementwise_common::unary_contig_impl<
         argTy, LogOutputType, LogContigFunctor, log_contig_kernel, vec_sz,

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/log10.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/log10.hpp
@@ -129,7 +129,7 @@ template <typename T> struct Log10OutputType
     static constexpr bool is_defined = !std::is_same_v<value_type, void>;
 };
 
-namespace
+namespace hyperparam_detail
 {
 
 namespace vsu_ns = dpctl::tensor::kernels::vec_size_utils;
@@ -146,7 +146,7 @@ template <typename argTy> struct Log10ContigHyperparameterSet
     constexpr static auto n_vecs = value_type::n_vecs;
 };
 
-} // end of anonymous namespace
+} // end of namespace hyperparam_detail
 
 template <typename T1, typename T2, std::uint8_t vec_sz, std::uint8_t n_vecs>
 class log10_contig_kernel;
@@ -158,8 +158,9 @@ sycl::event log10_contig_impl(sycl::queue &exec_q,
                               char *res_p,
                               const std::vector<sycl::event> &depends = {})
 {
-    constexpr std::uint8_t vec_sz = Log10ContigHyperparameterSet<argTy>::vec_sz;
-    constexpr std::uint8_t n_vecs = Log10ContigHyperparameterSet<argTy>::n_vecs;
+    using Log10HS = hyperparam_detail::Log10ContigHyperparameterSet<argTy>;
+    constexpr std::uint8_t vec_sz = Log10HS::vec_sz;
+    constexpr std::uint8_t n_vecs = Log10HS::n_vecs;
 
     return elementwise_common::unary_contig_impl<
         argTy, Log10OutputType, Log10ContigFunctor, log10_contig_kernel, vec_sz,

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/log1p.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/log1p.hpp
@@ -134,7 +134,7 @@ template <typename T> struct Log1pOutputType
     static constexpr bool is_defined = !std::is_same_v<value_type, void>;
 };
 
-namespace
+namespace hyperparam_detail
 {
 
 namespace vsu_ns = dpctl::tensor::kernels::vec_size_utils;
@@ -151,7 +151,7 @@ template <typename argTy> struct Log1pContigHyperparameterSet
     constexpr static auto n_vecs = value_type::n_vecs;
 };
 
-} // end of anonymous namespace
+} // end of namespace hyperparam_detail
 
 template <typename T1, typename T2, std::uint8_t vec_sz, std::uint8_t n_vecs>
 class log1p_contig_kernel;
@@ -163,8 +163,9 @@ sycl::event log1p_contig_impl(sycl::queue &exec_q,
                               char *res_p,
                               const std::vector<sycl::event> &depends = {})
 {
-    constexpr std::uint8_t vec_sz = Log1pContigHyperparameterSet<argTy>::vec_sz;
-    constexpr std::uint8_t n_vecs = Log1pContigHyperparameterSet<argTy>::n_vecs;
+    using Log1pHS = hyperparam_detail::Log1pContigHyperparameterSet<argTy>;
+    constexpr std::uint8_t vec_sz = Log1pHS::vec_sz;
+    constexpr std::uint8_t n_vecs = Log1pHS::n_vecs;
 
     return elementwise_common::unary_contig_impl<
         argTy, Log1pOutputType, Log1pContigFunctor, log1p_contig_kernel, vec_sz,

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/log2.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/log2.hpp
@@ -130,7 +130,7 @@ template <typename T> struct Log2OutputType
     static constexpr bool is_defined = !std::is_same_v<value_type, void>;
 };
 
-namespace
+namespace hyperparam_detail
 {
 
 namespace vsu_ns = dpctl::tensor::kernels::vec_size_utils;
@@ -147,7 +147,7 @@ template <typename argTy> struct Log2ContigHyperparameterSet
     constexpr static auto n_vecs = value_type::n_vecs;
 };
 
-} // end of anonymous namespace
+} // end of namespace hyperparam_detail
 
 template <typename T1, typename T2, std::uint8_t vec_sz, std::uint8_t n_vecs>
 class log2_contig_kernel;
@@ -159,8 +159,9 @@ sycl::event log2_contig_impl(sycl::queue &exec_q,
                              char *res_p,
                              const std::vector<sycl::event> &depends = {})
 {
-    constexpr std::uint8_t vec_sz = Log2ContigHyperparameterSet<argTy>::vec_sz;
-    constexpr std::uint8_t n_vecs = Log2ContigHyperparameterSet<argTy>::n_vecs;
+    using Log2HS = hyperparam_detail::Log2ContigHyperparameterSet<argTy>;
+    constexpr std::uint8_t vec_sz = Log2HS::vec_sz;
+    constexpr std::uint8_t n_vecs = Log2HS::n_vecs;
 
     return elementwise_common::unary_contig_impl<
         argTy, Log2OutputType, Log2ContigFunctor, log2_contig_kernel, vec_sz,

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/logaddexp.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/logaddexp.hpp
@@ -137,7 +137,7 @@ template <typename T1, typename T2> struct LogAddExpOutputType
     static constexpr bool is_defined = !std::is_same_v<value_type, void>;
 };
 
-namespace
+namespace hyperparam_detail
 {
 
 namespace vsu_ns = dpctl::tensor::kernels::vec_size_utils;
@@ -155,7 +155,7 @@ struct LogAddExpContigHyperparameterSet
     constexpr static auto n_vecs = value_type::n_vecs;
 };
 
-} // end of anonymous namespace
+} // end of namespace hyperparam_detail
 
 template <typename argT1,
           typename argT2,
@@ -175,10 +175,10 @@ sycl::event logaddexp_contig_impl(sycl::queue &exec_q,
                                   ssize_t res_offset,
                                   const std::vector<sycl::event> &depends = {})
 {
-    constexpr std::uint8_t vec_sz =
-        LogAddExpContigHyperparameterSet<argTy1, argTy2>::vec_sz;
-    constexpr std::uint8_t n_vecs =
-        LogAddExpContigHyperparameterSet<argTy1, argTy2>::n_vecs;
+    using LogAddExpHS =
+        hyperparam_detail::LogAddExpContigHyperparameterSet<argTy1, argTy2>;
+    constexpr std::uint8_t vec_sz = LogAddExpHS::vec_sz;
+    constexpr std::uint8_t n_vecs = LogAddExpHS::n_vecs;
 
     return elementwise_common::binary_contig_impl<
         argTy1, argTy2, LogAddExpOutputType, LogAddExpContigFunctor,

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/logical_and.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/logical_and.hpp
@@ -162,7 +162,7 @@ template <typename T1, typename T2> struct LogicalAndOutputType
     static constexpr bool is_defined = !std::is_same_v<value_type, void>;
 };
 
-namespace
+namespace hyperparam_detail
 {
 
 namespace vsu_ns = dpctl::tensor::kernels::vec_size_utils;
@@ -180,7 +180,7 @@ struct LogicalAndContigHyperparameterSet
     constexpr static auto n_vecs = value_type::n_vecs;
 };
 
-} // end of anonymous namespace
+} // end of namespace hyperparam_detail
 
 template <typename argT1,
           typename argT2,
@@ -201,10 +201,10 @@ logical_and_contig_impl(sycl::queue &exec_q,
                         ssize_t res_offset,
                         const std::vector<sycl::event> &depends = {})
 {
-    constexpr std::uint8_t vec_sz =
-        LogicalAndContigHyperparameterSet<argTy1, argTy2>::vec_sz;
-    constexpr std::uint8_t n_vecs =
-        LogicalAndContigHyperparameterSet<argTy1, argTy2>::n_vecs;
+    using LogicalAndHS =
+        hyperparam_detail::LogicalAndContigHyperparameterSet<argTy1, argTy2>;
+    constexpr std::uint8_t vec_sz = LogicalAndHS::vec_sz;
+    constexpr std::uint8_t n_vecs = LogicalAndHS::n_vecs;
 
     return elementwise_common::binary_contig_impl<
         argTy1, argTy2, LogicalAndOutputType, LogicalAndContigFunctor,

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/logical_not.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/logical_not.hpp
@@ -93,7 +93,7 @@ template <typename argTy> struct LogicalNotOutputType
     using value_type = bool;
 };
 
-namespace
+namespace hyperparam_detail
 {
 
 namespace vsu_ns = dpctl::tensor::kernels::vec_size_utils;
@@ -110,7 +110,7 @@ template <typename argTy> struct LogicalNotContigHyperparameterSet
     constexpr static auto n_vecs = value_type::n_vecs;
 };
 
-} // end of anonymous namespace
+} // end of namespace hyperparam_detail
 
 template <typename T1, typename T2, std::uint8_t vec_sz, std::uint8_t n_vecs>
 class logical_not_contig_kernel;
@@ -123,10 +123,10 @@ logical_not_contig_impl(sycl::queue &exec_q,
                         char *res_p,
                         const std::vector<sycl::event> &depends = {})
 {
-    constexpr std::uint8_t vec_sz =
-        LogicalNotContigHyperparameterSet<argTy>::vec_sz;
-    constexpr std::uint8_t n_vecs =
-        LogicalNotContigHyperparameterSet<argTy>::n_vecs;
+    using LogicalNotHS =
+        hyperparam_detail::LogicalNotContigHyperparameterSet<argTy>;
+    constexpr std::uint8_t vec_sz = LogicalNotHS::vec_sz;
+    constexpr std::uint8_t n_vecs = LogicalNotHS::n_vecs;
 
     return elementwise_common::unary_contig_impl<
         argTy, LogicalNotOutputType, LogicalNotContigFunctor,

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/logical_or.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/logical_or.hpp
@@ -161,7 +161,7 @@ template <typename T1, typename T2> struct LogicalOrOutputType
     static constexpr bool is_defined = !std::is_same_v<value_type, void>;
 };
 
-namespace
+namespace hyperparam_detail
 {
 
 namespace vsu_ns = dpctl::tensor::kernels::vec_size_utils;
@@ -179,7 +179,7 @@ struct LogicalOrContigHyperparameterSet
     constexpr static auto n_vecs = value_type::n_vecs;
 };
 
-} // end of anonymous namespace
+} // end of namespace hyperparam_detail
 
 template <typename argT1,
           typename argT2,
@@ -199,10 +199,10 @@ sycl::event logical_or_contig_impl(sycl::queue &exec_q,
                                    ssize_t res_offset,
                                    const std::vector<sycl::event> &depends = {})
 {
-    constexpr std::uint8_t vec_sz =
-        LogicalOrContigHyperparameterSet<argTy1, argTy2>::vec_sz;
-    constexpr std::uint8_t n_vecs =
-        LogicalOrContigHyperparameterSet<argTy1, argTy2>::n_vecs;
+    using LogicalOrHS =
+        hyperparam_detail::LogicalOrContigHyperparameterSet<argTy1, argTy2>;
+    constexpr std::uint8_t vec_sz = LogicalOrHS::vec_sz;
+    constexpr std::uint8_t n_vecs = LogicalOrHS::n_vecs;
 
     return elementwise_common::binary_contig_impl<
         argTy1, argTy2, LogicalOrOutputType, LogicalOrContigFunctor,

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/logical_xor.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/logical_xor.hpp
@@ -163,7 +163,7 @@ template <typename T1, typename T2> struct LogicalXorOutputType
     static constexpr bool is_defined = !std::is_same_v<value_type, void>;
 };
 
-namespace
+namespace hyperparam_detail
 {
 
 namespace vsu_ns = dpctl::tensor::kernels::vec_size_utils;
@@ -181,7 +181,7 @@ struct LogicalXorContigHyperparameterSet
     constexpr static auto n_vecs = value_type::n_vecs;
 };
 
-} // end of anonymous namespace
+} // end of namespace hyperparam_detail
 
 template <typename argT1,
           typename argT2,
@@ -202,10 +202,10 @@ logical_xor_contig_impl(sycl::queue &exec_q,
                         ssize_t res_offset,
                         const std::vector<sycl::event> &depends = {})
 {
-    constexpr std::uint8_t vec_sz =
-        LogicalXorContigHyperparameterSet<argTy1, argTy2>::vec_sz;
-    constexpr std::uint8_t n_vecs =
-        LogicalXorContigHyperparameterSet<argTy1, argTy2>::n_vecs;
+    using LogicalXorHS =
+        hyperparam_detail::LogicalXorContigHyperparameterSet<argTy1, argTy2>;
+    constexpr std::uint8_t vec_sz = LogicalXorHS::vec_sz;
+    constexpr std::uint8_t n_vecs = LogicalXorHS::n_vecs;
 
     return elementwise_common::binary_contig_impl<
         argTy1, argTy2, LogicalXorOutputType, LogicalXorContigFunctor,

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/maximum.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/maximum.hpp
@@ -195,7 +195,7 @@ template <typename T1, typename T2> struct MaximumOutputType
     static constexpr bool is_defined = !std::is_same_v<value_type, void>;
 };
 
-namespace
+namespace hyperparam_detail
 {
 
 namespace vsu_ns = dpctl::tensor::kernels::vec_size_utils;
@@ -213,7 +213,7 @@ struct MaximumContigHyperparameterSet
     constexpr static auto n_vecs = value_type::n_vecs;
 };
 
-} // end of anonymous namespace
+} // end of namespace hyperparam_detail
 
 template <typename argT1,
           typename argT2,
@@ -233,10 +233,10 @@ sycl::event maximum_contig_impl(sycl::queue &exec_q,
                                 ssize_t res_offset,
                                 const std::vector<sycl::event> &depends = {})
 {
-    constexpr std::uint8_t vec_sz =
-        MaximumContigHyperparameterSet<argTy1, argTy2>::vec_sz;
-    constexpr std::uint8_t n_vecs =
-        MaximumContigHyperparameterSet<argTy1, argTy2>::n_vecs;
+    using MaxHS =
+        hyperparam_detail::MaximumContigHyperparameterSet<argTy1, argTy2>;
+    constexpr std::uint8_t vec_sz = MaxHS::vec_sz;
+    constexpr std::uint8_t n_vecs = MaxHS::n_vecs;
 
     return elementwise_common::binary_contig_impl<
         argTy1, argTy2, MaximumOutputType, MaximumContigFunctor,

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/minimum.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/minimum.hpp
@@ -195,7 +195,7 @@ template <typename T1, typename T2> struct MinimumOutputType
     static constexpr bool is_defined = !std::is_same_v<value_type, void>;
 };
 
-namespace
+namespace hyperparam_detail
 {
 
 namespace vsu_ns = dpctl::tensor::kernels::vec_size_utils;
@@ -213,7 +213,7 @@ struct MinimumContigHyperparameterSet
     constexpr static auto n_vecs = value_type::n_vecs;
 };
 
-} // end of anonymous namespace
+} // end of namespace hyperparam_detail
 
 template <typename argT1,
           typename argT2,
@@ -233,10 +233,10 @@ sycl::event minimum_contig_impl(sycl::queue &exec_q,
                                 ssize_t res_offset,
                                 const std::vector<sycl::event> &depends = {})
 {
-    constexpr std::uint8_t vec_sz =
-        MinimumContigHyperparameterSet<argTy1, argTy2>::vec_sz;
-    constexpr std::uint8_t n_vecs =
-        MinimumContigHyperparameterSet<argTy1, argTy2>::n_vecs;
+    using MinHS =
+        hyperparam_detail::MinimumContigHyperparameterSet<argTy1, argTy2>;
+    constexpr std::uint8_t vec_sz = MinHS::vec_sz;
+    constexpr std::uint8_t n_vecs = MinHS::n_vecs;
 
     return elementwise_common::binary_contig_impl<
         argTy1, argTy2, MinimumOutputType, MinimumContigFunctor,

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/multiply.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/multiply.hpp
@@ -187,7 +187,7 @@ template <typename T1, typename T2> struct MultiplyOutputType
     static constexpr bool is_defined = !std::is_same_v<value_type, void>;
 };
 
-namespace
+namespace hyperparam_detail
 {
 
 namespace vsu_ns = dpctl::tensor::kernels::vec_size_utils;
@@ -205,7 +205,7 @@ struct MultiplyContigHyperparameterSet
     constexpr static auto n_vecs = value_type::n_vecs;
 };
 
-} // end of anonymous namespace
+} // end of namespace hyperparam_detail
 
 template <typename argT1,
           typename argT2,
@@ -225,10 +225,10 @@ sycl::event multiply_contig_impl(sycl::queue &exec_q,
                                  ssize_t res_offset,
                                  const std::vector<sycl::event> &depends = {})
 {
-    constexpr std::uint8_t vec_sz =
-        MultiplyContigHyperparameterSet<argTy1, argTy2>::vec_sz;
-    constexpr std::uint8_t n_vecs =
-        MultiplyContigHyperparameterSet<argTy1, argTy2>::n_vecs;
+    using MulHS =
+        hyperparam_detail::MultiplyContigHyperparameterSet<argTy1, argTy2>;
+    constexpr std::uint8_t vec_sz = MulHS::vec_sz;
+    constexpr std::uint8_t n_vecs = MulHS::n_vecs;
 
     return elementwise_common::binary_contig_impl<
         argTy1, argTy2, MultiplyOutputType, MultiplyContigFunctor,
@@ -511,10 +511,10 @@ multiply_inplace_contig_impl(sycl::queue &exec_q,
                              ssize_t res_offset,
                              const std::vector<sycl::event> &depends = {})
 {
-    constexpr std::uint8_t vec_sz =
-        MultiplyContigHyperparameterSet<resTy, argTy>::vec_sz;
-    constexpr std::uint8_t n_vecs =
-        MultiplyContigHyperparameterSet<resTy, argTy>::n_vecs;
+    using MulHS =
+        hyperparam_detail::MultiplyContigHyperparameterSet<resTy, argTy>;
+    constexpr std::uint8_t vec_sz = MulHS::vec_sz;
+    constexpr std::uint8_t n_vecs = MulHS::n_vecs;
 
     return elementwise_common::binary_inplace_contig_impl<
         argTy, resTy, MultiplyInplaceContigFunctor,

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/negative.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/negative.hpp
@@ -100,7 +100,7 @@ template <typename T> struct NegativeOutputType
     static constexpr bool is_defined = !std::is_same_v<value_type, void>;
 };
 
-namespace
+namespace hyperparam_detail
 {
 
 namespace vsu_ns = dpctl::tensor::kernels::vec_size_utils;
@@ -117,7 +117,7 @@ template <typename argTy> struct NegativeContigHyperparameterSet
     constexpr static auto n_vecs = value_type::n_vecs;
 };
 
-} // end of anonymous namespace
+} // end of namespace hyperparam_detail
 
 template <typename T1, typename T2, std::uint8_t vec_sz, std::uint8_t n_vecs>
 class negative_contig_kernel;
@@ -129,10 +129,9 @@ sycl::event negative_contig_impl(sycl::queue &exec_q,
                                  char *res_p,
                                  const std::vector<sycl::event> &depends = {})
 {
-    constexpr std::uint8_t vec_sz =
-        NegativeContigHyperparameterSet<argTy>::vec_sz;
-    constexpr std::uint8_t n_vecs =
-        NegativeContigHyperparameterSet<argTy>::n_vecs;
+    using NegHS = hyperparam_detail::NegativeContigHyperparameterSet<argTy>;
+    constexpr std::uint8_t vec_sz = NegHS::vec_sz;
+    constexpr std::uint8_t n_vecs = NegHS::n_vecs;
 
     return elementwise_common::unary_contig_impl<
         argTy, NegativeOutputType, NegativeContigFunctor,

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/nextafter.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/nextafter.hpp
@@ -120,7 +120,7 @@ template <typename T1, typename T2> struct NextafterOutputType
     static constexpr bool is_defined = !std::is_same_v<value_type, void>;
 };
 
-namespace
+namespace hyperparam_detail
 {
 
 namespace vsu_ns = dpctl::tensor::kernels::vec_size_utils;
@@ -138,7 +138,7 @@ struct NextafterContigHyperparameterSet
     constexpr static auto n_vecs = value_type::n_vecs;
 };
 
-} // end of anonymous namespace
+} // end of namespace hyperparam_detail
 
 template <typename argT1,
           typename argT2,
@@ -158,10 +158,10 @@ sycl::event nextafter_contig_impl(sycl::queue &exec_q,
                                   ssize_t res_offset,
                                   const std::vector<sycl::event> &depends = {})
 {
-    constexpr std::uint8_t vec_sz =
-        NextafterContigHyperparameterSet<argTy1, argTy2>::vec_sz;
-    constexpr std::uint8_t n_vecs =
-        NextafterContigHyperparameterSet<argTy1, argTy2>::n_vecs;
+    using NextafterHS =
+        hyperparam_detail::NextafterContigHyperparameterSet<argTy1, argTy2>;
+    constexpr std::uint8_t vec_sz = NextafterHS::vec_sz;
+    constexpr std::uint8_t n_vecs = NextafterHS::n_vecs;
 
     return elementwise_common::binary_contig_impl<
         argTy1, argTy2, NextafterOutputType, NextafterContigFunctor,

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/not_equal.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/not_equal.hpp
@@ -176,7 +176,7 @@ template <typename T1, typename T2> struct NotEqualOutputType
     static constexpr bool is_defined = !std::is_same_v<value_type, void>;
 };
 
-namespace
+namespace hyperparam_detail
 {
 
 namespace vsu_ns = dpctl::tensor::kernels::vec_size_utils;
@@ -194,7 +194,7 @@ struct NotEqualContigHyperparameterSet
     constexpr static auto n_vecs = value_type::n_vecs;
 };
 
-} // end of anonymous namespace
+} // end of namespace hyperparam_detail
 
 template <typename argT1,
           typename argT2,
@@ -214,10 +214,10 @@ sycl::event not_equal_contig_impl(sycl::queue &exec_q,
                                   ssize_t res_offset,
                                   const std::vector<sycl::event> &depends = {})
 {
-    constexpr std::uint8_t vec_sz =
-        NotEqualContigHyperparameterSet<argTy1, argTy2>::vec_sz;
-    constexpr std::uint8_t n_vecs =
-        NotEqualContigHyperparameterSet<argTy1, argTy2>::n_vecs;
+    using NotEqHS =
+        hyperparam_detail::NotEqualContigHyperparameterSet<argTy1, argTy2>;
+    constexpr std::uint8_t vec_sz = NotEqHS::vec_sz;
+    constexpr std::uint8_t n_vecs = NotEqHS::n_vecs;
 
     return elementwise_common::binary_contig_impl<
         argTy1, argTy2, NotEqualOutputType, NotEqualContigFunctor,

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/positive.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/positive.hpp
@@ -115,7 +115,7 @@ template <typename T> struct PositiveOutputType
     static constexpr bool is_defined = !std::is_same_v<value_type, void>;
 };
 
-namespace
+namespace hyperparam_detail
 {
 
 namespace vsu_ns = dpctl::tensor::kernels::vec_size_utils;
@@ -132,7 +132,7 @@ template <typename argTy> struct PositiveContigHyperparameterSet
     constexpr static auto n_vecs = value_type::n_vecs;
 };
 
-} // end of anonymous namespace
+} // end of namespace hyperparam_detail
 
 template <typename T1, typename T2, std::uint8_t vec_sz, std::uint8_t n_vecs>
 class positive_contig_kernel;
@@ -144,10 +144,9 @@ sycl::event positive_contig_impl(sycl::queue &exec_q,
                                  char *res_p,
                                  const std::vector<sycl::event> &depends = {})
 {
-    constexpr std::uint8_t vec_sz =
-        PositiveContigHyperparameterSet<argTy>::vec_sz;
-    constexpr std::uint8_t n_vecs =
-        PositiveContigHyperparameterSet<argTy>::n_vecs;
+    using PosHS = hyperparam_detail::PositiveContigHyperparameterSet<argTy>;
+    constexpr std::uint8_t vec_sz = PosHS::vec_sz;
+    constexpr std::uint8_t n_vecs = PosHS::n_vecs;
 
     return elementwise_common::unary_contig_impl<
         argTy, PositiveOutputType, PositiveContigFunctor,

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/pow.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/pow.hpp
@@ -239,7 +239,7 @@ template <typename T1, typename T2> struct PowOutputType
     static constexpr bool is_defined = !std::is_same_v<value_type, void>;
 };
 
-namespace
+namespace hyperparam_detail
 {
 
 namespace vsu_ns = dpctl::tensor::kernels::vec_size_utils;
@@ -256,7 +256,7 @@ template <typename argTy1, typename argTy2> struct PowContigHyperparameterSet
     constexpr static auto n_vecs = value_type::n_vecs;
 };
 
-} // end of anonymous namespace
+} // end of namespace hyperparam_detail
 
 template <typename argT1,
           typename argT2,
@@ -276,10 +276,9 @@ sycl::event pow_contig_impl(sycl::queue &exec_q,
                             ssize_t res_offset,
                             const std::vector<sycl::event> &depends = {})
 {
-    constexpr std::uint8_t vec_sz =
-        PowContigHyperparameterSet<argTy1, argTy2>::vec_sz;
-    constexpr std::uint8_t n_vecs =
-        PowContigHyperparameterSet<argTy1, argTy2>::n_vecs;
+    using PowHS = hyperparam_detail::PowContigHyperparameterSet<argTy1, argTy2>;
+    constexpr std::uint8_t vec_sz = PowHS::vec_sz;
+    constexpr std::uint8_t n_vecs = PowHS::n_vecs;
 
     return elementwise_common::binary_contig_impl<
         argTy1, argTy2, PowOutputType, PowContigFunctor, pow_contig_kernel,
@@ -522,10 +521,9 @@ pow_inplace_contig_impl(sycl::queue &exec_q,
                         ssize_t res_offset,
                         const std::vector<sycl::event> &depends = {})
 {
-    constexpr std::uint8_t vec_sz =
-        PowContigHyperparameterSet<resTy, argTy>::vec_sz;
-    constexpr std::uint8_t n_vecs =
-        PowContigHyperparameterSet<resTy, argTy>::n_vecs;
+    using PowHS = hyperparam_detail::PowContigHyperparameterSet<resTy, argTy>;
+    constexpr std::uint8_t vec_sz = PowHS::vec_sz;
+    constexpr std::uint8_t n_vecs = PowHS::n_vecs;
 
     return elementwise_common::binary_inplace_contig_impl<
         argTy, resTy, PowInplaceContigFunctor, pow_inplace_contig_kernel,

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/proj.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/proj.hpp
@@ -119,7 +119,7 @@ template <typename T> struct ProjOutputType
     static constexpr bool is_defined = !std::is_same_v<value_type, void>;
 };
 
-namespace
+namespace hyperparam_detail
 {
 
 namespace vsu_ns = dpctl::tensor::kernels::vec_size_utils;
@@ -136,7 +136,7 @@ template <typename argTy> struct ProjContigHyperparameterSet
     constexpr static auto n_vecs = value_type::n_vecs;
 };
 
-} // end of anonymous namespace
+} // end of namespace hyperparam_detail
 
 template <typename T1, typename T2, std::uint8_t vec_sz, std::uint8_t n_vecs>
 class proj_contig_kernel;
@@ -148,8 +148,9 @@ sycl::event proj_contig_impl(sycl::queue &exec_q,
                              char *res_p,
                              const std::vector<sycl::event> &depends = {})
 {
-    constexpr std::uint8_t vec_sz = ProjContigHyperparameterSet<argTy>::vec_sz;
-    constexpr std::uint8_t n_vecs = ProjContigHyperparameterSet<argTy>::n_vecs;
+    using ProjHS = hyperparam_detail::ProjContigHyperparameterSet<argTy>;
+    constexpr std::uint8_t vec_sz = ProjHS::vec_sz;
+    constexpr std::uint8_t n_vecs = ProjHS::n_vecs;
 
     return elementwise_common::unary_contig_impl<
         argTy, ProjOutputType, ProjContigFunctor, proj_contig_kernel, vec_sz,

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/real.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/real.hpp
@@ -118,7 +118,7 @@ template <typename T> struct RealOutputType
     static constexpr bool is_defined = !std::is_same_v<value_type, void>;
 };
 
-namespace
+namespace hyperparam_detail
 {
 
 namespace vsu_ns = dpctl::tensor::kernels::vec_size_utils;
@@ -135,7 +135,7 @@ template <typename argTy> struct RealContigHyperparameterSet
     constexpr static auto n_vecs = value_type::n_vecs;
 };
 
-} // end of anonymous namespace
+} // end of namespace hyperparam_detail
 
 template <typename T1, typename T2, std::uint8_t vec_sz, std::uint8_t n_vecs>
 class real_contig_kernel;
@@ -147,8 +147,9 @@ sycl::event real_contig_impl(sycl::queue &exec_q,
                              char *res_p,
                              const std::vector<sycl::event> &depends = {})
 {
-    constexpr std::uint8_t vec_sz = RealContigHyperparameterSet<argTy>::vec_sz;
-    constexpr std::uint8_t n_vecs = RealContigHyperparameterSet<argTy>::n_vecs;
+    using RealHS = hyperparam_detail::RealContigHyperparameterSet<argTy>;
+    constexpr std::uint8_t vec_sz = RealHS::vec_sz;
+    constexpr std::uint8_t n_vecs = RealHS::n_vecs;
 
     return elementwise_common::unary_contig_impl<
         argTy, RealOutputType, RealContigFunctor, real_contig_kernel, vec_sz,

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/reciprocal.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/reciprocal.hpp
@@ -115,7 +115,7 @@ template <typename T> struct ReciprocalOutputType
     static constexpr bool is_defined = !std::is_same_v<value_type, void>;
 };
 
-namespace
+namespace hyperparam_detail
 {
 
 namespace vsu_ns = dpctl::tensor::kernels::vec_size_utils;
@@ -132,7 +132,7 @@ template <typename argTy> struct ReciprocalContigHyperparameterSet
     constexpr static auto n_vecs = value_type::n_vecs;
 };
 
-} // end of anonymous namespace
+} // end of namespace hyperparam_detail
 
 template <typename T1, typename T2, std::uint8_t vec_sz, std::uint8_t n_vecs>
 class reciprocal_contig_kernel;
@@ -144,10 +144,9 @@ sycl::event reciprocal_contig_impl(sycl::queue &exec_q,
                                    char *res_p,
                                    const std::vector<sycl::event> &depends = {})
 {
-    constexpr std::uint8_t vec_sz =
-        ReciprocalContigHyperparameterSet<argTy>::vec_sz;
-    constexpr std::uint8_t n_vecs =
-        ReciprocalContigHyperparameterSet<argTy>::n_vecs;
+    using RecipHS = hyperparam_detail::ReciprocalContigHyperparameterSet<argTy>;
+    constexpr std::uint8_t vec_sz = RecipHS::vec_sz;
+    constexpr std::uint8_t n_vecs = RecipHS::n_vecs;
 
     return elementwise_common::unary_contig_impl<
         argTy, ReciprocalOutputType, ReciprocalContigFunctor,

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/remainder.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/remainder.hpp
@@ -222,7 +222,7 @@ template <typename T1, typename T2> struct RemainderOutputType
     static constexpr bool is_defined = !std::is_same_v<value_type, void>;
 };
 
-namespace
+namespace hyperparam_detail
 {
 
 namespace vsu_ns = dpctl::tensor::kernels::vec_size_utils;
@@ -240,7 +240,7 @@ struct RemainderContigHyperparameterSet
     constexpr static auto n_vecs = value_type::n_vecs;
 };
 
-} // end of anonymous namespace
+} // end of namespace hyperparam_detail
 
 template <typename argT1,
           typename argT2,
@@ -260,10 +260,10 @@ sycl::event remainder_contig_impl(sycl::queue &exec_q,
                                   ssize_t res_offset,
                                   const std::vector<sycl::event> &depends = {})
 {
-    constexpr std::uint8_t vec_sz =
-        RemainderContigHyperparameterSet<argTy1, argTy2>::vec_sz;
-    constexpr std::uint8_t n_vecs =
-        RemainderContigHyperparameterSet<argTy1, argTy2>::n_vecs;
+    using RemHS =
+        hyperparam_detail::RemainderContigHyperparameterSet<argTy1, argTy2>;
+    constexpr std::uint8_t vec_sz = RemHS::vec_sz;
+    constexpr std::uint8_t n_vecs = RemHS::n_vecs;
 
     return elementwise_common::binary_contig_impl<
         argTy1, argTy2, RemainderOutputType, RemainderContigFunctor,
@@ -493,10 +493,10 @@ remainder_inplace_contig_impl(sycl::queue &exec_q,
                               ssize_t res_offset,
                               const std::vector<sycl::event> &depends = {})
 {
-    constexpr std::uint8_t vec_sz =
-        RemainderContigHyperparameterSet<resTy, argTy>::vec_sz;
-    constexpr std::uint8_t n_vecs =
-        RemainderContigHyperparameterSet<resTy, argTy>::n_vecs;
+    using RemHS =
+        hyperparam_detail::RemainderContigHyperparameterSet<resTy, argTy>;
+    constexpr std::uint8_t vec_sz = RemHS::vec_sz;
+    constexpr std::uint8_t n_vecs = RemHS::n_vecs;
 
     return elementwise_common::binary_inplace_contig_impl<
         argTy, resTy, RemainderInplaceContigFunctor,

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/round.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/round.hpp
@@ -126,7 +126,7 @@ template <typename T> struct RoundOutputType
     static constexpr bool is_defined = !std::is_same_v<value_type, void>;
 };
 
-namespace
+namespace hyperparam_detail
 {
 
 namespace vsu_ns = dpctl::tensor::kernels::vec_size_utils;
@@ -143,7 +143,7 @@ template <typename argTy> struct RoundContigHyperparameterSet
     constexpr static auto n_vecs = value_type::n_vecs;
 };
 
-} // end of anonymous namespace
+} // end of namespace hyperparam_detail
 
 template <typename T1, typename T2, std::uint8_t vec_sz, std::uint8_t n_vecs>
 class round_contig_kernel;
@@ -155,8 +155,9 @@ sycl::event round_contig_impl(sycl::queue &exec_q,
                               char *res_p,
                               const std::vector<sycl::event> &depends = {})
 {
-    constexpr std::uint8_t vec_sz = RoundContigHyperparameterSet<argTy>::vec_sz;
-    constexpr std::uint8_t n_vecs = RoundContigHyperparameterSet<argTy>::n_vecs;
+    using RoundHS = hyperparam_detail::RoundContigHyperparameterSet<argTy>;
+    constexpr std::uint8_t vec_sz = RoundHS::vec_sz;
+    constexpr std::uint8_t n_vecs = RoundHS::n_vecs;
 
     return elementwise_common::unary_contig_impl<
         argTy, RoundOutputType, RoundContigFunctor, round_contig_kernel, vec_sz,

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/rsqrt.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/rsqrt.hpp
@@ -97,7 +97,7 @@ template <typename T> struct RsqrtOutputType
     static constexpr bool is_defined = !std::is_same_v<value_type, void>;
 };
 
-namespace
+namespace hyperparam_detail
 {
 
 namespace vsu_ns = dpctl::tensor::kernels::vec_size_utils;
@@ -114,7 +114,7 @@ template <typename argTy> struct RsqrtContigHyperparameterSet
     constexpr static auto n_vecs = value_type::n_vecs;
 };
 
-} // end of anonymous namespace
+} // namespace hyperparam_detail
 
 template <typename T1, typename T2, std::uint8_t vec_sz, std::uint8_t n_vecs>
 class rsqrt_contig_kernel;
@@ -126,8 +126,9 @@ sycl::event rsqrt_contig_impl(sycl::queue &exec_q,
                               char *res_p,
                               const std::vector<sycl::event> &depends = {})
 {
-    constexpr std::uint8_t vec_sz = RsqrtContigHyperparameterSet<argTy>::vec_sz;
-    constexpr std::uint8_t n_vecs = RsqrtContigHyperparameterSet<argTy>::n_vecs;
+    using RsqrtHS = hyperparam_detail::RsqrtContigHyperparameterSet<argTy>;
+    constexpr std::uint8_t vec_sz = RsqrtHS::vec_sz;
+    constexpr std::uint8_t n_vecs = RsqrtHS::n_vecs;
 
     return elementwise_common::unary_contig_impl<
         argTy, RsqrtOutputType, RsqrtContigFunctor, rsqrt_contig_kernel, vec_sz,

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/sign.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/sign.hpp
@@ -138,7 +138,7 @@ template <typename T> struct SignOutputType
     static constexpr bool is_defined = !std::is_same_v<value_type, void>;
 };
 
-namespace
+namespace hyperparam_detail
 {
 
 namespace vsu_ns = dpctl::tensor::kernels::vec_size_utils;
@@ -155,7 +155,7 @@ template <typename argTy> struct SignContigHyperparameterSet
     constexpr static auto n_vecs = value_type::n_vecs;
 };
 
-} // end of anonymous namespace
+} // end of namespace hyperparam_detail
 
 template <typename T1, typename T2, std::uint8_t vec_sz, std::uint8_t n_vecs>
 class sign_contig_kernel;
@@ -167,8 +167,9 @@ sycl::event sign_contig_impl(sycl::queue &exec_q,
                              char *res_p,
                              const std::vector<sycl::event> &depends = {})
 {
-    constexpr std::uint8_t vec_sz = SignContigHyperparameterSet<argTy>::vec_sz;
-    constexpr std::uint8_t n_vecs = SignContigHyperparameterSet<argTy>::n_vecs;
+    using SignHS = hyperparam_detail::SignContigHyperparameterSet<argTy>;
+    constexpr std::uint8_t vec_sz = SignHS::vec_sz;
+    constexpr std::uint8_t n_vecs = SignHS::n_vecs;
 
     return elementwise_common::unary_contig_impl<
         argTy, SignOutputType, SignContigFunctor, sign_contig_kernel, vec_sz,

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/signbit.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/signbit.hpp
@@ -104,7 +104,7 @@ template <typename argTy> struct SignbitOutputType
     static constexpr bool is_defined = !std::is_same_v<value_type, void>;
 };
 
-namespace
+namespace hyperparam_detail
 {
 
 namespace vsu_ns = dpctl::tensor::kernels::vec_size_utils;
@@ -121,7 +121,7 @@ template <typename argTy> struct SignbitContigHyperparameterSet
     constexpr static auto n_vecs = value_type::n_vecs;
 };
 
-} // end of anonymous namespace
+} // end of namespace hyperparam_detail
 
 template <typename T1, typename T2, std::uint8_t vec_sz, std::uint8_t n_vecs>
 class signbit_contig_kernel;
@@ -133,10 +133,9 @@ sycl::event signbit_contig_impl(sycl::queue &exec_q,
                                 char *res_p,
                                 const std::vector<sycl::event> &depends = {})
 {
-    constexpr std::uint8_t vec_sz =
-        SignbitContigHyperparameterSet<argTy>::vec_sz;
-    constexpr std::uint8_t n_vecs =
-        SignbitContigHyperparameterSet<argTy>::n_vecs;
+    using SignbitHS = hyperparam_detail::SignbitContigHyperparameterSet<argTy>;
+    constexpr std::uint8_t vec_sz = SignbitHS::vec_sz;
+    constexpr std::uint8_t n_vecs = SignbitHS::n_vecs;
 
     return elementwise_common::unary_contig_impl<
         argTy, SignbitOutputType, SignbitContigFunctor, signbit_contig_kernel,

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/sin.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/sin.hpp
@@ -217,7 +217,7 @@ template <typename T> struct SinOutputType
     static constexpr bool is_defined = !std::is_same_v<value_type, void>;
 };
 
-namespace
+namespace hyperparam_detail
 {
 
 namespace vsu_ns = dpctl::tensor::kernels::vec_size_utils;
@@ -234,7 +234,7 @@ template <typename argTy> struct SinContigHyperparameterSet
     constexpr static auto n_vecs = value_type::n_vecs;
 };
 
-} // end of anonymous namespace
+} // end of namespace hyperparam_detail
 
 template <typename T1, typename T2, std::uint8_t vec_sz, std::uint8_t n_vecs>
 class sin_contig_kernel;
@@ -246,8 +246,9 @@ sycl::event sin_contig_impl(sycl::queue &exec_q,
                             char *res_p,
                             const std::vector<sycl::event> &depends = {})
 {
-    constexpr std::uint8_t vec_sz = SinContigHyperparameterSet<argTy>::vec_sz;
-    constexpr std::uint8_t n_vecs = SinContigHyperparameterSet<argTy>::n_vecs;
+    using SinHS = hyperparam_detail::SinContigHyperparameterSet<argTy>;
+    constexpr std::uint8_t vec_sz = SinHS::vec_sz;
+    constexpr std::uint8_t n_vecs = SinHS::n_vecs;
 
     return elementwise_common::unary_contig_impl<
         argTy, SinOutputType, SinContigFunctor, sin_contig_kernel, vec_sz,

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/sinh.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/sinh.hpp
@@ -186,7 +186,7 @@ template <typename T> struct SinhOutputType
     static constexpr bool is_defined = !std::is_same_v<value_type, void>;
 };
 
-namespace
+namespace hyperparam_detail
 {
 
 namespace vsu_ns = dpctl::tensor::kernels::vec_size_utils;
@@ -203,7 +203,7 @@ template <typename argTy> struct SinhContigHyperparameterSet
     constexpr static auto n_vecs = value_type::n_vecs;
 };
 
-} // end of anonymous namespace
+} // end of namespace hyperparam_detail
 
 template <typename T1, typename T2, std::uint8_t vec_sz, std::uint8_t n_vecs>
 class sinh_contig_kernel;
@@ -215,8 +215,9 @@ sycl::event sinh_contig_impl(sycl::queue &exec_q,
                              char *res_p,
                              const std::vector<sycl::event> &depends = {})
 {
-    constexpr std::uint8_t vec_sz = SinhContigHyperparameterSet<argTy>::vec_sz;
-    constexpr std::uint8_t n_vecs = SinhContigHyperparameterSet<argTy>::n_vecs;
+    using SinhHS = hyperparam_detail::SinhContigHyperparameterSet<argTy>;
+    constexpr std::uint8_t vec_sz = SinhHS::vec_sz;
+    constexpr std::uint8_t n_vecs = SinhHS::n_vecs;
 
     return elementwise_common::unary_contig_impl<
         argTy, SinhOutputType, SinhContigFunctor, sinh_contig_kernel, vec_sz,

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/sqrt.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/sqrt.hpp
@@ -112,7 +112,7 @@ template <typename T> struct SqrtOutputType
     static constexpr bool is_defined = !std::is_same_v<value_type, void>;
 };
 
-namespace
+namespace hyperparam_detail
 {
 
 namespace vsu_ns = dpctl::tensor::kernels::vec_size_utils;
@@ -129,7 +129,7 @@ template <typename argTy> struct SqrtContigHyperparameterSet
     constexpr static auto n_vecs = value_type::n_vecs;
 };
 
-} // end of anonymous namespace
+} // end of namespace hyperparam_detail
 
 template <typename T1, typename T2, std::uint8_t vec_sz, std::uint8_t n_vecs>
 class sqrt_contig_kernel;
@@ -141,8 +141,9 @@ sycl::event sqrt_contig_impl(sycl::queue &exec_q,
                              char *res_p,
                              const std::vector<sycl::event> &depends = {})
 {
-    constexpr std::uint8_t vec_sz = SqrtContigHyperparameterSet<argTy>::vec_sz;
-    constexpr std::uint8_t n_vecs = SqrtContigHyperparameterSet<argTy>::n_vecs;
+    using SqrtHS = hyperparam_detail::SqrtContigHyperparameterSet<argTy>;
+    constexpr std::uint8_t vec_sz = SqrtHS::vec_sz;
+    constexpr std::uint8_t n_vecs = SqrtHS::n_vecs;
 
     return elementwise_common::unary_contig_impl<
         argTy, SqrtOutputType, SqrtContigFunctor, sqrt_contig_kernel, vec_sz,

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/square.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/square.hpp
@@ -137,7 +137,7 @@ template <typename T> struct SquareOutputType
     static constexpr bool is_defined = !std::is_same_v<value_type, void>;
 };
 
-namespace
+namespace hyperparam_detail
 {
 
 namespace vsu_ns = dpctl::tensor::kernels::vec_size_utils;
@@ -154,7 +154,7 @@ template <typename argTy> struct SquareContigHyperparameterSet
     constexpr static auto n_vecs = value_type::n_vecs;
 };
 
-} // end of anonymous namespace
+} // end of namespace hyperparam_detail
 
 template <typename T1, typename T2, std::uint8_t vec_sz, std::uint8_t n_vecs>
 class square_contig_kernel;
@@ -166,10 +166,9 @@ sycl::event square_contig_impl(sycl::queue &exec_q,
                                char *res_p,
                                const std::vector<sycl::event> &depends = {})
 {
-    constexpr std::uint8_t vec_sz =
-        SquareContigHyperparameterSet<argTy>::vec_sz;
-    constexpr std::uint8_t n_vecs =
-        SquareContigHyperparameterSet<argTy>::n_vecs;
+    using SquareHS = hyperparam_detail::SquareContigHyperparameterSet<argTy>;
+    constexpr std::uint8_t vec_sz = SquareHS::vec_sz;
+    constexpr std::uint8_t n_vecs = SquareHS::n_vecs;
 
     return elementwise_common::unary_contig_impl<
         argTy, SquareOutputType, SquareContigFunctor, square_contig_kernel,

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/subtract.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/subtract.hpp
@@ -173,7 +173,7 @@ template <typename T1, typename T2> struct SubtractOutputType
     static constexpr bool is_defined = !std::is_same_v<value_type, void>;
 };
 
-namespace
+namespace hyperparam_detail
 {
 
 namespace vsu_ns = dpctl::tensor::kernels::vec_size_utils;
@@ -191,7 +191,7 @@ struct SubtractContigHyperparameterSet
     constexpr static auto n_vecs = value_type::n_vecs;
 };
 
-} // end of anonymous namespace
+} // end of namespace hyperparam_detail
 
 template <typename argT1,
           typename argT2,
@@ -211,10 +211,10 @@ sycl::event subtract_contig_impl(sycl::queue &exec_q,
                                  ssize_t res_offset,
                                  const std::vector<sycl::event> &depends = {})
 {
-    constexpr std::uint8_t vec_sz =
-        SubtractContigHyperparameterSet<argTy1, argTy2>::vec_sz;
-    constexpr std::uint8_t n_vecs =
-        SubtractContigHyperparameterSet<argTy1, argTy2>::n_vecs;
+    using SubHS =
+        hyperparam_detail::SubtractContigHyperparameterSet<argTy1, argTy2>;
+    constexpr std::uint8_t vec_sz = SubHS::vec_sz;
+    constexpr std::uint8_t n_vecs = SubHS::n_vecs;
 
     return elementwise_common::binary_contig_impl<
         argTy1, argTy2, SubtractOutputType, SubtractContigFunctor,
@@ -509,10 +509,10 @@ subtract_inplace_contig_impl(sycl::queue &exec_q,
                              ssize_t res_offset,
                              const std::vector<sycl::event> &depends = {})
 {
-    constexpr std::uint8_t vec_sz =
-        SubtractContigHyperparameterSet<resTy, argTy>::vec_sz;
-    constexpr std::uint8_t n_vecs =
-        SubtractContigHyperparameterSet<resTy, argTy>::n_vecs;
+    using SubHS =
+        hyperparam_detail::SubtractContigHyperparameterSet<resTy, argTy>;
+    constexpr std::uint8_t vec_sz = SubHS::vec_sz;
+    constexpr std::uint8_t n_vecs = SubHS::n_vecs;
 
     return elementwise_common::binary_inplace_contig_impl<
         argTy, resTy, SubtractInplaceContigFunctor,

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/tan.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/tan.hpp
@@ -161,7 +161,7 @@ template <typename T> struct TanOutputType
     static constexpr bool is_defined = !std::is_same_v<value_type, void>;
 };
 
-namespace
+namespace hyperparam_detail
 {
 
 namespace vsu_ns = dpctl::tensor::kernels::vec_size_utils;
@@ -178,7 +178,7 @@ template <typename argTy> struct TanContigHyperparameterSet
     constexpr static auto n_vecs = value_type::n_vecs;
 };
 
-} // end of anonymous namespace
+} // end of namespace hyperparam_detail
 
 template <typename T1, typename T2, std::uint8_t vec_sz, std::uint8_t n_vecs>
 class tan_contig_kernel;
@@ -190,8 +190,9 @@ sycl::event tan_contig_impl(sycl::queue &exec_q,
                             char *res_p,
                             const std::vector<sycl::event> &depends = {})
 {
-    constexpr std::uint8_t vec_sz = TanContigHyperparameterSet<argTy>::vec_sz;
-    constexpr std::uint8_t n_vecs = TanContigHyperparameterSet<argTy>::n_vecs;
+    using TanHS = hyperparam_detail::TanContigHyperparameterSet<argTy>;
+    constexpr std::uint8_t vec_sz = TanHS::vec_sz;
+    constexpr std::uint8_t n_vecs = TanHS::n_vecs;
 
     return elementwise_common::unary_contig_impl<
         argTy, TanOutputType, TanContigFunctor, tan_contig_kernel, vec_sz,

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/tanh.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/tanh.hpp
@@ -155,7 +155,7 @@ template <typename T> struct TanhOutputType
     static constexpr bool is_defined = !std::is_same_v<value_type, void>;
 };
 
-namespace
+namespace hyperparam_detail
 {
 
 namespace vsu_ns = dpctl::tensor::kernels::vec_size_utils;
@@ -172,7 +172,7 @@ template <typename argTy> struct TanhContigHyperparameterSet
     constexpr static auto n_vecs = value_type::n_vecs;
 };
 
-} // end of anonymous namespace
+} // end of namespace hyperparam_detail
 
 template <typename T1, typename T2, std::uint8_t vec_sz, std::uint8_t n_vecs>
 class tanh_contig_kernel;
@@ -184,8 +184,9 @@ sycl::event tanh_contig_impl(sycl::queue &exec_q,
                              char *res_p,
                              const std::vector<sycl::event> &depends = {})
 {
-    constexpr std::uint8_t vec_sz = TanhContigHyperparameterSet<argTy>::vec_sz;
-    constexpr std::uint8_t n_vecs = TanhContigHyperparameterSet<argTy>::n_vecs;
+    using TanhHS = hyperparam_detail::TanhContigHyperparameterSet<argTy>;
+    constexpr std::uint8_t vec_sz = TanhHS::vec_sz;
+    constexpr std::uint8_t n_vecs = TanhHS::n_vecs;
 
     return elementwise_common::unary_contig_impl<
         argTy, TanhOutputType, TanhContigFunctor, tanh_contig_kernel, vec_sz,

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/true_divide.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/true_divide.hpp
@@ -180,7 +180,7 @@ template <typename T1, typename T2> struct TrueDivideOutputType
     static constexpr bool is_defined = !std::is_same_v<value_type, void>;
 };
 
-namespace
+namespace hyperparam_detail
 {
 
 namespace vsu_ns = dpctl::tensor::kernels::vec_size_utils;
@@ -198,7 +198,7 @@ struct TrueDivideContigHyperparameterSet
     constexpr static auto n_vecs = value_type::n_vecs;
 };
 
-} // end of anonymous namespace
+} // end of namespace hyperparam_detail
 
 template <typename argT1,
           typename argT2,
@@ -219,10 +219,10 @@ true_divide_contig_impl(sycl::queue &exec_q,
                         ssize_t res_offset,
                         const std::vector<sycl::event> &depends = {})
 {
-    constexpr std::uint8_t vec_sz =
-        TrueDivideContigHyperparameterSet<argTy1, argTy2>::vec_sz;
-    constexpr std::uint8_t n_vecs =
-        TrueDivideContigHyperparameterSet<argTy1, argTy2>::n_vecs;
+    using DivHS =
+        hyperparam_detail::TrueDivideContigHyperparameterSet<argTy1, argTy2>;
+    constexpr std::uint8_t vec_sz = DivHS::vec_sz;
+    constexpr std::uint8_t n_vecs = DivHS::n_vecs;
 
     return elementwise_common::binary_contig_impl<
         argTy1, argTy2, TrueDivideOutputType, TrueDivideContigFunctor,
@@ -538,10 +538,10 @@ true_divide_inplace_contig_impl(sycl::queue &exec_q,
                                 ssize_t res_offset,
                                 const std::vector<sycl::event> &depends = {})
 {
-    constexpr std::uint8_t vec_sz =
-        TrueDivideContigHyperparameterSet<resTy, argTy>::vec_sz;
-    constexpr std::uint8_t n_vecs =
-        TrueDivideContigHyperparameterSet<resTy, argTy>::vec_sz;
+    using DivHS =
+        hyperparam_detail::TrueDivideContigHyperparameterSet<resTy, argTy>;
+    constexpr std::uint8_t vec_sz = DivHS::vec_sz;
+    constexpr std::uint8_t n_vecs = DivHS::vec_sz;
 
     return elementwise_common::binary_inplace_contig_impl<
         argTy, resTy, TrueDivideInplaceContigFunctor,

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/trunc.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/trunc.hpp
@@ -112,7 +112,7 @@ template <typename T> struct TruncOutputType
     static constexpr bool is_defined = !std::is_same_v<value_type, void>;
 };
 
-namespace
+namespace hyperparam_detail
 {
 
 namespace vsu_ns = dpctl::tensor::kernels::vec_size_utils;
@@ -129,7 +129,7 @@ template <typename argTy> struct TruncContigHyperparameterSet
     constexpr static auto n_vecs = value_type::n_vecs;
 };
 
-} // end of anonymous namespace
+} // end of namespace hyperparam_detail
 
 template <typename T1, typename T2, std::uint8_t vec_sz, std::uint8_t n_vecs>
 class trunc_contig_kernel;
@@ -141,8 +141,9 @@ sycl::event trunc_contig_impl(sycl::queue &exec_q,
                               char *res_p,
                               const std::vector<sycl::event> &depends = {})
 {
-    constexpr std::uint8_t vec_sz = TruncContigHyperparameterSet<argTy>::vec_sz;
-    constexpr std::uint8_t n_vecs = TruncContigHyperparameterSet<argTy>::n_vecs;
+    using TruncHS = hyperparam_detail::TruncContigHyperparameterSet<argTy>;
+    constexpr std::uint8_t vec_sz = TruncHS::vec_sz;
+    constexpr std::uint8_t n_vecs = TruncHS::n_vecs;
 
     return elementwise_common::unary_contig_impl<
         argTy, TruncOutputType, TruncContigFunctor, trunc_contig_kernel, vec_sz,

--- a/dpctl/tensor/libtensor/include/kernels/sorting/merge_sort.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/sorting/merge_sort.hpp
@@ -211,8 +211,6 @@ void merge_impl(const std::size_t offset,
     }
 }
 
-namespace
-{
 template <typename Iter, typename Compare>
 void insertion_sort_impl(Iter first,
                          const std::size_t begin,
@@ -259,7 +257,6 @@ void leaf_sort_impl(Iter first,
     return insertion_sort_impl<Iter, Compare>(
         std::move(first), std::move(begin), std::move(end), std::move(comp));
 }
-} // namespace
 
 template <typename Iter> struct GetValueType
 {
@@ -768,9 +765,9 @@ sycl::event stable_sort_axis1_contig_impl(
     }
 }
 
-template <typename T1, typename T2, typename T3> class populate_index_data_krn;
+template <typename T1, typename T2> class populate_index_data_krn;
 
-template <typename T1, typename T2, typename T3> class index_map_to_rows_krn;
+template <typename T1, typename T2> class index_map_to_rows_krn;
 
 template <typename IndexT, typename ValueT, typename ValueComp> struct IndexComp
 {
@@ -820,7 +817,7 @@ sycl::event stable_argsort_axis1_contig_impl(
 
     using dpctl::tensor::kernels::sort_utils_detail::iota_impl;
 
-    using IotaKernelName = populate_index_data_krn<argTy, IndexTy, ValueComp>;
+    using IotaKernelName = populate_index_data_krn<argTy, IndexTy>;
 
     sycl::event populate_indexed_data_ev = iota_impl<IotaKernelName, IndexTy>(
         exec_q, res_tp, total_nelems, depends);
@@ -838,7 +835,7 @@ sycl::event stable_argsort_axis1_contig_impl(
         exec_q, iter_nelems, sort_nelems, res_tp, index_comp, sorted_block_size,
         {base_sort_ev});
 
-    using MapBackKernelName = index_map_to_rows_krn<argTy, IndexTy, ValueComp>;
+    using MapBackKernelName = index_map_to_rows_krn<argTy, IndexTy>;
     using dpctl::tensor::kernels::sort_utils_detail::map_back_impl;
 
     sycl::event write_out_ev = map_back_impl<MapBackKernelName, IndexTy>(

--- a/dpctl/tensor/libtensor/include/kernels/sorting/radix_sort.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/sorting/radix_sort.hpp
@@ -1759,6 +1759,8 @@ template <typename ValueT, typename IndexT> struct ValueProj
 
 template <typename IndexT, typename ValueT, typename ProjT> struct IndexedProj
 {
+    IndexedProj(const ValueT *arg_ptr) : ptr(arg_ptr), value_projector{} {}
+
     IndexedProj(const ValueT *arg_ptr, const ProjT &proj_op)
         : ptr(arg_ptr), value_projector(proj_op)
     {
@@ -1848,7 +1850,7 @@ radix_argsort_axis1_contig_impl(sycl::queue &exec_q,
     using IdentityProjT = radix_sort_details::IdentityProj;
     using IndexedProjT =
         radix_sort_details::IndexedProj<IndexTy, argTy, IdentityProjT>;
-    const IndexedProjT proj_op{arg_tp, IdentityProjT{}};
+    const IndexedProjT proj_op{arg_tp};
 
     using IotaKernelName = radix_argsort_iota_krn<argTy, IndexTy>;
 

--- a/dpctl/tensor/libtensor/include/utils/sycl_alloc_utils.hpp
+++ b/dpctl/tensor/libtensor/include/utils/sycl_alloc_utils.hpp
@@ -142,7 +142,7 @@ smart_malloc_host(std::size_t count,
     return smart_malloc<T>(count, q, sycl::usm::alloc::host, propList);
 }
 
-namespace
+namespace detail
 {
 template <typename T> struct valid_smart_ptr : public std::false_type
 {
@@ -172,7 +172,7 @@ struct all_valid_smart_ptrs<Arg, RestArgs...>
     static constexpr bool value = valid_smart_ptr<Arg>::value &&
                                   (all_valid_smart_ptrs<RestArgs...>::value);
 };
-} // namespace
+} // end of namespace detail
 
 template <typename... Args>
 sycl::event async_smart_free(sycl::queue &exec_q,
@@ -184,7 +184,7 @@ sycl::event async_smart_free(sycl::queue &exec_q,
         n > 0, "async_smart_free requires at least one smart pointer argument");
 
     static_assert(
-        all_valid_smart_ptrs<Args...>::value,
+        detail::all_valid_smart_ptrs<Args...>::value,
         "async_smart_free requires unique_ptr created with smart_malloc");
 
     std::vector<void *> ptrs;

--- a/dpctl/tensor/libtensor/include/utils/sycl_alloc_utils.hpp
+++ b/dpctl/tensor/libtensor/include/utils/sycl_alloc_utils.hpp
@@ -206,6 +206,10 @@ sycl::event async_smart_free(sycl::queue &exec_q,
             }
         });
     });
+
+    // Upon successful submission of host_task, USM allocations are owned
+    // by the host_task. Release smart pointer ownership to avoid double
+    // deallocation
     (unique_pointers.release(), ...);
 
     return ht_e;

--- a/dpctl/tensor/libtensor/include/utils/sycl_alloc_utils.hpp
+++ b/dpctl/tensor/libtensor/include/utils/sycl_alloc_utils.hpp
@@ -26,12 +26,13 @@
 
 #pragma once
 
-#include <cstddef>
-#include <exception>
-#include <iostream>
-#include <memory>
-#include <stdexcept>
-#include <type_traits>
+#include <cstddef>     // for std::size_t
+#include <exception>   // for std::exception
+#include <iostream>    // for std::cerr
+#include <memory>      // for std::unique_ptr
+#include <stdexcept>   // for std::runtime_error
+#include <type_traits> // for std::true_type, std::false_type
+#include <utility>     // for std::move
 #include <vector>
 
 #include "sycl/sycl.hpp"
@@ -174,37 +175,38 @@ struct all_valid_smart_ptrs<Arg, RestArgs...>
 };
 } // end of namespace detail
 
-template <typename... Args>
+/*! @brief Submit host_task and transfer ownership from smart pointers to it */
+template <typename... UniquePtrTs>
 sycl::event async_smart_free(sycl::queue &exec_q,
                              const std::vector<sycl::event> &depends,
-                             Args &&...args)
+                             UniquePtrTs &&...unique_pointers)
 {
-    constexpr std::size_t n = sizeof...(Args);
+    constexpr std::size_t n = sizeof...(UniquePtrTs);
     static_assert(
         n > 0, "async_smart_free requires at least one smart pointer argument");
 
     static_assert(
-        detail::all_valid_smart_ptrs<Args...>::value,
+        detail::all_valid_smart_ptrs<UniquePtrTs...>::value,
         "async_smart_free requires unique_ptr created with smart_malloc");
 
     std::vector<void *> ptrs;
     ptrs.reserve(n);
-    (ptrs.push_back(reinterpret_cast<void *>(args.get())), ...);
+    (ptrs.push_back(reinterpret_cast<void *>(unique_pointers.get())), ...);
 
     std::vector<USMDeleter> dels;
     dels.reserve(n);
-    (dels.push_back(args.get_deleter()), ...);
+    (dels.emplace_back(unique_pointers.get_deleter()), ...);
 
     sycl::event ht_e = exec_q.submit([&](sycl::handler &cgh) {
         cgh.depends_on(depends);
 
-        cgh.host_task([ptrs, dels]() {
+        cgh.host_task([ptrs = std::move(ptrs), dels = std::move(dels)]() {
             for (std::size_t i = 0; i < ptrs.size(); ++i) {
                 dels[i](ptrs[i]);
             }
         });
     });
-    (args.release(), ...);
+    (unique_pointers.release(), ...);
 
     return ht_e;
 }

--- a/dpctl/tensor/libtensor/include/utils/sycl_utils.hpp
+++ b/dpctl/tensor/libtensor/include/utils/sycl_utils.hpp
@@ -132,7 +132,7 @@ std::size_t choose_workgroup_size(const std::size_t nelems,
     return wg;
 }
 
-namespace
+namespace detail
 {
 
 template <typename LocAccT, typename OpT>
@@ -158,7 +158,7 @@ void _fold(LocAccT &local_mem_acc,
     }
 }
 
-} // namespace
+} // end of namespace detail
 
 template <typename T, typename GroupT, typename LocAccT, typename OpT>
 T custom_reduce_over_group(const GroupT &wg,
@@ -184,7 +184,8 @@ T custom_reduce_over_group(const GroupT &wg,
         for (std::uint32_t sz = high_sz; sz >= low_sz; sz >>= 1) {
             if (n_witems >= sz) {
                 const std::uint32_t n_witems_ = (n_witems + 1) >> 1;
-                _fold(local_mem_acc, lid, n_witems - n_witems_, n_witems_, op);
+                detail::_fold(local_mem_acc, lid, n_witems - n_witems_,
+                              n_witems_, op);
                 sycl::group_barrier(wg, sycl::memory_scope::work_group);
                 n_witems = n_witems_;
             }
@@ -196,7 +197,7 @@ T custom_reduce_over_group(const GroupT &wg,
         for (std::uint32_t sz = high_sz; sz >= low_sz; sz >>= 1) {
             if (n_witems >= sz) {
                 n_witems >>= 1;
-                _fold(local_mem_acc, lid, n_witems, op);
+                detail::_fold(local_mem_acc, lid, n_witems, op);
                 sycl::group_barrier(wg, sycl::memory_scope::work_group);
             }
         }

--- a/dpctl/tensor/libtensor/source/clip.cpp
+++ b/dpctl/tensor/libtensor/source/clip.cpp
@@ -228,11 +228,10 @@ py_clip(const dpctl::tensor::usm_ndarray &src,
         // common shape and strides
         simplified_shape, simplified_src_strides, simplified_min_strides,
         simplified_max_strides, simplified_dst_strides);
-    py::ssize_t *packed_shape_strides = std::get<0>(ptr_size_event_tuple);
-    if (!packed_shape_strides) {
-        throw std::runtime_error("USM-host memory allocation failure");
-    }
+    auto packed_shape_strides_owner =
+        std::move(std::get<0>(ptr_size_event_tuple));
     sycl::event copy_shape_strides_ev = std::get<2>(ptr_size_event_tuple);
+    const py::ssize_t *packed_shape_strides = packed_shape_strides_owner.get();
 
     std::vector<sycl::event> all_deps;
     all_deps.reserve(depends.size() + 1);
@@ -246,15 +245,9 @@ py_clip(const dpctl::tensor::usm_ndarray &src,
                              min_offset, max_offset, dst_offset, all_deps);
 
     // free packed temporaries
-    sycl::event temporaries_cleanup_ev = exec_q.submit([&](sycl::handler &cgh) {
-        cgh.depends_on(clip_ev);
-        const auto &ctx = exec_q.get_context();
-        using dpctl::tensor::alloc_utils::sycl_free_noexcept;
-        cgh.host_task([packed_shape_strides, ctx]() {
-            sycl_free_noexcept(packed_shape_strides, ctx);
-        });
-    });
-
+    sycl::event temporaries_cleanup_ev =
+        dpctl::tensor::alloc_utils::async_smart_free(
+            exec_q, {clip_ev}, packed_shape_strides_owner);
     host_task_events.push_back(temporaries_cleanup_ev);
 
     sycl::event arg_cleanup_ev =

--- a/dpctl/tensor/libtensor/source/copy_and_cast_usm_to_usm.cpp
+++ b/dpctl/tensor/libtensor/source/copy_and_cast_usm_to_usm.cpp
@@ -251,28 +251,21 @@ copy_usm_ndarray_into_usm_ndarray(const dpctl::tensor::usm_ndarray &src,
     host_task_events.reserve(2);
 
     using dpctl::tensor::offset_utils::device_allocate_and_pack;
-    const auto &ptr_size_event_tuple = device_allocate_and_pack<py::ssize_t>(
+    auto ptr_size_event_tuple = device_allocate_and_pack<py::ssize_t>(
         exec_q, host_task_events, simplified_shape, simplified_src_strides,
         simplified_dst_strides);
-    py::ssize_t *shape_strides = std::get<0>(ptr_size_event_tuple);
-    if (shape_strides == nullptr) {
-        throw std::runtime_error("Unable to allocate device memory");
-    }
+    auto shape_strides_owner = std::move(std::get<0>(ptr_size_event_tuple));
     const sycl::event &copy_shape_ev = std::get<2>(ptr_size_event_tuple);
+    const py::ssize_t *shape_strides = shape_strides_owner.get();
 
     const sycl::event &copy_and_cast_generic_ev = copy_and_cast_fn(
         exec_q, src_nelems, nd, shape_strides, src_data, src_offset, dst_data,
         dst_offset, depends, {copy_shape_ev});
 
     // async free of shape_strides temporary
-    const auto &ctx = exec_q.get_context();
-    const auto &temporaries_cleanup_ev = exec_q.submit([&](sycl::handler &cgh) {
-        cgh.depends_on(copy_and_cast_generic_ev);
-        using dpctl::tensor::alloc_utils::sycl_free_noexcept;
-        cgh.host_task(
-            [ctx, shape_strides]() { sycl_free_noexcept(shape_strides, ctx); });
-    });
-
+    const auto &temporaries_cleanup_ev =
+        dpctl::tensor::alloc_utils::async_smart_free(
+            exec_q, {copy_and_cast_generic_ev}, shape_strides_owner);
     host_task_events.push_back(temporaries_cleanup_ev);
 
     return std::make_pair(keep_args_alive(exec_q, {src, dst}, host_task_events),

--- a/dpctl/tensor/libtensor/source/copy_for_roll.cpp
+++ b/dpctl/tensor/libtensor/source/copy_for_roll.cpp
@@ -218,15 +218,12 @@ copy_usm_ndarray_for_roll_1d(const dpctl::tensor::usm_ndarray &src,
 
     // shape_strides = [src_shape, src_strides, dst_strides]
     using dpctl::tensor::offset_utils::device_allocate_and_pack;
-    const auto &ptr_size_event_tuple = device_allocate_and_pack<py::ssize_t>(
+    auto ptr_size_event_tuple = device_allocate_and_pack<py::ssize_t>(
         exec_q, host_task_events, simplified_shape, simplified_src_strides,
         simplified_dst_strides);
-
-    py::ssize_t *shape_strides = std::get<0>(ptr_size_event_tuple);
-    if (shape_strides == nullptr) {
-        throw std::runtime_error("Unable to allocate device memory");
-    }
+    auto shape_strides_owner = std::move(std::get<0>(ptr_size_event_tuple));
     sycl::event copy_shape_ev = std::get<2>(ptr_size_event_tuple);
+    const py::ssize_t *shape_strides = shape_strides_owner.get();
 
     std::vector<sycl::event> all_deps(depends.size() + 1);
     all_deps.push_back(copy_shape_ev);
@@ -236,14 +233,9 @@ copy_usm_ndarray_for_roll_1d(const dpctl::tensor::usm_ndarray &src,
         fn(exec_q, offset, src_nelems, src_nd, shape_strides, src_data,
            src_offset, dst_data, dst_offset, all_deps);
 
-    auto temporaries_cleanup_ev = exec_q.submit([&](sycl::handler &cgh) {
-        cgh.depends_on(copy_for_roll_event);
-        const auto &ctx = exec_q.get_context();
-        using dpctl::tensor::alloc_utils::sycl_free_noexcept;
-        cgh.host_task(
-            [shape_strides, ctx]() { sycl_free_noexcept(shape_strides, ctx); });
-    });
-
+    sycl::event temporaries_cleanup_ev =
+        dpctl::tensor::alloc_utils::async_smart_free(
+            exec_q, {copy_for_roll_event}, shape_strides_owner);
     host_task_events.push_back(temporaries_cleanup_ev);
 
     return std::make_pair(keep_args_alive(exec_q, {src, dst}, host_task_events),
@@ -349,15 +341,13 @@ copy_usm_ndarray_for_roll_nd(const dpctl::tensor::usm_ndarray &src,
 
     // shape_strides = [src_shape, src_strides, dst_strides]
     using dpctl::tensor::offset_utils::device_allocate_and_pack;
-    const auto &ptr_size_event_tuple = device_allocate_and_pack<py::ssize_t>(
+    auto ptr_size_event_tuple = device_allocate_and_pack<py::ssize_t>(
         exec_q, host_task_events, common_shape, src_strides, dst_strides,
         normalized_shifts);
-
-    py::ssize_t *shape_strides_shifts = std::get<0>(ptr_size_event_tuple);
-    if (shape_strides_shifts == nullptr) {
-        throw std::runtime_error("Unable to allocate device memory");
-    }
+    auto shape_strides_shifts_owner =
+        std::move(std::get<0>(ptr_size_event_tuple));
     sycl::event copy_shape_ev = std::get<2>(ptr_size_event_tuple);
+    const py::ssize_t *shape_strides_shifts = shape_strides_shifts_owner.get();
 
     std::vector<sycl::event> all_deps(depends.size() + 1);
     all_deps.push_back(copy_shape_ev);
@@ -367,15 +357,8 @@ copy_usm_ndarray_for_roll_nd(const dpctl::tensor::usm_ndarray &src,
         fn(exec_q, src_nelems, src_nd, shape_strides_shifts, src_data,
            src_offset, dst_data, dst_offset, all_deps);
 
-    auto temporaries_cleanup_ev = exec_q.submit([&](sycl::handler &cgh) {
-        cgh.depends_on(copy_for_roll_event);
-        const auto &ctx = exec_q.get_context();
-        using dpctl::tensor::alloc_utils::sycl_free_noexcept;
-        cgh.host_task([shape_strides_shifts, ctx]() {
-            sycl_free_noexcept(shape_strides_shifts, ctx);
-        });
-    });
-
+    auto temporaries_cleanup_ev = dpctl::tensor::alloc_utils::async_smart_free(
+        exec_q, {copy_for_roll_event}, shape_strides_shifts_owner);
     host_task_events.push_back(temporaries_cleanup_ev);
 
     return std::make_pair(keep_args_alive(exec_q, {src, dst}, host_task_events),

--- a/dpctl/tensor/libtensor/source/elementwise_functions/add.cpp
+++ b/dpctl/tensor/libtensor/source/elementwise_functions/add.cpp
@@ -30,13 +30,13 @@
 #include <sycl/sycl.hpp>
 #include <vector>
 
-#include "add.hpp"
-#include "elementwise_functions.hpp"
-#include "utils/type_dispatch.hpp"
-
 #include "kernels/elementwise_functions/add.hpp"
 #include "kernels/elementwise_functions/common.hpp"
 #include "kernels/elementwise_functions/common_inplace.hpp"
+#include "utils/type_dispatch.hpp"
+
+#include "add.hpp"
+#include "elementwise_functions.hpp"
 
 namespace py = pybind11;
 

--- a/dpctl/tensor/libtensor/source/sorting/topk.cpp
+++ b/dpctl/tensor/libtensor/source/sorting/topk.cpp
@@ -31,18 +31,19 @@
 #include <utility>
 #include <vector>
 
+#include <sycl/sycl.hpp>
+
 #include "dpctl4pybind11.hpp"
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
-#include <sycl/sycl.hpp>
 
+#include "kernels/sorting/topk.hpp"
 #include "utils/math_utils.hpp"
 #include "utils/memory_overlap.hpp"
 #include "utils/output_validation.hpp"
 #include "utils/type_dispatch.hpp"
 #include "utils/type_utils.hpp"
 
-#include "kernels/sorting/topk.hpp"
 #include "rich_comparisons.hpp"
 #include "topk.hpp"
 

--- a/dpctl/tensor/libtensor/source/tensor_sorting.cpp
+++ b/dpctl/tensor/libtensor/source/tensor_sorting.cpp
@@ -27,6 +27,8 @@
 
 #include "sorting/merge_argsort.hpp"
 #include "sorting/merge_sort.hpp"
+#include "sorting/radix_argsort.hpp"
+#include "sorting/radix_sort.hpp"
 #include "sorting/searchsorted.hpp"
 #include "sorting/topk.hpp"
 
@@ -37,5 +39,7 @@ PYBIND11_MODULE(_tensor_sorting_impl, m)
     dpctl::tensor::py_internal::init_merge_sort_functions(m);
     dpctl::tensor::py_internal::init_merge_argsort_functions(m);
     dpctl::tensor::py_internal::init_searchsorted_functions(m);
+    dpctl::tensor::py_internal::init_radix_sort_functions(m);
+    dpctl::tensor::py_internal::init_radix_argsort_functions(m);
     dpctl::tensor::py_internal::init_topk_functions(m);
 }


### PR DESCRIPTION
This PR checks in some technical debt changes.

- Do not user anonymous namespace in C++ header files.  

*Rationale*: Entities defined in anonymous namespace have internal linkage, that is, they are generated in every translation units that includes the header file bloating the size of compiled binary, as well increasing compilation time

- Move inline kernel submissions for tasks that do not depend on all template parameters of the function to a separate function.

*Rationale*: Inline use requires kernel names to be distinct for function different instantiations, producing multiple copies of identical kernels, bloating the binary. 

This change alone shed 13MB off the size of `_tensor_accumulation_impl` native extension (from 49MB to 36MB).


---

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [x] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [ ] Have you added your changes to the changelog?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
