### PR TITLE
[MAINT] Do not use conda-build 25.1.2 to fix Conda package workflow

### DIFF
--- a/.github/workflows/conda-package.yml
+++ b/.github/workflows/conda-package.yml
@@ -48,7 +48,7 @@ jobs:
         run: echo $CONDA/bin >> $GITHUB_PATH
       - name: Install conda-build
         # FIXME: unpin when conda-build fixes issues with lief
-        run: conda install conda-build -c conda-forge --override-channels
+        run: conda install conda-build"<25.1.2" -c conda-forge --override-channels
       - name: Store conda paths as envs
         shell: bash -l {0}
         run: |
@@ -100,7 +100,7 @@ jobs:
         # FIXME: unpin when conda-build fixes issues with lief
         run: |
           conda activate
-          conda install -y conda-build
+          conda install -y conda-build"<25.1.2"
           conda list -n base
 
       - name: Cache conda packages


### PR DESCRIPTION
Conda workflow has been failing due to issues with LIEF, which jumped to 0.16.1 in CI. Bring conda-build version down to 25.1.1 while waiting for stability to improve.

- [X] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [ ] Have you added your changes to the changelog?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
