### PR TITLE
Support peer access DPC++ extension

### DIFF
--- a/docs/doc_sources/urls.json
+++ b/docs/doc_sources/urls.json
@@ -5,6 +5,7 @@
     "oneapi_filter_selection": "https://github.com/intel/llvm/blob/sycl/sycl/doc/extensions/supported/sycl_ext_oneapi_filter_selector.asciidoc",
     "oneapi_default_context": "https://github.com/intel/llvm/blob/sycl/sycl/doc/extensions/supported/sycl_ext_oneapi_default_context.asciidoc",
     "oneapi_enqueue_barrier": "https://github.com/intel/llvm/blob/sycl/sycl/doc/extensions/supported/sycl_ext_oneapi_enqueue_barrier.asciidoc",
+    "oneapi_peer_access": "https://github.com/intel/llvm/blob/sycl/sycl/doc/extensions/supported/sycl_ext_oneapi_peer_access.asciidoc",
     "sycl_aspects": "https://www.khronos.org/registry/SYCL/specs/sycl-2020/html/sycl-2020.html#table.device.aspect",
     "sycl_context": "https://sycl.readthedocs.io/en/latest/iface/context.html",
     "sycl_device": "https://sycl.readthedocs.io/en/latest/iface/device.html",

--- a/dpctl/_backend.pxd
+++ b/dpctl/_backend.pxd
@@ -112,6 +112,10 @@ cdef extern from "syclinterface/dpctl_sycl_enum_types.h":
         _L1_cache                           "L1_cache",
         _next_partitionable                 "next_partitionable",
 
+    ctypedef enum _peer_access "DPCTLPeerAccessType":
+        _access_supported                   "access_supported",
+        _atomics_supported                  "atomics_supported",
+
     ctypedef enum _event_status_type "DPCTLSyclEventStatusType":
         _UNKNOWN_STATUS     "DPCTL_UNKNOWN_STATUS"
         _SUBMITTED          "DPCTL_SUBMITTED"
@@ -278,7 +282,14 @@ cdef extern from "syclinterface/dpctl_sycl_device_interface.h":
     cdef DPCTLDeviceVectorRef DPCTLDevice_GetComponentDevices(
         const DPCTLSyclDeviceRef DRef
     )
+    cdef bool DPCTLDevice_CanAccessPeer(const DPCTLSyclDeviceRef DRef,
+                                        const DPCTLSyclDeviceRef PDRef,
+                                        _peer_access PT)
+    cdef void DPCTLDevice_EnablePeerAccess(const DPCTLSyclDeviceRef DRef,
+                                           const DPCTLSyclDeviceRef PDRef)
 
+    cdef void DPCTLDevice_DisablePeerAccess(const DPCTLSyclDeviceRef DRef,
+                                            const DPCTLSyclDeviceRef PDRef)
 
 cdef extern from "syclinterface/dpctl_sycl_device_manager.h":
     cdef DPCTLDeviceVectorRef DPCTLDeviceVector_CreateFromArray(

--- a/dpctl/_sycl_device.pyx
+++ b/dpctl/_sycl_device.pyx
@@ -1980,6 +1980,8 @@ cdef class SyclDevice(_SyclDevice):
     def disable_peer_access(self, peer):
         """ Disables peer access to ``peer`` from this device (``self``).
 
+        Peer access may be enabled by calling :meth:`.enable_peer_access`.
+
         For details, see
         :oneapi_peer_access:`DPC++ peer access SYCL extension <>`.
 

--- a/dpctl/_sycl_device.pyx
+++ b/dpctl/_sycl_device.pyx
@@ -1892,8 +1892,8 @@ cdef class SyclDevice(_SyclDevice):
 
         Returns:
             bool:
-                ``True`` if this device may access USM device memory on
-                ``peer`` when peer access is enabled, otherwise ``False``.
+                ``True`` if the kind of peer access specified by ``value`` is
+                supported between this device and ``peer``, otherwise ``False``.
 
         Raises:
             TypeError:

--- a/dpctl/_sycl_device.pyx
+++ b/dpctl/_sycl_device.pyx
@@ -1870,7 +1870,9 @@ cdef class SyclDevice(_SyclDevice):
                 The :class:`dpctl.SyclDevice` instance to check for peer access
                 by this device.
             value (str, optional):
-                Specifies the kind of peer access being queried
+                Specifies the kind of peer access being queried.
+
+                The supported values are
 
                 - ``"access_supported"``
                     Returns ``True`` if it is possible for this device to
@@ -1879,13 +1881,12 @@ cdef class SyclDevice(_SyclDevice):
                 - ``"atomics_supported"``
                     Returns ``True`` if it is possible for this device to
                     concurrently access and atomically modify USM device
-                    memory on ``peer`` when enabled.
+                    memory on ``peer`` when enabled. Atomics must have
+                    ``memory_scope::system`` when modifying memory on a peer
+                    device.
 
                     If ``False`` is returned, these operations result in
                     undefined behavior.
-
-                    Note: atomics must have ``memory_scope::system`` when
-                    modifying memory on a peer device.
 
                 Default: ``"access_supported"``
 

--- a/dpctl/_sycl_device.pyx
+++ b/dpctl/_sycl_device.pyx
@@ -1842,13 +1842,13 @@ cdef class SyclDevice(_SyclDevice):
         BTy1 = DPCTLDevice_GetBackend(self._device_ref)
         if BTy1 not in _peer_access_backends:
             raise ValueError(
-                "Peer access not supported for backend "
+                "Peer access not supported for this device backend "
                 f"{_backend_type_to_filter_string_part(BTy1)}"
             )
         BTy2 = DPCTLDevice_GetBackend(p_dev.get_device_ref())
         if BTy2 not in _peer_access_backends:
             raise ValueError(
-                "Peer access not supported for backend "
+                "Peer access not supported for peer device backend "
                 f"{_backend_type_to_filter_string_part(BTy2)}"
             )
 
@@ -1906,13 +1906,13 @@ cdef class SyclDevice(_SyclDevice):
         BTy1 = DPCTLDevice_GetBackend(self._device_ref)
         if BTy1 not in _peer_access_backends:
             raise ValueError(
-                "Peer access not supported for backend "
+                "Peer access not supported for this device backend "
                 f"{_backend_type_to_filter_string_part(BTy1)}"
             )
         BTy2 = DPCTLDevice_GetBackend(p_dev.get_device_ref())
         if BTy2 not in _peer_access_backends:
             raise ValueError(
-                "Peer access not supported for backend "
+                "Peer access not supported for peer device backend "
                 f"{_backend_type_to_filter_string_part(BTy2)}"
             )
 
@@ -1964,13 +1964,13 @@ cdef class SyclDevice(_SyclDevice):
         )
         if BTy1 not in _peer_access_backends:
             raise ValueError(
-                "Peer access not supported for backend "
+                "Peer access not supported for this device backend "
                 f"{_backend_type_to_filter_string_part(BTy1)}"
             )
         BTy2 = DPCTLDevice_GetBackend(p_dev.get_device_ref())
         if BTy2 not in _peer_access_backends:
             raise ValueError(
-                "Peer access not supported for backend "
+                "Peer access not supported for peer device backend "
                 f"{_backend_type_to_filter_string_part(BTy2)}"
             )
 
@@ -2016,13 +2016,13 @@ cdef class SyclDevice(_SyclDevice):
         BTy1 = DPCTLDevice_GetBackend(self._device_ref)
         if BTy1 not in _peer_access_backends:
             raise ValueError(
-                "Peer access not supported for backend "
+                "Peer access not supported for this device backend "
                 f"{_backend_type_to_filter_string_part(BTy1)}"
             )
         BTy2 = DPCTLDevice_GetBackend(p_dev.get_device_ref())
         if BTy2 not in _peer_access_backends:
             raise ValueError(
-                "Peer access not supported for backend "
+                "Peer access not supported for peer device backend "
                 f"{_backend_type_to_filter_string_part(BTy2)}"
             )
 

--- a/dpctl/_sycl_device.pyx
+++ b/dpctl/_sycl_device.pyx
@@ -217,7 +217,7 @@ cdef void _init_helper(_SyclDevice device, DPCTLSyclDeviceRef DRef) except *:
         raise RuntimeError("Descriptor 'max_work_item_sizes3d' not available")
 
 
-cdef bint _check_peer_access(SyclDevice dev, SyclDevice peer) except *:
+cdef inline bint _check_peer_access(SyclDevice dev, SyclDevice peer) except *:
     """
     Check peer access ahead of time to avoid errors from unified runtime or
     compiler implementation.

--- a/dpctl/_sycl_device.pyx
+++ b/dpctl/_sycl_device.pyx
@@ -1829,26 +1829,24 @@ cdef class SyclDevice(_SyclDevice):
 
         if not isinstance(peer, SyclDevice):
             raise TypeError(
-                "second argument must be a `dpctl.SyclDevice`, got "
+                "peer device must be a `dpctl.SyclDevice`, got "
                 f"{type(peer)}"
             )
         p_dev = <SyclDevice>peer
+
+        _peer_access_backends = [
+            _backend_type._CUDA,
+            _backend_type._HIP,
+            _backend_type._LEVEL_ZERO
+        ]
         BTy1 = DPCTLDevice_GetBackend(self._device_ref)
-        if (
-            BTy1 != _backend_type._CUDA and
-            BTy1 != _backend_type._HIP and
-            BTy1 != _backend_type._LEVEL_ZERO
-        ):
+        if BTy1 not in _peer_access_backends:
             raise ValueError(
                 "Peer access not supported for backend "
                 f"{_backend_type_to_filter_string_part(BTy1)}"
             )
         BTy2 = DPCTLDevice_GetBackend(p_dev.get_device_ref())
-        if (
-            BTy2 != _backend_type._CUDA and
-            BTy2 != _backend_type._HIP and
-            BTy2 != _backend_type._LEVEL_ZERO
-        ):
+        if BTy2 not in _peer_access_backends:
             raise ValueError(
                 "Peer access not supported for backend "
                 f"{_backend_type_to_filter_string_part(BTy2)}"
@@ -1895,26 +1893,24 @@ cdef class SyclDevice(_SyclDevice):
 
         if not isinstance(peer, SyclDevice):
             raise TypeError(
-                "second argument must be a `dpctl.SyclDevice`, got "
+                "peer device must be a `dpctl.SyclDevice`, got "
                 f"{type(peer)}"
             )
         p_dev = <SyclDevice>peer
+
+        _peer_access_backends = [
+            _backend_type._CUDA,
+            _backend_type._HIP,
+            _backend_type._LEVEL_ZERO
+        ]
         BTy1 = DPCTLDevice_GetBackend(self._device_ref)
-        if (
-            BTy1 != _backend_type._CUDA and
-            BTy1 != _backend_type._HIP and
-            BTy1 != _backend_type._LEVEL_ZERO
-        ):
+        if BTy1 not in _peer_access_backends:
             raise ValueError(
                 "Peer access not supported for backend "
                 f"{_backend_type_to_filter_string_part(BTy1)}"
             )
         BTy2 = DPCTLDevice_GetBackend(p_dev.get_device_ref())
-        if (
-            BTy2 != _backend_type._CUDA and
-            BTy2 != _backend_type._HIP and
-            BTy2 != _backend_type._LEVEL_ZERO
-        ):
+        if BTy2 not in _peer_access_backends:
             raise ValueError(
                 "Peer access not supported for backend "
                 f"{_backend_type_to_filter_string_part(BTy2)}"
@@ -1953,28 +1949,26 @@ cdef class SyclDevice(_SyclDevice):
 
         if not isinstance(peer, SyclDevice):
             raise TypeError(
-                "second argument must be a `dpctl.SyclDevice`, got "
+                "peer device must be a `dpctl.SyclDevice`, got "
                 f"{type(peer)}"
             )
         p_dev = <SyclDevice>peer
+
+        _peer_access_backends = [
+            _backend_type._CUDA,
+            _backend_type._HIP,
+            _backend_type._LEVEL_ZERO
+        ]
         BTy1 = (
             DPCTLDevice_GetBackend(self._device_ref)
         )
-        if (
-            BTy1 != _backend_type._CUDA and
-            BTy1 != _backend_type._HIP and
-            BTy1 != _backend_type._LEVEL_ZERO
-        ):
+        if BTy1 not in _peer_access_backends:
             raise ValueError(
                 "Peer access not supported for backend "
                 f"{_backend_type_to_filter_string_part(BTy1)}"
             )
         BTy2 = DPCTLDevice_GetBackend(p_dev.get_device_ref())
-        if (
-            BTy2 != _backend_type._CUDA and
-            BTy2 != _backend_type._HIP and
-            BTy2 != _backend_type._LEVEL_ZERO
-        ):
+        if BTy2 not in _peer_access_backends:
             raise ValueError(
                 "Peer access not supported for backend "
                 f"{_backend_type_to_filter_string_part(BTy2)}"
@@ -2007,26 +2001,24 @@ cdef class SyclDevice(_SyclDevice):
 
         if not isinstance(peer, SyclDevice):
             raise TypeError(
-                "second argument must be a `dpctl.SyclDevice`, got "
+                "peer device must be a `dpctl.SyclDevice`, got "
                 f"{type(peer)}"
             )
         p_dev = <SyclDevice>peer
+
+        _peer_access_backends = [
+            _backend_type._CUDA,
+            _backend_type._HIP,
+            _backend_type._LEVEL_ZERO
+        ]
         BTy1 = DPCTLDevice_GetBackend(self._device_ref)
-        if (
-            BTy1 != _backend_type._CUDA and
-            BTy1 != _backend_type._HIP and
-            BTy1 != _backend_type._LEVEL_ZERO
-        ):
+        if BTy1 not in _peer_access_backends:
             raise ValueError(
                 "Peer access not supported for backend "
                 f"{_backend_type_to_filter_string_part(BTy1)}"
             )
         BTy2 = DPCTLDevice_GetBackend(p_dev.get_device_ref())
-        if (
-            BTy2 != _backend_type._CUDA and
-            BTy2 != _backend_type._HIP and
-            BTy2 != _backend_type._LEVEL_ZERO
-        ):
+        if BTy2 not in _peer_access_backends:
             raise ValueError(
                 "Peer access not supported for backend "
                 f"{_backend_type_to_filter_string_part(BTy2)}"

--- a/dpctl/_sycl_device.pyx
+++ b/dpctl/_sycl_device.pyx
@@ -224,7 +224,7 @@ def _cached_filter_string(d : SyclDevice):
     and cached with `functools.cache`.
 
     Args:
-        d (dpctl.SyclDevice):
+        d (:class:`dpctl.SyclDevice`):
             A device for which to compute the filter string.
     Returns:
         out(str):
@@ -1797,24 +1797,30 @@ cdef class SyclDevice(_SyclDevice):
         return _get_devices(cDVRef)
 
     def can_access_peer_access_supported(self, peer):
-        """ Returns ``True`` if `self` can enable peer access
-        to `peer`, ``False`` otherwise.
+        """ Returns ``True`` if this device (``self``) can enable peer access
+        to USM device memory on ``peer``, ``False`` otherwise.
+
+        If peer access is supported, it may be enabled by calling
+        :meth:`.enable_peer_access`.
+
+        For details, see
+        :oneapi_peer_access:`DPC++ peer access SYCL extension <>`.
 
         Args:
-            peer (dpctl.SyclDevice):
-                The :class:`dpctl.SyclDevice` instance to
-                check.
+            peer (:class:`dpctl.SyclDevice`):
+                The :class:`dpctl.SyclDevice` instance to check for peer access
+                by this device.
 
         Returns:
             bool:
-                ``True`` if `self` can enable peer access
-                to `peer`, otherwise ``False``.
+                ``True`` if this device may access USM device memory on
+                ``peer`` when peer access is enabled, otherwise ``False``.
 
         Raises:
             TypeError:
-                If `peer` is not `dpctl.SyclDevice`.
+                If ``peer`` is not :class:`dpctl.SyclDevice`.
             ValueError:
-                If the backend associated with `self` or `peer` does not
+                If the backend associated with this device or ``peer`` does not
                 support peer access.
         """
         cdef SyclDevice p_dev
@@ -1855,25 +1861,32 @@ cdef class SyclDevice(_SyclDevice):
         )
 
     def can_access_peer_atomics_supported(self, peer):
-        """ Returns ``True`` if `self` can enable peer access
-        to and can atomically modify memory on `peer`, ``False`` otherwise.
+        """ Returns ``True`` if this device (``self``) can concurrently access
+        and modify USM device memory on ``peer`` when peer access is enabled,
+        ``False`` otherwise.
+
+        If peer access is supported, it may be enabled by calling
+        :meth:`.enable_peer_access`.
+
+        For details, see
+        :oneapi_peer_access:`DPC++ peer access SYCL extension <>`.
 
         Args:
-            peer (dpctl.SyclDevice):
-                The :class:`dpctl.SyclDevice` instance to
-                check.
+            peer (:class:`dpctl.SyclDevice`):
+                The :class:`dpctl.SyclDevice` instance to check for concurrent
+                peer access and modification by this device.
 
         Returns:
             bool:
-                ``True`` if `self` can enable peer access
-                to and can atomically modify memory on `peer`,
+                ``True`` if this device may concurrently access and modify USM
+                device memory on ``peer`` when peer access is enabled,
                 otherwise ``False``.
 
         Raises:
             TypeError:
-                If `peer` is not `dpctl.SyclDevice`.
+                If ``peer`` is not :class:`dpctl.SyclDevice`.
             ValueError:
-                If the backend associated with `self` or `peer` does not
+                If the backend associated with this device or ``peer`` does not
                 support peer access.
         """
         cdef SyclDevice p_dev
@@ -1914,19 +1927,24 @@ cdef class SyclDevice(_SyclDevice):
         )
 
     def enable_peer_access(self, peer):
-        """ Enables this device (`self`) to access USM device allocations
-        located on `peer`.
+        """ Enables this device (``self``) to access USM device allocations
+        located on ``peer``.
+
+        Peer access may be disabled by calling :meth:`.disable_peer_access`.
+
+        For details, see
+        :oneapi_peer_access:`DPC++ peer access SYCL extension <>`.
 
         Args:
-            peer (dpctl.SyclDevice):
-                The :class:`dpctl.SyclDevice` instance to
-                enable peer access to.
+            peer (:class:`dpctl.SyclDevice`):
+                The :class:`dpctl.SyclDevice` instance to enable peer access
+                to.
 
         Raises:
             TypeError:
-                If `peer` is not `dpctl.SyclDevice`.
+                If ``peer`` is not :class:`dpctl.SyclDevice`.
             ValueError:
-                If the backend associated with `self` or `peer` does not
+                If the backend associated with this device or ``peer`` does not
                 support peer access.
         """
         cdef SyclDevice p_dev
@@ -1966,18 +1984,21 @@ cdef class SyclDevice(_SyclDevice):
         return
 
     def disable_peer_access(self, peer):
-        """ Disables peer access to `peer` from `self`.
+        """ Disables peer access to ``peer`` from this device (``self``).
+
+        For details, see
+        :oneapi_peer_access:`DPC++ peer access SYCL extension <>`.
 
         Args:
-            peer (dpctl.SyclDevice):
+            peer (:class:`dpctl.SyclDevice`):
                 The :class:`dpctl.SyclDevice` instance to
                 disable peer access to.
 
         Raises:
             TypeError:
-                If `peer` is not `dpctl.SyclDevice`.
+                If ``peer`` is not :class:`dpctl.SyclDevice`.
             ValueError:
-                If the backend associated with `self` or `peer` does not
+                If the backend associated with this device or ``peer`` does not
                 support peer access.
         """
         cdef SyclDevice p_dev
@@ -2134,7 +2155,7 @@ cdef class SyclDevice(_SyclDevice):
         same _device_ref as this SyclDevice.
 
         Args:
-            other (dpctl.SyclDevice):
+            other (:class:`dpctl.SyclDevice`):
                 A :class:`dpctl.SyclDevice` instance to
                 compare against.
 

--- a/dpctl/_sycl_device.pyx
+++ b/dpctl/_sycl_device.pyx
@@ -1796,7 +1796,7 @@ cdef class SyclDevice(_SyclDevice):
             raise ValueError("Internal error: NULL device vector encountered")
         return _get_devices(cDVRef)
 
-    def can_access_peer(self, peer):
+    def can_access_peer_access_supported(self, peer):
         """ Returns ``True`` if `self` can enable peer access
         to `peer`, ``False`` otherwise.
 
@@ -1809,14 +1809,45 @@ cdef class SyclDevice(_SyclDevice):
             bool:
                 ``True`` if `self` can enable peer access
                 to `peer`, otherwise ``False``.
+
+        Raises:
+            TypeError:
+                If `peer` is not `dpctl.SyclDevice`.
+            ValueError:
+                If the backend associated with `self` or `peer` does not
+                support peer access.
         """
         cdef SyclDevice p_dev
+        cdef _backend_type BTy1
+        cdef _backend_type BTy2
+
         if not isinstance(peer, SyclDevice):
             raise TypeError(
                 "second argument must be a `dpctl.SyclDevice`, got "
                 f"{type(peer)}"
             )
         p_dev = <SyclDevice>peer
+        BTy1 = DPCTLDevice_GetBackend(self._device_ref)
+        if (
+            BTy1 != _backend_type._CUDA and
+            BTy1 != _backend_type._HIP and
+            BTy1 != _backend_type._LEVEL_ZERO
+        ):
+            raise ValueError(
+                "Peer access not supported for backend "
+                f"{_backend_type_to_filter_string_part(BTy1)}"
+            )
+        BTy2 = DPCTLDevice_GetBackend(p_dev.get_device_ref())
+        if (
+            BTy2 != _backend_type._CUDA and
+            BTy2 != _backend_type._HIP and
+            BTy2 != _backend_type._LEVEL_ZERO
+        ):
+            raise ValueError(
+                "Peer access not supported for backend "
+                f"{_backend_type_to_filter_string_part(BTy2)}"
+            )
+
         return DPCTLDevice_CanAccessPeer(
             self._device_ref,
             p_dev.get_device_ref(),
@@ -1837,14 +1868,45 @@ cdef class SyclDevice(_SyclDevice):
                 ``True`` if `self` can enable peer access
                 to and can atomically modify memory on `peer`,
                 otherwise ``False``.
+
+        Raises:
+            TypeError:
+                If `peer` is not `dpctl.SyclDevice`.
+            ValueError:
+                If the backend associated with `self` or `peer` does not
+                support peer access.
         """
         cdef SyclDevice p_dev
+        cdef _backend_type BTy1
+        cdef _backend_type BTy2
+
         if not isinstance(peer, SyclDevice):
             raise TypeError(
                 "second argument must be a `dpctl.SyclDevice`, got "
                 f"{type(peer)}"
             )
         p_dev = <SyclDevice>peer
+        BTy1 = DPCTLDevice_GetBackend(self._device_ref)
+        if (
+            BTy1 != _backend_type._CUDA and
+            BTy1 != _backend_type._HIP and
+            BTy1 != _backend_type._LEVEL_ZERO
+        ):
+            raise ValueError(
+                "Peer access not supported for backend "
+                f"{_backend_type_to_filter_string_part(BTy1)}"
+            )
+        BTy2 = DPCTLDevice_GetBackend(p_dev.get_device_ref())
+        if (
+            BTy2 != _backend_type._CUDA and
+            BTy2 != _backend_type._HIP and
+            BTy2 != _backend_type._LEVEL_ZERO
+        ):
+            raise ValueError(
+                "Peer access not supported for backend "
+                f"{_backend_type_to_filter_string_part(BTy2)}"
+            )
+
         return DPCTLDevice_CanAccessPeer(
             self._device_ref,
             p_dev.get_device_ref(),
@@ -1861,17 +1923,45 @@ cdef class SyclDevice(_SyclDevice):
                 enable peer access to.
 
         Raises:
+            TypeError:
+                If `peer` is not `dpctl.SyclDevice`.
             ValueError:
-                If the ``DPCTLDevice_GetComponentDevices`` call returned
-                ``NULL`` instead of a ``DPCTLDeviceVectorRef`` object.
+                If the backend associated with `self` or `peer` does not
+                support peer access.
         """
         cdef SyclDevice p_dev
+        cdef _backend_type BTy1
+        cdef _backend_type BTy2
+
         if not isinstance(peer, SyclDevice):
             raise TypeError(
                 "second argument must be a `dpctl.SyclDevice`, got "
                 f"{type(peer)}"
             )
         p_dev = <SyclDevice>peer
+        BTy1 = (
+            DPCTLDevice_GetBackend(self._device_ref)
+        )
+        if (
+            BTy1 != _backend_type._CUDA and
+            BTy1 != _backend_type._HIP and
+            BTy1 != _backend_type._LEVEL_ZERO
+        ):
+            raise ValueError(
+                "Peer access not supported for backend "
+                f"{_backend_type_to_filter_string_part(BTy1)}"
+            )
+        BTy2 = DPCTLDevice_GetBackend(p_dev.get_device_ref())
+        if (
+            BTy2 != _backend_type._CUDA and
+            BTy2 != _backend_type._HIP and
+            BTy2 != _backend_type._LEVEL_ZERO
+        ):
+            raise ValueError(
+                "Peer access not supported for backend "
+                f"{_backend_type_to_filter_string_part(BTy2)}"
+            )
+
         DPCTLDevice_EnablePeerAccess(self._device_ref, p_dev.get_device_ref())
         return
 
@@ -1884,17 +1974,43 @@ cdef class SyclDevice(_SyclDevice):
                 disable peer access to.
 
         Raises:
+            TypeError:
+                If `peer` is not `dpctl.SyclDevice`.
             ValueError:
-                If the ``DPCTLDevice_GetComponentDevices`` call returned
-                ``NULL`` instead of a ``DPCTLDeviceVectorRef`` object.
+                If the backend associated with `self` or `peer` does not
+                support peer access.
         """
         cdef SyclDevice p_dev
+        cdef _backend_type BTy1
+        cdef _backend_type BTy2
+
         if not isinstance(peer, SyclDevice):
             raise TypeError(
                 "second argument must be a `dpctl.SyclDevice`, got "
                 f"{type(peer)}"
             )
         p_dev = <SyclDevice>peer
+        BTy1 = DPCTLDevice_GetBackend(self._device_ref)
+        if (
+            BTy1 != _backend_type._CUDA and
+            BTy1 != _backend_type._HIP and
+            BTy1 != _backend_type._LEVEL_ZERO
+        ):
+            raise ValueError(
+                "Peer access not supported for backend "
+                f"{_backend_type_to_filter_string_part(BTy1)}"
+            )
+        BTy2 = DPCTLDevice_GetBackend(p_dev.get_device_ref())
+        if (
+            BTy2 != _backend_type._CUDA and
+            BTy2 != _backend_type._HIP and
+            BTy2 != _backend_type._LEVEL_ZERO
+        ):
+            raise ValueError(
+                "Peer access not supported for backend "
+                f"{_backend_type_to_filter_string_part(BTy2)}"
+            )
+
         DPCTLDevice_DisablePeerAccess(self._device_ref, p_dev.get_device_ref())
         return
 

--- a/dpctl/tests/test_sycl_device.py
+++ b/dpctl/tests/test_sycl_device.py
@@ -365,7 +365,7 @@ def test_can_access_peer(platform_name):
 
 
 @pytest.mark.parametrize("platform_name", ["level_zero", "cuda", "hip"])
-def test_enable_disable_peer(platform_name):
+def test_enable_disable_peer_access(platform_name):
     """
     Test that peer access can be enabled and disabled.
     """
@@ -411,3 +411,19 @@ def test_peer_device_arg_validation(method):
     callable = getattr(dev, method)
     with pytest.raises(TypeError):
         callable(bad_dev)
+
+
+@pytest.mark.parametrize("platform_name", ["level_zero", "cuda", "hip"])
+def test_peer_access_to_self(platform_name):
+    """
+    Test for validation of arguments to peer access related methods.
+    """
+    try:
+        platform = dpctl.SyclPlatform(platform_name)
+    except ValueError as e:
+        pytest.skip(f"{str(e)} {platform_name}")
+    dev = platform.get_devices()[0]
+    with pytest.raises(ValueError):
+        dev.enable_peer_access(dev)
+    with pytest.raises(ValueError):
+        dev.enable_peer_access(dev)

--- a/dpctl/tests/test_sycl_device.py
+++ b/dpctl/tests/test_sycl_device.py
@@ -426,4 +426,4 @@ def test_peer_access_to_self(platform_name):
     with pytest.raises(ValueError):
         dev.enable_peer_access(dev)
     with pytest.raises(ValueError):
-        dev.enable_peer_access(dev)
+        dev.disable_peer_access(dev)

--- a/dpctl/tests/test_sycl_device.py
+++ b/dpctl/tests/test_sycl_device.py
@@ -416,7 +416,7 @@ def test_peer_device_arg_validation(method):
 @pytest.mark.parametrize("platform_name", ["level_zero", "cuda", "hip"])
 def test_peer_access_to_self(platform_name):
     """
-    Test for validation of arguments to peer access related methods.
+    Validate behavior of a device attempting to enable peer access to itself.
     """
     try:
         platform = dpctl.SyclPlatform(platform_name)

--- a/dpctl/tests/test_sycl_device.py
+++ b/dpctl/tests/test_sycl_device.py
@@ -390,7 +390,16 @@ def test_enable_disable_peer(platform_name):
         )
 
 
-def test_peer_device_arg_validation():
+@pytest.mark.parametrize(
+    "method",
+    [
+        "can_access_peer_access_supported",
+        "can_access_peer_atomics_supported",
+        "enable_peer_access",
+        "disable_peer_access",
+    ],
+)
+def test_peer_device_arg_validation(method):
     """
     Test for validation of arguments to peer access related methods.
     """
@@ -399,11 +408,6 @@ def test_peer_device_arg_validation():
     except dpctl.SyclDeviceCreationError:
         pytest.skip("No default device available")
     bad_dev = dict()
+    callable = getattr(dev, method)
     with pytest.raises(TypeError):
-        dev.can_access_peer_access_supported(bad_dev)
-    with pytest.raises(TypeError):
-        dev.can_access_peer_atomics_supported(bad_dev)
-    with pytest.raises(TypeError):
-        dev.enable_peer_access(bad_dev)
-    with pytest.raises(TypeError):
-        dev.disable_peer_access(bad_dev)
+        callable(bad_dev)

--- a/libsyclinterface/helper/include/dpctl_utils_helper.h
+++ b/libsyclinterface/helper/include/dpctl_utils_helper.h
@@ -180,6 +180,33 @@ DPCTLPartitionAffinityDomainType DPCTL_SyclPartitionAffinityDomainToDPCTLType(
     sycl::info::partition_affinity_domain PartitionAffinityDomain);
 
 /*!
+ * @brief Converts a DPCTLPeerAccessType enum value to its corresponding
+ * sycl::ext::oneapi::peer_access enum value.
+ *
+ * @param    PeerAccessTy A DPCTLPeerAccessType enum value
+ * @return   A sycl::ext::oneapi::peer_access enum value for the input
+ * DPCTLPeerAccessType enum value.
+ * @throws runtime_error
+ */
+DPCTL_API
+sycl::ext::oneapi::peer_access
+DPCTL_DPCTLPeerAccessTypeToSycl(DPCTLPeerAccessType PeerAccessTy);
+
+/*!
+ * @brief Converts a sycl::ext::oneapi::peer_access enum value to
+ * corresponding DPCTLPeerAccessType enum value.
+ *
+ * @param    PeerAccess sycl::ext::oneapi::peer_access to be
+ * converted to DPCTLPeerAccessType enum.
+ * @return   A DPCTLPeerAccessType enum value for the input
+ * sycl::ext::oneapi::peer_access enum value.
+ * @throws runtime_error
+ */
+DPCTL_API
+DPCTLPeerAccessType
+DPCTL_SyclPeerAccessToDPCTLType(sycl::ext::oneapi::peer_access PeerAccess);
+
+/*!
  * @brief Gives the index of the given device with respective to all the other
  * devices of the same type in the device's platform.
  *

--- a/libsyclinterface/helper/source/dpctl_utils_helper.cpp
+++ b/libsyclinterface/helper/source/dpctl_utils_helper.cpp
@@ -452,6 +452,32 @@ DPCTLPartitionAffinityDomainType DPCTL_SyclPartitionAffinityDomainToDPCTLType(
     }
 }
 
+ext::oneapi::peer_access
+DPCTL_DPCTLPeerAccessTypeToSycl(DPCTLPeerAccessType PeerAccessTy)
+{
+    switch (PeerAccessTy) {
+    case DPCTLPeerAccessType::access_supported:
+        return ext::oneapi::peer_access::access_supported;
+    case DPCTLPeerAccessType::atomics_supported:
+        return ext::oneapi::peer_access::atomics_supported;
+    default:
+        throw std::runtime_error("Unsupported peer_access type");
+    }
+}
+
+DPCTLPeerAccessType
+DPCTL_SyclPeerAccessToDPCTLType(ext::oneapi::peer_access PeerAccess)
+{
+    switch (PeerAccess) {
+    case ext::oneapi::peer_access::access_supported:
+        return DPCTLPeerAccessType::access_supported;
+    case ext::oneapi::peer_access::atomics_supported:
+        return DPCTLPeerAccessType::atomics_supported;
+    default:
+        throw std::runtime_error("Unsupported peer_access type");
+    }
+}
+
 int64_t DPCTL_GetRelativeDeviceId(const device &Device)
 {
     auto relid = -1;

--- a/libsyclinterface/include/syclinterface/dpctl_sycl_device_interface.h
+++ b/libsyclinterface/include/syclinterface/dpctl_sycl_device_interface.h
@@ -792,4 +792,40 @@ DPCTL_API
 __dpctl_give DPCTLDeviceVectorRef
 DPCTLDevice_GetComponentDevices(__dpctl_keep const DPCTLSyclDeviceRef DRef);
 
+/*!
+ * @brief Checks if device supports peer access to another device.
+ *
+ * @param    DRef       Opaque pointer to a ``sycl::device``
+ * @param    PDRef      Opaque pointer to a ``sycl::device``
+ * @param    PT         DPCTLPeerAccessType of ``ext::oneapi::peer_access``.
+ * @return   True if sycl::device supports the kind of peer access, else false.
+ * @ingroup DeviceInterface
+ */
+DPCTL_API
+bool DPCTLDevice_CanAccessPeer(__dpctl_keep const DPCTLSyclDeviceRef DRef,
+                               __dpctl_keep const DPCTLSyclDeviceRef PDRef,
+                               DPCTLPeerAccessType PT);
+
+/*!
+ * @brief Checks if device supports peer access to another device.
+ *
+ * @param    DRef       Opaque pointer to a ``sycl::device``
+ * @param    PDRef      Opaque pointer to a ``sycl::device``
+ * @ingroup DeviceInterface
+ */
+DPCTL_API
+void DPCTLDevice_EnablePeerAccess(__dpctl_keep const DPCTLSyclDeviceRef DRef,
+                                  __dpctl_keep const DPCTLSyclDeviceRef PDRef);
+
+/*!
+ * @brief Checks if device supports peer access to another device.
+ *
+ * @param    DRef       Opaque pointer to a ``sycl::device``
+ * @param    PDRef      Opaque pointer to a ``sycl::device``
+ * @ingroup DeviceInterface
+ */
+DPCTL_API
+void DPCTLDevice_DisablePeerAccess(__dpctl_keep const DPCTLSyclDeviceRef DRef,
+                                   __dpctl_keep const DPCTLSyclDeviceRef PDRef);
+
 DPCTL_C_EXTERN_C_END

--- a/libsyclinterface/include/syclinterface/dpctl_sycl_device_interface.h
+++ b/libsyclinterface/include/syclinterface/dpctl_sycl_device_interface.h
@@ -807,7 +807,7 @@ bool DPCTLDevice_CanAccessPeer(__dpctl_keep const DPCTLSyclDeviceRef DRef,
                                DPCTLPeerAccessType PT);
 
 /*!
- * @brief Checks if device supports peer access to another device.
+ * @brief Enables peer access to another device.
  *
  * @param    DRef       Opaque pointer to a ``sycl::device``
  * @param    PDRef      Opaque pointer to a ``sycl::device``
@@ -818,7 +818,7 @@ void DPCTLDevice_EnablePeerAccess(__dpctl_keep const DPCTLSyclDeviceRef DRef,
                                   __dpctl_keep const DPCTLSyclDeviceRef PDRef);
 
 /*!
- * @brief Checks if device supports peer access to another device.
+ * @brief Disables peer access to another device.
  *
  * @param    DRef       Opaque pointer to a ``sycl::device``
  * @param    PDRef      Opaque pointer to a ``sycl::device``

--- a/libsyclinterface/include/syclinterface/dpctl_sycl_enum_types.h
+++ b/libsyclinterface/include/syclinterface/dpctl_sycl_enum_types.h
@@ -152,6 +152,16 @@ typedef enum
 } DPCTLPartitionAffinityDomainType;
 
 /*!
+ * @brief DPCTL analogue of ``sycl::ext::oneapi::peer_access`` enum.
+ *
+ */
+typedef enum
+{
+    access_supported,
+    atomics_supported
+} DPCTLPeerAccessType;
+
+/*!
  * @brief Enums to depict the properties that can be passed to a sycl::queue
  * constructor.
  *

--- a/libsyclinterface/source/dpctl_sycl_device_interface.cpp
+++ b/libsyclinterface/source/dpctl_sycl_device_interface.cpp
@@ -912,6 +912,28 @@ bool DPCTLDevice_CanAccessPeer(__dpctl_keep const DPCTLSyclDeviceRef DRef,
     auto D = unwrap<device>(DRef);
     auto PD = unwrap<device>(PDRef);
     if (D && PD) {
+        auto BE1 = D->get_backend();
+        auto BE2 = PD->get_backend();
+
+        if (BE1 != sycl::backend::ext_oneapi_level_zero &&
+            BE1 != sycl::backend::ext_oneapi_cuda &&
+            BE1 != sycl::backend::ext_oneapi_hip)
+        {
+            error_handler("Backend " + std::to_string(static_cast<int>(BE1)) +
+                              " does not support peer access",
+                          __FILE__, __func__, __LINE__);
+            return false;
+        }
+
+        if (BE2 != sycl::backend::ext_oneapi_level_zero &&
+            BE2 != sycl::backend::ext_oneapi_cuda &&
+            BE2 != sycl::backend::ext_oneapi_hip)
+        {
+            error_handler("Backend " + std::to_string(static_cast<int>(BE2)) +
+                              " does not support peer access",
+                          __FILE__, __func__, __LINE__);
+            return false;
+        }
         try {
             canAccess = D->ext_oneapi_can_access_peer(
                 *PD, DPCTL_DPCTLPeerAccessTypeToSycl(PT));
@@ -928,6 +950,28 @@ void DPCTLDevice_EnablePeerAccess(__dpctl_keep const DPCTLSyclDeviceRef DRef,
     auto D = unwrap<device>(DRef);
     auto PD = unwrap<device>(PDRef);
     if (D && PD) {
+        auto BE1 = D->get_backend();
+        auto BE2 = PD->get_backend();
+
+        if (BE1 != sycl::backend::ext_oneapi_level_zero &&
+            BE1 != sycl::backend::ext_oneapi_cuda &&
+            BE1 != sycl::backend::ext_oneapi_hip)
+        {
+            error_handler("Backend " + std::to_string(static_cast<int>(BE1)) +
+                              " does not support peer access",
+                          __FILE__, __func__, __LINE__);
+            return;
+        }
+
+        if (BE2 != sycl::backend::ext_oneapi_level_zero &&
+            BE2 != sycl::backend::ext_oneapi_cuda &&
+            BE2 != sycl::backend::ext_oneapi_hip)
+        {
+            error_handler("Backend " + std::to_string(static_cast<int>(BE2)) +
+                              " does not support peer access",
+                          __FILE__, __func__, __LINE__);
+            return;
+        }
         try {
             D->ext_oneapi_enable_peer_access(*PD);
         } catch (std::exception const &e) {
@@ -943,6 +987,28 @@ void DPCTLDevice_DisablePeerAccess(__dpctl_keep const DPCTLSyclDeviceRef DRef,
     auto D = unwrap<device>(DRef);
     auto PD = unwrap<device>(PDRef);
     if (D && PD) {
+        auto BE1 = D->get_backend();
+        auto BE2 = PD->get_backend();
+
+        if (BE1 != sycl::backend::ext_oneapi_level_zero &&
+            BE1 != sycl::backend::ext_oneapi_cuda &&
+            BE1 != sycl::backend::ext_oneapi_hip)
+        {
+            error_handler("Backend " + std::to_string(static_cast<int>(BE1)) +
+                              " does not support peer access",
+                          __FILE__, __func__, __LINE__);
+            return;
+        }
+
+        if (BE2 != sycl::backend::ext_oneapi_level_zero &&
+            BE2 != sycl::backend::ext_oneapi_cuda &&
+            BE2 != sycl::backend::ext_oneapi_hip)
+        {
+            error_handler("Backend " + std::to_string(static_cast<int>(BE2)) +
+                              " does not support peer access",
+                          __FILE__, __func__, __LINE__);
+            return;
+        }
         try {
             D->ext_oneapi_disable_peer_access(*PD);
         } catch (std::exception const &e) {

--- a/libsyclinterface/source/dpctl_sycl_device_interface.cpp
+++ b/libsyclinterface/source/dpctl_sycl_device_interface.cpp
@@ -115,7 +115,7 @@ __dpctl_give DPCTLSyclDeviceRef DPCTLDevice_CreateFromSelector(
 {
     auto Selector = unwrap<dpctl_device_selector>(DSRef);
     if (!Selector) {
-        error_handler("Cannot difine device selector for DPCTLSyclDeviceRef "
+        error_handler("Cannot define device selector for DPCTLSyclDeviceRef "
                       "as input is a nullptr.",
                       __FILE__, __func__, __LINE__);
         return nullptr;

--- a/libsyclinterface/source/dpctl_sycl_device_interface.cpp
+++ b/libsyclinterface/source/dpctl_sycl_device_interface.cpp
@@ -908,17 +908,18 @@ bool _CallPeerAccess(device dev, device peer)
     auto BE1 = dev.get_backend();
     auto BE2 = peer.get_backend();
 
-    if ((BE1 != sycl::backend::ext_oneapi_level_zero &&
-         BE1 != sycl::backend::ext_oneapi_cuda &&
-         BE1 != sycl::backend::ext_oneapi_hip) ||
-        (BE2 != sycl::backend::ext_oneapi_level_zero &&
-         BE2 != sycl::backend::ext_oneapi_cuda &&
-         BE2 != sycl::backend::ext_oneapi_hip) ||
-        (dev == peer))
+    if ((BE1 == BE2) &&
+        (BE1 == sycl::backend::ext_oneapi_level_zero ||
+         BE1 == sycl::backend::ext_oneapi_cuda ||
+         BE1 == sycl::backend::ext_oneapi_hip) &&
+        (BE2 == sycl::backend::ext_oneapi_level_zero ||
+         BE2 == sycl::backend::ext_oneapi_cuda ||
+         BE2 == sycl::backend::ext_oneapi_hip) &&
+        (dev != peer))
     {
-        return false;
+        return true;
     }
-    return true;
+    return false;
 }
 
 bool DPCTLDevice_CanAccessPeer(__dpctl_keep const DPCTLSyclDeviceRef DRef,

--- a/libsyclinterface/source/dpctl_sycl_device_interface.cpp
+++ b/libsyclinterface/source/dpctl_sycl_device_interface.cpp
@@ -184,8 +184,7 @@ DPCTLDevice_GetBackend(__dpctl_keep const DPCTLSyclDeviceRef DRef)
     DPCTLSyclBackendType BTy = DPCTLSyclBackendType::DPCTL_UNKNOWN_BACKEND;
     auto D = unwrap<device>(DRef);
     if (D) {
-        BTy = DPCTL_SyclBackendToDPCTLBackendType(
-            D->get_platform().get_backend());
+        BTy = DPCTL_SyclBackendToDPCTLBackendType(D->get_backend());
     }
     return BTy;
 }

--- a/libsyclinterface/source/dpctl_sycl_device_interface.cpp
+++ b/libsyclinterface/source/dpctl_sycl_device_interface.cpp
@@ -33,7 +33,6 @@
 #include "dpctl_sycl_type_casters.hpp"
 #include "dpctl_utils_helper.h"
 #include <algorithm>
-#include <sstream>
 #include <stddef.h>
 #include <sycl/sycl.hpp> /* SYCL headers   */
 #include <utility>
@@ -956,9 +955,8 @@ void DPCTLDevice_EnablePeerAccess(__dpctl_keep const DPCTLSyclDeviceRef DRef,
             }
         }
         else {
-            std::ostringstream os;
-            os << "Given devices do not support peer access";
-            error_handler(os.str(), __FILE__, __func__, __LINE__);
+            error_handler("Devices do not support peer access", __FILE__,
+                          __func__, __LINE__);
         }
     }
     return;
@@ -978,9 +976,8 @@ void DPCTLDevice_DisablePeerAccess(__dpctl_keep const DPCTLSyclDeviceRef DRef,
             }
         }
         else {
-            std::ostringstream os;
-            os << "Given devices do not support peer access";
-            error_handler(os.str(), __FILE__, __func__, __LINE__);
+            error_handler("Devices do not support peer access", __FILE__,
+                          __func__, __LINE__);
         }
     }
     return;

--- a/libsyclinterface/source/dpctl_sycl_device_interface.cpp
+++ b/libsyclinterface/source/dpctl_sycl_device_interface.cpp
@@ -903,7 +903,7 @@ DPCTLDevice_GetCompositeDevice(__dpctl_keep const DPCTLSyclDeviceRef DRef)
         return nullptr;
 }
 
-bool _CallPeerAccess(device dev, device peer)
+static inline bool _CallPeerAccess(device dev, device peer)
 {
     auto BE1 = dev.get_backend();
     auto BE2 = peer.get_backend();

--- a/libsyclinterface/source/dpctl_sycl_device_interface.cpp
+++ b/libsyclinterface/source/dpctl_sycl_device_interface.cpp
@@ -903,3 +903,51 @@ DPCTLDevice_GetCompositeDevice(__dpctl_keep const DPCTLSyclDeviceRef DRef)
     else
         return nullptr;
 }
+
+bool DPCTLDevice_CanAccessPeer(__dpctl_keep const DPCTLSyclDeviceRef DRef,
+                               __dpctl_keep const DPCTLSyclDeviceRef PDRef,
+                               DPCTLPeerAccessType PT)
+{
+    bool canAccess = false;
+    auto D = unwrap<device>(DRef);
+    auto PD = unwrap<device>(PDRef);
+    if (D && PD) {
+        try {
+            canAccess = D->ext_oneapi_can_access_peer(
+                *PD, DPCTL_DPCTLPeerAccessTypeToSycl(PT));
+        } catch (std::exception const &e) {
+            error_handler(e, __FILE__, __func__, __LINE__);
+        }
+    }
+    return canAccess;
+}
+
+void DPCTLDevice_EnablePeerAccess(__dpctl_keep const DPCTLSyclDeviceRef DRef,
+                                  __dpctl_keep const DPCTLSyclDeviceRef PDRef)
+{
+    auto D = unwrap<device>(DRef);
+    auto PD = unwrap<device>(PDRef);
+    if (D && PD) {
+        try {
+            D->ext_oneapi_enable_peer_access(*PD);
+        } catch (std::exception const &e) {
+            error_handler(e, __FILE__, __func__, __LINE__);
+        }
+    }
+    return;
+}
+
+void DPCTLDevice_DisablePeerAccess(__dpctl_keep const DPCTLSyclDeviceRef DRef,
+                                   __dpctl_keep const DPCTLSyclDeviceRef PDRef)
+{
+    auto D = unwrap<device>(DRef);
+    auto PD = unwrap<device>(PDRef);
+    if (D && PD) {
+        try {
+            D->ext_oneapi_disable_peer_access(*PD);
+        } catch (std::exception const &e) {
+            error_handler(e, __FILE__, __func__, __LINE__);
+        }
+    }
+    return;
+}

--- a/libsyclinterface/source/dpctl_sycl_device_interface.cpp
+++ b/libsyclinterface/source/dpctl_sycl_device_interface.cpp
@@ -33,7 +33,7 @@
 #include "dpctl_sycl_type_casters.hpp"
 #include "dpctl_utils_helper.h"
 #include <algorithm>
-#include <cstring>
+#include <sstream>
 #include <stddef.h>
 #include <sycl/sycl.hpp> /* SYCL headers   */
 #include <utility>
@@ -918,9 +918,9 @@ bool DPCTLDevice_CanAccessPeer(__dpctl_keep const DPCTLSyclDeviceRef DRef,
             BE1 != sycl::backend::ext_oneapi_cuda &&
             BE1 != sycl::backend::ext_oneapi_hip)
         {
-            error_handler("Backend " + std::to_string(static_cast<int>(BE1)) +
-                              " does not support peer access",
-                          __FILE__, __func__, __LINE__);
+            std::ostringstream os;
+            os << "Backend " << BE1 << " does not support peer access";
+            error_handler(os.str(), __FILE__, __func__, __LINE__);
             return false;
         }
 
@@ -928,9 +928,9 @@ bool DPCTLDevice_CanAccessPeer(__dpctl_keep const DPCTLSyclDeviceRef DRef,
             BE2 != sycl::backend::ext_oneapi_cuda &&
             BE2 != sycl::backend::ext_oneapi_hip)
         {
-            error_handler("Backend " + std::to_string(static_cast<int>(BE2)) +
-                              " does not support peer access",
-                          __FILE__, __func__, __LINE__);
+            std::ostringstream os;
+            os << "Backend " << BE2 << " does not support peer access";
+            error_handler(os.str(), __FILE__, __func__, __LINE__);
             return false;
         }
         try {
@@ -956,20 +956,18 @@ void DPCTLDevice_EnablePeerAccess(__dpctl_keep const DPCTLSyclDeviceRef DRef,
             BE1 != sycl::backend::ext_oneapi_cuda &&
             BE1 != sycl::backend::ext_oneapi_hip)
         {
-            error_handler("Backend " + std::to_string(static_cast<int>(BE1)) +
-                              " does not support peer access",
-                          __FILE__, __func__, __LINE__);
-            return;
+            std::ostringstream os;
+            os << "Backend " << BE1 << " does not support peer access";
+            error_handler(os.str(), __FILE__, __func__, __LINE__);
         }
 
         if (BE2 != sycl::backend::ext_oneapi_level_zero &&
             BE2 != sycl::backend::ext_oneapi_cuda &&
             BE2 != sycl::backend::ext_oneapi_hip)
         {
-            error_handler("Backend " + std::to_string(static_cast<int>(BE2)) +
-                              " does not support peer access",
-                          __FILE__, __func__, __LINE__);
-            return;
+            std::ostringstream os;
+            os << "Backend " << BE2 << " does not support peer access";
+            error_handler(os.str(), __FILE__, __func__, __LINE__);
         }
         try {
             D->ext_oneapi_enable_peer_access(*PD);
@@ -993,20 +991,18 @@ void DPCTLDevice_DisablePeerAccess(__dpctl_keep const DPCTLSyclDeviceRef DRef,
             BE1 != sycl::backend::ext_oneapi_cuda &&
             BE1 != sycl::backend::ext_oneapi_hip)
         {
-            error_handler("Backend " + std::to_string(static_cast<int>(BE1)) +
-                              " does not support peer access",
-                          __FILE__, __func__, __LINE__);
-            return;
+            std::ostringstream os;
+            os << "Backend " << BE1 << " does not support peer access";
+            error_handler(os.str(), __FILE__, __func__, __LINE__);
         }
 
         if (BE2 != sycl::backend::ext_oneapi_level_zero &&
             BE2 != sycl::backend::ext_oneapi_cuda &&
             BE2 != sycl::backend::ext_oneapi_hip)
         {
-            error_handler("Backend " + std::to_string(static_cast<int>(BE2)) +
-                              " does not support peer access",
-                          __FILE__, __func__, __LINE__);
-            return;
+            std::ostringstream os;
+            os << "Backend " << BE2 << " does not support peer access";
+            error_handler(os.str(), __FILE__, __func__, __LINE__);
         }
         try {
             D->ext_oneapi_disable_peer_access(*PD);

--- a/libsyclinterface/source/dpctl_sycl_kernel_bundle_interface.cpp
+++ b/libsyclinterface/source/dpctl_sycl_kernel_bundle_interface.cpp
@@ -620,9 +620,9 @@ DPCTLKernelBundle_CreateFromSpirv(__dpctl_keep const DPCTLSyclContextRef CtxRef,
         break;
 #endif
     default:
-        error_handler("Backend " + std::to_string(static_cast<int>(BE)) +
-                          " is not supported",
-                      __FILE__, __func__, __LINE__);
+        std::ostringstream os;
+        os << "Backend " << BE << " is not supported";
+        error_handler(os.str(), __FILE__, __func__, __LINE__);
         break;
     }
     return KBRef;
@@ -700,9 +700,9 @@ DPCTLKernelBundle_GetKernel(__dpctl_keep DPCTLSyclKernelBundleRef KBRef,
         return _GetKernel_ze_impl(*SyclKB, KernelName);
 #endif
     default:
-        error_handler("Backend " + std::to_string(static_cast<int>(be)) +
-                          " is not supported.",
-                      __FILE__, __func__, __LINE__);
+        std::ostringstream os;
+        os << "Backend " << be << " is not supported";
+        error_handler(os.str(), __FILE__, __func__, __LINE__);
         return nullptr;
     }
 }
@@ -730,9 +730,9 @@ bool DPCTLKernelBundle_HasKernel(__dpctl_keep DPCTLSyclKernelBundleRef KBRef,
         return _HasKernel_ze_impl(*SyclKB, KernelName);
 #endif
     default:
-        error_handler("Backend " + std::to_string(static_cast<int>(be)) +
-                          " is not supported.",
-                      __FILE__, __func__, __LINE__);
+        std::ostringstream os;
+        os << "Backend " << be << " is not supported";
+        error_handler(os.str(), __FILE__, __func__, __LINE__);
         return false;
     }
 }

--- a/libsyclinterface/tests/CMakeLists.txt
+++ b/libsyclinterface/tests/CMakeLists.txt
@@ -47,6 +47,7 @@ add_sycl_to_target(
     ${CMAKE_CURRENT_SOURCE_DIR}/test_sycl_device_selector_interface.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/test_sycl_device_aspects.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/test_sycl_event_interface.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/test_sycl_peer_access.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/test_sycl_platform_interface.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/test_sycl_kernel_interface.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/test_sycl_kernel_bundle_interface.cpp

--- a/libsyclinterface/tests/test_helper.cpp
+++ b/libsyclinterface/tests/test_helper.cpp
@@ -184,3 +184,32 @@ TEST_F(TestHelperFns, SyclDeviceTypeToDPCTLDeviceType)
                                 sycl::info::device_type::custom));
     ASSERT_TRUE(DTy == DPCTLSyclDeviceType::DPCTL_CUSTOM);
 }
+
+TEST_F(TestHelperFns, ChkDPCTLPeerAccessTypeToSycl)
+{
+    sycl::ext::oneapi::peer_access peer_type =
+        sycl::ext::oneapi::peer_access::atomics_supported;
+
+    EXPECT_NO_FATAL_FAILURE(peer_type = DPCTL_DPCTLPeerAccessTypeToSycl(
+                                DPCTLPeerAccessType::access_supported));
+    ASSERT_TRUE(peer_type == sycl::ext::oneapi::peer_access::access_supported);
+
+    EXPECT_NO_FATAL_FAILURE(peer_type = DPCTL_DPCTLPeerAccessTypeToSycl(
+                                DPCTLPeerAccessType::atomics_supported));
+    ASSERT_TRUE(peer_type == sycl::ext::oneapi::peer_access::atomics_supported);
+}
+
+TEST_F(TestHelperFns, ChkSyclPeerAccessToDPCTLType)
+{
+    DPCTLPeerAccessType PTy = DPCTLPeerAccessType::atomics_supported;
+
+    EXPECT_NO_FATAL_FAILURE(
+        PTy = DPCTL_SyclPeerAccessToDPCTLType(
+            sycl::ext::oneapi::peer_access::access_supported));
+    ASSERT_TRUE(PTy == DPCTLPeerAccessType::access_supported);
+
+    EXPECT_NO_FATAL_FAILURE(
+        PTy = DPCTL_SyclPeerAccessToDPCTLType(
+            sycl::ext::oneapi::peer_access::atomics_supported));
+    ASSERT_TRUE(PTy == DPCTLPeerAccessType::atomics_supported);
+}

--- a/libsyclinterface/tests/test_sycl_peer_access.cpp
+++ b/libsyclinterface/tests/test_sycl_peer_access.cpp
@@ -1,0 +1,139 @@
+//===--- test_sycl_peer_access.cpp - Test cases for device peer access  ===//
+//
+//                      Data Parallel Control (dpctl)
+//
+// Copyright 2020-2025 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// This file has unit test cases for peer access functions defined in
+/// dpctl_sycl_device_interface.h.
+///
+//===----------------------------------------------------------------------===//
+
+#include "dpctl_sycl_device_interface.h"
+#include "dpctl_sycl_device_selector_interface.h"
+#include "dpctl_sycl_platform_interface.h"
+#include "dpctl_utils_helper.h"
+
+#include <gtest/gtest.h>
+#include <sycl/sycl.hpp>
+
+struct TestDPCTLPeerAccess : public ::testing::TestWithParam<const char *>
+{
+    DPCTLSyclPlatformRef P = nullptr;
+    DPCTLDeviceVectorRef DV = nullptr;
+
+    TestDPCTLPeerAccess()
+    {
+        auto DS = DPCTLFilterSelector_Create(GetParam());
+        if (DS) {
+            EXPECT_NO_FATAL_FAILURE(P = DPCTLPlatform_CreateFromSelector(DS));
+        }
+        DPCTLDeviceSelector_Delete(DS);
+        if (P) {
+            DV = DPCTLPlatform_GetDevices(P, DPCTLSyclDeviceType::DPCTL_ALL);
+        }
+    }
+
+    void SetUp()
+    {
+        if (!P || !DV) {
+            auto message = "Skipping as no devices of type " +
+                           std::string(GetParam()) + ".";
+            GTEST_SKIP_(message.c_str());
+        }
+
+        if (DPCTLDeviceVector_Size(DV) < 2) {
+            GTEST_SKIP_("Peer access tests require more than one device.");
+        }
+    }
+
+    ~TestDPCTLPeerAccess()
+    {
+        DPCTLDeviceVector_Delete(DV);
+        DPCTLPlatform_Delete(P);
+    }
+};
+
+TEST_P(TestDPCTLPeerAccess, ChkAccessSupported)
+{
+    auto D0 = DPCTLDeviceVector_GetAt(DV, 0);
+    auto D1 = DPCTLDeviceVector_GetAt(DV, 1);
+    ASSERT_TRUE(D0 != nullptr);
+    ASSERT_TRUE(D1 != nullptr);
+    EXPECT_NO_FATAL_FAILURE(DPCTLDevice_CanAccessPeer(
+        D0, D1, DPCTLPeerAccessType::access_supported));
+}
+
+TEST_P(TestDPCTLPeerAccess, ChkAtomicsSupported)
+{
+    auto D0 = DPCTLDeviceVector_GetAt(DV, 0);
+    auto D1 = DPCTLDeviceVector_GetAt(DV, 1);
+    ASSERT_TRUE(D0 != nullptr);
+    ASSERT_TRUE(D1 != nullptr);
+    EXPECT_NO_FATAL_FAILURE(DPCTLDevice_CanAccessPeer(
+        D0, D1, DPCTLPeerAccessType::atomics_supported));
+}
+
+TEST_P(TestDPCTLPeerAccess, ChkPeerAccess)
+{
+    auto D0 = DPCTLDeviceVector_GetAt(DV, 0);
+    auto D1 = DPCTLDeviceVector_GetAt(DV, 1);
+    ASSERT_TRUE(D0 != nullptr);
+    ASSERT_TRUE(D1 != nullptr);
+    bool canEnable = false;
+    EXPECT_NO_FATAL_FAILURE(canEnable = DPCTLDevice_CanAccessPeer(
+                                D0, D1, DPCTLPeerAccessType::access_supported));
+    if (canEnable) {
+        EXPECT_NO_FATAL_FAILURE(DPCTLDevice_EnablePeerAccess(D0, D1));
+        EXPECT_NO_FATAL_FAILURE(DPCTLDevice_DisablePeerAccess(D0, D1));
+    }
+}
+
+INSTANTIATE_TEST_SUITE_P(DPCTLDeviceFns,
+                         TestDPCTLPeerAccess,
+                         ::testing::Values("level_zero", "cuda", "hip"));
+
+struct TestDPCTLPeerAccessNullArgs : public ::testing::Test
+{
+    DPCTLSyclDeviceRef Null_DR0 = nullptr;
+    DPCTLSyclDeviceRef Null_DR1 = nullptr;
+};
+
+TEST_F(TestDPCTLPeerAccessNullArgs, ChkAccessSupported)
+{
+    bool accessSupported = true;
+    EXPECT_NO_FATAL_FAILURE(
+        accessSupported = DPCTLDevice_CanAccessPeer(
+            Null_DR0, Null_DR1, DPCTLPeerAccessType::access_supported));
+    ASSERT_FALSE(accessSupported);
+}
+
+TEST_F(TestDPCTLPeerAccessNullArgs, ChkAtomicsSupported)
+{
+    bool accessSupported = true;
+    EXPECT_NO_FATAL_FAILURE(
+        accessSupported = DPCTLDevice_CanAccessPeer(
+            Null_DR0, Null_DR1, DPCTLPeerAccessType::atomics_supported));
+    ASSERT_FALSE(accessSupported);
+}
+
+TEST_F(TestDPCTLPeerAccessNullArgs, ChkPeerAccess)
+{
+    EXPECT_NO_FATAL_FAILURE(DPCTLDevice_EnablePeerAccess(Null_DR0, Null_DR1));
+    EXPECT_NO_FATAL_FAILURE(DPCTLDevice_DisablePeerAccess(Null_DR0, Null_DR1));
+}

--- a/libsyclinterface/tests/test_sycl_peer_access.cpp
+++ b/libsyclinterface/tests/test_sycl_peer_access.cpp
@@ -104,6 +104,16 @@ TEST_P(TestDPCTLPeerAccess, ChkPeerAccess)
     }
 }
 
+TEST_P(TestDPCTLPeerAccess, ChkPeerAccessToSelf)
+{
+    auto D0 = DPCTLDeviceVector_GetAt(DV, 0);
+    ASSERT_TRUE(D0 != nullptr);
+    EXPECT_NO_FATAL_FAILURE(DPCTLDevice_CanAccessPeer(
+        D0, D0, DPCTLPeerAccessType::access_supported));
+    EXPECT_NO_FATAL_FAILURE(DPCTLDevice_EnablePeerAccess(D0, D0));
+    EXPECT_NO_FATAL_FAILURE(DPCTLDevice_DisablePeerAccess(D0, D0));
+}
+
 INSTANTIATE_TEST_SUITE_P(DPCTLDeviceFns,
                          TestDPCTLPeerAccess,
                          ::testing::Values("level_zero", "cuda", "hip"));


### PR DESCRIPTION
This PR adds full support for the [DPC++ `sycl_ext_oneapi_peer_access` extension](https://github.com/intel/llvm/blob/sycl/sycl/doc/extensions/supported/sycl_ext_oneapi_peer_access.asciidoc)

This adds a Python interface to calls that check if a `dpctl.SyclDevice` can enable peer access to another `dpctl.SyclDevice` and, if so, to enable or disable it.

- [X] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [X] Have you tested your changes locally for CPU and GPU devices?
- [X] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [X] Have you added documentation for your changes, if necessary?
- [ ] Have you added your changes to the changelog?
- [X] If this PR is a work in progress, are you opening the PR as a draft?
