### PR TITLE
Correct a path to `cl.cfg` file

### DIFF
--- a/.github/workflows/conda-package.yml
+++ b/.github/workflows/conda-package.yml
@@ -382,7 +382,7 @@ jobs:
             Write-Warning "File $script_path was NOT found!"
           }
           # Check the variable assisting OpenCL CPU driver to find TBB DLLs which are not located where it expects them by default
-          $cl_cfg="$env:CONDA_PREFIX\Library\lib\cl.cfg"
+          $cl_cfg="$env:CONDA_PREFIX\Library\bin\cl.cfg"
           Get-Content -Tail 5 -Path $cl_cfg
 
       - name: Smoke test, step 1

--- a/.github/workflows/run-tests-from-dppy-bits.yaml
+++ b/.github/workflows/run-tests-from-dppy-bits.yaml
@@ -123,7 +123,7 @@ jobs:
             Write-Warning "File $script_path was NOT found!"
           }
           # Check the variable assisting OpenCL CPU driver to find TBB DLLs which are not located where it expects them by default
-          $cl_cfg="$env:CONDA_PREFIX\Library\lib\cl.cfg"
+          $cl_cfg="$env:CONDA_PREFIX\Library\bin\cl.cfg"
           Get-Content -Tail 5 -Path $cl_cfg
 
       - name: Smoke test


### PR DESCRIPTION
The location of `cl.cfg` file created by installing `intel-opencl-rt` conda package has been changed few releases back from `%CONDA_PREFIX%\Library\lib\cl.cfg` to `%CONDA_PREFIX%\Library\bin\cl.cfg`.
The file is still created at `Library\lib\cl.cfg` path by `intel-opencl-rt-post-link.bat` script but with empty content.

The PR updates public CI to rely on correct path towards `cl.cfg` configuration file.
The issue with `intel-opencl-rt-post-link.bat` script has to be updated by a separate PR in the compiler repo.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [ ] Have you added your changes to the changelog?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
