### PR TITLE
Fix smart-pointer-managed USM leaks in synchronizing kernel calls

### DIFF
--- a/dpctl/tensor/libtensor/source/accumulators.cpp
+++ b/dpctl/tensor/libtensor/source/accumulators.cpp
@@ -210,7 +210,7 @@ std::size_t py_mask_positions(const dpctl::tensor::usm_ndarray &mask,
             sycl::event::wait(host_task_events);
 
             // ensure deleter of smart pointer is invoked with GIL released
-            shape_strides_owner.release();
+            shape_strides_owner.reset(nullptr);
         }
         throw std::runtime_error("Unexpected error");
     }
@@ -231,7 +231,7 @@ std::size_t py_mask_positions(const dpctl::tensor::usm_ndarray &mask,
 
         sycl::event::wait(host_task_events);
         // ensure deleter of smart pointer is invoked with GIL released
-        shape_strides_owner.release();
+        shape_strides_owner.reset(nullptr);
     }
 
     return total_set;
@@ -367,7 +367,7 @@ std::size_t py_cumsum_1d(const dpctl::tensor::usm_ndarray &src,
             sycl::event::wait(host_task_events);
 
             // ensure USM deleter is called with GIL released
-            shape_strides_owner.release();
+            shape_strides_owner.reset(nullptr);
         }
         throw std::runtime_error("Unexpected error");
     }
@@ -387,7 +387,7 @@ std::size_t py_cumsum_1d(const dpctl::tensor::usm_ndarray &src,
         sycl::event::wait(host_task_events);
 
         // ensure USM deleter is called with GIL released
-        shape_strides_owner.release();
+        shape_strides_owner.reset(nullptr);
     }
 
     return total;

--- a/dpctl/tensor/libtensor/source/copy_numpy_ndarray_into_usm_ndarray.cpp
+++ b/dpctl/tensor/libtensor/source/copy_numpy_ndarray_into_usm_ndarray.cpp
@@ -325,7 +325,7 @@ void copy_numpy_ndarray_into_usm_ndarray(
             dst_offset, depends, {copy_shape_ev});
 
         // invoke USM deleter in smart pointer while GIL is held
-        shape_strides_owner.release();
+        shape_strides_owner.reset(nullptr);
     }
 
     return;


### PR DESCRIPTION
In blocking (i.e., synchronizing) calls in accumulators and copy to `usm_ndarray` from NumPy array, smart pointers were being released instead of reset without freeing underlying memory.

This PR changes these `release`s to `reset`.

- [X] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [ ] Have you added your changes to the changelog?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
