### PR TITLE
Fix a typo in beginners guide

### DIFF
--- a/docs/doc_sources/beginners_guides/tensor_intro.rst
+++ b/docs/doc_sources/beginners_guides/tensor_intro.rst
@@ -151,7 +151,7 @@ An alternative way to migrate data is to use :py:func:`asarray` and specify devi
     x_cpu = tensor.concat((tensor.ones(10, device="cpu"), tensor.zeros(1000, device="cpu")))
 
     # data migration is performed via host
-    x_gpu = tensor.asarray(x_cpu, device="cpu")
+    x_gpu = tensor.asarray(x_cpu, device="gpu")
 
 An advantage of using the function ``asarray`` is that migration from ``usm_ndarray`` instances allocated on different
 devices as well migration from :py:class:`numpy.ndarray` may be accomplished in a single call:


### PR DESCRIPTION
This PR updates one of the [example](https://intelpython.github.io/dpctl/latest/beginners_guides/tensor_intro.html#id3) for migrating arrays in beginners guide to fix a typo there.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [ ] Have you added your changes to the changelog?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
