### PR TITLE
add support for Boolean dtypes for `dpctl.tensor.ceil`, `dpctl.tensor.floor`, and `dpctl.tensor.trunc`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+* Support for Boolean data-type is added to `dpctl.tensor.ceil`, `dpctl.tensor.floor`, and `dpctl.tensor.trunc` [gh-2033](https://github.com/IntelPython/dpctl/pull/2033)
+
 ### Fixed
 
 ## [0.19.0] - Feb. 26, 2025

--- a/dpctl/tensor/_elementwise_funcs.py
+++ b/dpctl/tensor/_elementwise_funcs.py
@@ -528,7 +528,7 @@ The ceil of `x_i` is the smallest integer `n`, such that `n >= x_i`.
 
 Args:
     x (usm_ndarray):
-        Input array, expected to have a real-valued data type.
+        Input array, expected to have a boolean or real-valued data type.
     out (Union[usm_ndarray, None], optional):
         Output array to populate.
         Array must have the correct shape and the expected data type.
@@ -767,7 +767,7 @@ The floor of `x_i` is the largest integer `n`, such that `n <= x_i`.
 
 Args:
     x (usm_ndarray):
-        Input array, expected to have a real-valued data type.
+        Input array, expected to have a boolean or real-valued data type.
     out (Union[usm_ndarray, None], optional):
         Output array to populate.
         Array must have the correct shape and the expected data type.
@@ -2017,7 +2017,7 @@ signed number `x` is discarded.
 
 Args:
     x (usm_ndarray):
-        Input array, expected to have a real-valued data type.
+        Input array, expected to have a boolean or real-valued data type.
     out (Union[usm_ndarray, None], optional):
         Output array to populate.
         Array must have the correct shape and the expected data type.

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/ceil.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/ceil.hpp
@@ -99,7 +99,8 @@ using CeilStridedFunctor = elementwise_common::
 template <typename T> struct CeilOutputType
 {
     using value_type =
-        typename std::disjunction<td_ns::TypeMapResultEntry<T, std::uint8_t>,
+        typename std::disjunction<td_ns::TypeMapResultEntry<T, bool>,
+                                  td_ns::TypeMapResultEntry<T, std::uint8_t>,
                                   td_ns::TypeMapResultEntry<T, std::uint16_t>,
                                   td_ns::TypeMapResultEntry<T, std::uint32_t>,
                                   td_ns::TypeMapResultEntry<T, std::uint64_t>,

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/floor.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/floor.hpp
@@ -99,7 +99,8 @@ using FloorStridedFunctor = elementwise_common::
 template <typename T> struct FloorOutputType
 {
     using value_type =
-        typename std::disjunction<td_ns::TypeMapResultEntry<T, std::uint8_t>,
+        typename std::disjunction<td_ns::TypeMapResultEntry<T, bool>,
+                                  td_ns::TypeMapResultEntry<T, std::uint8_t>,
                                   td_ns::TypeMapResultEntry<T, std::uint16_t>,
                                   td_ns::TypeMapResultEntry<T, std::uint32_t>,
                                   td_ns::TypeMapResultEntry<T, std::uint64_t>,

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/trunc.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/trunc.hpp
@@ -96,7 +96,8 @@ using TruncStridedFunctor = elementwise_common::
 template <typename T> struct TruncOutputType
 {
     using value_type =
-        typename std::disjunction<td_ns::TypeMapResultEntry<T, std::uint8_t>,
+        typename std::disjunction<td_ns::TypeMapResultEntry<T, bool>,
+                                  td_ns::TypeMapResultEntry<T, std::uint8_t>,
                                   td_ns::TypeMapResultEntry<T, std::uint16_t>,
                                   td_ns::TypeMapResultEntry<T, std::uint32_t>,
                                   td_ns::TypeMapResultEntry<T, std::uint64_t>,

--- a/dpctl/tests/elementwise/test_floor_ceil_trunc.py
+++ b/dpctl/tests/elementwise/test_floor_ceil_trunc.py
@@ -24,13 +24,13 @@ from numpy.testing import assert_allclose, assert_array_equal
 import dpctl.tensor as dpt
 from dpctl.tests.helper import get_queue_or_skip, skip_if_dtype_not_supported
 
-from .utils import _map_to_device_dtype, _real_value_dtypes
+from .utils import _map_to_device_dtype, _no_complex_dtypes, _real_value_dtypes
 
 _all_funcs = [(np.floor, dpt.floor), (np.ceil, dpt.ceil), (np.trunc, dpt.trunc)]
 
 
 @pytest.mark.parametrize("dpt_call", [dpt.floor, dpt.ceil, dpt.trunc])
-@pytest.mark.parametrize("dtype", _real_value_dtypes)
+@pytest.mark.parametrize("dtype", _no_complex_dtypes)
 def test_floor_ceil_trunc_out_type(dpt_call, dtype):
     q = get_queue_or_skip()
     skip_if_dtype_not_supported(dtype, q)
@@ -69,7 +69,7 @@ def test_floor_ceil_trunc_usm_type(np_call, dpt_call, usm_type):
 
 
 @pytest.mark.parametrize("np_call, dpt_call", _all_funcs)
-@pytest.mark.parametrize("dtype", _real_value_dtypes)
+@pytest.mark.parametrize("dtype", _no_complex_dtypes)
 def test_floor_ceil_trunc_order(np_call, dpt_call, dtype):
     q = get_queue_or_skip()
     skip_if_dtype_not_supported(dtype, q)
@@ -102,7 +102,7 @@ def test_floor_ceil_trunc_error_dtype(dpt_call, dtype):
 
 
 @pytest.mark.parametrize("np_call, dpt_call", _all_funcs)
-@pytest.mark.parametrize("dtype", _real_value_dtypes)
+@pytest.mark.parametrize("dtype", _no_complex_dtypes)
 def test_floor_ceil_trunc_contig(np_call, dpt_call, dtype):
     q = get_queue_or_skip()
     skip_if_dtype_not_supported(dtype, q)
@@ -123,7 +123,7 @@ def test_floor_ceil_trunc_contig(np_call, dpt_call, dtype):
 
 
 @pytest.mark.parametrize("np_call, dpt_call", _all_funcs)
-@pytest.mark.parametrize("dtype", _real_value_dtypes)
+@pytest.mark.parametrize("dtype", _no_complex_dtypes)
 def test_floor_ceil_trunc_strided(np_call, dpt_call, dtype):
     q = get_queue_or_skip()
     skip_if_dtype_not_supported(dtype, q)


### PR DESCRIPTION
In this PR, support for Boolean dtype is added to `dpctl.tensor.ceil`, `dpctl.tensor.floor`, and `dpctl.tensor.trunc`.
resolves #2030 

- [x] Have you provided a meaningful PR description?
- [x] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [x] Have you added your changes to the changelog?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
