### PR TITLE
Add `get_devices` method to `dpctl.SyclPlatform` class

### DIFF
--- a/dpctl/_backend.pxd
+++ b/dpctl/_backend.pxd
@@ -313,6 +313,8 @@ cdef extern from "syclinterface/dpctl_sycl_platform_interface.h":
     cdef DPCTLPlatformVectorRef DPCTLPlatform_GetPlatforms()
     cdef DPCTLSyclContextRef DPCTLPlatform_GetDefaultContext(
         const DPCTLSyclPlatformRef)
+    cdef DPCTLDeviceVectorRef DPCTLPlatform_GetDevices(
+        const DPCTLSyclPlatformRef PRef, _device_type DTy)
 
 
 cdef extern from "syclinterface/dpctl_sycl_context_interface.h":

--- a/dpctl/_sycl_device_factory.pyx
+++ b/dpctl/_sycl_device_factory.pyx
@@ -154,12 +154,12 @@ cpdef list get_devices(backend=backend_type.all, device_type=device_type_t.all):
     ``backend`` in addition to only ``device_type``.
 
     Args:
-        backend (optional):
+        backend (str, :class:`dpctl.backend_type`, optional):
             A :class:`dpctl.backend_type` enum value or a string that
             specifies a SYCL backend. Currently, accepted values are: "cuda",
             "hip", "opencl", "level_zero", or "all".
             Default: ``dpctl.backend_type.all``.
-        device_type (optional):
+        device_type (str, :class:`dpctl.device_type`, optional):
             A :class:`dpctl.device_type` enum value or a string that
             specifies a SYCL device type. Currently, accepted values are:
             "gpu", "cpu", "accelerator", or "all".
@@ -210,12 +210,12 @@ cpdef int get_num_devices(
     :class:`dpctl.device_type` and :class:`dpctl.backend_type`.
 
     Args:
-        backend (optional):
+        backend (str, :class:`dpctl.backend_type`, optional):
             A :class:`dpctl.backend_type` enum value or a string that
             specifies a SYCL backend. Currently, accepted values are: "cuda",
             "hip", "opencl", "level_zero", or "all".
             Default: ``dpctl.backend_type.all``.
-        device_type (optional):
+        device_type (str, :class:`dpctl.device_type`, optional):
             A :class:`dpctl.device_type` enum value or a string that
             specifies a SYCL device type. Currently, accepted values are:
             "gpu", "cpu", "accelerator", or "all".

--- a/dpctl/_sycl_device_factory.pyx
+++ b/dpctl/_sycl_device_factory.pyx
@@ -162,7 +162,7 @@ cpdef list get_devices(backend=backend_type.all, device_type=device_type_t.all):
         device_type (optional):
             A :class:`dpctl.device_type` enum value or a string that
             specifies a SYCL device type. Currently, accepted values are:
-            "gpu", "cpu", "accelerator", "host", or "all".
+            "gpu", "cpu", "accelerator", or "all".
             Default: ``dpctl.device_type.all``.
     Returns:
         list:
@@ -218,7 +218,7 @@ cpdef int get_num_devices(
         device_type (optional):
             A :class:`dpctl.device_type` enum value or a string that
             specifies a SYCL device type. Currently, accepted values are:
-            "gpu", "cpu", "accelerator", "host", or "all".
+            "gpu", "cpu", "accelerator", or "all".
             Default: ``dpctl.device_type.all``.
     Returns:
         int:

--- a/dpctl/_sycl_platform.pyx
+++ b/dpctl/_sycl_platform.pyx
@@ -395,7 +395,7 @@ cdef class SyclPlatform(_SyclPlatform):
 
         Raises:
             TypeError:
-                If `device_type` is not a str or :class:`dpctl.device_type`
+                If `device_type` is not a string or :class:`dpctl.device_type`
                 enum.
             ValueError:
                 If the ``DPCTLPlatform_GetDevices`` call returned

--- a/dpctl/_sycl_platform.pyx
+++ b/dpctl/_sycl_platform.pyx
@@ -382,10 +382,11 @@ cdef class SyclPlatform(_SyclPlatform):
         the given :class:`dpctl.device_type`.
 
         Args:
-            device_type (optional):
+            device_type (str, :class:`dpctl.device_type`):
                 A :class:`dpctl.device_type` enum value or a string that
                 specifies a SYCL device type. Currently, accepted values are:
-                "gpu", "cpu", "accelerator", or "all".
+                "gpu", "cpu", "accelerator", or "all", and their equivalent
+                ``dpctl.device_type`` enumerators.
                 Default: ``dpctl.device_type.all``.
 
         Returns:

--- a/dpctl/_sycl_platform.pyx
+++ b/dpctl/_sycl_platform.pyx
@@ -413,12 +413,8 @@ cdef class SyclPlatform(_SyclPlatform):
                 DTy = _device_type._ACCELERATOR
             elif dty_str == "all":
                 DTy = _device_type._ALL_DEVICES
-            elif dty_str == "automatic":
-                DTy = _device_type._AUTOMATIC
             elif dty_str == "cpu":
                 DTy = _device_type._CPU
-            elif dty_str == "custom":
-                DTy = _device_type._CUSTOM
             elif dty_str == "gpu":
                 DTy = _device_type._GPU
             else:
@@ -428,12 +424,8 @@ cdef class SyclPlatform(_SyclPlatform):
                 DTy = _device_type._ALL_DEVICES
             elif device_type == device_type_t.accelerator:
                 DTy = _device_type._ACCELERATOR
-            elif device_type == device_type_t.automatic:
-                DTy = _device_type._AUTOMATIC
             elif device_type == device_type_t.cpu:
                 DTy = _device_type._CPU
-            elif device_type == device_type_t.custom:
-                DTy = _device_type._CUSTOM
             elif device_type == device_type_t.gpu:
                 DTy = _device_type._GPU
             else:

--- a/dpctl/_sycl_platform.pyx
+++ b/dpctl/_sycl_platform.pyx
@@ -398,8 +398,6 @@ cdef class SyclPlatform(_SyclPlatform):
                 If `device_type` is not a str or :class:`dpctl.device_type`
                 enum.
             ValueError:
-                If the value of `device_type` is not supported.
-
                 If the ``DPCTLPlatform_GetDevices`` call returned
                 ``NULL`` instead of a ``DPCTLDeviceVectorRef`` object.
         """
@@ -424,9 +422,7 @@ cdef class SyclPlatform(_SyclPlatform):
             elif dty_str == "gpu":
                 DTy = _device_type._GPU
             else:
-                raise ValueError(
-                    "Unexpected value of `device_type`."
-                )
+                DTy = _device_type._UNKNOWN_DEVICE
         elif isinstance(device_type, device_type_t):
             if device_type == device_type_t.all:
                 DTy = _device_type._ALL_DEVICES
@@ -441,9 +437,7 @@ cdef class SyclPlatform(_SyclPlatform):
             elif device_type == device_type_t.gpu:
                 DTy = _device_type._GPU
             else:
-                raise ValueError(
-                    "Unexpected value of `device_type`."
-                )
+                DTy = _device_type._UNKNOWN_DEVICE
         else:
             raise TypeError(
                 "device type should be specified as a str or an "

--- a/dpctl/_sycl_platform.pyx
+++ b/dpctl/_sycl_platform.pyx
@@ -382,7 +382,7 @@ cdef class SyclPlatform(_SyclPlatform):
         the given :class:`dpctl.device_type`.
 
         Args:
-            device_type (str, :class:`dpctl.device_type`):
+            device_type (str, :class:`dpctl.device_type`, optional):
                 A :class:`dpctl.device_type` enum value or a string that
                 specifies a SYCL device type. Currently, accepted values are:
                 "gpu", "cpu", "accelerator", or "all", and their equivalent

--- a/dpctl/_sycl_platform.pyx
+++ b/dpctl/_sycl_platform.pyx
@@ -385,7 +385,7 @@ cdef class SyclPlatform(_SyclPlatform):
             device_type (optional):
                 A :class:`dpctl.device_type` enum value or a string that
                 specifies a SYCL device type. Currently, accepted values are:
-                "gpu", "cpu", "accelerator", "host", or "all".
+                "gpu", "cpu", "accelerator", or "all".
                 Default: ``dpctl.device_type.all``.
 
         Returns:

--- a/dpctl/tests/test_sycl_device_factory.py
+++ b/dpctl/tests/test_sycl_device_factory.py
@@ -51,8 +51,6 @@ def string_to_device_type(dty_str):
         return dty.accelerator
     elif dty_str == "cpu":
         return dty.cpu
-    elif dty_str == "host":
-        return dty.host
     elif dty_str == "gpu":
         return dty.gpu
 
@@ -62,8 +60,6 @@ def string_to_backend_type(bty_str):
         return bty.cuda
     elif bty_str == "hip":
         return bty.hip
-    elif bty_str == "host":
-        return bty.host
     elif bty_str == "level_zero":
         return bty.level_zero
     elif bty_str == "opencl":

--- a/dpctl/tests/test_sycl_platform.py
+++ b/dpctl/tests/test_sycl_platform.py
@@ -22,6 +22,7 @@ import sys
 import pytest
 
 import dpctl
+from dpctl import device_type
 
 from .helper import has_sycl_platforms
 
@@ -212,3 +213,49 @@ def test_get_platforms():
             assert has_sycl_platforms()
     except Exception:
         pytest.fail("Encountered an exception inside get_platforms().")
+
+
+def test_platform_get_devices():
+    platforms = dpctl.get_platforms()
+    if platforms:
+        for p in platforms:
+            assert len(p.get_devices())
+    else:
+        pytest.skip("No platforms available")
+
+
+def _str_device_type_to_enum(dty):
+    if dty == "accelerator":
+        return device_type.accelerator
+    elif dty == "cpu":
+        return device_type.cpu
+    elif dty == "gpu":
+        return device_type.gpu
+
+
+def test_platform_get_devices_str_device_type():
+    platforms = dpctl.get_platforms()
+    dtys = ["accelerator", "all", "cpu", "gpu"]
+    if platforms:
+        for p in platforms:
+            for dty in dtys:
+                devices = p.get_devices(device_type=dty)
+                if len(devices):
+                    dty_enum = _str_device_type_to_enum(dty)
+                    assert (d.device_type == dty_enum for d in devices)
+
+
+def test_platform_get_devices_enum_device_type():
+    platforms = dpctl.get_platforms()
+    dtys = [
+        device_type.accelerator,
+        device_type.all,
+        device_type.cpu,
+        device_type.gpu,
+    ]
+    if platforms:
+        for p in platforms:
+            for dty in dtys:
+                devices = p.get_devices(device_type=dty)
+                if len(devices):
+                    assert (d.device_type == dty for d in devices)

--- a/libsyclinterface/helper/source/dpctl_utils_helper.cpp
+++ b/libsyclinterface/helper/source/dpctl_utils_helper.cpp
@@ -73,9 +73,6 @@ info::device_type DPCTL_StrToDeviceType(const std::string &devTyStr)
     else if (devTyStr == "custom") {
         devTy = info::device_type::custom;
     }
-    else if (devTyStr == "host") {
-        devTy = info::device_type::host;
-    }
     else {
         // \todo handle the error
         throw std::runtime_error("Unknown device type.");

--- a/libsyclinterface/include/syclinterface/dpctl_sycl_device_manager.h
+++ b/libsyclinterface/include/syclinterface/dpctl_sycl_device_manager.h
@@ -145,7 +145,7 @@ DPCTL_API
 size_t DPCTLDeviceMgr_GetNumDevices(int device_identifier);
 
 /*!
- * @brief Prints out the info::deivice attributes for the device that are
+ * @brief Prints out the info::device attributes for the device that are
  * currently supported by dpctl.
  *
  * @param    DRef           A #DPCTLSyclDeviceRef opaque pointer.

--- a/libsyclinterface/include/syclinterface/dpctl_sycl_platform_interface.h
+++ b/libsyclinterface/include/syclinterface/dpctl_sycl_platform_interface.h
@@ -29,6 +29,7 @@
 #include "Support/ExternC.h"
 #include "Support/MemOwnershipAttrs.h"
 #include "dpctl_data_types.h"
+#include "dpctl_sycl_device_manager.h"
 #include "dpctl_sycl_enum_types.h"
 #include "dpctl_sycl_platform_manager.h"
 #include "dpctl_sycl_types.h"
@@ -176,6 +177,20 @@ DPCTLPlatform_GetDefaultContext(__dpctl_keep const DPCTLSyclPlatformRef PRef);
  * @ingroup PlatformInterface
  */
 DPCTL_API
-size_t DPCTLPlatform_Hash(__dpctl_keep DPCTLSyclPlatformRef PRef);
+size_t DPCTLPlatform_Hash(__dpctl_keep const DPCTLSyclPlatformRef PRef);
+
+/*!
+ * @brief Returns a vector of devices associated with sycl::platform referenced
+ * by DPCTLSyclPlatformRef object.
+ *
+ * @param    PRef           The DPCTLSyclPlatformRef pointer.
+ * @param    DTy            A DPCTLSyclDeviceType enum value.
+ * @return   A DPCTLDeviceVectorRef with devices associated with given PRef.
+ * @ingroup PlatformInterface
+ */
+DPCTL_API
+__dpctl_give DPCTLDeviceVectorRef
+DPCTLPlatform_GetDevices(__dpctl_keep const DPCTLSyclPlatformRef PRef,
+                         DPCTLSyclDeviceType DTy);
 
 DPCTL_C_EXTERN_C_END

--- a/libsyclinterface/source/dpctl_sycl_platform_interface.cpp
+++ b/libsyclinterface/source/dpctl_sycl_platform_interface.cpp
@@ -294,6 +294,9 @@ DPCTLPlatform_GetDevices(__dpctl_keep const DPCTLSyclPlatformRef PRef,
     }
 
     // handle unknown device
+    // custom and automatic are also treated as unknown
+    // as DPC++ would normally treat as `all`
+    // see CMPLRLLVM-65826
     if (DTy == DPCTLSyclDeviceType::DPCTL_UNKNOWN_DEVICE) {
         return wrap<vecTy>(DevicesVectorPtr);
     }

--- a/libsyclinterface/source/dpctl_sycl_platform_interface.cpp
+++ b/libsyclinterface/source/dpctl_sycl_platform_interface.cpp
@@ -294,7 +294,7 @@ DPCTLPlatform_GetDevices(__dpctl_keep const DPCTLSyclPlatformRef PRef,
     }
 
     // handle unknown device
-    if (!DTy) {
+    if (DTy == DPCTLSyclDeviceType::DPCTL_UNKNOWN_DEVICE) {
         return wrap<vecTy>(DevicesVectorPtr);
     }
 

--- a/libsyclinterface/source/dpctl_sycl_platform_interface.cpp
+++ b/libsyclinterface/source/dpctl_sycl_platform_interface.cpp
@@ -282,6 +282,7 @@ DPCTLPlatform_GetDevices(__dpctl_keep const DPCTLSyclPlatformRef PRef,
                       __FILE__, __func__, __LINE__);
         return nullptr;
     }
+
     using vecTy = std::vector<DPCTLSyclDeviceRef>;
     vecTy *DevicesVectorPtr = nullptr;
     try {
@@ -291,6 +292,12 @@ DPCTLPlatform_GetDevices(__dpctl_keep const DPCTLSyclPlatformRef PRef,
         error_handler(e, __FILE__, __func__, __LINE__);
         return nullptr;
     }
+
+    // handle unknown device
+    if (!DTy) {
+        return wrap<vecTy>(DevicesVectorPtr);
+    }
+
     try {
         auto SyclDTy = DPCTL_DPCTLDeviceTypeToSyclDeviceType(DTy);
         auto Devices = P->get_devices(SyclDTy);

--- a/libsyclinterface/tests/test_sycl_device_selector_interface.cpp
+++ b/libsyclinterface/tests/test_sycl_device_selector_interface.cpp
@@ -220,8 +220,7 @@ INSTANTIATE_TEST_SUITE_P(FilterSelectorCreation,
                                            "gpu:0",
                                            "gpu:1",
                                            "1",
-                                           "0",
-                                           "host"));
+                                           "0"));
 
 INSTANTIATE_TEST_SUITE_P(NegativeFilterSelectorCreation,
                          TestUnsupportedFilters,

--- a/libsyclinterface/tests/test_sycl_platform_interface.cpp
+++ b/libsyclinterface/tests/test_sycl_platform_interface.cpp
@@ -25,6 +25,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "dpctl_sycl_context_interface.h"
+#include "dpctl_sycl_device_interface.h"
 #include "dpctl_sycl_device_selector_interface.h"
 #include "dpctl_sycl_platform_interface.h"
 #include "dpctl_sycl_platform_manager.h"
@@ -90,6 +91,26 @@ void check_platform_default_context(
     EXPECT_TRUE(CRef != nullptr);
 
     EXPECT_NO_FATAL_FAILURE(DPCTLContext_Delete(CRef));
+}
+
+void check_platform_get_devices(__dpctl_keep const DPCTLSyclPlatformRef PRef)
+{
+    DPCTLDeviceVectorRef DVRef = nullptr;
+    size_t nDevices = 0;
+
+    DPCTLSyclDeviceType defDTy = DPCTLSyclDeviceType::DPCTL_ALL;
+    EXPECT_NO_FATAL_FAILURE(DVRef = DPCTLPlatform_GetDevices(PRef, defDTy));
+    EXPECT_TRUE(DVRef != nullptr);
+    EXPECT_NO_FATAL_FAILURE(nDevices = DPCTLDeviceVector_Size(DVRef));
+    for (auto i = 0ul; i < nDevices; ++i) {
+        DPCTLSyclDeviceRef DRef = nullptr;
+        EXPECT_NO_FATAL_FAILURE(DRef = DPCTLDeviceVector_GetAt(DVRef, i));
+        ASSERT_TRUE(DRef != nullptr);
+        EXPECT_NO_FATAL_FAILURE(DPCTLDevice_Delete(DRef));
+    }
+
+    EXPECT_NO_FATAL_FAILURE(DPCTLDeviceVector_Clear(DVRef));
+    EXPECT_NO_FATAL_FAILURE(DPCTLDeviceVector_Delete(DVRef));
 }
 
 } // namespace
@@ -280,6 +301,11 @@ TEST_P(TestDPCTLSyclPlatformInterface, ChkAreEqNullArg)
     DPCTLSyclPlatformRef Null_PRef = nullptr;
     ASSERT_FALSE(DPCTLPlatform_AreEq(PRef, Null_PRef));
     ASSERT_TRUE(DPCTLPlatform_Hash(Null_PRef) == 0);
+}
+
+TEST_P(TestDPCTLSyclPlatformInterface, ChkGetDevices)
+{
+    check_platform_get_devices(PRef);
 }
 
 TEST_F(TestDPCTLSyclDefaultPlatform, ChkGetName) { check_platform_name(PRef); }


### PR DESCRIPTION
This PR proposes implementing the `get_devices` method to `dpctl.SyclPlatform` class as per SYCL 2020 spec, which specifies including a `device_type` filter.

Cleans up some remaining references to host devices, missed in https://github.com/IntelPython/dpctl/pull/1028

Closes #509 

- [ ] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [ ] Have you added your changes to the changelog?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
