### PR TITLE
Support compilation from SYCL source code

### DIFF
--- a/dpctl/_backend.pxd
+++ b/dpctl/_backend.pxd
@@ -287,9 +287,12 @@ cdef extern from "syclinterface/dpctl_sycl_device_interface.h":
                                         _peer_access PT)
     cdef void DPCTLDevice_EnablePeerAccess(const DPCTLSyclDeviceRef DRef,
                                            const DPCTLSyclDeviceRef PDRef)
-
     cdef void DPCTLDevice_DisablePeerAccess(const DPCTLSyclDeviceRef DRef,
                                             const DPCTLSyclDeviceRef PDRef)
+    cdef bool DPCTLDevice_CanCompileSPIRV(const DPCTLSyclDeviceRef DRef)
+    cdef bool DPCTLDevice_CanCompileOpenCL(const DPCTLSyclDeviceRef DRef)
+    cdef bool DPCTLDevice_CanCompileSYCL(const DPCTLSyclDeviceRef DRef)
+
 
 cdef extern from "syclinterface/dpctl_sycl_device_manager.h":
     cdef DPCTLDeviceVectorRef DPCTLDeviceVector_CreateFromArray(
@@ -451,6 +454,51 @@ cdef extern from "syclinterface/dpctl_sycl_kernel_bundle_interface.h":
     cdef void DPCTLKernelBundle_Delete(DPCTLSyclKernelBundleRef KBRef)
     cdef DPCTLSyclKernelBundleRef DPCTLKernelBundle_Copy(
         const DPCTLSyclKernelBundleRef KBRef)
+
+    cdef struct DPCTLBuildOptionList
+    cdef struct DPCTLKernelNameList
+    cdef struct DPCTLVirtualHeaderList
+    cdef struct DPCTLKernelBuildLog
+    ctypedef DPCTLBuildOptionList* DPCTLBuildOptionListRef
+    ctypedef DPCTLKernelNameList* DPCTLKernelNameListRef
+    ctypedef DPCTLVirtualHeaderList* DPCTLVirtualHeaderListRef
+    ctypedef DPCTLKernelBuildLog* DPCTLKernelBuildLogRef
+
+    cdef DPCTLBuildOptionListRef DPCTLBuildOptionList_Create()
+    cdef void DPCTLBuildOptionList_Delete(DPCTLBuildOptionListRef Ref)
+    cdef void DPCTLBuildOptionList_Append(DPCTLBuildOptionListRef Ref,
+                                          const char *Option)
+
+    cdef DPCTLKernelNameListRef DPCTLKernelNameList_Create()
+    cdef void DPCTLKernelNameList_Delete(DPCTLKernelNameListRef Ref)
+    cdef void DPCTLKernelNameList_Append(DPCTLKernelNameListRef Ref,
+                                         const char *Option)
+
+    cdef DPCTLVirtualHeaderListRef DPCTLVirtualHeaderList_Create()
+    cdef void DPCTLVirtualHeaderList_Delete(DPCTLVirtualHeaderListRef Ref)
+    cdef void DPCTLVirtualHeaderList_Append(DPCTLVirtualHeaderListRef Ref,
+                                            const char *Name,
+                                            const char *Content)
+
+    cdef DPCTLKernelBuildLogRef DPCTLKernelBuildLog_Create()
+    cdef void DPCTLKernelBuildLog_Delete(DPCTLKernelBuildLogRef Ref)
+    cdef const char *DPCTLKernelBuildLog_Get(DPCTLKernelBuildLogRef)
+
+    cdef DPCTLSyclKernelBundleRef DPCTLKernelBundle_CreateFromSYCLSource(
+        const DPCTLSyclContextRef Ctx,
+        const DPCTLSyclDeviceRef Dev,
+        const char *Source,
+        DPCTLVirtualHeaderListRef Headers,
+        DPCTLKernelNameListRef Names,
+        DPCTLBuildOptionListRef BuildOptions,
+        DPCTLKernelBuildLogRef BuildLog)
+
+    cdef DPCTLSyclKernelRef DPCTLKernelBundle_GetSyclKernel(
+                                                DPCTLSyclKernelBundleRef KBRef,
+                                                const char *KernelName)
+
+    cdef bool DPCTLKernelBundle_HasSyclKernel(DPCTLSyclKernelBundleRef KBRef,
+                                              const char *KernelName)
 
 
 cdef extern from "syclinterface/dpctl_sycl_queue_interface.h":

--- a/dpctl/_sycl_device.pxd
+++ b/dpctl/_sycl_device.pxd
@@ -61,3 +61,4 @@ cdef public api class SyclDevice(_SyclDevice) [
     cdef int get_overall_ordinal(self)
     cdef int get_backend_ordinal(self)
     cdef int get_backend_and_device_type_ordinal(self)
+    cpdef bint can_compile(self, str language)

--- a/dpctl/_sycl_device.pyx
+++ b/dpctl/_sycl_device.pyx
@@ -26,6 +26,9 @@ from ._backend cimport (  # noqa: E211
     DPCTLDefaultSelector_Create,
     DPCTLDevice_AreEq,
     DPCTLDevice_CanAccessPeer,
+    DPCTLDevice_CanCompileOpenCL,
+    DPCTLDevice_CanCompileSPIRV,
+    DPCTLDevice_CanCompileSYCL,
     DPCTLDevice_Copy,
     DPCTLDevice_CreateFromSelector,
     DPCTLDevice_CreateSubDevicesByAffinity,
@@ -2366,6 +2369,34 @@ cdef class SyclDevice(_SyclDevice):
         if dev_id < 0:
             raise ValueError("device could not be found")
         return dev_id
+
+    cpdef bint can_compile(self, str language):
+        """
+        Check whether it is possible to create an executable kernel_bundle
+        for this device from the given source language.
+
+        Parameters:
+            language
+                Input language. Possible values are "spirv" for SPIR-V binary
+                files, "opencl" for OpenCL C device code and "sycl" for SYCL
+                device code.
+
+        Returns:
+            bool:
+                True if compilation is supported, False otherwise.
+
+        Raises:
+            ValueError:
+                If an unknown source language is used.
+        """
+        if language == "spirv" or language == "spv":
+            return DPCTLDevice_CanCompileSPIRV(self._device_ref)
+        if language == "opencl" or language == "ocl":
+            return DPCTLDevice_CanCompileOpenCL(self._device_ref)
+        if language == "sycl":
+            return DPCTLDevice_CanCompileSYCL(self._device_ref)
+
+        raise ValueError(f"Unknown source language {language}")
 
 
 cdef api DPCTLSyclDeviceRef SyclDevice_GetDeviceRef(SyclDevice dev):

--- a/dpctl/program/__init__.py
+++ b/dpctl/program/__init__.py
@@ -26,11 +26,13 @@ from ._program import (
     SyclProgramCompilationError,
     create_program_from_source,
     create_program_from_spirv,
+    create_program_from_sycl_source,
 )
 
 __all__ = [
     "create_program_from_source",
     "create_program_from_spirv",
+    "create_program_from_sycl_source",
     "SyclKernel",
     "SyclProgram",
     "SyclProgramCompilationError",

--- a/dpctl/program/_program.pxd
+++ b/dpctl/program/_program.pxd
@@ -49,9 +49,11 @@ cdef api class SyclProgram [object PySyclProgramObject, type PySyclProgramType]:
     binary file.
     """
     cdef DPCTLSyclKernelBundleRef _program_ref
+    cdef bint _is_sycl_source
 
     @staticmethod
-    cdef  SyclProgram _create (DPCTLSyclKernelBundleRef pref)
+    cdef  SyclProgram _create (DPCTLSyclKernelBundleRef pref,
+                               bint _is_sycl_source)
     cdef  DPCTLSyclKernelBundleRef get_program_ref (self)
     cpdef SyclKernel get_sycl_kernel(self, str kernel_name)
 
@@ -59,3 +61,6 @@ cdef api class SyclProgram [object PySyclProgramObject, type PySyclProgramType]:
 cpdef create_program_from_source (SyclQueue q, unicode source, unicode copts=*)
 cpdef create_program_from_spirv (SyclQueue q, const unsigned char[:] IL,
                                  unicode copts=*)
+cpdef create_program_from_sycl_source(SyclQueue q, unicode source,
+                                      list headers=*, list registered_names=*,
+                                      list copts=*)

--- a/libsyclinterface/include/syclinterface/dpctl_sycl_device_interface.h
+++ b/libsyclinterface/include/syclinterface/dpctl_sycl_device_interface.h
@@ -828,4 +828,40 @@ DPCTL_API
 void DPCTLDevice_DisablePeerAccess(__dpctl_keep const DPCTLSyclDeviceRef DRef,
                                    __dpctl_keep const DPCTLSyclDeviceRef PDRef);
 
+/*!
+ * @brief Checks whether it is possible to create executables kernel bundles
+ * from SPIR-V binaries on this device.
+ *
+ * @param DRef  Opaque pointer to a ``sycl::device``.
+ * @return True if creation is supported.
+ * #DPCTLSyclDeviceRef objects
+ * @ingroup DeviceInterface
+ */
+DPCTL_API
+bool DPCTLDevice_CanCompileSPIRV(__dpctl_keep const DPCTLSyclDeviceRef DRef);
+
+/*!
+ * @brief Checks whether it is possible to create executables kernel bundles
+ * from OpenCL source code on this device.
+ *
+ * @param DRef  Opaque pointer to a ``sycl::device``.
+ * @return True if creation is supported.
+ * #DPCTLSyclDeviceRef objects
+ * @ingroup DeviceInterface
+ */
+DPCTL_API
+bool DPCTLDevice_CanCompileOpenCL(__dpctl_keep const DPCTLSyclDeviceRef DRef);
+
+/*!
+ * @brief Checks whether it is possible to create executables kernel bundles
+ * from SYCL source code on this device.
+ *
+ * @param DRef  Opaque pointer to a ``sycl::device``.
+ * @return True if creation is supported.
+ * #DPCTLSyclDeviceRef objects
+ * @ingroup DeviceInterface
+ */
+DPCTL_API
+bool DPCTLDevice_CanCompileSYCL(__dpctl_keep const DPCTLSyclDeviceRef DRef);
+
 DPCTL_C_EXTERN_C_END

--- a/libsyclinterface/include/syclinterface/dpctl_sycl_kernel_bundle_interface.h
+++ b/libsyclinterface/include/syclinterface/dpctl_sycl_kernel_bundle_interface.h
@@ -129,4 +129,173 @@ DPCTL_API
 __dpctl_give DPCTLSyclKernelBundleRef
 DPCTLKernelBundle_Copy(__dpctl_keep const DPCTLSyclKernelBundleRef KBRef);
 
+typedef struct DPCTLBuildOptionList *DPCTLBuildOptionListRef;
+typedef struct DPCTLKernelNameList *DPCTLKernelNameListRef;
+typedef struct DPCTLVirtualHeaderList *DPCTLVirtualHeaderListRef;
+typedef struct DPCTLKernelBuildLog *DPCTLKernelBuildLogRef;
+
+/*!
+ * @brief Create an empty list of build options.
+ *
+ * @return Opaque pointer to the build option file list.
+ * @ingroup KernelBundleInterface
+ */
+DPCTL_API
+__dpctl_give DPCTLBuildOptionListRef DPCTLBuildOptionList_Create();
+
+/*!
+ * @brief Frees the DPCTLBuildOptionListRef pointer.
+ *
+ * @param   Ref           Opaque pointer to a list of build options
+ * @ingroup KernelBundleInterface
+ */
+DPCTL_API void
+DPCTLBuildOptionList_Delete(__dpctl_take DPCTLBuildOptionListRef Ref);
+
+/*!
+ * @brief Append a build option to the list of build options
+ *
+ * @param Ref Opaque pointer to the list of build options
+ * @param Option Option to append
+ */
+DPCTL_API
+void DPCTLBuildOptionList_Append(__dpctl_keep DPCTLBuildOptionListRef Ref,
+                                 __dpctl_keep const char *Option);
+
+/*!
+ * @brief Create an empty list of kernel names to register.
+ *
+ * @return Opaque pointer to the list of kernel names to register.
+ * @ingroup KernelBundleInterface
+ */
+DPCTL_API
+__dpctl_give DPCTLKernelNameListRef DPCTLKernelNameList_Create();
+
+/*!
+ * @brief Frees the DPCTLKernelNameListRef pointer.
+ *
+ * @param   Ref           Opaque pointer to a list of kernels to register
+ * @ingroup KernelBundleInterface
+ */
+DPCTL_API void
+DPCTLKernelNameList_Delete(__dpctl_take DPCTLKernelNameListRef Ref);
+
+/*!
+ * @brief Append a kernel name to register to the list of build options
+ *
+ * @param Ref Opaque pointer to the list of kernel names
+ * @param Option Kernel name to append
+ */
+DPCTL_API
+void DPCTLKernelNameList_Append(__dpctl_keep DPCTLKernelNameListRef Ref,
+                                __dpctl_keep const char *Option);
+/*!
+ * @brief Create an empty list of virtual header files.
+ *
+ * @return Opaque pointer to the virtual header file list.
+ * @ingroup KernelBundleInterface
+ */
+DPCTL_API
+__dpctl_give DPCTLVirtualHeaderListRef DPCTLVirtualHeaderList_Create();
+
+/*!
+ * @brief Frees the DPCTLVirtualHeaderListRef pointer.
+ *
+ * @param   Ref           Opaque pointer to a list of virtual headers
+ * @ingroup KernelBundleInterface
+ */
+DPCTL_API void
+DPCTLVirtualHeaderList_Delete(__dpctl_take DPCTLVirtualHeaderListRef Ref);
+
+/*!
+ * @brief Append a kernel name to register to the list of virtual header files
+ *
+ * @param Ref Opaque pointer to the list of header files
+ * @param Name Name of the virtual header file
+ * @param Content Content of the virtual header
+ */
+DPCTL_API
+void DPCTLVirtualHeaderList_Append(__dpctl_keep DPCTLVirtualHeaderListRef Ref,
+                                   __dpctl_keep const char *Name,
+                                   __dpctl_keep const char *Content);
+
+/*!
+ * @brief Create an empty kernel build log.
+ *
+ * @return Opaque pointer to the kernel build log.
+ * @ingroup KernelBundleInterface
+ */
+DPCTL_API __dpctl_give DPCTLKernelBuildLogRef DPCTLKernelBuildLog_Create();
+
+/*!
+ * @brief Frees the DPCTLKernelBuildLogRef pointer.
+ *
+ * @param   Ref           Opaque pointer to a kernel build log.
+ * @ingroup KernelBundleInterface
+ */
+DPCTL_API
+void DPCTLKernelBuildLog_Delete(__dpctl_take DPCTLKernelBuildLogRef Ref);
+
+/*!
+ * @brief Get the content of the build log.
+ *
+ * @param Ref   Opaque pointer to the kernel build log.
+ * @return      Content of the build log
+ * @ingroup     KernelBundleInterface
+ */
+DPCTL_API const char *
+DPCTLKernelBuildLog_Get(__dpctl_keep DPCTLKernelBuildLogRef);
+
+/*!
+ * @brief Create a SYCL kernel bundle from an SYCL kernel source string.
+ *
+ * @param    Ctx            An opaque pointer to a sycl::context
+ * @param    Dev            An opaque pointer to a sycl::device
+ * @param    Source         SYCL source string
+ * @param    Headers        List of virtual headers
+ * @param    Names          List of kernel names to register
+ * @param    CompileOpts    List of extra compiler flags (refer Sycl spec.)
+ * @return   A new SyclKernelBundleRef pointer if the program creation
+ * succeeded, else returns NULL.
+ * @ingroup KernelBundleInterface
+ */
+DPCTL_API
+__dpctl_give DPCTLSyclKernelBundleRef DPCTLKernelBundle_CreateFromSYCLSource(
+    __dpctl_keep const DPCTLSyclContextRef Ctx,
+    __dpctl_keep const DPCTLSyclDeviceRef Dev,
+    __dpctl_keep const char *Source,
+    __dpctl_keep DPCTLVirtualHeaderListRef Headers,
+    __dpctl_keep DPCTLKernelNameListRef Names,
+    __dpctl_keep DPCTLBuildOptionListRef BuildOptions,
+    __dpctl_keep DPCTLKernelBuildLogRef BuildLog);
+
+/*!
+ * @brief Returns the SyclKernel with given name from the program compiled from
+ * SYCL source code, if not found then return NULL.
+ *
+ * @param    KBRef          Opaque pointer to a sycl::kernel_bundle
+ * @param    KernelName     Name of kernel
+ * @return   A SyclKernel reference if the kernel exists, else NULL
+ * @ingroup KernelBundleInterface
+ */
+DPCTL_API
+__dpctl_give DPCTLSyclKernelRef
+DPCTLKernelBundle_GetSyclKernel(__dpctl_keep DPCTLSyclKernelBundleRef KBRef,
+                                __dpctl_keep const char *KernelName);
+
+/*!
+ * @brief Return True if a SyclKernel with given name exists in the program
+ * compiled from SYCL source code, if not found then returns False.
+ *
+ * @param    KBRef          Opaque pointer to a sycl::kernel_bundle
+ * @param    KernelName     Name of kernel
+ * @return   True if the kernel exists, else False
+ * @ingroup KernelBundleInterface
+ */
+
+DPCTL_API
+bool DPCTLKernelBundle_HasSyclKernel(__dpctl_keep DPCTLSyclKernelBundleRef
+                                         KBRef,
+                                     __dpctl_keep const char *KernelName);
+
 DPCTL_C_EXTERN_C_END

--- a/libsyclinterface/source/dpctl_sycl_device_interface.cpp
+++ b/libsyclinterface/source/dpctl_sycl_device_interface.cpp
@@ -982,3 +982,28 @@ void DPCTLDevice_DisablePeerAccess(__dpctl_keep const DPCTLSyclDeviceRef DRef,
     }
     return;
 }
+
+bool DPCTLDevice_CanCompileSPIRV(__dpctl_keep const DPCTLSyclDeviceRef DRef)
+{
+    auto Dev = unwrap<device>(DRef);
+    auto Backend = Dev->get_platform().get_backend();
+    return Backend == backend::opencl ||
+           Backend == backend::ext_oneapi_level_zero;
+}
+
+bool DPCTLDevice_CanCompileOpenCL(__dpctl_keep const DPCTLSyclDeviceRef DRef)
+{
+    auto Dev = unwrap<device>(DRef);
+    return Dev->get_platform().get_backend() == backend::opencl;
+}
+
+bool DPCTLDevice_CanCompileSYCL(__dpctl_keep const DPCTLSyclDeviceRef DRef)
+{
+#ifdef SYCL_EXT_ONEAPI_KERNEL_COMPILER
+    auto Dev = unwrap<device>(DRef);
+    return Dev->ext_oneapi_can_compile(
+        ext::oneapi::experimental::source_language::sycl);
+#else
+    return false;
+#endif
+}

--- a/libsyclinterface/tests/test_sycl_kernel_bundle_interface.cpp
+++ b/libsyclinterface/tests/test_sycl_kernel_bundle_interface.cpp
@@ -273,6 +273,132 @@ TEST_P(TestOCLKernelBundleFromSource, CheckGetKernelOCLSource)
     DPCTLKernel_Delete(AxpyKernel);
 }
 
+struct TestSYCLKernelBundleFromSource
+    : public ::testing::TestWithParam<const char *>
+{
+    const char *sycl_source = R"===(
+    #include <sycl/sycl.hpp>
+    #include "math_ops.hpp"
+    #include "math_template_ops.hpp"
+
+    namespace syclext = sycl::ext::oneapi::experimental;
+
+    extern "C" SYCL_EXTERNAL SYCL_EXT_ONEAPI_FUNCTION_PROPERTY((syclext::nd_range_kernel<1>))
+    void vector_add(int* in1, int* in2, int* out){
+        sycl::nd_item<1> item = sycl::ext::oneapi::this_work_item::get_nd_item<1>();
+        size_t globalID = item.get_global_linear_id();
+        out[globalID] = math_op(in1[globalID],in2[globalID]);
+    }
+
+    template<typename T>
+    SYCL_EXTERNAL SYCL_EXT_ONEAPI_FUNCTION_PROPERTY((syclext::nd_range_kernel<1>))
+    void vector_add_template(T* in1, T* in2, T* out){
+        sycl::nd_item<1> item = sycl::ext::oneapi::this_work_item::get_nd_item<1>();
+        size_t globalID = item.get_global_linear_id();
+        out[globalID] = math_op_template(in1[globalID], in2[globalID]);
+    }
+    )===";
+
+    const char *header1_content = R"===(
+    int math_op(int a, int b){
+        return a + b;
+    }
+    )===";
+
+    const char *header2_content = R"===(
+    template<typename T>
+    T math_op_template(T a, T b){
+        return a + b;
+    }
+    )===";
+
+    const char *CompileOpt = "-fno-fast-math";
+    const char *KernelName = "vector_add_template<int>";
+    const char *Header1Name = "math_ops.hpp";
+    const char *Header2Name = "math_template_ops.hpp";
+    DPCTLSyclDeviceRef DRef = nullptr;
+    DPCTLSyclContextRef CRef = nullptr;
+    DPCTLSyclKernelBundleRef KBRef = nullptr;
+
+    TestSYCLKernelBundleFromSource()
+    {
+        auto DS = DPCTLFilterSelector_Create(GetParam());
+        DRef = DPCTLDevice_CreateFromSelector(DS);
+        DPCTLDeviceSelector_Delete(DS);
+        CRef = DPCTLDeviceMgr_GetCachedContext(DRef);
+
+        if (DRef) {
+            DPCTLBuildOptionListRef BORef = DPCTLBuildOptionList_Create();
+            DPCTLBuildOptionList_Append(BORef, CompileOpt);
+            DPCTLKernelNameListRef KNRef = DPCTLKernelNameList_Create();
+            DPCTLKernelNameList_Append(KNRef, KernelName);
+            DPCTLVirtualHeaderListRef VHRef = DPCTLVirtualHeaderList_Create();
+            DPCTLVirtualHeaderList_Append(VHRef, Header1Name, header1_content);
+            DPCTLVirtualHeaderList_Append(VHRef, Header2Name, header2_content);
+            DPCTLKernelBuildLogRef KBLRef = DPCTLKernelBuildLog_Create();
+            KBRef = DPCTLKernelBundle_CreateFromSYCLSource(
+                CRef, DRef, sycl_source, VHRef, KNRef, BORef, KBLRef);
+            DPCTLVirtualHeaderList_Delete(VHRef);
+            DPCTLKernelNameList_Delete(KNRef);
+            DPCTLBuildOptionList_Delete(BORef);
+            DPCTLKernelBuildLog_Delete(KBLRef);
+        }
+    }
+
+    void SetUp()
+    {
+        if (!DRef) {
+            auto message = "Skipping as no device of type " +
+                           std::string(GetParam()) + ".";
+            GTEST_SKIP_(message.c_str());
+        }
+        if (!DPCTLDevice_CanCompileSYCL(DRef)) {
+            const char *message = "Skipping as SYCL compilation not supported";
+            GTEST_SKIP_(message);
+        }
+    }
+
+    ~TestSYCLKernelBundleFromSource()
+    {
+        if (DRef)
+            DPCTLDevice_Delete(DRef);
+        if (CRef)
+            DPCTLContext_Delete(CRef);
+        if (KBRef)
+            DPCTLKernelBundle_Delete(KBRef);
+    }
+};
+
+TEST_P(TestSYCLKernelBundleFromSource, CheckCreateFromSYCLSource)
+{
+    ASSERT_TRUE(KBRef != nullptr);
+    ASSERT_TRUE(DPCTLKernelBundle_HasSyclKernel(KBRef, "vector_add"));
+    // DPC++ version 2025.1 supports compilation of SYCL template kernels,
+    // but does not yet support referencing them with the unmangled name.
+    ASSERT_TRUE(
+        DPCTLKernelBundle_HasSyclKernel(KBRef, "vector_add_template<int>") ||
+        DPCTLKernelBundle_HasSyclKernel(
+            KBRef, "_Z33__sycl_kernel_vector_add_templateIiEvPT_S1_S1_"));
+}
+
+TEST_P(TestSYCLKernelBundleFromSource, CheckGetKernelSYCLSource)
+{
+    auto AddKernel = DPCTLKernelBundle_GetSyclKernel(KBRef, "vector_add");
+    auto AxpyKernel =
+        DPCTLKernelBundle_GetSyclKernel(KBRef, "vector_add_template<int>");
+    if (AxpyKernel == nullptr) {
+        // DPC++ version 2025.1 supports compilation of SYCL template kernels,
+        // but does not yet support referencing them with the unmangled name.
+        AxpyKernel = DPCTLKernelBundle_GetSyclKernel(
+            KBRef, "_Z33__sycl_kernel_vector_add_templateIiEvPT_S1_S1_");
+    }
+
+    ASSERT_TRUE(AddKernel != nullptr);
+    ASSERT_TRUE(AxpyKernel != nullptr);
+    DPCTLKernel_Delete(AddKernel);
+    DPCTLKernel_Delete(AxpyKernel);
+}
+
 INSTANTIATE_TEST_SUITE_P(KernelBundleCreationFromSpirv,
                          TestDPCTLSyclKernelBundleInterface,
                          ::testing::Values("opencl",
@@ -288,6 +414,12 @@ INSTANTIATE_TEST_SUITE_P(KernelBundleCreationFromSpirv,
 INSTANTIATE_TEST_SUITE_P(KernelBundleCreationFromSource,
                          TestOCLKernelBundleFromSource,
                          ::testing::Values("opencl:gpu", "opencl:cpu"));
+
+INSTANTIATE_TEST_SUITE_P(KernelBundleCreationFromSYCL,
+                         TestSYCLKernelBundleFromSource,
+                         ::testing::Values("opencl:gpu",
+                                           "opencl:cpu",
+                                           "level_zero:gpu"));
 
 struct TestKernelBundleUnsupportedBackend : public ::testing::Test
 {


### PR DESCRIPTION
This adds support to create a program/executable kernel_bundle from SYCL source code.

It uses the DPC++ `kernel_compiler` extension. As this is only an extension and not all backends are supported, a query on the device was added to check for support for compilation. 

- [x] Have you provided a meaningful PR description?
- [x] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [x] Have you added documentation for your changes, if necessary?
- [ ] Have you added your changes to the changelog?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
