### PR TITLE
Copy from/to multidimensional buffers

### DIFF
--- a/dpctl/_sycl_queue.pyx
+++ b/dpctl/_sycl_queue.pyx
@@ -66,13 +66,13 @@ from .enum_types import backend_type
 
 from cpython cimport pycapsule
 from cpython.buffer cimport (
-    PyObject_CheckBuffer,
     Py_buffer,
-    PyObject_GetBuffer,
-    PyBUF_SIMPLE,
     PyBUF_ANY_CONTIGUOUS,
+    PyBUF_SIMPLE,
     PyBUF_WRITABLE,
-    PyBuffer_Release
+    PyBuffer_Release,
+    PyObject_CheckBuffer,
+    PyObject_GetBuffer,
 )
 from cpython.ref cimport Py_DECREF, Py_INCREF, PyObject
 from libc.stdlib cimport free, malloc

--- a/dpctl/_sycl_queue.pyx
+++ b/dpctl/_sycl_queue.pyx
@@ -372,6 +372,8 @@ cdef DPCTLSyclEventRef _memcpy_impl(
     elif _is_buffer(dst):
         ret_code = PyObject_GetBuffer(dst, &dst_buf_view, PyBUF_SIMPLE | PyBUF_ANY_CONTIGUOUS | PyBUF_WRITABLE)
         if ret_code != 0: # pragma: no cover
+            if src_is_buf:
+                PyBuffer_Release(&src_buf_view)
             raise RuntimeError("Could not access buffer")
         c_dst_ptr = dst_buf_view.buf
         dst_is_buf = True

--- a/dpctl/_sycl_queue.pyx
+++ b/dpctl/_sycl_queue.pyx
@@ -65,7 +65,15 @@ import ctypes
 from .enum_types import backend_type
 
 from cpython cimport pycapsule
-from cpython.buffer cimport PyObject_CheckBuffer
+from cpython.buffer cimport (
+    PyObject_CheckBuffer,
+    Py_buffer,
+    PyObject_GetBuffer,
+    PyBUF_SIMPLE,
+    PyBUF_ANY_CONTIGUOUS,
+    PyBUF_WRITABLE,
+    PyBuffer_Release
+)
 from cpython.ref cimport Py_DECREF, Py_INCREF, PyObject
 from libc.stdlib cimport free, malloc
 
@@ -338,14 +346,20 @@ cdef DPCTLSyclEventRef _memcpy_impl(
     cdef void *c_dst_ptr = NULL
     cdef void *c_src_ptr = NULL
     cdef DPCTLSyclEventRef ERef = NULL
-    cdef const unsigned char[::1] src_host_buf = None
-    cdef unsigned char[::1] dst_host_buf = None
+    cdef Py_buffer src_buf_view
+    cdef Py_buffer dst_buf_view
+    cdef bint src_is_buf = False
+    cdef bint dst_is_buf = False
+    cdef int ret_code = 0
 
     if isinstance(src, _Memory):
         c_src_ptr = <void*>(<_Memory>src).get_data_ptr()
     elif _is_buffer(src):
-        src_host_buf = src
-        c_src_ptr = <void *>&src_host_buf[0]
+        ret_code = PyObject_GetBuffer(src, &src_buf_view, PyBUF_SIMPLE | PyBUF_ANY_CONTIGUOUS)
+        if ret_code != 0:
+            raise RuntimeError("Could not access buffer")
+        c_src_ptr = src_buf_view.buf
+        src_is_buf = True
     else:
         raise TypeError(
              "Parameter `src` should have either type "
@@ -356,8 +370,11 @@ cdef DPCTLSyclEventRef _memcpy_impl(
     if isinstance(dst, _Memory):
         c_dst_ptr = <void*>(<_Memory>dst).get_data_ptr()
     elif _is_buffer(dst):
-        dst_host_buf = dst
-        c_dst_ptr = <void *>&dst_host_buf[0]
+        ret_code = PyObject_GetBuffer(dst, &dst_buf_view, PyBUF_SIMPLE | PyBUF_ANY_CONTIGUOUS | PyBUF_WRITABLE)
+        if ret_code != 0:
+            raise RuntimeError("Could not access buffer")
+        c_dst_ptr = dst_buf_view.buf
+        dst_is_buf = True
     else:
         raise TypeError(
              "Parameter `dst` should have either type "
@@ -376,6 +393,12 @@ cdef DPCTLSyclEventRef _memcpy_impl(
             dep_events,
             dep_events_count
         )
+
+    if src_is_buf:
+        PyBuffer_Release(&src_buf_view)
+    if dst_is_buf:
+        PyBuffer_Release(&dst_buf_view)
+
     return ERef
 
 

--- a/dpctl/_sycl_queue.pyx
+++ b/dpctl/_sycl_queue.pyx
@@ -356,7 +356,7 @@ cdef DPCTLSyclEventRef _memcpy_impl(
         c_src_ptr = <void*>(<_Memory>src).get_data_ptr()
     elif _is_buffer(src):
         ret_code = PyObject_GetBuffer(src, &src_buf_view, PyBUF_SIMPLE | PyBUF_ANY_CONTIGUOUS)
-        if ret_code != 0:
+        if ret_code != 0: # pragma: no cover
             raise RuntimeError("Could not access buffer")
         c_src_ptr = src_buf_view.buf
         src_is_buf = True
@@ -371,7 +371,7 @@ cdef DPCTLSyclEventRef _memcpy_impl(
         c_dst_ptr = <void*>(<_Memory>dst).get_data_ptr()
     elif _is_buffer(dst):
         ret_code = PyObject_GetBuffer(dst, &dst_buf_view, PyBUF_SIMPLE | PyBUF_ANY_CONTIGUOUS | PyBUF_WRITABLE)
-        if ret_code != 0:
+        if ret_code != 0: # pragma: no cover
             raise RuntimeError("Could not access buffer")
         c_dst_ptr = dst_buf_view.buf
         dst_is_buf = True

--- a/dpctl/tests/test_sycl_queue_memcpy.py
+++ b/dpctl/tests/test_sycl_queue_memcpy.py
@@ -17,12 +17,11 @@
 """Defines unit test cases for the SyclQueue.memcpy.
 """
 
+import numpy as np
 import pytest
 
 import dpctl
 import dpctl.memory
-
-import numpy as np
 
 
 def _create_memory(q):


### PR DESCRIPTION
Using typed memoryviews restricts queue `memcpy` to buffers with a single dimension only.

With this change, multi-dimensional buffers with contiguous layout can now be `memcpy`'d.

- [x] Have you provided a meaningful PR description?
- [x] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [ ] Have you added your changes to the changelog?
