### PR TITLE
Fix possible `itemsize` overflows in `usm_ndarray` from-pointer constructors

### DIFF
--- a/dpctl/tensor/_usmarray.pyx
+++ b/dpctl/tensor/_usmarray.pyx
@@ -1777,8 +1777,10 @@ cdef api object UsmNDArray_MakeSimpleFromPtr(
     Returns:
         Created usm_ndarray instance
     """
-    cdef size_t itemsize = type_bytesize(typenum)
-    cdef size_t nbytes = itemsize * nelems
+    cdef int itemsize = type_bytesize(typenum)
+    if (itemsize < 1):
+        raise ValueError("dtype with typenum=" + str(typenum) + " is not supported.")
+    cdef size_t nbytes = (<size_t> itemsize) * nelems
     cdef c_dpmem._Memory mobj = c_dpmem._Memory.create_from_usm_pointer_size_qref(
         ptr, nbytes, QRef, memory_owner=owner
     )
@@ -1817,7 +1819,7 @@ cdef api object UsmNDArray_MakeFromPtr(
     Returns:
         Created usm_ndarray instance
     """
-    cdef size_t itemsize = type_bytesize(typenum)
+    cdef int itemsize = type_bytesize(typenum)
     cdef int err = 0
     cdef size_t nelems = 1
     cdef Py_ssize_t min_disp = 0
@@ -1830,6 +1832,8 @@ cdef api object UsmNDArray_MakeFromPtr(
     cdef object obj_shape
     cdef object obj_strides
 
+    if (itemsize < 1):
+        raise ValueError("dtype with typenum=" + str(typenum) + " is not supported.")
     if (nd < 0):
         raise ValueError("Dimensionality must be non-negative")
     if (ptr is NULL or QRef is NULL):
@@ -1881,7 +1885,7 @@ cdef api object UsmNDArray_MakeFromPtr(
         raise ValueError(
             "Given shape, strides and offset reference out-of-bound memory"
         )
-    nbytes = itemsize * (offset + max_disp + 1)
+    nbytes = (<size_t> itemsize) * (offset + max_disp + 1)
     mobj = c_dpmem._Memory.create_from_usm_pointer_size_qref(
         ptr, nbytes, QRef, memory_owner=owner
     )


### PR DESCRIPTION
C-API functions which make a `usm_ndarray` from a pointer (`UsmNDArray_MakeSimpleFromPtr` and `UsmNDArray_MakeFromPtr`) take an integral `typenum` argument

If this argument is invalid, the `itemsize` declared in the functions would be returned from `type_bytesize` as -1 and could potentially overflow

- [X] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [ ] Have you added your changes to the changelog?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
