### PR TITLE
DOC: Remove outdated conda link

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ to program on XPUs.
 
 # Installing
 
-You can install the library using [conda](https://anaconda.org/intel/dpctl) or
+You can install the library using conda (from Intel's channel - see instructions below) or
 [pip](https://pypi.org/project/dpctl/) package managers. It is also available in the [Intel(R)
 Distribution for
 Python](https://www.intel.com/content/www/us/en/developer/tools/oneapi/distribution-for-python.html)


### PR DESCRIPTION
The readme provides a link to intel conda, which is deprecated and shows no packages to download. Since this package is not on conda-forge and the intel channel links do not have a browsable URL like anaconda ones, this PR removes the link altogether.