### PR TITLE
Set subprocess to no use fork

### DIFF
--- a/dpctl/_init_helper.py
+++ b/dpctl/_init_helper.py
@@ -32,3 +32,20 @@ if is_venv_win32:  # pragma: no cover
         os.add_dll_directory(dll_dir)
 
 del is_venv_win32
+
+is_linux = sys.platform.startswith("linux")
+
+if is_linux:
+    # forking is not supported by device drivers
+    # Configure subprocess (used by versioneer) to
+    # use SPAWN method over FORK method to enable
+    # use of gdb-oneapi to debug code launched by
+    # native extensions that used dpctl C/C++ API
+    import subprocess
+
+    subprocess._USE_VFORK = False
+    subprocess._USE_POSIX_SPAWN = True
+    # remove qualifier from this namespace
+    del subprocess
+
+del is_linux


### PR DESCRIPTION
This PR modified initialization of `dpctl` to set subprocess to not use FORK, but use SPAWN to launch subprocesses on Linux.

This is a tentative fix to allows `oneapi-gdb` to debug kernels submitted by Python applications.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [ ] Have you added your changes to the changelog?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
