### PR TITLE
[MAINT] Add missing license header to `elementwise_functions/sycl_complex.hpp`

### DIFF
--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/sycl_complex.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/sycl_complex.hpp
@@ -1,3 +1,29 @@
+//=== sycl_complex.hpp ----------------------------------------  *-C++-*--/===//
+//
+//                      Data Parallel Control (dpctl)
+//
+// Copyright 2020-2025 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+//===---------------------------------------------------------------------===//
+///
+/// \file
+/// This file defines a macro for defining the SYCL_EXT_ONEAPI_COMPLEX macro
+/// and indirect inclusion of the experimental oneAPI SYCL complex extension
+/// header file.
+//===---------------------------------------------------------------------===//
+
 #pragma once
 
 #define SYCL_EXT_ONEAPI_COMPLEX


### PR DESCRIPTION
This PR adds a license header which was missing from the `sycl_complex.hpp` header file.

- [X] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [ ] Have you added your changes to the changelog?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
