### PR TITLE
[MAINT] Use Intel channel for build step of conda package workflow on Linux

### DIFF
--- a/.github/workflows/conda-package.yml
+++ b/.github/workflows/conda-package.yml
@@ -59,8 +59,9 @@ jobs:
           echo "WHEELS_OUTPUT_FOLDER=$GITHUB_WORKSPACE${{ runner.os == 'Linux' && '/' || '\\' }}" >> $GITHUB_ENV
       - name: Build conda package
         run: |
-          # use bootstrap channel to pull NumPy linked with OpenBLAS
-          CHANNELS="-c conda-forge --override-channels"
+          # use bootstrap channel to pull NumPy linked with
+          # TODO: roll back use of Intel channel when 2025.1 is available on conda-forge
+          CHANNELS="-c ${{ env.INTEL_CHANNEL }} -c conda-forge --override-channels"
           VERSIONS="--python ${{ matrix.python }} --numpy 2.0"
           TEST="--no-test"
           conda build \


### PR DESCRIPTION
This change makes the conda package workflow install 2025.1 packages instead of 2025.0, because the 2025.1 packages are not on conda-forge.

- [X] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [ ] Have you added your changes to the changelog?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
