### PR TITLE
Replace np.empty_like(usm_ndarray_inst) with np.empty(shape, dtype=dt)

### DIFF
--- a/dpctl/tests/elementwise/test_add.py
+++ b/dpctl/tests/elementwise/test_add.py
@@ -306,7 +306,7 @@ def test_add_errors():
 
     ar1 = dpt.ones(2, dtype="float32")
     ar2 = dpt.ones_like(ar1, dtype="int32")
-    y = np.empty_like(ar1)
+    y = np.empty(ar1.shape, dtype=ar1.dtype)
     with pytest.raises(TypeError) as excinfo:
         dpt.add(ar1, ar2, out=y)
     assert "output array must be of usm_ndarray type" in str(excinfo.value)

--- a/dpctl/tests/test_tensor_clip.py
+++ b/dpctl/tests/test_tensor_clip.py
@@ -544,7 +544,7 @@ def test_clip_errors():
     ar1 = dpt.ones(2, dtype="i4")
     ar2 = dpt.ones_like(ar1, dtype="i4")
     ar3 = dpt.ones_like(ar1, dtype="i4")
-    ar4 = np.empty_like(ar1)
+    ar4 = np.empty(ar1.shape, dtype=ar1.dtype)
     assert_raises_regex(
         TypeError,
         "output array must be of usm_ndarray type",


### PR DESCRIPTION
Corrected uses of `np.empty_like(usm_ar)` in test suite which error own due to recent change disallowing implicit data conversions.
These were subtle, albeit harmless, bugs.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [ ] Have you added your changes to the changelog?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
