### PR TITLE
Correct mistake in the test that causes compilation error

### DIFF
--- a/libsyclinterface/tests/test_sycl_device_interface.cpp
+++ b/libsyclinterface/tests/test_sycl_device_interface.cpp
@@ -208,7 +208,7 @@ TEST_P(TestDPCTLSyclDeviceInterface, ChkGetSubGroupSizes)
     else
         EXPECT_TRUE(sg_sizes_len > 0);
     for (size_t i = 0; i < sg_sizes_len; ++i) {
-        EXPECT_TRUE(sg_sizes > 0);
+        EXPECT_TRUE(sg_sizes[i] > 0);
     }
     EXPECT_NO_FATAL_FAILURE(DPCTLSize_t_Array_Delete(sg_sizes));
 }


### PR DESCRIPTION
Compilation of `"libsyclinterface/tests/test_sycl_device_interface.cpp"` by Clang version 20.0 fails with "error: ordered comparison between pointer and zero".

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [ ] Have you added your changes to the changelog?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
