### PR TITLE
[MAINT] Fix Windows CI with 2025.1.0 compiler

### DIFF
--- a/.github/workflows/conda-package.yml
+++ b/.github/workflows/conda-package.yml
@@ -124,7 +124,7 @@ jobs:
           OVERRIDE_INTEL_IPO: 1   # IPO requires more resources that GH actions VM provides
         run: |
           conda activate
-          conda build --no-test --python ${{ matrix.python }} --numpy 2 -c conda-forge --override-channels conda-recipe
+          conda build --no-test --python ${{ matrix.python }} --numpy 2.0 -c ${{ env.INTEL_CHANNEL }} -c conda-forge --override-channels conda-recipe
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4.6.2

--- a/.github/workflows/conda-package.yml
+++ b/.github/workflows/conda-package.yml
@@ -124,6 +124,7 @@ jobs:
           OVERRIDE_INTEL_IPO: 1   # IPO requires more resources that GH actions VM provides
         run: |
           conda activate
+          # TODO: roll back use of Intel channel when 2025.1 is available on conda-forge
           conda build --no-test --python ${{ matrix.python }} --numpy 2.0 -c ${{ env.INTEL_CHANNEL }} -c conda-forge --override-channels conda-recipe
 
       - name: Upload artifact


### PR DESCRIPTION
After the release of 2025.1.0 compiler, Windows CI broke when building with 2025.0.4 and testing on 2025.1.0

This PR works around the problem by installing the 2025.1.0 compiler in the environment when building

- [ ] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [ ] Have you added your changes to the changelog?
- [X] If this PR is a work in progress, are you opening the PR as a draft?
