### PR TITLE
Use constant value in `imag` implementation for real-valued data types

### DIFF
--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/imag.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/imag.hpp
@@ -53,14 +53,16 @@ using dpctl::tensor::ssize_t;
 namespace td_ns = dpctl::tensor::type_dispatch;
 
 using dpctl::tensor::type_utils::is_complex;
+using dpctl::tensor::type_utils::is_complex_v;
 
 template <typename argT, typename resT> struct ImagFunctor
 {
 
     // is function constant for given argT
-    using is_constant = typename std::false_type;
+    using is_constant =
+        typename std::is_same<is_complex<argT>, std::false_type>;
     // constant value, if constant
-    // constexpr resT constant_value = resT{};
+    static constexpr resT constant_value = resT{0};
     // is function defined for sycl::vec
     using supports_vec = typename std::false_type;
     // do both argTy and resTy support sugroup store/load operation
@@ -74,7 +76,7 @@ template <typename argT, typename resT> struct ImagFunctor
         }
         else {
             static_assert(std::is_same_v<resT, argT>);
-            return resT{0};
+            return constant_value;
         }
     }
 };

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/imag.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/imag.hpp
@@ -71,7 +71,7 @@ template <typename argT, typename resT> struct ImagFunctor
 
     resT operator()(const argT &in) const
     {
-        if constexpr (is_complex<argT>::value) {
+        if constexpr (is_complex_v<argT>) {
             return std::imag(in);
         }
         else {

--- a/dpctl/tensor/libtensor/include/kernels/elementwise_functions/real.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/elementwise_functions/real.hpp
@@ -53,6 +53,7 @@ using dpctl::tensor::ssize_t;
 namespace td_ns = dpctl::tensor::type_dispatch;
 
 using dpctl::tensor::type_utils::is_complex;
+using dpctl::tensor::type_utils::is_complex_v;
 
 template <typename argT, typename resT> struct RealFunctor
 {
@@ -69,7 +70,7 @@ template <typename argT, typename resT> struct RealFunctor
 
     resT operator()(const argT &in) const
     {
-        if constexpr (is_complex<argT>::value) {
+        if constexpr (is_complex_v<argT>) {
             return std::real(in);
         }
         else {


### PR DESCRIPTION
This PR proposes to add a `constant_value` of 0 to be used by the implementation of the element-wise kernel when the input is a real-valued data type

Slips in change to use `is_complex_v` in `imag` and `real`

- [X] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [X] Have you tested your changes locally for CPU and GPU devices?
- [X] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [ ] Have you added your changes to the changelog?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
