### PR TITLE
Pin `setuptools` to <80 throughout project

### DIFF
--- a/.github/workflows/generate-coverage.yaml
+++ b/.github/workflows/generate-coverage.yaml
@@ -91,7 +91,7 @@ jobs:
       - name: Install dpctl dependencies
         shell: bash -l {0}
         run: |
-          pip install numpy cython setuptools"<80" pytest pytest-cov scikit-build cmake coverage[toml] versioneer[toml]==0.29
+          pip install numpy cython setuptools pytest pytest-cov scikit-build cmake coverage[toml] versioneer[toml]==0.29
 
       - name: Build dpctl with coverage
         shell: bash -l {0}

--- a/.github/workflows/os-llvm-sycl-build.yml
+++ b/.github/workflows/os-llvm-sycl-build.yml
@@ -107,7 +107,7 @@ jobs:
       - name: Install dpctl dependencies
         shell: bash -l {0}
         run: |
-          pip install numpy cython setuptools"<80" pytest scikit-build cmake ninja versioneer[toml]==0.29
+          pip install numpy cython setuptools pytest scikit-build cmake ninja versioneer[toml]==0.29
 
       - name: Checkout repo
         uses: actions/checkout@v4.2.2

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
 -   repo: https://github.com/PyCQA/bandit
-    rev: '1.7.9'
+    rev: '1.8.3'
     hooks:
     -   id: bandit
         pass_filenames: false

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -33,7 +33,7 @@ requirements:
         - {{ pin_compatible('intel-cmplr-lib-rt', min_pin='x.x', max_pin='x') }}
         # Ensure we are using latest version of setuptools, since we don't need
         # editable environments for release.
-        - setuptools >=69
+        - setuptools >=69,<80
         {% for dep in py_build_deps %}
         {% if dep.startswith('ninja') %}
         - {{ dep.split(';')[0] }} # [not win]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ requires = [
   # TODO: keep in sync with [project.dependencies]
   "wheel>=0.43",
   "build>=1.1",
-  "setuptools>=63.0.0",
+  "setuptools>=63.0.0,<80",
   "scikit-build>=0.17.0",
   "ninja>=1.11.1; platform_system!='Windows'",
   "cmake>=3.29.0",


### PR DESCRIPTION
Builds currently fail for `setuptools>=80.0.0`, so pin while resolving to fix CI

- [ ] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [ ] Have you added your changes to the changelog?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
