### PR TITLE
Add passing dependent events to `copy` calls

### DIFF
--- a/dpctl/tensor/libtensor/source/copy_for_reshape.cpp
+++ b/dpctl/tensor/libtensor/source/copy_for_reshape.cpp
@@ -108,7 +108,7 @@ copy_usm_ndarray_for_reshape(const dpctl::tensor::usm_ndarray &src,
         const char *src_data = src.get_data();
         char *dst_data = dst.get_data();
         sycl::event copy_ev =
-            exec_q.copy<char>(src_data, dst_data, src_elemsize);
+            exec_q.copy<char>(src_data, dst_data, src_elemsize, depends);
         return std::make_pair(keep_args_alive(exec_q, {src, dst}, {copy_ev}),
                               copy_ev);
     }

--- a/dpctl/tensor/libtensor/source/copy_for_roll.cpp
+++ b/dpctl/tensor/libtensor/source/copy_for_roll.cpp
@@ -132,7 +132,7 @@ copy_usm_ndarray_for_roll_1d(const dpctl::tensor::usm_ndarray &src,
         const char *src_data = src.get_data();
         char *dst_data = dst.get_data();
         sycl::event copy_ev =
-            exec_q.copy<char>(src_data, dst_data, src_elemsize);
+            exec_q.copy<char>(src_data, dst_data, src_elemsize, depends);
         return std::make_pair(keep_args_alive(exec_q, {src, dst}, {copy_ev}),
                               copy_ev);
     }
@@ -282,7 +282,7 @@ copy_usm_ndarray_for_roll_nd(const dpctl::tensor::usm_ndarray &src,
     // typenames must be the same
     if (src_typenum != dst_typenum) {
         throw py::value_error(
-            "copy_usm_ndarray_for_reshape requires src and dst to "
+            "copy_usm_ndarray_for_roll_nd requires src and dst to "
             "have the same type.");
     }
 
@@ -304,7 +304,7 @@ copy_usm_ndarray_for_roll_nd(const dpctl::tensor::usm_ndarray &src,
         const char *src_data = src.get_data();
         char *dst_data = dst.get_data();
         sycl::event copy_ev =
-            exec_q.copy<char>(src_data, dst_data, src_elemsize);
+            exec_q.copy<char>(src_data, dst_data, src_elemsize, depends);
         return std::make_pair(keep_args_alive(exec_q, {src, dst}, {copy_ev}),
                               copy_ev);
     }


### PR DESCRIPTION
The reshape and roll kernels have a special handling for 1-element input array, where `exec_q.copy()` is used.
But it is still possible that the array data depends on submitted events even in that case with only 1-element.

Thus this PR is fixing the issue with unsafe copying of 1-element input array.
The issue was initially detected in dpnp tests on ARL BMG Linux machine in scope of internal testing.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [ ] Have you added your changes to the changelog?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
