### PR TITLE
Correct a link to `CHANGELOG.md` in package metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,7 +76,7 @@ docs = [
 ]
 
 [project.urls]
-Changelog = "https://github.com/IntelPython/dpctl/blob/main/CHANGELOG.md"
+Changelog = "https://github.com/IntelPython/dpctl/blob/master/CHANGELOG.md"
 Documentation = "https://intelpython.github.io/dpctl/"
 Homepage = "https://github.com/IntelPython/dpctl"
 Issues = "https://github.com/IntelPython/dpctl/issues"


### PR DESCRIPTION
There is invalid link to `CHANGELOG.md` on PyPi [page](https://pypi.org/project/dpctl/).
This PR update the link with proper path to the file in the dpctl repo.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [ ] Have you added your changes to the changelog?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
