### PR TITLE
Fix spacing in string representation of `dpctl.SyclPlatform`

### DIFF
--- a/dpctl/_sycl_platform.pyx
+++ b/dpctl/_sycl_platform.pyx
@@ -181,7 +181,6 @@ cdef class SyclPlatform(_SyclPlatform):
             + ", "
             + self.vendor
             + ", "
-            + " "
             + self.version + "] at {}>".format(hex(id(self)))
         )
 


### PR DESCRIPTION
This PR removes an unnecessary space from `dpctl.SyclPlatform.__repr__`, fixing spacing in the string representation of `dpctl.SyclPlatform`

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [ ] Have you added your changes to the changelog?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
