### PR TITLE
Resolve gh-1046

### DIFF
--- a/dpctl/tensor/_ctors.py
+++ b/dpctl/tensor/_ctors.py
@@ -111,8 +111,6 @@ def _asarray_from_usm_ndarray(
         raise TypeError(
             f"Expected dpctl.tensor.usm_ndarray, got {type(usm_ndary)}"
         )
-    if dtype is None:
-        dtype = usm_ndary.dtype
     if usm_type is None:
         usm_type = usm_ndary.usm_type
     if sycl_queue is not None:
@@ -122,6 +120,8 @@ def _asarray_from_usm_ndarray(
         copy_q = normalize_queue_device(sycl_queue=sycl_queue, device=exec_q)
     else:
         copy_q = usm_ndary.sycl_queue
+    if dtype is None:
+        dtype = _map_to_device_dtype(usm_ndary.dtype, copy_q)
     # Conditions for zero copy:
     can_zero_copy = copy is not True
     #    dtype is unchanged

--- a/dpctl/tests/test_tensor_asarray.py
+++ b/dpctl/tests/test_tensor_asarray.py
@@ -633,23 +633,17 @@ def test_asarray_to_device_with_unsupported_dtype(dt):
     except dpctl.SyclDeviceCreationError:
         pytest.skip("No device with aspect for test")
     d1 = None
-    try:
-        d1 = dpctl.select_device_with_aspects("cpu", excluded_aspects=[aspect])
-    except dpctl.SyclDeviceCreationError:
-        pass
-    try:
-        d1 = dpctl.select_device_with_aspects("gpu", excluded_aspects=[aspect])
-    except dpctl.SyclDeviceCreationError:
-        pass
-    try:
-        d1 = dpctl.select_device_with_aspects(
-            "accelerator", excluded_aspects=[aspect]
-        )
-    except dpctl.SyclDeviceCreationError:
-        pass
+    for d in dpctl.get_devices():
+        if d.default_selector_score < 0:
+            pass
+        try:
+            d1 = dpctl.select_device_with_aspects(
+                d.device_type.name, excluded_aspects=[aspect]
+            )
+        except dpctl.SyclDeviceCreationError:
+            pass
     if d1 is None:
         pytest.skip("No device with missing aspect for test")
-
     x = dpt.ones(10, dtype=dt, device=d0)
     y = dpt.asarray(x, device=d1)
     assert y.sycl_device == d1

--- a/dpctl/tests/test_tensor_asarray.py
+++ b/dpctl/tests/test_tensor_asarray.py
@@ -623,3 +623,33 @@ def test_asarray_support_for_usm_ndarray_protocol(usm_type):
     assert x.dtype == y3.dtype
     assert y3.usm_data.reference_obj is None
     assert dpt.all(x[dpt.newaxis, :] == y3)
+
+
+@pytest.mark.parametrize("dt", [dpt.float16, dpt.float64, dpt.complex128])
+def test_asarray_to_device_with_unsupported_dtype(dt):
+    aspect = "fp16" if dt == dpt.float16 else "fp64"
+    try:
+        d0 = dpctl.select_device_with_aspects(aspect)
+    except dpctl.SyclDeviceCreationError:
+        pytest.skip("No device with aspect for test")
+    d1 = None
+    try:
+        d1 = dpctl.select_device_with_aspects("cpu", excluded_aspects=[aspect])
+    except dpctl.SyclDeviceCreationError:
+        pass
+    try:
+        d1 = dpctl.select_device_with_aspects("gpu", excluded_aspects=[aspect])
+    except dpctl.SyclDeviceCreationError:
+        pass
+    try:
+        d1 = dpctl.select_device_with_aspects(
+            "accelerator", excluded_aspects=[aspect]
+        )
+    except dpctl.SyclDeviceCreationError:
+        pass
+    if d1 is None:
+        pytest.skip("No device with missing aspect for test")
+
+    x = dpt.ones(10, dtype=dt, device=d0)
+    y = dpt.asarray(x, device=d1)
+    assert y.sycl_device == d1


### PR DESCRIPTION
Closes gh-1046 

This PR resolves `dpt.asarray(x, device=dev)` failing for some array `x` with dtype not supported by device `dev`

- [X] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [X] Have you tested your changes locally for CPU and GPU devices?
- [X] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [ ] Have you added your changes to the changelog?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
