### PR TITLE
Run array API tests using 2024.12 version of spec

### DIFF
--- a/.github/workflows/conda-package.yml
+++ b/.github/workflows/conda-package.yml
@@ -763,6 +763,8 @@ jobs:
         id: run-array-api-tests
         shell: bash -l {0}
         env:
+          ARRAY_API_TESTS_MODULE: 'dpctl.tensor'
+          ARRAY_API_TESTS_VERSION: '2024.12'
           SYCL_CACHE_PERSISTENT: 1
         run: |
           FILE=/home/runner/work/.report.json
@@ -770,8 +772,6 @@ jobs:
           conda activate ${{ env.TEST_ENV_NAME }}
           cd /home/runner/work/array-api-tests
           ${CONDA_PREFIX}/bin/python -c "import dpctl; dpctl.lsplatform()"
-          export ARRAY_API_TESTS_MODULE=dpctl.tensor
-          export ARRAY_API_TESTS_VERSION=2024.12
           ${CONDA_PREFIX}/bin/python -m pytest --json-report --json-report-file=$FILE --disable-deadline --skips-file ${GITHUB_WORKSPACE}/.github/workflows/array-api-skips.txt array_api_tests/ || true
       - name: Set Github environment variables
         shell: bash -l {0}

--- a/.github/workflows/conda-package.yml
+++ b/.github/workflows/conda-package.yml
@@ -771,6 +771,7 @@ jobs:
           cd /home/runner/work/array-api-tests
           ${CONDA_PREFIX}/bin/python -c "import dpctl; dpctl.lsplatform()"
           export ARRAY_API_TESTS_MODULE=dpctl.tensor
+          export ARRAY_API_TESTS_VERSION=2024.12
           ${CONDA_PREFIX}/bin/python -m pytest --json-report --json-report-file=$FILE --disable-deadline --skips-file ${GITHUB_WORKSPACE}/.github/workflows/array-api-skips.txt array_api_tests/ || true
       - name: Set Github environment variables
         shell: bash -l {0}


### PR DESCRIPTION
This PR sets `ARRAY_API_TESTS_VERSION` to 2024.12 when running array API conformity job in CI

- [X] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [ ] Have you added your changes to the changelog?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
