### PR TITLE
Update array API spec version supported to 2024.12

### DIFF
--- a/dpctl/tensor/_array_api.py
+++ b/dpctl/tensor/_array_api.py
@@ -63,7 +63,7 @@ def _get_device_impl(d):
             raise TypeError(f"Unsupported type for device argument: {type(d)}")
 
 
-__array_api_version__ = "2023.12"
+__array_api_version__ = "2024.12"
 
 
 class Info:

--- a/dpctl/tests/test_usm_ndarray_ctor.py
+++ b/dpctl/tests/test_usm_ndarray_ctor.py
@@ -1427,6 +1427,8 @@ def test_array_namespace():
     X.__array_namespace__()
     X._set_namespace(dpt)
     assert X.__array_namespace__() is dpt
+    X.__array_namespace__(api_version=dpt.__array_api_version__)
+    assert X.__array_namespace__() is dpt
 
 
 def test_dlpack():


### PR DESCRIPTION
This PR updates `__array_api_version__` to `2024.12` as the new spec version is now supported, with advanced indexing update now in place

- [X] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [ ] Have you added your changes to the changelog?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
