### PR TITLE
Disable scheduled workflow to be run in fork repos

### DIFF
--- a/.github/workflows/run-tests-from-dppy-bits.yaml
+++ b/.github/workflows/run-tests-from-dppy-bits.yaml
@@ -19,6 +19,9 @@ env:
 
 jobs:
   test_linux:
+    # disable scheduled workflow to be run in forks
+    if: github.event.repository.fork == false
+
     runs-on:  ${{ matrix.runner }}
     timeout-minutes: 45
 


### PR DESCRIPTION
This PR proposes to enable nightly tests run to be scheduled only for main repo, excluding fork ones.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [ ] Have you added your changes to the changelog?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
