### PR TITLE
Use --offload-compress linker option to compress offload sections

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,8 +34,16 @@ set(DPCTL_TARGET_HIP
     CACHE STRING
     "Build DPCTL to target a HIP device architecture"
 )
-option(DPCTL_WITH_REDIST "Build DPCTL assuming DPC++ redistributable is installed into Python prefix" OFF)
-option(DPCTL_OFFLOAD_COMPRESS "Build using offload section compression feature of DPC++" OFF)
+option(
+     DPCTL_WITH_REDIST
+     "Build DPCTL assuming DPC++ redistributable is installed into Python prefix"
+     OFF)
+option(
+     DPCTL_OFFLOAD_COMPRESS
+     "Build using offload section compression feature of DPC++ to reduce \
+size of shared object with offloading sections"
+     OFF
+)
 
 find_package(IntelSYCL REQUIRED PATHS ${CMAKE_SOURCE_DIR}/cmake NO_DEFAULT_PATH)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,6 +35,7 @@ set(DPCTL_TARGET_HIP
     "Build DPCTL to target a HIP device architecture"
 )
 option(DPCTL_WITH_REDIST "Build DPCTL assuming DPC++ redistributable is installed into Python prefix" OFF)
+option(DPCTL_OFFLOAD_COMPRESS "Build using offload section compression feature of DPC++" OFF)
 
 find_package(IntelSYCL REQUIRED PATHS ${CMAKE_SOURCE_DIR}/cmake NO_DEFAULT_PATH)
 

--- a/dpctl/CMakeLists.txt
+++ b/dpctl/CMakeLists.txt
@@ -111,6 +111,8 @@ function(build_dpctl_ext _trgt _src _dest)
     Python_add_library(${_trgt} MODULE WITH_SOABI ${_generated_src})
     if (BUILD_DPCTL_EXT_SYCL)
         add_sycl_to_target(TARGET ${_trgt} SOURCES ${_generated_src})
+        target_compile_options(${_trgt} PRIVATE -fno-sycl-id-queries-fit-in-int)
+        target_link_options(${_trgt} PRIVATE -fsycl-device-code-split=per_kernel --offload-compress)
         if(_dpctl_sycl_targets)
             # make fat binary
             target_compile_options(

--- a/dpctl/CMakeLists.txt
+++ b/dpctl/CMakeLists.txt
@@ -112,7 +112,10 @@ function(build_dpctl_ext _trgt _src _dest)
     if (BUILD_DPCTL_EXT_SYCL)
         add_sycl_to_target(TARGET ${_trgt} SOURCES ${_generated_src})
         target_compile_options(${_trgt} PRIVATE -fno-sycl-id-queries-fit-in-int)
-        target_link_options(${_trgt} PRIVATE -fsycl-device-code-split=per_kernel --offload-compress)
+	target_link_options(${_trgt} PRIVATE -fsycl-device-code-split=per_kernel)
+	if (DPCTL_OFFLOAD_COMPRESS)
+            target_link_options(${_trgt} PRIVATE --offload-compress)
+	endif()
         if(_dpctl_sycl_targets)
             # make fat binary
             target_compile_options(

--- a/dpctl/tensor/CMakeLists.txt
+++ b/dpctl/tensor/CMakeLists.txt
@@ -267,7 +267,7 @@ endforeach()
 set(_linker_options "LINKER:${DPCTL_LDFLAGS}")
 foreach(python_module_name ${_py_trgts})
     target_compile_options(${python_module_name} PRIVATE -fno-sycl-id-queries-fit-in-int)
-    target_link_options(${python_module_name} PRIVATE -fsycl-device-code-split=per_kernel)
+    target_link_options(${python_module_name} PRIVATE -fsycl-device-code-split=per_kernel --offload-compress)
     target_include_directories(${python_module_name}
         PRIVATE
         ${CMAKE_CURRENT_SOURCE_DIR}/libtensor/include
@@ -279,7 +279,7 @@ foreach(python_module_name ${_py_trgts})
             target_compile_options(${python_module_name}
                 PRIVATE -fprofile-instr-generate -fcoverage-mapping
             )
-	endif()
+        endif()
         target_link_options(${python_module_name}
             PRIVATE -fprofile-instr-generate -fcoverage-mapping
         )

--- a/dpctl/tensor/CMakeLists.txt
+++ b/dpctl/tensor/CMakeLists.txt
@@ -267,7 +267,11 @@ endforeach()
 set(_linker_options "LINKER:${DPCTL_LDFLAGS}")
 foreach(python_module_name ${_py_trgts})
     target_compile_options(${python_module_name} PRIVATE -fno-sycl-id-queries-fit-in-int)
-    target_link_options(${python_module_name} PRIVATE -fsycl-device-code-split=per_kernel --offload-compress)
+    target_link_options(${python_module_name} PRIVATE -fsycl-device-code-split=per_kernel)
+    if (DPCTL_OFFLOAD_COMPRESS)
+        target_link_options(${python_module_name} PRIVATE --offload-compress)
+    endif()
+
     target_include_directories(${python_module_name}
         PRIVATE
         ${CMAKE_CURRENT_SOURCE_DIR}/libtensor/include

--- a/dpctl/utils/CMakeLists.txt
+++ b/dpctl/utils/CMakeLists.txt
@@ -28,7 +28,7 @@ list(APPEND _pybind11_targets ${python_module_name})
 set(_linker_options "LINKER:${DPCTL_LDFLAGS}")
 foreach(python_module_name ${_pybind11_targets})
     target_compile_options(${python_module_name} PRIVATE -fno-sycl-id-queries-fit-in-int)
-    target_link_options(${python_module_name} PRIVATE -fsycl-device-code-split=per_kernel)
+    target_link_options(${python_module_name} PRIVATE -fsycl-device-code-split=per_kernel --offload-compress)
     target_include_directories(${python_module_name}
         PRIVATE
         ${CMAKE_CURRENT_SOURCE_DIR}/libtensor/include
@@ -40,7 +40,7 @@ foreach(python_module_name ${_pybind11_targets})
             target_compile_options(${python_module_name}
                 PRIVATE -fprofile-instr-generate -fcoverage-mapping
             )
-	endif()
+        endif()
         target_link_options(${python_module_name}
             PRIVATE -fprofile-instr-generate -fcoverage-mapping
         )

--- a/dpctl/utils/CMakeLists.txt
+++ b/dpctl/utils/CMakeLists.txt
@@ -28,7 +28,11 @@ list(APPEND _pybind11_targets ${python_module_name})
 set(_linker_options "LINKER:${DPCTL_LDFLAGS}")
 foreach(python_module_name ${_pybind11_targets})
     target_compile_options(${python_module_name} PRIVATE -fno-sycl-id-queries-fit-in-int)
-    target_link_options(${python_module_name} PRIVATE -fsycl-device-code-split=per_kernel --offload-compress)
+    target_link_options(${python_module_name} PRIVATE -fsycl-device-code-split=per_kernel)
+    if (DPCTL_OFFLOAD_COMPRESS)
+        target_link_options(${python_module_name} PRIVATE --offload-compress)
+    endif()
+
     target_include_directories(${python_module_name}
         PRIVATE
         ${CMAKE_CURRENT_SOURCE_DIR}/libtensor/include


### PR DESCRIPTION
See https://www.intel.com/content/www/us/en/developer/articles/technical/sycl-compilation-device-image-compression.html

It is applicable for any SYCL targets. This change results in 28.4% reduction in shared objects sizes with offload sections on Linux.

```
(* in base branch *)
(dev_dpctl) :~/repos/dpctl$ ls -l dpctl/tensor/_tensor*_impl*
-rw-r--r-- 1 me myself 36403864 Jan  9 16:32 dpctl/tensor/_tensor_accumulation_impl.cpython-312-x86_64-linux-gnu.so
-rw-r--r-- 1 me myself 38666520 Jan  9 16:32 dpctl/tensor/_tensor_elementwise_impl.cpython-312-x86_64-linux-gnu.so
-rw-r--r-- 1 me myself 60695704 Jan  9 16:32 dpctl/tensor/_tensor_impl.cpython-312-x86_64-linux-gnu.so
-rw-r--r-- 1 me myself 16431464 Jan  9 16:32 dpctl/tensor/_tensor_linalg_impl.cpython-312-x86_64-linux-gnu.so
-rw-r--r-- 1 me myself 55497816 Jan  9 16:32 dpctl/tensor/_tensor_reductions_impl.cpython-312-x86_64-linux-gnu.so
-rw-r--r-- 1 me myself 49789576 Jan  9 16:32 dpctl/tensor/_tensor_sorting_impl.cpython-312-x86_64-linux-gnu.so
```

```
(* this PR *)
(dev_dpctl) :~/repos/dpctl$ ls -l dpctl/tensor/_tensor*_impl*
-rw-r--r-- 1 me myself 19480664 Jan 10 12:05 dpctl/tensor/_tensor_accumulation_impl.cpython-312-x86_64-linux-gnu.so
-rw-r--r-- 1 me myself 21665576 Jan 10 12:05 dpctl/tensor/_tensor_elementwise_impl.cpython-312-x86_64-linux-gnu.so
-rw-r--r-- 1 me myself 35233512 Jan 10 12:05 dpctl/tensor/_tensor_impl.cpython-312-x86_64-linux-gnu.so
-rw-r--r-- 1 me myself 10868840 Jan 10 12:05 dpctl/tensor/_tensor_linalg_impl.cpython-312-x86_64-linux-gnu.so
-rw-r--r-- 1 me myself 33741656 Jan 10 12:05 dpctl/tensor/_tensor_reductions_impl.cpython-312-x86_64-linux-gnu.so
-rw-r--r-- 1 me myself 31597128 Jan 10 12:05 dpctl/tensor/_tensor_sorting_impl.cpython-312-x86_64-linux-gnu.so
```

```
Python 3.12.3 | packaged by conda-forge | (main, Apr 15 2024, 18:38:13) [GCC 12.3.0]
Type 'copyright', 'credits' or 'license' for more information
IPython 8.24.0 -- An enhanced Interactive Python. Type '?' for help.

In [1]: sum([36403864, 38666520, 60695704, 16431464, 55497816, 49789576])
Out[1]: 257484944

In [2]: sum([19480664, 21665576, 35233512, 10868840, 33741656, 31597128, 31931848])
Out[2]: 184519224

In [3]: sum([19480664, 21665576, 35233512, 10868840, 33741656, 31597128])
Out[3]: 152587376

In [4]: Out[3]/Out[2], Out[3]/Out[1]
Out[4]: (0.8269456845320355, 0.592606983653382)

In [5]: (1 - x for x in _)
Out[5]: <generator object <genexpr> at 0x7f0153f23ac0>

In [6]: list(_)
Out[6]: [0.17305431546796446, 0.40739301634661795]

In [7]: quit
```

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [ ] Have you added your changes to the changelog?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
