### PR TITLE
Usm ndrray array protocol must raise

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Improved performance of `tensor.cumulative_sum`, `tensor.cumulative_prod`, `tensor.cumulative_logsumexp` as well as performance of boolean indexing [gh-1923](https://github.com/IntelPython/dpctl/pull/1923)
 * Improved performance of `tensor.min`, `tensor.max`, `tensor.logsumexp`, `tensor.reduce_hypot` for floating point type arrays by at least 2x [gh-1932](https://github.com/IntelPython/dpctl/pull/1932)
 * Extended `tensor.asarray` to support objects that implement `__usm_ndarray__` property to be interpreted as `usm_ndarray` objects [gh-1959](https://github.com/IntelPython/dpctl/pull/1959)
+* `dpctl.tensor.usm_ndarray` object disallows implicit conversions to NumPy array [gh-1964](https://github.com/IntelPython/dpctl/pull/1964)
 
 ### Fixed
 

--- a/dpctl/tensor/_usmarray.pyx
+++ b/dpctl/tensor/_usmarray.pyx
@@ -1552,6 +1552,14 @@ cdef class usm_ndarray:
     def __repr__(self):
         return usm_ndarray_repr(self)
 
+    def __array__(self, dtype=None, copy=None):
+        "NumPy array protocol"
+        raise TypeError(
+            "Implicit conversion to a NumPy array is not allowed. "
+	    "Use `dpctl.tensor.asnumpy` to copy data from this "
+	    "`dpctl.tensor.usm_ndarray` instance to NumPy array"
+	)
+
 
 cdef usm_ndarray _real_view(usm_ndarray ary):
     """

--- a/dpctl/tensor/_usmarray.pyx
+++ b/dpctl/tensor/_usmarray.pyx
@@ -1552,8 +1552,15 @@ cdef class usm_ndarray:
     def __repr__(self):
         return usm_ndarray_repr(self)
 
-    def __array__(self, dtype=None, copy=None):
-        "NumPy array protocol"
+    def __array__(self, dtype=None, /, *, copy=None):
+        """NumPy's array protocol method to disallow implicit conversion.
+
+	Without this definition, `numpy.asarray(usm_ar)` converts
+	usm_ndarray instance into NumPy array with data type `object`
+	and every element being 0d usm_ndarray.
+
+        https://github.com/IntelPython/dpctl/pull/1384#issuecomment-1707212972
+	"""
         raise TypeError(
             "Implicit conversion to a NumPy array is not allowed. "
 	    "Use `dpctl.tensor.asnumpy` to copy data from this "

--- a/dpctl/tests/test_usm_ndarray_ctor.py
+++ b/dpctl/tests/test_usm_ndarray_ctor.py
@@ -2659,3 +2659,12 @@ def test_setitem_copy_as_contig_alignment(dt):
     x[1:, ...] = vals
     assert dpt.all(x[0] == 0)
     assert dpt.all(x[1:, :] == vals)
+
+
+def test_asarray_property():
+    get_queue_or_skip()
+
+    x = dpt.ones(11, dtype="i4")
+
+    with pytest.raises(TypeError):
+        np.asarray(x)


### PR DESCRIPTION
Implement `usm_ndarray.__array__` that raises `TypeError` to disallow implicit conversion of `usm_ndarray` to `numpy.ndarray` with `dtype=object`.

- [x] Have you provided a meaningful PR description?
- [x] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [x] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [ ] Have you added your changes to the changelog?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
