### PR TITLE
[MAINT] Update Windows version used by GitHub CI

### DIFF
--- a/.github/workflows/conda-package.yml
+++ b/.github/workflows/conda-package.yml
@@ -80,7 +80,7 @@ jobs:
           path: ${{ env.WHEELS_OUTPUT_FOLDER }}${{ env.PACKAGE_NAME }}-*.whl
 
   build_windows:
-    runs-on: windows-2019
+    runs-on: windows-latest
     timeout-minutes: 150
 
     strategy:
@@ -254,7 +254,7 @@ jobs:
       matrix:
         python: ['3.9', '3.10', '3.11', '3.12', '3.13']
         experimental: [false]
-        runner: [windows-2019]
+        runner: [windows-latest]
     continue-on-error: ${{ matrix.experimental }}
     env:
       workdir: '${{ github.workspace }}'
@@ -458,7 +458,7 @@ jobs:
     if: |
       (github.repository == 'IntelPython/dpctl') &&
       (github.ref == 'refs/heads/master' || (startsWith(github.ref, 'refs/heads/release') == true) || github.event_name == 'push' && contains(github.ref, 'refs/tags/'))
-    runs-on: windows-2019
+    runs-on: windows-latest
     timeout-minutes: 20
     strategy:
       matrix:

--- a/.github/workflows/run-tests-from-dppy-bits.yaml
+++ b/.github/workflows/run-tests-from-dppy-bits.yaml
@@ -80,7 +80,7 @@ jobs:
       matrix:
         python: ['3.9', '3.10', '3.11', '3.12', '3.13']
         experimental: [false]
-        runner: [windows-2019]
+        runner: [windows-latest]
 
     continue-on-error: ${{ matrix.experimental }}
     env:


### PR DESCRIPTION
This PR proposes changing the version of Windows used by the GitHub CI, since Windows 2019 image will soon no longer be supported

- [ ] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [ ] Have you added your changes to the changelog?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
