### PR TITLE
Updating `repr()` function

### DIFF
--- a/dpctl/tensor/_print.py
+++ b/dpctl/tensor/_print.py
@@ -40,6 +40,17 @@ _print_options = {
 }
 
 
+def _move_to_next_line(string, s, line_width, prefix):
+    """
+    Move string to next line if it doesn't fit in the current line.
+    """
+    bottom_len = len(s) - (s.rfind("\n") + 1)
+    next_line = bottom_len + len(string) + 1 > line_width
+    string = ",\n" + " " * len(prefix) + string if next_line else ", " + string
+
+    return string
+
+
 def _options_dict(
     linewidth=None,
     edgeitems=None,
@@ -463,16 +474,18 @@ def usm_ndarray_repr(
         suffix=suffix,
     )
 
-    if show_dtype:
-        dtype_str = "dtype={}".format(x.dtype.name)
-        bottom_len = len(s) - (s.rfind("\n") + 1)
-        next_line = bottom_len + len(dtype_str) + 1 > line_width
-        dtype_str = (
-            ",\n" + " " * len(prefix) + dtype_str
-            if next_line
-            else ", " + dtype_str
-        )
+    if show_dtype or x.size == 0:
+        dtype_str = f"dtype={x.dtype.name}"
+        dtype_str = _move_to_next_line(dtype_str, s, line_width, prefix)
     else:
         dtype_str = ""
 
-    return prefix + s + dtype_str + suffix
+    options = get_print_options()
+    threshold = options["threshold"]
+    if x.size == 0 and x.shape != (0,) or x.size > threshold:
+        shape_str = f"shape={x.shape}"
+        shape_str = _move_to_next_line(shape_str, s, line_width, prefix)
+    else:
+        shape_str = ""
+
+    return prefix + s + shape_str + dtype_str + suffix

--- a/dpctl/tests/test_usm_ndarray_print.py
+++ b/dpctl/tests/test_usm_ndarray_print.py
@@ -282,9 +282,7 @@ class TestPrintFns(TestPrint):
         )
 
         x = dpt.arange(4, dtype="i4", sycl_queue=q)
-        x.sycl_queue.wait()
-        r = repr(x)
-        assert r == "usm_ndarray([0, 1, 2, 3], dtype=int32)"
+        assert repr(x) == "usm_ndarray([0, 1, 2, 3], dtype=int32)"
 
         dpt.set_print_options(linewidth=1)
         np.testing.assert_equal(
@@ -296,22 +294,27 @@ class TestPrintFns(TestPrint):
             "\n            dtype=int32)",
         )
 
+        # zero-size array
+        dpt.set_print_options(linewidth=75)
+        x = dpt.ones((9, 0), dtype="i4", sycl_queue=q)
+        assert repr(x) == "usm_ndarray([], shape=(9, 0), dtype=int32)"
+
     def test_print_repr_abbreviated(self):
         q = get_queue_or_skip()
 
         dpt.set_print_options(threshold=0, edgeitems=1)
         x = dpt.arange(9, dtype="int64", sycl_queue=q)
-        assert repr(x) == "usm_ndarray([0, ..., 8])"
+        assert repr(x) == "usm_ndarray([0, ..., 8], shape=(9,))"
 
         y = dpt.asarray(x, dtype="i4", copy=True)
-        assert repr(y) == "usm_ndarray([0, ..., 8], dtype=int32)"
+        assert repr(y) == "usm_ndarray([0, ..., 8], shape=(9,), dtype=int32)"
 
         x = dpt.reshape(x, (3, 3))
         np.testing.assert_equal(
             repr(x),
             "usm_ndarray([[0, ..., 2],"
             "\n             ...,"
-            "\n             [6, ..., 8]])",
+            "\n             [6, ..., 8]], shape=(3, 3))",
         )
 
         y = dpt.reshape(y, (3, 3))
@@ -319,7 +322,7 @@ class TestPrintFns(TestPrint):
             repr(y),
             "usm_ndarray([[0, ..., 2],"
             "\n             ...,"
-            "\n             [6, ..., 8]], dtype=int32)",
+            "\n             [6, ..., 8]], shape=(3, 3), dtype=int32)",
         )
 
         dpt.set_print_options(linewidth=1)
@@ -332,6 +335,7 @@ class TestPrintFns(TestPrint):
             "\n             [6,"
             "\n              ...,"
             "\n              8]],"
+            "\n            shape=(3, 3),"
             "\n            dtype=int32)",
         )
 


### PR DESCRIPTION
Updating `repr()` to show that shape of the array for large arrays and shape and dtype of arrays for zero-size arrays
With this change, we will have
```python
import dpctl.tensor as dpt
a = dpt.ones(1001)
a
# usm_ndarray([1., 1., 1., ..., 1., 1., 1.], shape=(1001,))

b = dpt.ones((10, 0))
b
# usm_ndarray([], shape=(10, 0), dtype=float64)
```

- [x] Have you provided a meaningful PR description?
- [x] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [x] Have you added your changes to the changelog?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
