### PR TITLE
Fix incorrect tests in `test_usm_ndarray_dlpack`

### DIFF
--- a/dpctl/tests/test_usm_ndarray_dlpack.py
+++ b/dpctl/tests/test_usm_ndarray_dlpack.py
@@ -84,7 +84,7 @@ def test_dlpack_device(usm_type, all_root_devices):
         assert type(dev) is tuple
         assert len(dev) == 2
         assert dev[0] == device_oneAPI
-        assert sycl_dev == all_root_devices[dev[1]]
+        assert dev[1] == sycl_dev.get_device_id()
 
 
 def test_dlpack_exporter(typestr, usm_type, all_root_devices):
@@ -834,7 +834,7 @@ def test_sycl_device_to_dldevice(all_root_devices):
         assert type(dev) is tuple
         assert len(dev) == 2
         assert dev[0] == device_oneAPI
-        assert dev[1] == all_root_devices.index(sycl_dev)
+        assert dev[1] == sycl_dev.get_device_id()
 
 
 def test_dldevice_to_sycl_device(all_root_devices):
@@ -842,7 +842,7 @@ def test_dldevice_to_sycl_device(all_root_devices):
         dldev = dpt.empty(0, device=sycl_dev).__dlpack_device__()
         dev = dpt.dldevice_to_sycl_device(dldev)
         assert type(dev) is dpctl.SyclDevice
-        assert dev == all_root_devices[dldev[1]]
+        assert dev.get_device_id() == sycl_dev.get_device_id()
 
 
 def test_dldevice_conversion_arg_validation():


### PR DESCRIPTION
The test `test_dlpack_device` attempted to query a device using DLPack device ID from the list of root devices created by `all_root_devices` fixture in `test_usm_ndarray_dlpack`.

This logic is incorrect, as `all_root_devices` caches only the first two root devices per platform. As the DLPack device ID is based on the ordinal ID of the device as it is canonically presented in `get_devices`, this could fail if a given platform had more than 2 associated devices (in this case, for a machine with 2 PVC. Each has 2 stacks, and therefore, 4 `level_zero` and `opencl:gpu` devices).

- [X] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [X] Have you tested your changes locally for CPU and GPU devices?
- [X] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [ ] Have you added your changes to the changelog?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
