### PR TITLE
Fix a typo in documentation

### DIFF
--- a/dpctl/tensor/_copy_utils.py
+++ b/dpctl/tensor/_copy_utils.py
@@ -126,7 +126,7 @@ def from_numpy(np_ary, /, *, device=None, usm_type="device", sycl_queue=None):
         arg:
             Input convertible to :class:`numpy.ndarray`
         device (object): array API specification of device where the
-            output array is created. Device can be specified by a
+            output array is created. Device can be specified by
             a filter selector string, an instance of
             :class:`dpctl.SyclDevice`, an instance of
             :class:`dpctl.SyclQueue`, or an instance of
@@ -620,7 +620,7 @@ def astype(
             If this keyword is set to `False`, a view of the input array
             may be returned when possible.
         device (object): array API specification of device where the
-            output array is created. Device can be specified by a
+            output array is created. Device can be specified by
             a filter selector string, an instance of
             :class:`dpctl.SyclDevice`, an instance of
             :class:`dpctl.SyclQueue`, or an instance of


### PR DESCRIPTION
This PR updates docstrings of `from_numpy` and `astype` functions to remove a duplicating `a` in description of `device` keyword.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [ ] Have you added your changes to the changelog?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
