### PR TITLE
Make `stream` a keyword-only argument in `usm_ndarray.to_device`

### DIFF
--- a/dpctl/tensor/_usmarray.pyx
+++ b/dpctl/tensor/_usmarray.pyx
@@ -981,8 +981,8 @@ cdef class usm_ndarray:
         res.flags_ = _copy_writable(res.flags_, self.flags_)
         return res
 
-    def to_device(self, target_device, stream=None):
-        """ to_device(target_device)
+    def to_device(self, target_device, /, *, stream=None):
+        """ to_device(target_device, /, *, stream=None)
 
         Transfers this array to specified target device.
 


### PR DESCRIPTION
This PR fixes a small nonconformity with the array API by making `stream` a keyword-only argument, and adds a test for `stream`.

Closes https://github.com/IntelPython/dpctl/issues/1965

- [X] Have you provided a meaningful PR description?
- [X] Have you added a test, reproducer or referred to an issue with a reproducer?
- [X] Have you tested your changes locally for CPU and GPU devices?
- [X] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [X] Have you added documentation for your changes, if necessary?
- [ ] Have you added your changes to the changelog?
- [X] If this PR is a work in progress, are you opening the PR as a draft?
