### PR TITLE
Add versioneer as build requirement in documentation

### DIFF
--- a/docs/doc_sources/contributor_guides/building.rst
+++ b/docs/doc_sources/contributor_guides/building.rst
@@ -94,6 +94,7 @@ To build using Python ``setuptools`` and ``scikit-build``, install the following
 - ``cmake``
 - ``scikit-build``
 - ``ninja``
+- ``versioneer``
 - ``gtest`` (optional to run C API tests)
 - ``gmock`` (optional to run C API tests)
 - ``pytest`` (optional to run Python API tests)


### PR DESCRIPTION
This PR adds to the documentation that versioneer is a build requirement for dpctl.

It is listed in pyproject.toml, but not referenced in docs.

- [X] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [ ] Have you added your changes to the changelog?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
