### PR TITLE
[MAINT] Unpin conda-build in Conda package workflow

### DIFF
--- a/.github/workflows/conda-package.yml
+++ b/.github/workflows/conda-package.yml
@@ -47,8 +47,7 @@ jobs:
       - name: Add conda to system path
         run: echo $CONDA/bin >> $GITHUB_PATH
       - name: Install conda-build
-        # FIXME: unpin when conda-build fixes issues with lief
-        run: conda install conda-build"<25.1.2" -c conda-forge --override-channels
+        run: conda install conda-build -c conda-forge --override-channels
       - name: Store conda paths as envs
         shell: bash -l {0}
         run: |
@@ -97,10 +96,9 @@ jobs:
           python-version: ${{ matrix.python }}
 
       - name: Install conda build
-        # FIXME: unpin when conda-build fixes issues with lief
         run: |
           conda activate
-          conda install -y conda-build"<25.1.2"
+          conda install -y conda-build
           conda list -n base
 
       - name: Cache conda packages


### PR DESCRIPTION
This PR unpins conda-build, which was pinned in https://github.com/IntelPython/dpctl/pull/2001 due to issues with a new version of lief

- [X] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [ ] Have you added your changes to the changelog?
- [X] If this PR is a work in progress, are you opening the PR as a draft?
