### PR TITLE
Change `"max dimensions"` to `None` in array API capabilities

### DIFF
--- a/dpctl/tensor/_array_api.py
+++ b/dpctl/tensor/_array_api.py
@@ -75,7 +75,7 @@ class Info:
         self._capabilities = {
             "boolean indexing": True,
             "data-dependent shapes": True,
-            "max dimensions": 64,
+            "max dimensions": None,
         }
         self._all_dtypes = {
             "bool": dpt.bool,
@@ -108,7 +108,7 @@ class Info:
                 Value: ``True``
             ``max dimensions``:
                 integer indication the maximum array dimension supported by ``dpctl``.
-                Value: ``64``
+                Value: ``None``
 
         Returns:
             dict:

--- a/dpctl/tests/test_tensor_array_api_inspection.py
+++ b/dpctl/tests/test_tensor_array_api_inspection.py
@@ -74,7 +74,7 @@ def test_array_api_inspection_capabilities():
     capabilities = dpt.__array_namespace_info__().capabilities()
     assert capabilities["boolean indexing"]
     assert capabilities["data-dependent shapes"]
-    assert capabilities["max dimensions"] == 64
+    assert capabilities["max dimensions"] is None
 
 
 def test_array_api_inspection_default_dtypes():


### PR DESCRIPTION
`tensor.usm_ndarray` can support potentially arbitrary dimensions

Changes will need to be made where NumPy arrays are created from `usm_ndarray` (printing, dlpack with `kDLCPU`, `asnumpy`/`from_numpy`)

- [ ] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [ ] Have you added your changes to the changelog?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
