### PR TITLE
Change docstring in `can_access_peer` method

### DIFF
--- a/dpctl/_sycl_device.pyx
+++ b/dpctl/_sycl_device.pyx
@@ -1885,8 +1885,8 @@ cdef class SyclDevice(_SyclDevice):
                     ``memory_scope::system`` when modifying memory on a peer
                     device.
 
-                    If ``False`` is returned, these operations result in
-                    undefined behavior.
+                If ``False`` is returned, these operations result in
+                undefined behavior.
 
                 Default: ``"access_supported"``
 


### PR DESCRIPTION
This PR follows up on #2077 by adjusting the docstring for the `can_access_peer` method

- [X] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [ ] Have you added your changes to the changelog?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
