### PR TITLE
Reduce elementwise extension size

### DIFF
--- a/dpctl/tensor/libtensor/include/kernels/clip.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/clip.hpp
@@ -218,7 +218,6 @@ sycl::event clip_contig_impl(sycl::queue &q,
             using KernelName = clip_contig_kernel<T, vec_sz, n_vecs>;
             using Impl =
                 ClipContigFunctor<T, vec_sz, n_vecs, enable_sg_loadstore>;
-            static_assert(sycl::is_device_copyable_v<Impl>);
 
             cgh.parallel_for<KernelName>(
                 sycl::nd_range<1>(gws_range, lws_range),
@@ -231,7 +230,6 @@ sycl::event clip_contig_impl(sycl::queue &q,
                 disabled_sg_loadstore_wrapper_krn<InnerKernelName>;
             using Impl =
                 ClipContigFunctor<T, vec_sz, n_vecs, disable_sg_loadstore>;
-            static_assert(sycl::is_device_copyable_v<Impl>);
 
             cgh.parallel_for<KernelName>(
                 sycl::nd_range<1>(gws_range, lws_range),

--- a/dpctl/tensor/libtensor/include/kernels/clip.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/clip.hpp
@@ -216,22 +216,26 @@ sycl::event clip_contig_impl(sycl::queue &q,
         {
             constexpr bool enable_sg_loadstore = true;
             using KernelName = clip_contig_kernel<T, vec_sz, n_vecs>;
+            using Impl =
+                ClipContigFunctor<T, vec_sz, n_vecs, enable_sg_loadstore>;
+            static_assert(sycl::is_device_copyable_v<Impl>);
 
             cgh.parallel_for<KernelName>(
                 sycl::nd_range<1>(gws_range, lws_range),
-                ClipContigFunctor<T, vec_sz, n_vecs, enable_sg_loadstore>(
-                    nelems, x_tp, min_tp, max_tp, dst_tp));
+                Impl(nelems, x_tp, min_tp, max_tp, dst_tp));
         }
         else {
             constexpr bool disable_sg_loadstore = false;
             using InnerKernelName = clip_contig_kernel<T, vec_sz, n_vecs>;
             using KernelName =
                 disabled_sg_loadstore_wrapper_krn<InnerKernelName>;
+            using Impl =
+                ClipContigFunctor<T, vec_sz, n_vecs, disable_sg_loadstore>;
+            static_assert(sycl::is_device_copyable_v<Impl>);
 
             cgh.parallel_for<KernelName>(
                 sycl::nd_range<1>(gws_range, lws_range),
-                ClipContigFunctor<T, vec_sz, n_vecs, disable_sg_loadstore>(
-                    nelems, x_tp, min_tp, max_tp, dst_tp));
+                Impl(nelems, x_tp, min_tp, max_tp, dst_tp));
         }
     });
 
@@ -311,10 +315,12 @@ sycl::event clip_strided_impl(sycl::queue &q,
         const FourOffsets_StridedIndexer indexer{
             nd, x_offset, min_offset, max_offset, dst_offset, shape_strides};
 
-        cgh.parallel_for<clip_strided_kernel<T, FourOffsets_StridedIndexer>>(
+        using KernelName = clip_strided_kernel<T, FourOffsets_StridedIndexer>;
+        using Impl = ClipStridedFunctor<T, FourOffsets_StridedIndexer>;
+
+        cgh.parallel_for<KernelName>(
             sycl::range<1>(nelems),
-            ClipStridedFunctor<T, FourOffsets_StridedIndexer>(
-                x_tp, min_tp, max_tp, dst_tp, indexer));
+            Impl(x_tp, min_tp, max_tp, dst_tp, indexer));
     });
 
     return clip_ev;

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/common_detail.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/common_detail.hpp
@@ -1,0 +1,70 @@
+//=== common_detail.hpp -                                     - *-C++-*--/===//
+//
+//                      Data Parallel Control (dpctl)
+//
+// Copyright 2020-2025 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+//===---------------------------------------------------------------------===//
+///
+/// \file
+/// This file defines common code for elementwise tensor operations.
+//===---------------------------------------------------------------------===//
+
+#pragma once
+#include <cstddef>
+#include <vector>
+
+#include <sycl/sycl.hpp>
+
+namespace dpctl
+{
+namespace tensor
+{
+namespace kernels
+{
+namespace elementwise_detail
+{
+
+template <typename T> class populate_padded_vec_krn;
+
+template <typename T>
+sycl::event
+populate_padded_vector(sycl::queue &exec_q,
+                       const T *vec,
+                       std::size_t vec_sz,
+                       T *padded_vec,
+                       size_t padded_vec_sz,
+                       const std::vector<sycl::event> &dependent_events)
+{
+    sycl::event populate_padded_vec_ev = exec_q.submit([&](sycl::handler &cgh) {
+        // ensure vec contains actual data
+        cgh.depends_on(dependent_events);
+
+        sycl::range<1> gRange{padded_vec_sz};
+
+        cgh.parallel_for<class populate_padded_vec_krn<T>>(
+            gRange, [=](sycl::id<1> id) {
+                std::size_t i = id[0];
+                padded_vec[i] = vec[i % vec_sz];
+            });
+    });
+
+    return populate_padded_vec_ev;
+}
+
+} // end of namespace elementwise_detail
+} // end of namespace kernels
+} // end of namespace tensor
+} // end of namespace dpctl

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/common_inplace.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/common_inplace.hpp
@@ -27,10 +27,12 @@
 #include <cstddef>
 #include <cstdint>
 #include <stdexcept>
+
 #include <sycl/sycl.hpp>
 
 #include "kernels/alignment.hpp"
 #include "kernels/dpctl_tensor_types.hpp"
+#include "kernels/elementwise_functions/common_detail.hpp"
 #include "utils/offset_utils.hpp"
 #include "utils/sycl_alloc_utils.hpp"
 #include "utils/sycl_utils.hpp"
@@ -337,23 +339,26 @@ binary_inplace_contig_impl(sycl::queue &exec_q,
         {
             constexpr bool enable_sg_loadstore = true;
             using KernelName = kernel_name<argTy, resTy, vec_sz, n_vecs>;
+            using Impl =
+                BinaryInplaceContigFunctorT<argTy, resTy, vec_sz, n_vecs,
+                                            enable_sg_loadstore>;
+
             cgh.parallel_for<KernelName>(
                 sycl::nd_range<1>(gws_range, lws_range),
-                BinaryInplaceContigFunctorT<argTy, resTy, vec_sz, n_vecs,
-                                            enable_sg_loadstore>(arg_tp, res_tp,
-                                                                 nelems));
+                Impl(arg_tp, res_tp, nelems));
         }
         else {
             constexpr bool disable_sg_loadstore = true;
             using InnerKernelName = kernel_name<argTy, resTy, vec_sz, n_vecs>;
             using KernelName =
                 disabled_sg_loadstore_wrapper_krn<InnerKernelName>;
+            using Impl =
+                BinaryInplaceContigFunctorT<argTy, resTy, vec_sz, n_vecs,
+                                            disable_sg_loadstore>;
 
             cgh.parallel_for<KernelName>(
                 sycl::nd_range<1>(gws_range, lws_range),
-                BinaryInplaceContigFunctorT<argTy, resTy, vec_sz, n_vecs,
-                                            disable_sg_loadstore>(
-                    arg_tp, res_tp, nelems));
+                Impl(arg_tp, res_tp, nelems));
         }
     });
     return comp_ev;
@@ -389,9 +394,10 @@ binary_inplace_strided_impl(sycl::queue &exec_q,
         const argTy *arg_tp = reinterpret_cast<const argTy *>(rhs_p);
         resTy *res_tp = reinterpret_cast<resTy *>(lhs_p);
 
+        using Impl = BinaryInplaceStridedFunctorT<argTy, resTy, IndexerT>;
+
         cgh.parallel_for<kernel_name<argTy, resTy, IndexerT>>(
-            {nelems}, BinaryInplaceStridedFunctorT<argTy, resTy, IndexerT>(
-                          arg_tp, res_tp, indexer));
+            {nelems}, Impl(arg_tp, res_tp, indexer));
     });
     return comp_ev;
 }
@@ -428,13 +434,9 @@ sycl::event binary_inplace_row_matrix_broadcast_impl(
                                                               exec_q);
     argT *padded_vec = padded_vec_owner.get();
 
-    sycl::event make_padded_vec_ev = exec_q.submit([&](sycl::handler &cgh) {
-        cgh.depends_on(depends); // ensure vec contains actual data
-        cgh.parallel_for({n1_padded}, [=](sycl::id<1> id) {
-            auto i = id[0];
-            padded_vec[i] = vec[i % n1];
-        });
-    });
+    sycl::event make_padded_vec_ev =
+        dpctl::tensor::kernels::elementwise_detail::populate_padded_vector<
+            argT>(exec_q, vec, n1, padded_vec, n1_padded, depends);
 
     // sub-group spans work-items [I, I + sgSize)
     // base = ndit.get_global_linear_id() - sg.get_local_id()[0]
@@ -453,10 +455,11 @@ sycl::event binary_inplace_row_matrix_broadcast_impl(
         std::size_t n_groups = (n_elems + lws - 1) / lws;
         auto gwsRange = sycl::range<1>(n_groups * lws);
 
+        using Impl = BinaryInplaceRowMatrixBroadcastFunctorT<argT, resT>;
+
         cgh.parallel_for<class kernel_name<argT, resT>>(
             sycl::nd_range<1>(gwsRange, lwsRange),
-            BinaryInplaceRowMatrixBroadcastFunctorT<argT, resT>(padded_vec, mat,
-                                                                n_elems, n1));
+            Impl(padded_vec, mat, n_elems, n1));
     });
 
     sycl::event tmp_cleanup_ev = dpctl::tensor::alloc_utils::async_smart_free(

--- a/dpctl/tensor/libtensor/include/utils/offset_utils.hpp
+++ b/dpctl/tensor/libtensor/include/utils/offset_utils.hpp
@@ -176,6 +176,9 @@ private:
     }
 };
 
+// ensure that indexer is device copyable
+static_assert(sycl::is_device_copyable_v<StridedIndexer>);
+
 /* @brief Indexer with shape, strides provided separately */
 struct UnpackedStridedIndexer
 {
@@ -214,6 +217,9 @@ private:
         return starting_offset + relative_offset;
     }
 };
+
+// ensure that indexer is device copyable
+static_assert(sycl::is_device_copyable_v<UnpackedStridedIndexer>);
 
 struct Strided1DIndexer
 {
@@ -259,6 +265,8 @@ private:
     ssize_t step = 1;
 };
 
+static_assert(sycl::is_device_copyable_v<Strided1DIndexer>);
+
 struct Strided1DCyclicIndexer
 {
     Strided1DCyclicIndexer(ssize_t _offset, ssize_t _size, ssize_t _step)
@@ -276,6 +284,8 @@ private:
     std::size_t size = 1;
     ssize_t step = 1;
 };
+
+static_assert(sycl::is_device_copyable_v<Strided1DCyclicIndexer>);
 
 template <typename displacementT> struct TwoOffsets
 {
@@ -350,6 +360,8 @@ struct TwoZeroOffsets_Indexer
         return TwoOffsets<ssize_t>();
     }
 };
+
+static_assert(sycl::is_device_copyable_v<TwoZeroOffsets_Indexer>);
 
 template <typename FirstIndexerT, typename SecondIndexerT>
 struct TwoOffsets_CombinedIndexer
@@ -449,6 +461,8 @@ private:
     }
 };
 
+static_assert(sycl::is_device_copyable_v<ThreeOffsets_StridedIndexer>);
+
 struct ThreeZeroOffsets_Indexer
 {
     constexpr ThreeZeroOffsets_Indexer() {}
@@ -463,6 +477,8 @@ struct ThreeZeroOffsets_Indexer
         return ThreeOffsets<ssize_t>();
     }
 };
+
+static_assert(sycl::is_device_copyable_v<ThreeZeroOffsets_Indexer>);
 
 template <typename FirstIndexerT,
           typename SecondIndexerT,
@@ -577,6 +593,8 @@ private:
     }
 };
 
+static_assert(sycl::is_device_copyable_v<FourOffsets_StridedIndexer>);
+
 struct FourZeroOffsets_Indexer
 {
     constexpr FourZeroOffsets_Indexer() {}
@@ -586,6 +604,8 @@ struct FourZeroOffsets_Indexer
         return FourOffsets<ssize_t>();
     }
 };
+
+static_assert(sycl::is_device_copyable_v<FourZeroOffsets_Indexer>);
 
 struct NthStrideOffset
 {
@@ -614,6 +634,8 @@ private:
     ssize_t const *offsets;
     ssize_t const *shape_strides;
 };
+
+static_assert(sycl::is_device_copyable_v<NthStrideOffset>);
 
 template <int nd> struct FixedDimStridedIndexer
 {
@@ -645,6 +667,8 @@ private:
     std::array<ssize_t, nd> strides;
     ssize_t starting_offset;
 };
+
+static_assert(sycl::is_device_copyable_v<FixedDimStridedIndexer<1>>);
 
 template <int nd> struct TwoOffsets_FixedDimStridedIndexer
 {
@@ -689,6 +713,8 @@ private:
     ssize_t starting_offset1;
     ssize_t starting_offset2;
 };
+
+static_assert(sycl::is_device_copyable_v<TwoOffsets_FixedDimStridedIndexer<1>>);
 
 template <int nd> struct ThreeOffsets_FixedDimStridedIndexer
 {
@@ -746,6 +772,9 @@ private:
     ssize_t starting_offset2;
     ssize_t starting_offset3;
 };
+
+static_assert(
+    sycl::is_device_copyable_v<ThreeOffsets_FixedDimStridedIndexer<1>>);
 
 } // namespace offset_utils
 } // namespace tensor


### PR DESCRIPTION
This PR factors out inline submit to populate padded vector in specializations for binary operations on matrix and a vector.

Doing so allows to generate fewer of such kernels, resulting in the binary size decrease.

Before:
```
(dev_dpctl) opavlyk@mtl-world:~/repos/dpctl$ ls -l dpctl/tensor/_tensor_elementwise_impl.cpython-312-x86_64-linux-gnu.so
-rw-r--r-- 1 opavlyk opavlyk 38659896 Jan 19 20:58 dpctl/tensor/_tensor_elementwise_impl.cpython-312-x86_64-linux-gnu.so
```

After:
```
(dev_dpctl) opavlyk@mtl-world:~/repos/dpctl$ ls -l dpctl/tensor/_tensor_elementwise_impl.cpython-312-x86_64-linux-gnu.so
-rw-r--r-- 1 opavlyk opavlyk 37176600 Jan 21 06:36 dpctl/tensor/_tensor_elementwise_impl.cpython-312-x86_64-linux-gnu.so
```

Also this PR adds `static_assert` in `offset_utils.hpp` to verify that indexers are device copyable.

It also sneaks in changes of defining local typename for the functor being submitted in `cgh.parallel_for` to simplify the invocation.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [ ] Have you added your changes to the changelog?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
