### PR TITLE
Avoid copy in triul ctor host task

### DIFF
--- a/dpctl/tensor/libtensor/source/triul_ctor.cpp
+++ b/dpctl/tensor/libtensor/source/triul_ctor.cpp
@@ -206,7 +206,8 @@ usm_ndarray_triul(sycl::queue &exec_q,
         const auto &ctx = exec_q.get_context();
         using dpctl::tensor::alloc_utils::sycl_free_noexcept;
         cgh.host_task(
-            [shp_host_shape_and_strides, dev_shape_and_strides, ctx]() {
+            [shp_host_shape_and_strides = std::move(shp_host_shape_and_strides),
+             dev_shape_and_strides, ctx]() {
                 // capture of shp_host_shape_and_strides ensure the underlying
                 // vector exists for the entire execution of copying kernel
                 sycl_free_noexcept(dev_shape_and_strides, ctx);

--- a/dpctl/tensor/libtensor/source/triul_ctor.cpp
+++ b/dpctl/tensor/libtensor/source/triul_ctor.cpp
@@ -22,11 +22,14 @@
 /// This file defines functions of dpctl.tensor._tensor_impl extensions
 //===--------------------------------------------------------------------===//
 
-#include <cstddef>
-#include <stdexcept>
+#include <algorithm> // for std::copy
+#include <cstddef>   // for std::size_t
+#include <memory>    // for std::make_shared
+#include <stdexcept> // for std::runtime_error
+#include <utility>   // for std::pair, std::move
+#include <vector>    // for std::vector, std::begin, std::end
+
 #include <sycl/sycl.hpp>
-#include <utility>
-#include <vector>
 
 #include "dpctl4pybind11.hpp"
 #include <pybind11/pybind11.h>


### PR DESCRIPTION
Add missing includes to `triul_ctor.cpp`. Use `std::move` to move vector of shared pointers into lambda function executed by `host_task` for lifetime management of temporaries.


- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [ ] Have you added your changes to the changelog?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
