### PR TITLE
Fix incorrect results from `cumulative_sum` and `cumulative_prod` with `dtype=bool`

### DIFF
--- a/dpctl/tensor/libtensor/include/kernels/accumulators.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/accumulators.hpp
@@ -86,6 +86,7 @@ template <typename srcTy, typename dstTy> struct CastTransformer
 
 template <typename ScanOpT, typename T> struct needs_workaround
 {
+    // work-around needed due to crash in JITing on CPU
     static constexpr bool value =
         std::is_same_v<ScanOpT, sycl::logical_or<T>> ||
         std::is_same_v<ScanOpT, sycl::logical_and<T>>;

--- a/dpctl/tensor/libtensor/include/kernels/accumulators.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/accumulators.hpp
@@ -88,7 +88,8 @@ template <typename srcTy, typename dstTy> struct CastTransformer
 
 template <typename ScanOpT, typename T> struct needs_workaround
 {
-    // work-around needed due to crash in JITing on CPU
+    // workaround needed due to crash in JITing on CPU
+    // remove when CMPLRLLVM-65813 is resolved
     static constexpr bool value = su_ns::IsSyclLogicalAnd<T, ScanOpT>::value ||
                                   su_ns::IsSyclLogicalOr<T, ScanOpT>::value;
 };

--- a/dpctl/tensor/libtensor/include/kernels/accumulators.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/accumulators.hpp
@@ -84,9 +84,17 @@ template <typename srcTy, typename dstTy> struct CastTransformer
     }
 };
 
+template <typename ScanOpT, typename T> struct needs_workaround
+{
+    static constexpr bool value =
+        std::is_same_v<ScanOpT, sycl::logical_or<T>> ||
+        std::is_same_v<ScanOpT, sycl::logical_and<T>>;
+};
+
 template <typename BinOpT, typename T> struct can_use_inclusive_scan_over_group
 {
-    static constexpr bool value = sycl::has_known_identity<BinOpT, T>::value;
+    static constexpr bool value = sycl::has_known_identity<BinOpT, T>::value &&
+                                  !needs_workaround<BinOpT, T>::value;
 };
 
 namespace detail

--- a/dpctl/tensor/libtensor/include/kernels/accumulators.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/accumulators.hpp
@@ -47,6 +47,8 @@ namespace kernels
 namespace accumulators
 {
 
+namespace su_ns = dpctl::tensor::sycl_utils;
+
 using dpctl::tensor::ssize_t;
 using namespace dpctl::tensor::offset_utils;
 
@@ -87,9 +89,8 @@ template <typename srcTy, typename dstTy> struct CastTransformer
 template <typename ScanOpT, typename T> struct needs_workaround
 {
     // work-around needed due to crash in JITing on CPU
-    static constexpr bool value =
-        std::is_same_v<ScanOpT, sycl::logical_or<T>> ||
-        std::is_same_v<ScanOpT, sycl::logical_and<T>>;
+    static constexpr bool value = su_ns::IsSyclLogicalAnd<T, ScanOpT>::value ||
+                                  su_ns::IsSyclLogicalOr<T, ScanOpT>::value;
 };
 
 template <typename BinOpT, typename T> struct can_use_inclusive_scan_over_group
@@ -152,8 +153,6 @@ public:
 } // end of namespace detail
 
 // Iterative cumulative summation
-
-namespace su_ns = dpctl::tensor::sycl_utils;
 
 using nwiT = std::uint32_t;
 

--- a/dpctl/tensor/libtensor/source/accumulators/cumulative_prod.cpp
+++ b/dpctl/tensor/libtensor/source/accumulators/cumulative_prod.cpp
@@ -132,6 +132,11 @@ struct TypePairSupportDataForProdAccumulation
         td_ns::NotDefinedEntry>::is_defined;
 };
 
+template <typename T>
+using CumProdScanOpT = std::conditional_t<std::is_same_v<T, bool>,
+                                          sycl::logical_and<T>,
+                                          sycl::multiplies<T>>;
+
 template <typename fnT, typename srcTy, typename dstTy>
 struct CumProd1DContigFactory
 {
@@ -140,9 +145,7 @@ struct CumProd1DContigFactory
         if constexpr (TypePairSupportDataForProdAccumulation<srcTy,
                                                              dstTy>::is_defined)
         {
-            using ScanOpT = std::conditional_t<std::is_same_v<dstTy, bool>,
-                                               sycl::logical_and<dstTy>,
-                                               sycl::multiplies<dstTy>>;
+            using ScanOpT = CumProdScanOpT<dstTy>;
             constexpr bool include_initial = false;
             if constexpr (std::is_same_v<srcTy, dstTy>) {
                 using dpctl::tensor::kernels::accumulators::NoOpTransformer;
@@ -175,9 +178,7 @@ struct CumProd1DIncludeInitialContigFactory
         if constexpr (TypePairSupportDataForProdAccumulation<srcTy,
                                                              dstTy>::is_defined)
         {
-            using ScanOpT = std::conditional_t<std::is_same_v<dstTy, bool>,
-                                               sycl::logical_and<dstTy>,
-                                               sycl::multiplies<dstTy>>;
+            using ScanOpT = CumProdScanOpT<dstTy>;
             constexpr bool include_initial = true;
             if constexpr (std::is_same_v<srcTy, dstTy>) {
                 using dpctl::tensor::kernels::accumulators::NoOpTransformer;
@@ -210,9 +211,7 @@ struct CumProdStridedFactory
         if constexpr (TypePairSupportDataForProdAccumulation<srcTy,
                                                              dstTy>::is_defined)
         {
-            using ScanOpT = std::conditional_t<std::is_same_v<dstTy, bool>,
-                                               sycl::logical_and<dstTy>,
-                                               sycl::multiplies<dstTy>>;
+            using ScanOpT = CumProdScanOpT<dstTy>;
             constexpr bool include_initial = false;
             if constexpr (std::is_same_v<srcTy, dstTy>) {
                 using dpctl::tensor::kernels::accumulators::NoOpTransformer;
@@ -245,9 +244,7 @@ struct CumProdIncludeInitialStridedFactory
         if constexpr (TypePairSupportDataForProdAccumulation<srcTy,
                                                              dstTy>::is_defined)
         {
-            using ScanOpT = std::conditional_t<std::is_same_v<dstTy, bool>,
-                                               sycl::logical_and<dstTy>,
-                                               sycl::multiplies<dstTy>>;
+            using ScanOpT = CumProdScanOpT<dstTy>;
             constexpr bool include_initial = true;
             if constexpr (std::is_same_v<srcTy, dstTy>) {
                 using dpctl::tensor::kernels::accumulators::NoOpTransformer;

--- a/dpctl/tensor/libtensor/source/accumulators/cumulative_prod.cpp
+++ b/dpctl/tensor/libtensor/source/accumulators/cumulative_prod.cpp
@@ -70,10 +70,12 @@ template <typename argTy, typename outTy>
 struct TypePairSupportDataForProdAccumulation
 {
     static constexpr bool is_defined = std::disjunction<
+        td_ns::TypePairDefinedEntry<argTy, bool, outTy, bool>,
         td_ns::TypePairDefinedEntry<argTy, bool, outTy, std::int32_t>,
         td_ns::TypePairDefinedEntry<argTy, bool, outTy, std::int64_t>,
 
         // input int8_t
+        td_ns::TypePairDefinedEntry<argTy, std::int8_t, outTy, std::int8_t>,
         td_ns::TypePairDefinedEntry<argTy, std::int8_t, outTy, std::int32_t>,
         td_ns::TypePairDefinedEntry<argTy, std::int8_t, outTy, std::int64_t>,
 
@@ -138,7 +140,9 @@ struct CumProd1DContigFactory
         if constexpr (TypePairSupportDataForProdAccumulation<srcTy,
                                                              dstTy>::is_defined)
         {
-            using ScanOpT = sycl::multiplies<dstTy>;
+            using ScanOpT = std::conditional_t<std::is_same_v<dstTy, bool>,
+                                               sycl::logical_and<dstTy>,
+                                               sycl::multiplies<dstTy>>;
             constexpr bool include_initial = false;
             if constexpr (std::is_same_v<srcTy, dstTy>) {
                 using dpctl::tensor::kernels::accumulators::NoOpTransformer;
@@ -171,7 +175,9 @@ struct CumProd1DIncludeInitialContigFactory
         if constexpr (TypePairSupportDataForProdAccumulation<srcTy,
                                                              dstTy>::is_defined)
         {
-            using ScanOpT = sycl::multiplies<dstTy>;
+            using ScanOpT = std::conditional_t<std::is_same_v<dstTy, bool>,
+                                               sycl::logical_and<dstTy>,
+                                               sycl::multiplies<dstTy>>;
             constexpr bool include_initial = true;
             if constexpr (std::is_same_v<srcTy, dstTy>) {
                 using dpctl::tensor::kernels::accumulators::NoOpTransformer;
@@ -204,7 +210,9 @@ struct CumProdStridedFactory
         if constexpr (TypePairSupportDataForProdAccumulation<srcTy,
                                                              dstTy>::is_defined)
         {
-            using ScanOpT = sycl::multiplies<dstTy>;
+            using ScanOpT = std::conditional_t<std::is_same_v<dstTy, bool>,
+                                               sycl::logical_and<dstTy>,
+                                               sycl::multiplies<dstTy>>;
             constexpr bool include_initial = false;
             if constexpr (std::is_same_v<srcTy, dstTy>) {
                 using dpctl::tensor::kernels::accumulators::NoOpTransformer;
@@ -237,7 +245,9 @@ struct CumProdIncludeInitialStridedFactory
         if constexpr (TypePairSupportDataForProdAccumulation<srcTy,
                                                              dstTy>::is_defined)
         {
-            using ScanOpT = sycl::multiplies<dstTy>;
+            using ScanOpT = std::conditional_t<std::is_same_v<dstTy, bool>,
+                                               sycl::logical_and<dstTy>,
+                                               sycl::multiplies<dstTy>>;
             constexpr bool include_initial = true;
             if constexpr (std::is_same_v<srcTy, dstTy>) {
                 using dpctl::tensor::kernels::accumulators::NoOpTransformer;

--- a/dpctl/tensor/libtensor/source/accumulators/cumulative_sum.cpp
+++ b/dpctl/tensor/libtensor/source/accumulators/cumulative_sum.cpp
@@ -132,6 +132,10 @@ struct TypePairSupportDataForSumAccumulation
         td_ns::NotDefinedEntry>::is_defined;
 };
 
+template <typename T>
+using CumSumScanOpT = std::
+    conditional_t<std::is_same_v<T, bool>, sycl::logical_or<T>, sycl::plus<T>>;
+
 template <typename fnT, typename srcTy, typename dstTy>
 struct CumSum1DContigFactory
 {
@@ -140,9 +144,7 @@ struct CumSum1DContigFactory
         if constexpr (TypePairSupportDataForSumAccumulation<srcTy,
                                                             dstTy>::is_defined)
         {
-            using ScanOpT =
-                std::conditional_t<std::is_same_v<dstTy, bool>,
-                                   sycl::logical_or<dstTy>, sycl::plus<dstTy>>;
+            using ScanOpT = CumSumScanOpT<dstTy>;
             constexpr bool include_initial = false;
             if constexpr (std::is_same_v<srcTy, dstTy>) {
                 using dpctl::tensor::kernels::accumulators::NoOpTransformer;
@@ -175,9 +177,7 @@ struct CumSum1DIncludeInitialContigFactory
         if constexpr (TypePairSupportDataForSumAccumulation<srcTy,
                                                             dstTy>::is_defined)
         {
-            using ScanOpT =
-                std::conditional_t<std::is_same_v<dstTy, bool>,
-                                   sycl::logical_or<dstTy>, sycl::plus<dstTy>>;
+            using ScanOpT = CumSumScanOpT<dstTy>;
             constexpr bool include_initial = true;
             if constexpr (std::is_same_v<srcTy, dstTy>) {
                 using dpctl::tensor::kernels::accumulators::NoOpTransformer;
@@ -210,9 +210,7 @@ struct CumSumStridedFactory
         if constexpr (TypePairSupportDataForSumAccumulation<srcTy,
                                                             dstTy>::is_defined)
         {
-            using ScanOpT =
-                std::conditional_t<std::is_same_v<dstTy, bool>,
-                                   sycl::logical_or<dstTy>, sycl::plus<dstTy>>;
+            using ScanOpT = CumSumScanOpT<dstTy>;
             constexpr bool include_initial = false;
             if constexpr (std::is_same_v<srcTy, dstTy>) {
                 using dpctl::tensor::kernels::accumulators::NoOpTransformer;
@@ -245,9 +243,7 @@ struct CumSumIncludeInitialStridedFactory
         if constexpr (TypePairSupportDataForSumAccumulation<srcTy,
                                                             dstTy>::is_defined)
         {
-            using ScanOpT =
-                std::conditional_t<std::is_same_v<dstTy, bool>,
-                                   sycl::logical_or<dstTy>, sycl::plus<dstTy>>;
+            using ScanOpT = CumSumScanOpT<dstTy>;
             constexpr bool include_initial = true;
             if constexpr (std::is_same_v<srcTy, dstTy>) {
                 using dpctl::tensor::kernels::accumulators::NoOpTransformer;

--- a/dpctl/tensor/libtensor/source/accumulators/cumulative_sum.cpp
+++ b/dpctl/tensor/libtensor/source/accumulators/cumulative_sum.cpp
@@ -70,10 +70,12 @@ template <typename argTy, typename outTy>
 struct TypePairSupportDataForSumAccumulation
 {
     static constexpr bool is_defined = std::disjunction<
+        td_ns::TypePairDefinedEntry<argTy, bool, outTy, bool>,
         td_ns::TypePairDefinedEntry<argTy, bool, outTy, std::int32_t>,
         td_ns::TypePairDefinedEntry<argTy, bool, outTy, std::int64_t>,
 
         // input int8_t
+        td_ns::TypePairDefinedEntry<argTy, std::int8_t, outTy, std::int8_t>,
         td_ns::TypePairDefinedEntry<argTy, std::int8_t, outTy, std::int32_t>,
         td_ns::TypePairDefinedEntry<argTy, std::int8_t, outTy, std::int64_t>,
 
@@ -138,7 +140,9 @@ struct CumSum1DContigFactory
         if constexpr (TypePairSupportDataForSumAccumulation<srcTy,
                                                             dstTy>::is_defined)
         {
-            using ScanOpT = sycl::plus<dstTy>;
+            using ScanOpT =
+                std::conditional_t<std::is_same_v<dstTy, bool>,
+                                   sycl::logical_or<dstTy>, sycl::plus<dstTy>>;
             constexpr bool include_initial = false;
             if constexpr (std::is_same_v<srcTy, dstTy>) {
                 using dpctl::tensor::kernels::accumulators::NoOpTransformer;
@@ -171,7 +175,9 @@ struct CumSum1DIncludeInitialContigFactory
         if constexpr (TypePairSupportDataForSumAccumulation<srcTy,
                                                             dstTy>::is_defined)
         {
-            using ScanOpT = sycl::plus<dstTy>;
+            using ScanOpT =
+                std::conditional_t<std::is_same_v<dstTy, bool>,
+                                   sycl::logical_or<dstTy>, sycl::plus<dstTy>>;
             constexpr bool include_initial = true;
             if constexpr (std::is_same_v<srcTy, dstTy>) {
                 using dpctl::tensor::kernels::accumulators::NoOpTransformer;
@@ -204,7 +210,9 @@ struct CumSumStridedFactory
         if constexpr (TypePairSupportDataForSumAccumulation<srcTy,
                                                             dstTy>::is_defined)
         {
-            using ScanOpT = sycl::plus<dstTy>;
+            using ScanOpT =
+                std::conditional_t<std::is_same_v<dstTy, bool>,
+                                   sycl::logical_or<dstTy>, sycl::plus<dstTy>>;
             constexpr bool include_initial = false;
             if constexpr (std::is_same_v<srcTy, dstTy>) {
                 using dpctl::tensor::kernels::accumulators::NoOpTransformer;
@@ -237,7 +245,9 @@ struct CumSumIncludeInitialStridedFactory
         if constexpr (TypePairSupportDataForSumAccumulation<srcTy,
                                                             dstTy>::is_defined)
         {
-            using ScanOpT = sycl::plus<dstTy>;
+            using ScanOpT =
+                std::conditional_t<std::is_same_v<dstTy, bool>,
+                                   sycl::logical_or<dstTy>, sycl::plus<dstTy>>;
             constexpr bool include_initial = true;
             if constexpr (std::is_same_v<srcTy, dstTy>) {
                 using dpctl::tensor::kernels::accumulators::NoOpTransformer;

--- a/dpctl/tests/test_tensor_accumulation.py
+++ b/dpctl/tests/test_tensor_accumulation.py
@@ -421,3 +421,15 @@ def test_cumulative_sum_gh_1901(p):
     inp = dpt.ones(n, dtype=dt)
     r = dpt.cumulative_sum(inp, dtype=dt)
     assert dpt.all(r == dpt.arange(1, n + 1, dtype=dt))
+
+
+@pytest.mark.parametrize(
+    "dt", ["i1", "i2", "i4", "i8", "f2", "f4", "f8", "c8", "c16"]
+)
+def test_gh_2017(dt):
+    "See https://github.com/IntelPython/dpctl/issues/2017"
+    q = get_queue_or_skip()
+    skip_if_dtype_not_supported(dt, q)
+    x = dpt.asarray([-1, 1], dtype=dpt.dtype(dt), sycl_queue=q)
+    r = dpt.cumulative_sum(x, dtype="?")
+    assert dpt.all(r)


### PR DESCRIPTION
This PR resolves gh-2017 by introducing missing dedicated kernels for `bool->bool` in the type matrix of `cumulative_sum` and `cumulative_prod`.

Also slips in the addition of `int8->int8`

- [X] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [ ] Have you added your changes to the changelog?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
