### PR TITLE
Disable upload job from forked repo

### DIFF
--- a/.github/workflows/conda-package.yml
+++ b/.github/workflows/conda-package.yml
@@ -416,7 +416,9 @@ jobs:
 
   upload_linux:
     needs: test_linux
-    if: ${{github.ref == 'refs/heads/master' || (startsWith(github.ref, 'refs/heads/release') == true) || github.event_name == 'push' && contains(github.ref, 'refs/tags/')}}
+    if: |
+      (github.repository == 'IntelPython/dpctl') &&
+      (github.ref == 'refs/heads/master' || (startsWith(github.ref, 'refs/heads/release') == true) || github.event_name == 'push' && contains(github.ref, 'refs/tags/'))
     runs-on: ubuntu-22.04
     timeout-minutes: 20
     strategy:
@@ -453,7 +455,9 @@ jobs:
 
   upload_windows:
     needs: test_windows
-    if: ${{github.ref == 'refs/heads/master' || (startsWith(github.ref, 'refs/heads/release') == true) || github.event_name == 'push' && contains(github.ref, 'refs/tags/')}}
+    if: |
+      (github.repository == 'IntelPython/dpctl') &&
+      (github.ref == 'refs/heads/master' || (startsWith(github.ref, 'refs/heads/release') == true) || github.event_name == 'push' && contains(github.ref, 'refs/tags/'))
     runs-on: windows-2019
     timeout-minutes: 20
     strategy:


### PR DESCRIPTION
Currently a push on `master` branch in the forked repo starts the `Conda package` workflow with enabled uploading of the resulting dpctl conda package to public channel (which is not supported and has to be prohibited). Here is a [log](https://github.com/antonwolfy/dpctl/actions/runs/14617157851/job/41010880625) for reference with the failed step.
This PR proposes to explicitly disable `upload` job for any repo except origin `IntelPython/dpctl`.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [ ] Have you added your changes to the changelog?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
