### PR TITLE
Fix typo in `_memory.pyx` docstring

### DIFF
--- a/dpctl/memory/_memory.pyx
+++ b/dpctl/memory/_memory.pyx
@@ -86,7 +86,7 @@ cdef extern from "_opaque_smart_ptr.hpp":
 
 class USMAllocationError(Exception):
     """
-    An exception raised when Universal Shared Memory (USM) allocation
+    An exception raised when Unified Shared Memory (USM) allocation
     call returns a null pointer, signaling a failure to perform the allocation.
     Some common reasons for allocation failure are:
 


### PR DESCRIPTION
This PR proposes a very small fix to a typo in a docstring in `_memory.pyx`

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [ ] Have you added your changes to the changelog?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
