### PR TITLE
Implement `tensor.isin`

### DIFF
--- a/docs/doc_sources/api_reference/dpctl/tensor.set_functions.rst
+++ b/docs/doc_sources/api_reference/dpctl/tensor.set_functions.rst
@@ -8,6 +8,7 @@ Set Functions
 .. autosummary::
     :toctree: generated
 
+    isin
     unique_all
     unique_counts
     unique_inverse

--- a/dpctl/tensor/CMakeLists.txt
+++ b/dpctl/tensor/CMakeLists.txt
@@ -112,6 +112,7 @@ set(_reduction_sources
     ${CMAKE_CURRENT_SOURCE_DIR}/libtensor/source/reductions/sum.cpp
 )
 set(_sorting_sources
+    ${CMAKE_CURRENT_SOURCE_DIR}/libtensor/source/sorting/isin.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/libtensor/source/sorting/merge_sort.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/libtensor/source/sorting/merge_argsort.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/libtensor/source/sorting/radix_sort.cpp

--- a/dpctl/tensor/__init__.py
+++ b/dpctl/tensor/__init__.py
@@ -198,6 +198,7 @@ from ._reduction import (
 )
 from ._searchsorted import searchsorted
 from ._set_functions import (
+    isin,
     unique_all,
     unique_counts,
     unique_inverse,
@@ -394,4 +395,5 @@ __all__ = [
     "top_k",
     "dldevice_to_sycl_device",
     "sycl_device_to_dldevice",
+    "isin",
 ]

--- a/dpctl/tensor/_clip.py
+++ b/dpctl/tensor/_clip.py
@@ -23,16 +23,16 @@ from dpctl.tensor._copy_utils import (
     _empty_like_pair_orderK,
     _empty_like_triple_orderK,
 )
-from dpctl.tensor._elementwise_common import (
+from dpctl.tensor._manipulation_functions import _broadcast_shape_impl
+from dpctl.tensor._type_utils import _can_cast
+from dpctl.utils import ExecutionPlacementError, SequentialOrderManager
+
+from ._scalar_utils import (
     _get_dtype,
     _get_queue_usm_type,
     _get_shape,
     _validate_dtype,
 )
-from dpctl.tensor._manipulation_functions import _broadcast_shape_impl
-from dpctl.tensor._type_utils import _can_cast
-from dpctl.utils import ExecutionPlacementError, SequentialOrderManager
-
 from ._type_utils import (
     _resolve_one_strong_one_weak_types,
     _resolve_one_strong_two_weak_types,

--- a/dpctl/tensor/_elementwise_common.py
+++ b/dpctl/tensor/_elementwise_common.py
@@ -14,24 +14,20 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-import numbers
-
-import numpy as np
-
 import dpctl
-import dpctl.memory as dpm
 import dpctl.tensor as dpt
 import dpctl.tensor._tensor_impl as ti
 from dpctl.tensor._manipulation_functions import _broadcast_shape_impl
-from dpctl.tensor._usmarray import _is_object_with_buffer_protocol as _is_buffer
 from dpctl.utils import ExecutionPlacementError, SequentialOrderManager
 
 from ._copy_utils import _empty_like_orderK, _empty_like_pair_orderK
+from ._scalar_utils import (
+    _get_dtype,
+    _get_queue_usm_type,
+    _get_shape,
+    _validate_dtype,
+)
 from ._type_utils import (
-    WeakBooleanType,
-    WeakComplexType,
-    WeakFloatingType,
-    WeakIntegralType,
     _acceptance_fn_default_binary,
     _acceptance_fn_default_unary,
     _all_data_types,
@@ -39,7 +35,6 @@ from ._type_utils import (
     _find_buf_dtype2,
     _find_buf_dtype_in_place_op,
     _resolve_weak_types,
-    _to_device_supported_dtype,
 )
 
 
@@ -287,78 +282,6 @@ class UnaryElementwiseFunc:
         _manager.add_event_pair(ht, uf_ev)
 
         return out
-
-
-def _get_queue_usm_type(o):
-    """Return SYCL device where object `o` allocated memory, or None."""
-    if isinstance(o, dpt.usm_ndarray):
-        return o.sycl_queue, o.usm_type
-    elif hasattr(o, "__sycl_usm_array_interface__"):
-        try:
-            m = dpm.as_usm_memory(o)
-            return m.sycl_queue, m.get_usm_type()
-        except Exception:
-            return None, None
-    return None, None
-
-
-def _get_dtype(o, dev):
-    if isinstance(o, dpt.usm_ndarray):
-        return o.dtype
-    if hasattr(o, "__sycl_usm_array_interface__"):
-        return dpt.asarray(o).dtype
-    if _is_buffer(o):
-        host_dt = np.array(o).dtype
-        dev_dt = _to_device_supported_dtype(host_dt, dev)
-        return dev_dt
-    if hasattr(o, "dtype"):
-        dev_dt = _to_device_supported_dtype(o.dtype, dev)
-        return dev_dt
-    if isinstance(o, bool):
-        return WeakBooleanType(o)
-    if isinstance(o, int):
-        return WeakIntegralType(o)
-    if isinstance(o, float):
-        return WeakFloatingType(o)
-    if isinstance(o, complex):
-        return WeakComplexType(o)
-    return np.object_
-
-
-def _validate_dtype(dt) -> bool:
-    return isinstance(
-        dt,
-        (WeakBooleanType, WeakIntegralType, WeakFloatingType, WeakComplexType),
-    ) or (
-        isinstance(dt, dpt.dtype)
-        and dt
-        in [
-            dpt.bool,
-            dpt.int8,
-            dpt.uint8,
-            dpt.int16,
-            dpt.uint16,
-            dpt.int32,
-            dpt.uint32,
-            dpt.int64,
-            dpt.uint64,
-            dpt.float16,
-            dpt.float32,
-            dpt.float64,
-            dpt.complex64,
-            dpt.complex128,
-        ]
-    )
-
-
-def _get_shape(o):
-    if isinstance(o, dpt.usm_ndarray):
-        return o.shape
-    if _is_buffer(o):
-        return memoryview(o).shape
-    if isinstance(o, numbers.Number):
-        return tuple()
-    return getattr(o, "shape", tuple())
 
 
 class BinaryElementwiseFunc:

--- a/dpctl/tensor/_scalar_utils.py
+++ b/dpctl/tensor/_scalar_utils.py
@@ -1,0 +1,111 @@
+#                       Data Parallel Control (dpctl)
+#
+#  Copyright 2020-2025 Intel Corporation
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import numbers
+
+import numpy as np
+
+import dpctl.memory as dpm
+import dpctl.tensor as dpt
+from dpctl.tensor._usmarray import _is_object_with_buffer_protocol as _is_buffer
+
+from ._type_utils import (
+    WeakBooleanType,
+    WeakComplexType,
+    WeakFloatingType,
+    WeakIntegralType,
+    _to_device_supported_dtype,
+)
+
+
+def _get_queue_usm_type(o):
+    """Return SYCL device where object `o` allocated memory, or None."""
+    if isinstance(o, dpt.usm_ndarray):
+        return o.sycl_queue, o.usm_type
+    elif hasattr(o, "__sycl_usm_array_interface__"):
+        try:
+            m = dpm.as_usm_memory(o)
+            return m.sycl_queue, m.get_usm_type()
+        except Exception:
+            return None, None
+    return None, None
+
+
+def _get_dtype(o, dev):
+    if isinstance(o, dpt.usm_ndarray):
+        return o.dtype
+    if hasattr(o, "__sycl_usm_array_interface__"):
+        return dpt.asarray(o).dtype
+    if _is_buffer(o):
+        host_dt = np.array(o).dtype
+        dev_dt = _to_device_supported_dtype(host_dt, dev)
+        return dev_dt
+    if hasattr(o, "dtype"):
+        dev_dt = _to_device_supported_dtype(o.dtype, dev)
+        return dev_dt
+    if isinstance(o, bool):
+        return WeakBooleanType(o)
+    if isinstance(o, int):
+        return WeakIntegralType(o)
+    if isinstance(o, float):
+        return WeakFloatingType(o)
+    if isinstance(o, complex):
+        return WeakComplexType(o)
+    return np.object_
+
+
+def _validate_dtype(dt) -> bool:
+    return isinstance(
+        dt,
+        (WeakBooleanType, WeakIntegralType, WeakFloatingType, WeakComplexType),
+    ) or (
+        isinstance(dt, dpt.dtype)
+        and dt
+        in [
+            dpt.bool,
+            dpt.int8,
+            dpt.uint8,
+            dpt.int16,
+            dpt.uint16,
+            dpt.int32,
+            dpt.uint32,
+            dpt.int64,
+            dpt.uint64,
+            dpt.float16,
+            dpt.float32,
+            dpt.float64,
+            dpt.complex64,
+            dpt.complex128,
+        ]
+    )
+
+
+def _get_shape(o):
+    if isinstance(o, dpt.usm_ndarray):
+        return o.shape
+    if _is_buffer(o):
+        return memoryview(o).shape
+    if isinstance(o, numbers.Number):
+        return tuple()
+    return getattr(o, "shape", tuple())
+
+
+__all__ = [
+    "_get_dtype",
+    "_get_queue_usm_type",
+    "_get_shape",
+    "_validate_dtype",
+]

--- a/dpctl/tensor/_search_functions.py
+++ b/dpctl/tensor/_search_functions.py
@@ -17,16 +17,16 @@
 import dpctl
 import dpctl.tensor as dpt
 import dpctl.tensor._tensor_impl as ti
-from dpctl.tensor._elementwise_common import (
+from dpctl.tensor._manipulation_functions import _broadcast_shape_impl
+from dpctl.utils import ExecutionPlacementError, SequentialOrderManager
+
+from ._copy_utils import _empty_like_orderK, _empty_like_triple_orderK
+from ._scalar_utils import (
     _get_dtype,
     _get_queue_usm_type,
     _get_shape,
     _validate_dtype,
 )
-from dpctl.tensor._manipulation_functions import _broadcast_shape_impl
-from dpctl.utils import ExecutionPlacementError, SequentialOrderManager
-
-from ._copy_utils import _empty_like_orderK, _empty_like_triple_orderK
 from ._type_utils import (
     WeakBooleanType,
     WeakComplexType,

--- a/dpctl/tensor/_set_functions.py
+++ b/dpctl/tensor/_set_functions.py
@@ -744,7 +744,9 @@ def isin(
 
     if test_dt != dt:
         # copy into C-contiguous memory, because the array will be flattened
-        test_buf = dpt.empty_like(test_arr, dtype=dt, order="C")
+        test_buf = dpt.empty_like(
+            test_arr, dtype=dt, order="C", usm_type=res_usm_type
+        )
         ht_ev, ev = _copy_usm_ndarray_into_usm_ndarray(
             src=test_arr, dst=test_buf, sycl_queue=exec_q, depends=dep_evs
         )

--- a/dpctl/tensor/_set_functions.py
+++ b/dpctl/tensor/_set_functions.py
@@ -698,8 +698,11 @@ def isin(
     du.validate_usm_type(res_usm_type, allow_none=False)
     sycl_dev = exec_q.sycl_device
 
-    if invert not in [True, False]:
-        raise ValueError(f"`invert` must be `True` or `False`, got {invert}")
+    if not isinstance(invert, bool):
+        raise TypeError(
+            "`invert` keyword argument must be of boolean type, "
+            f"got {type(invert)}"
+        )
 
     x_dt = _get_dtype(x, sycl_dev)
     test_dt = _get_dtype(test_elements, sycl_dev)

--- a/dpctl/tensor/_set_functions.py
+++ b/dpctl/tensor/_set_functions.py
@@ -698,6 +698,9 @@ def isin(
     du.validate_usm_type(res_usm_type, allow_none=False)
     sycl_dev = exec_q.sycl_device
 
+    if invert not in [True, False]:
+        raise ValueError(f"`invert` must be `True` or `False`, got {invert}")
+
     x_dt = _get_dtype(x, sycl_dev)
     test_dt = _get_dtype(test_elements, sycl_dev)
     if not all(_validate_dtype(dt) for dt in (x_dt, test_dt)):

--- a/dpctl/tensor/_set_functions.py
+++ b/dpctl/tensor/_set_functions.py
@@ -16,10 +16,12 @@
 
 from typing import NamedTuple
 
+import dpctl
 import dpctl.tensor as dpt
 import dpctl.utils as du
 
 from ._copy_utils import _empty_like_orderK
+from ._scalar_utils import _get_dtype, _get_queue_usm_type, _validate_dtype
 from ._tensor_elementwise_impl import _not_equal, _subtract
 from ._tensor_impl import (
     _copy_usm_ndarray_into_usm_ndarray,
@@ -36,8 +38,10 @@ from ._tensor_sorting_impl import (
     _searchsorted_left,
     _sort_ascending,
 )
+from ._type_utils import _resolve_weak_types_all_py_ints
 
 __all__ = [
+    "isin",
     "unique_values",
     "unique_counts",
     "unique_inverse",
@@ -629,61 +633,101 @@ def unique_all(x: dpt.usm_ndarray) -> UniqueAllResult:
 
 
 def isin(x, test_elements, /, *, assume_unique=False, invert=False):
+    """
+    Tests `x in test_elements` for each element of `x`. Returns a boolean array
+    with the same shape as `x` that is `True` where the element is in
+    `test_elements`, `False` otherwise.
+
+    Args:
+        x (usm_ndarray):
+            input array.
+        test_elements (Union[usm_ndarray, bool, int, float, complex]):
+            elements against which to test each value of `x`.
+            Default: `None`.
+        assume_unique (Optional[bool]):
+            if `True`, the input arrays are both assumed to be unique, which
+            currently has no effect.
+            Default: `False`.
+        invert (Optional[bool]):
+            if `True`, the output results are inverted, i.e., are equivalent to
+            testing `x not in test_elements` for each element of `x`.
+            Default: `False`.
+
+    Returns:
+        usm_ndarray:
+            an array of the inclusion test results. The returned array has a
+            boolean data type and the same shape as `x`.
+    """
     if not isinstance(x, dpt.usm_ndarray):
         raise TypeError(f"Expected dpctl.tensor.usm_ndarray, got {type(x)}")
+    q1, x_usm_type = x.sycl_queue, x.usm_type
+    q2, test_usm_type = _get_queue_usm_type(test_elements)
+    if q2 is None:
+        exec_q = q1
+        res_usm_type = x_usm_type
+    else:
+        exec_q = dpctl.utils.get_execution_queue((q1, q2))
+        if exec_q is None:
+            raise du.ExecutionPlacementError(
+                "Execution placement can not be unambiguously inferred "
+                "from input arguments."
+            )
+        res_usm_type = dpctl.utils.get_coerced_usm_type(
+            (
+                x_usm_type,
+                test_usm_type,
+            )
+        )
+    dpctl.utils.validate_usm_type(res_usm_type, allow_none=False)
+    sycl_dev = exec_q.sycl_device
+
+    x_dt = x.dtype
+    test_dt = _get_dtype(test_elements, sycl_dev)
+    if not _validate_dtype(test_dt):
+        raise ValueError("`test_elements` has unsupported dtype")
+
+    dt = dpt.result_type(
+        *_resolve_weak_types_all_py_ints(x_dt, test_dt, sycl_dev)
+    )
+
+    _manager = du.SequentialOrderManager[exec_q]
+
+    if x_dt != dt:
+        x_buf = _empty_like_orderK(x, dt)
+        dep_evs = _manager.submitted_events
+        ht_ev, ev = _copy_usm_ndarray_into_usm_ndarray(
+            src=x, dst=x_buf, sycl_queue=exec_q, depends=dep_evs
+        )
+        _manager.add_event_pair(ht_ev, ev)
+    else:
+        x_buf = x
+
     if not isinstance(test_elements, dpt.usm_ndarray):
-        raise TypeError(
-            f"Expected dpctl.tensor.usm_ndarray, got {type(test_elements)}"
+        test_buf = dpt.asarray(test_elements, dtype=dt, sycl_queue=exec_q)
+    elif test_dt != dt:
+        # copy into C-contiguous memory, because the array will be flattened
+        test_buf = dpt.empty_like(test_elements, dt, order="C")
+        dep_evs = _manager.submitted_events
+        ht_ev, ev = _copy_usm_ndarray_into_usm_ndarray(
+            src=test_elements, dst=test_buf, sycl_queue=exec_q, depends=dep_evs
         )
+        _manager.add_event_pair(ht_ev, ev)
+    else:
+        test_buf = test_elements
 
-    q = du.get_execution_queue([x.sycl_queue, test_elements.sycl_queue])
-    if q is None:
-        raise du.ExecutionPlacementError(
-            "Execution placement can not be unambiguously "
-            "inferred from input arguments."
-        )
+    test_buf = dpt.reshape(test_buf, -1)
+    test_buf = dpt.sort(test_buf)
 
-    x1 = x
-    x2 = dpt.reshape(test_elements, -1)
-
-    x1_dt = x1.dtype
-    x2_dt = x2.dtype
-
-    _manager = du.SequentialOrderManager[q]
-    dep_evs = _manager.submitted_events
-
-    if x1_dt != x2_dt:
-        dt = dpt.result_type(x1, x2)
-        if x1_dt != dt:
-            x1_buf = _empty_like_orderK(x1, dt)
-            dep_evs = _manager.submitted_events
-            ht_ev, ev = _copy_usm_ndarray_into_usm_ndarray(
-                src=x1, dst=x1_buf, sycl_queue=q, depends=dep_evs
-            )
-            _manager.add_event_pair(ht_ev, ev)
-            x1 = x1_buf
-        if x2_dt != dt:
-            x2_buf = _empty_like_orderK(x2, dt)
-            dep_evs = _manager.submitted_events
-            ht_ev, ev = _copy_usm_ndarray_into_usm_ndarray(
-                src=x2, dst=x2_buf, sycl_queue=q, depends=dep_evs
-            )
-            _manager.add_event_pair(ht_ev, ev)
-            x2 = x2_buf
-
-    x2 = dpt.sort(x2)
-
-    dst_usm_type = du.get_coerced_usm_type([x1.usm_type, x2.usm_type])
-    dst = _empty_like_orderK(x1, dpt.bool, usm_type=dst_usm_type)
+    dst = _empty_like_orderK(x_buf, dpt.bool, usm_type=res_usm_type)
 
     dep_evs = _manager.submitted_events
     ht_ev, s_ev = _isin(
-        needles=x1,
-        hay=x2,
+        needles=x_buf,
+        hay=test_buf,
         dst=dst,
-        sycl_queue=q,
+        sycl_queue=exec_q,
         invert=invert,
         depends=dep_evs,
     )
     _manager.add_event_pair(ht_ev, s_ev)
-    return dpt.reshape(dst, x.shape)
+    return dst

--- a/dpctl/tensor/_set_functions.py
+++ b/dpctl/tensor/_set_functions.py
@@ -646,7 +646,8 @@ def isin(
     *,
     invert: Optional[bool] = False,
 ) -> dpt.usm_ndarray:
-    """
+    """isin(x, test_elements, /, *, invert=False)
+
     Tests `x in test_elements` for each element of `x`. Returns a boolean array
     with the same shape as `x` that is `True` where the element is in
     `test_elements`, `False` otherwise.

--- a/dpctl/tensor/_set_functions.py
+++ b/dpctl/tensor/_set_functions.py
@@ -21,7 +21,12 @@ import dpctl.tensor as dpt
 import dpctl.utils as du
 
 from ._copy_utils import _empty_like_orderK
-from ._scalar_utils import _get_dtype, _get_queue_usm_type, _validate_dtype
+from ._scalar_utils import (
+    _get_dtype,
+    _get_queue_usm_type,
+    _get_shape,
+    _validate_dtype,
+)
 from ._tensor_elementwise_impl import _not_equal, _subtract
 from ._tensor_impl import (
     _copy_usm_ndarray_into_usm_ndarray,
@@ -38,7 +43,10 @@ from ._tensor_sorting_impl import (
     _searchsorted_left,
     _sort_ascending,
 )
-from ._type_utils import _resolve_weak_types_all_py_ints
+from ._type_utils import (
+    _resolve_weak_types_all_py_ints,
+    _to_device_supported_dtype,
+)
 
 __all__ = [
     "isin",
@@ -632,21 +640,17 @@ def unique_all(x: dpt.usm_ndarray) -> UniqueAllResult:
     )
 
 
-def isin(x, test_elements, /, *, assume_unique=False, invert=False):
+def isin(x, test_elements, /, *, invert=False):
     """
     Tests `x in test_elements` for each element of `x`. Returns a boolean array
     with the same shape as `x` that is `True` where the element is in
     `test_elements`, `False` otherwise.
 
     Args:
-        x (usm_ndarray):
-            input array.
+        x (Union[usm_ndarray, bool, int, float, complex]):
+            input element or elements.
         test_elements (Union[usm_ndarray, bool, int, float, complex]):
             elements against which to test each value of `x`.
-        assume_unique (Optional[bool]):
-            if `True`, the input arrays are both assumed to be unique, which
-            currently has no effect.
-            Default: `False`.
         invert (Optional[bool]):
             if `True`, the output results are inverted, i.e., are equivalent to
             testing `x not in test_elements` for each element of `x`.
@@ -657,11 +661,19 @@ def isin(x, test_elements, /, *, assume_unique=False, invert=False):
             an array of the inclusion test results. The returned array has a
             boolean data type and the same shape as `x`.
     """
-    if not isinstance(x, dpt.usm_ndarray):
-        raise TypeError(f"Expected dpctl.tensor.usm_ndarray, got {type(x)}")
-    q1, x_usm_type = x.sycl_queue, x.usm_type
+    q1, x_usm_type = _get_queue_usm_type(x)
     q2, test_usm_type = _get_queue_usm_type(test_elements)
-    if q2 is None:
+    if q1 is None and q2 is None:
+        raise du.ExecutionPlacementError(
+            "Execution placement can not be unambiguously inferred "
+            "from input arguments. "
+            "One of the arguments must represent USM allocation and "
+            "expose `__sycl_usm_array_interface__` property"
+        )
+    if q1 is None:
+        exec_q = q2
+        res_usm_type = test_usm_type
+    elif q2 is None:
         exec_q = q1
         res_usm_type = x_usm_type
     else:
@@ -680,45 +692,60 @@ def isin(x, test_elements, /, *, assume_unique=False, invert=False):
     dpctl.utils.validate_usm_type(res_usm_type, allow_none=False)
     sycl_dev = exec_q.sycl_device
 
+    x_dt = _get_dtype(x, sycl_dev)
+    test_dt = _get_dtype(test_elements, sycl_dev)
+    if not all(_validate_dtype(dt) for dt in (x_dt, test_dt)):
+        raise ValueError("Operands have unsupported data types")
+
+    x_sh = _get_shape(x)
     if isinstance(test_elements, dpt.usm_ndarray) and test_elements.size == 0:
         if invert:
-            return dpt.ones_like(x, dtype=dpt.bool, usm_type=res_usm_type)
+            return dpt.ones(
+                x_sh, dtype=dpt.bool, usm_type=res_usm_type, sycl_queue=exec_q
+            )
         else:
-            return dpt.zeros_like(x, dtype=dpt.bool, usm_type=res_usm_type)
+            return dpt.zeros(
+                x_sh, dtype=dpt.bool, usm_type=res_usm_type, sycl_queue=exec_q
+            )
 
-    x_dt = x.dtype
-    test_dt = _get_dtype(test_elements, sycl_dev)
-    if not _validate_dtype(test_dt):
-        raise ValueError("`test_elements` has unsupported dtype")
+    dt1, dt2 = _resolve_weak_types_all_py_ints(x_dt, test_dt, sycl_dev)
+    dt = _to_device_supported_dtype(dpt.result_type(dt1, dt2), sycl_dev)
+
+    if not isinstance(x, dpt.usm_ndarray):
+        x_arr = dpt.asarray(
+            x, dtype=dt1, usm_type=res_usm_type, sycl_queue=exec_q
+        )
+    else:
+        x_arr = x
+
+    if not isinstance(test_elements, dpt.usm_ndarray):
+        test_arr = dpt.asarray(
+            test_elements, dtype=dt2, usm_type=res_usm_type, sycl_queue=exec_q
+        )
+    else:
+        test_arr = test_elements
 
     _manager = du.SequentialOrderManager[exec_q]
     dep_evs = _manager.submitted_events
 
-    dt1, dt2 = _resolve_weak_types_all_py_ints(x_dt, test_dt, sycl_dev)
-    dt = dpt.result_type(dt1, dt2)
-
     if x_dt != dt:
-        x_buf = _empty_like_orderK(x, dt)
+        x_buf = _empty_like_orderK(x_arr, dt, res_usm_type, sycl_dev)
         ht_ev, ev = _copy_usm_ndarray_into_usm_ndarray(
-            src=x, dst=x_buf, sycl_queue=exec_q, depends=dep_evs
+            src=x_arr, dst=x_buf, sycl_queue=exec_q, depends=dep_evs
         )
         _manager.add_event_pair(ht_ev, ev)
     else:
-        x_buf = x
+        x_buf = x_arr
 
-    if not isinstance(test_elements, dpt.usm_ndarray):
-        test_buf = dpt.asarray(
-            test_elements, dtype=dt, usm_type=res_usm_type, sycl_queue=exec_q
-        )
-    elif test_dt != dt:
+    if test_dt != dt:
         # copy into C-contiguous memory, because the array will be flattened
-        test_buf = dpt.empty_like(test_elements, dtype=dt, order="C")
+        test_buf = dpt.empty_like(test_arr, dtype=dt, order="C")
         ht_ev, ev = _copy_usm_ndarray_into_usm_ndarray(
-            src=test_elements, dst=test_buf, sycl_queue=exec_q, depends=dep_evs
+            src=test_arr, dst=test_buf, sycl_queue=exec_q, depends=dep_evs
         )
         _manager.add_event_pair(ht_ev, ev)
     else:
-        test_buf = test_elements
+        test_buf = test_arr
 
     test_buf = dpt.reshape(test_buf, -1)
     test_buf = dpt.sort(test_buf)

--- a/dpctl/tensor/_set_functions.py
+++ b/dpctl/tensor/_set_functions.py
@@ -14,7 +14,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-from typing import NamedTuple
+from typing import NamedTuple, Optional, Union
 
 import dpctl.tensor as dpt
 import dpctl.utils as du
@@ -639,7 +639,13 @@ def unique_all(x: dpt.usm_ndarray) -> UniqueAllResult:
     )
 
 
-def isin(x, test_elements, /, *, invert=False):
+def isin(
+    x: Union[dpt.usm_ndarray, int, float, complex, bool],
+    test_elements: Union[dpt.usm_ndarray, int, float, complex, bool],
+    /,
+    *,
+    invert: Optional[bool] = False,
+) -> dpt.usm_ndarray:
     """
     Tests `x in test_elements` for each element of `x`. Returns a boolean array
     with the same shape as `x` that is `True` where the element is in

--- a/dpctl/tensor/_set_functions.py
+++ b/dpctl/tensor/_set_functions.py
@@ -16,7 +16,6 @@
 
 from typing import NamedTuple
 
-import dpctl
 import dpctl.tensor as dpt
 import dpctl.utils as du
 
@@ -677,19 +676,19 @@ def isin(x, test_elements, /, *, invert=False):
         exec_q = q1
         res_usm_type = x_usm_type
     else:
-        exec_q = dpctl.utils.get_execution_queue((q1, q2))
+        exec_q = du.get_execution_queue((q1, q2))
         if exec_q is None:
             raise du.ExecutionPlacementError(
                 "Execution placement can not be unambiguously inferred "
                 "from input arguments."
             )
-        res_usm_type = dpctl.utils.get_coerced_usm_type(
+        res_usm_type = du.get_coerced_usm_type(
             (
                 x_usm_type,
                 test_usm_type,
             )
         )
-    dpctl.utils.validate_usm_type(res_usm_type, allow_none=False)
+    du.validate_usm_type(res_usm_type, allow_none=False)
     sycl_dev = exec_q.sycl_device
 
     x_dt = _get_dtype(x, sycl_dev)

--- a/dpctl/tensor/_set_functions.py
+++ b/dpctl/tensor/_set_functions.py
@@ -734,7 +734,7 @@ def isin(
     dep_evs = _manager.submitted_events
 
     if x_dt != dt:
-        x_buf = _empty_like_orderK(x_arr, dt, res_usm_type, sycl_dev)
+        x_buf = _empty_like_orderK(x_arr, dt, res_usm_type, exec_q)
         ht_ev, ev = _copy_usm_ndarray_into_usm_ndarray(
             src=x_arr, dst=x_buf, sycl_queue=exec_q, depends=dep_evs
         )

--- a/dpctl/tensor/_utility_functions.py
+++ b/dpctl/tensor/_utility_functions.py
@@ -21,14 +21,14 @@ import dpctl.tensor as dpt
 import dpctl.tensor._tensor_impl as ti
 import dpctl.tensor._tensor_reductions_impl as tri
 import dpctl.utils as du
-from dpctl.tensor._elementwise_common import (
+
+from ._numpy_helper import normalize_axis_index, normalize_axis_tuple
+from ._scalar_utils import (
     _get_dtype,
     _get_queue_usm_type,
     _get_shape,
     _validate_dtype,
 )
-
-from ._numpy_helper import normalize_axis_index, normalize_axis_tuple
 from ._type_utils import (
     _resolve_one_strong_one_weak_types,
     _resolve_one_strong_two_weak_types,

--- a/dpctl/tensor/libtensor/include/kernels/sorting/isin.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/sorting/isin.hpp
@@ -1,0 +1,240 @@
+//=== isin.hpp -                                      ---*-C++-*--/===//
+//    Implementation of searching for membership in sorted array
+//
+//                      Data Parallel Control (dpctl)
+//
+// Copyright 2020-2025 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// This file defines kernels for tensor membership operations.
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <sycl/sycl.hpp>
+#include <vector>
+
+#include "kernels/dpctl_tensor_types.hpp"
+#include "kernels/sorting/search_sorted_detail.hpp"
+#include "utils/offset_utils.hpp"
+
+namespace dpctl
+{
+namespace tensor
+{
+namespace kernels
+{
+
+using dpctl::tensor::ssize_t;
+
+template <typename T,
+          typename HayIndexerT,
+          typename NeedlesIndexerT,
+          typename OutIndexerT,
+          typename Compare>
+struct IsinFunctor
+{
+private:
+    bool invert;
+    const T *hay_tp;
+    const T *needles_tp;
+    bool *out_tp;
+    std::size_t hay_nelems;
+    HayIndexerT hay_indexer;
+    NeedlesIndexerT needles_indexer;
+    OutIndexerT out_indexer;
+
+public:
+    IsinFunctor(const bool invert_,
+                const T *hay_,
+                const T *needles_,
+                bool *out_,
+                const std::size_t hay_nelems_,
+                const HayIndexerT &hay_indexer_,
+                const NeedlesIndexerT &needles_indexer_,
+                const OutIndexerT &out_indexer_)
+        : invert(invert_), hay_tp(hay_), needles_tp(needles_), out_tp(out_),
+          hay_nelems(hay_nelems_), hay_indexer(hay_indexer_),
+          needles_indexer(needles_indexer_), out_indexer(out_indexer_)
+    {
+    }
+
+    void operator()(sycl::id<1> id) const
+    {
+        const Compare comp{};
+
+        const std::size_t i = id[0];
+        const T needle_v = needles_tp[needles_indexer(i)];
+
+        // position of the needle_v in the hay array
+        std::size_t pos{};
+
+        static constexpr std::size_t zero(0);
+        // search in hay in left-closed interval, give `pos` such that
+        // hay[pos - 1] < needle_v <= hay[pos]
+
+        // lower_bound returns the first pos such that bool(hay[pos] <
+        // needle_v) is false, i.e. needle_v <= hay[pos]
+        pos = static_cast<std::size_t>(
+            search_sorted_detail::lower_bound_indexed_impl(
+                hay_tp, zero, hay_nelems, needle_v, comp, hay_indexer));
+        bool out = (pos == hay_nelems ? false : hay_tp[pos] == needle_v);
+        out_tp[out_indexer(i)] = (invert) ? !out : out;
+    }
+};
+
+typedef sycl::event (*isin_contig_impl_fp_ptr_t)(
+    sycl::queue &,
+    const bool,
+    const std::size_t,
+    const std::size_t,
+    const char *,
+    const ssize_t,
+    const char *,
+    const ssize_t,
+    char *,
+    const ssize_t,
+    const std::vector<sycl::event> &);
+
+template <typename T> class isin_contig_impl_krn;
+
+template <typename T, typename Compare>
+sycl::event isin_contig_impl(sycl::queue &exec_q,
+                             const bool invert,
+                             const std::size_t hay_nelems,
+                             const std::size_t needles_nelems,
+                             const char *hay_cp,
+                             const ssize_t hay_offset,
+                             const char *needles_cp,
+                             const ssize_t needles_offset,
+                             char *out_cp,
+                             const ssize_t out_offset,
+                             const std::vector<sycl::event> &depends)
+{
+    const T *hay_tp = reinterpret_cast<const T *>(hay_cp) + hay_offset;
+    const T *needles_tp =
+        reinterpret_cast<const T *>(needles_cp) + needles_offset;
+
+    bool *out_tp = reinterpret_cast<bool *>(out_cp) + out_offset;
+
+    sycl::event comp_ev = exec_q.submit([&](sycl::handler &cgh) {
+        cgh.depends_on(depends);
+
+        using KernelName = class isin_contig_impl_krn<T>;
+
+        sycl::range<1> gRange(needles_nelems);
+
+        using TrivialIndexerT = dpctl::tensor::offset_utils::NoOpIndexer;
+
+        constexpr TrivialIndexerT hay_indexer{};
+        constexpr TrivialIndexerT needles_indexer{};
+        constexpr TrivialIndexerT out_indexer{};
+
+        const auto fnctr =
+            IsinFunctor<T, TrivialIndexerT, TrivialIndexerT, TrivialIndexerT,
+                        Compare>(invert, hay_tp, needles_tp, out_tp, hay_nelems,
+                                 hay_indexer, needles_indexer, out_indexer);
+
+        cgh.parallel_for<KernelName>(gRange, fnctr);
+    });
+
+    return comp_ev;
+}
+
+typedef sycl::event (*isin_strided_impl_fp_ptr_t)(
+    sycl::queue &,
+    const bool,
+    const std::size_t,
+    const std::size_t,
+    const char *,
+    const ssize_t,
+    const ssize_t,
+    const char *,
+    const ssize_t,
+    char *,
+    const ssize_t,
+    int,
+    const ssize_t *,
+    const std::vector<sycl::event> &);
+
+template <typename T> class isin_strided_impl_krn;
+
+template <typename T, typename Compare>
+sycl::event isin_strided_impl(
+    sycl::queue &exec_q,
+    const bool invert,
+    const std::size_t hay_nelems,
+    const std::size_t needles_nelems,
+    const char *hay_cp,
+    const ssize_t hay_offset,
+    // hay is 1D, so hay_nelems, hay_offset, hay_stride describe strided array
+    const ssize_t hay_stride,
+    const char *needles_cp,
+    const ssize_t needles_offset,
+    char *out_cp,
+    const ssize_t out_offset,
+    const int needles_nd,
+    // packed_shape_strides is [needles_shape, needles_strides,
+    // out_strides] has length of 3*needles_nd
+    const ssize_t *packed_shape_strides,
+    const std::vector<sycl::event> &depends)
+{
+    const T *hay_tp = reinterpret_cast<const T *>(hay_cp);
+    const T *needles_tp = reinterpret_cast<const T *>(needles_cp);
+
+    bool *out_tp = reinterpret_cast<bool *>(out_cp);
+
+    sycl::event comp_ev = exec_q.submit([&](sycl::handler &cgh) {
+        cgh.depends_on(depends);
+
+        sycl::range<1> gRange(needles_nelems);
+
+        using HayIndexerT = dpctl::tensor::offset_utils::Strided1DIndexer;
+        const HayIndexerT hay_indexer(
+            /* offset */ hay_offset,
+            /* size   */ hay_nelems,
+            /* step   */ hay_stride);
+
+        using NeedlesIndexerT = dpctl::tensor::offset_utils::StridedIndexer;
+        const ssize_t *needles_shape_strides = packed_shape_strides;
+        const NeedlesIndexerT needles_indexer(needles_nd, needles_offset,
+                                              needles_shape_strides);
+        using OutIndexerT = dpctl::tensor::offset_utils::UnpackedStridedIndexer;
+
+        const ssize_t *out_shape = packed_shape_strides;
+        const ssize_t *out_strides = packed_shape_strides + 2 * needles_nd;
+        const OutIndexerT out_indexer(needles_nd, out_offset, out_shape,
+                                      out_strides);
+
+        const auto fnctr =
+            IsinFunctor<T, HayIndexerT, NeedlesIndexerT, OutIndexerT, Compare>(
+                invert, hay_tp, needles_tp, out_tp, hay_nelems, hay_indexer,
+                needles_indexer, out_indexer);
+        using KernelName = class isin_strided_impl_krn<T>;
+
+        cgh.parallel_for<KernelName>(gRange, fnctr);
+    });
+
+    return comp_ev;
+}
+
+} // namespace kernels
+} // namespace tensor
+} // namespace dpctl

--- a/dpctl/tensor/libtensor/include/kernels/sorting/isin.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/sorting/isin.hpp
@@ -78,7 +78,7 @@ public:
 
     void operator()(sycl::id<1> id) const
     {
-        const Compare comp{};
+        static constexpr Compare comp{};
 
         const std::size_t i = id[0];
         const T needle_v = needles_tp[needles_indexer(i)];

--- a/dpctl/tensor/libtensor/include/kernels/sorting/isin.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/sorting/isin.hpp
@@ -25,9 +25,7 @@
 
 #pragma once
 
-#include <algorithm>
 #include <cstddef>
-#include <cstdint>
 #include <sycl/sycl.hpp>
 #include <vector>
 
@@ -94,9 +92,8 @@ public:
 
         // lower_bound returns the first pos such that bool(hay[pos] <
         // needle_v) is false, i.e. needle_v <= hay[pos]
-        pos = static_cast<std::size_t>(
-            search_sorted_detail::lower_bound_indexed_impl(
-                hay_tp, zero, hay_nelems, needle_v, comp, hay_indexer));
+        pos = search_sorted_detail::lower_bound_indexed_impl(
+            hay_tp, zero, hay_nelems, needle_v, comp, hay_indexer);
         bool out = (pos == hay_nelems ? false : hay_tp[pos] == needle_v);
         out_tp[out_indexer(i)] = (invert) ? !out : out;
     }

--- a/dpctl/tensor/libtensor/include/kernels/sorting/isin.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/sorting/isin.hpp
@@ -143,9 +143,9 @@ sycl::event isin_contig_impl(sycl::queue &exec_q,
 
         using TrivialIndexerT = dpctl::tensor::offset_utils::NoOpIndexer;
 
-        constexpr TrivialIndexerT hay_indexer{};
-        constexpr TrivialIndexerT needles_indexer{};
-        constexpr TrivialIndexerT out_indexer{};
+        static constexpr TrivialIndexerT hay_indexer{};
+        static constexpr TrivialIndexerT needles_indexer{};
+        static constexpr TrivialIndexerT out_indexer{};
 
         const auto fnctr =
             IsinFunctor<T, TrivialIndexerT, TrivialIndexerT, TrivialIndexerT,

--- a/dpctl/tensor/libtensor/include/utils/rich_comparisons.hpp
+++ b/dpctl/tensor/libtensor/include/utils/rich_comparisons.hpp
@@ -31,7 +31,7 @@ namespace dpctl
 {
 namespace tensor
 {
-namespace py_internal
+namespace rich_comparisons
 {
 
 namespace detail
@@ -129,6 +129,6 @@ template <typename T> struct DescendingSorter<std::complex<T>>
     using type = detail::ExtendedComplexFPGreater<std::complex<T>>;
 };
 
-} // end of namespace py_internal
+} // end of namespace rich_comparisons
 } // end of namespace tensor
 } // end of namespace dpctl

--- a/dpctl/tensor/libtensor/include/utils/rich_comparisons.hpp
+++ b/dpctl/tensor/libtensor/include/utils/rich_comparisons.hpp
@@ -24,8 +24,11 @@
 
 #pragma once
 
-#include "sycl/sycl.hpp"
+#include <cmath>
+#include <complex>
 #include <type_traits>
+
+#include "sycl/sycl.hpp"
 
 namespace dpctl
 {

--- a/dpctl/tensor/libtensor/source/sorting/isin.cpp
+++ b/dpctl/tensor/libtensor/source/sorting/isin.cpp
@@ -35,7 +35,6 @@
 #include "kernels/sorting/isin.hpp"
 #include "utils/memory_overlap.hpp"
 #include "utils/output_validation.hpp"
-#include "utils/rich_comparisons.hpp"
 #include "utils/sycl_alloc_utils.hpp"
 #include "utils/type_dispatch.hpp"
 #include "utils/type_utils.hpp"
@@ -68,11 +67,7 @@ template <typename fnT, typename argTy> struct IsinContigFactory
     fnT get() const
     {
         using dpctl::tensor::kernels::isin_contig_impl;
-        using dpctl::tensor::rich_comparisons::AscendingSorter;
-
-        using Compare = typename AscendingSorter<argTy>::type;
-
-        return isin_contig_impl<argTy, Compare>;
+        return isin_contig_impl<argTy>;
     }
 };
 
@@ -88,11 +83,7 @@ template <typename fnT, typename argTy> struct IsinStridedFactory
     fnT get() const
     {
         using dpctl::tensor::kernels::isin_strided_impl;
-        using dpctl::tensor::rich_comparisons::AscendingSorter;
-
-        using Compare = typename AscendingSorter<argTy>::type;
-
-        return isin_strided_impl<argTy, Compare>;
+        return isin_strided_impl<argTy>;
     }
 };
 

--- a/dpctl/tensor/libtensor/source/sorting/isin.cpp
+++ b/dpctl/tensor/libtensor/source/sorting/isin.cpp
@@ -35,11 +35,11 @@
 #include "kernels/sorting/isin.hpp"
 #include "utils/memory_overlap.hpp"
 #include "utils/output_validation.hpp"
+#include "utils/rich_comparisons.hpp"
 #include "utils/sycl_alloc_utils.hpp"
 #include "utils/type_dispatch.hpp"
 #include "utils/type_utils.hpp"
 
-#include "rich_comparisons.hpp"
 #include "simplify_iteration_space.hpp"
 
 namespace py = pybind11;
@@ -68,7 +68,10 @@ template <typename fnT, typename argTy> struct IsinContigFactory
     fnT get() const
     {
         using dpctl::tensor::kernels::isin_contig_impl;
+        using dpctl::tensor::rich_comparisons::AscendingSorter;
+
         using Compare = typename AscendingSorter<argTy>::type;
+
         return isin_contig_impl<argTy, Compare>;
     }
 };
@@ -85,7 +88,10 @@ template <typename fnT, typename argTy> struct IsinStridedFactory
     fnT get() const
     {
         using dpctl::tensor::kernels::isin_strided_impl;
+        using dpctl::tensor::rich_comparisons::AscendingSorter;
+
         using Compare = typename AscendingSorter<argTy>::type;
+
         return isin_strided_impl<argTy, Compare>;
     }
 };

--- a/dpctl/tensor/libtensor/source/sorting/isin.cpp
+++ b/dpctl/tensor/libtensor/source/sorting/isin.cpp
@@ -1,0 +1,322 @@
+//
+//                      Data Parallel Control (dpctl)
+//
+// Copyright 2020-2025 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+//===--------------------------------------------------------------------===//
+///
+/// \file
+/// This file defines functions of dpctl.tensor._tensor_sorting_impl
+/// extension.
+//===--------------------------------------------------------------------===//
+
+#include <cstddef>
+#include <stdexcept>
+#include <sycl/sycl.hpp>
+#include <utility>
+#include <vector>
+
+#include "dpctl4pybind11.hpp"
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+
+#include "kernels/sorting/isin.hpp"
+#include "utils/memory_overlap.hpp"
+#include "utils/output_validation.hpp"
+#include "utils/sycl_alloc_utils.hpp"
+#include "utils/type_dispatch.hpp"
+#include "utils/type_utils.hpp"
+
+#include "rich_comparisons.hpp"
+#include "simplify_iteration_space.hpp"
+
+namespace py = pybind11;
+namespace td_ns = dpctl::tensor::type_dispatch;
+namespace tu_ns = dpctl::tensor::type_utils;
+
+namespace dpctl
+{
+namespace tensor
+{
+namespace py_internal
+{
+
+namespace detail
+{
+
+using dpctl::tensor::kernels::isin_contig_impl_fp_ptr_t;
+
+static isin_contig_impl_fp_ptr_t
+    isin_contig_impl_dispatch_vector[td_ns::num_types];
+
+template <typename fnT, typename argTy> struct IsinContigFactory
+{
+    constexpr IsinContigFactory() {}
+
+    fnT get() const
+    {
+        using dpctl::tensor::kernels::isin_contig_impl;
+        using Compare = typename AscendingSorter<argTy>::type;
+        return isin_contig_impl<argTy, Compare>;
+    }
+};
+
+using dpctl::tensor::kernels::isin_strided_impl_fp_ptr_t;
+
+static isin_strided_impl_fp_ptr_t
+    isin_strided_impl_dispatch_vector[td_ns::num_types];
+
+template <typename fnT, typename argTy> struct IsinStridedFactory
+{
+    constexpr IsinStridedFactory() {}
+
+    fnT get() const
+    {
+        using dpctl::tensor::kernels::isin_strided_impl;
+        using Compare = typename AscendingSorter<argTy>::type;
+        return isin_strided_impl<argTy, Compare>;
+    }
+};
+
+void init_isin_dispatch_vector(void)
+{
+
+    // Contiguous input function dispatch
+    td_ns::DispatchVectorBuilder<isin_contig_impl_fp_ptr_t, IsinContigFactory,
+                                 td_ns::num_types>
+        dvb1;
+    dvb1.populate_dispatch_vector(isin_contig_impl_dispatch_vector);
+
+    // Strided input function dispatch
+    td_ns::DispatchVectorBuilder<isin_strided_impl_fp_ptr_t, IsinStridedFactory,
+                                 td_ns::num_types>
+        dvb2;
+    dvb2.populate_dispatch_vector(isin_strided_impl_dispatch_vector);
+}
+
+} // namespace detail
+
+/*! @brief search for needle from needles in sorted hay */
+std::pair<sycl::event, sycl::event>
+py_isin(const dpctl::tensor::usm_ndarray &needles,
+        const dpctl::tensor::usm_ndarray &hay,
+        const dpctl::tensor::usm_ndarray &dst,
+        sycl::queue &exec_q,
+        const bool invert,
+        const std::vector<sycl::event> &depends)
+{
+    const int hay_nd = hay.get_ndim();
+    const int needles_nd = needles.get_ndim();
+    const int dst_nd = dst.get_ndim();
+
+    if (hay_nd != 1 || needles_nd != dst_nd) {
+        throw py::value_error("Array dimensions mismatch");
+    }
+
+    // check that needle and dst have the same shape
+    std::size_t needles_nelems(1);
+    bool same_shape(true);
+
+    const std::size_t hay_nelems = static_cast<std::size_t>(hay.get_shape(0));
+
+    const py::ssize_t *needles_shape_ptr = needles.get_shape_raw();
+    const py::ssize_t *dst_shape_ptr = needles.get_shape_raw();
+
+    for (int i = 0; (i < needles_nd) && same_shape; ++i) {
+        const auto needles_sh_i = needles_shape_ptr[i];
+        const auto dst_sh_i = dst_shape_ptr[i];
+
+        same_shape = same_shape && (needles_sh_i == dst_sh_i);
+        needles_nelems *= static_cast<std::size_t>(needles_sh_i);
+    }
+
+    if (!same_shape) {
+        throw py::value_error(
+            "Array of values to search for and array of their "
+            "dst do not have the same shape");
+    }
+
+    // check that dst is ample enough
+    dpctl::tensor::validation::AmpleMemory::throw_if_not_ample(dst,
+                                                               needles_nelems);
+
+    // check that dst is writable
+    dpctl::tensor::validation::CheckWritable::throw_if_not_writable(dst);
+
+    // check that queues are compatible
+    if (!dpctl::utils::queues_are_compatible(exec_q, {hay, needles, dst})) {
+        throw py::value_error(
+            "Execution queue is not compatible with allocation queues");
+    }
+
+    // if output array overlaps with input arrays, race condition results
+    auto const &overlap = dpctl::tensor::overlap::MemoryOverlap();
+    if (overlap(dst, hay) || overlap(dst, needles)) {
+        throw py::value_error("Destination array overlaps with input.");
+    }
+
+    const int hay_typenum = hay.get_typenum();
+    const int needles_typenum = needles.get_typenum();
+    const int dst_typenum = dst.get_typenum();
+
+    auto const &array_types = td_ns::usm_ndarray_types();
+    const int hay_typeid = array_types.typenum_to_lookup_id(hay_typenum);
+    const int needles_typeid =
+        array_types.typenum_to_lookup_id(needles_typenum);
+    const int dst_typeid = array_types.typenum_to_lookup_id(dst_typenum);
+
+    // check hay and needle have the same data-type
+    if (needles_typeid != hay_typeid) {
+        throw py::value_error(
+            "Hay array and needles array must have the same data types");
+    }
+    // check that dst has boolean data type
+    const auto dst_typenum_t_v = static_cast<td_ns::typenum_t>(dst_typeid);
+    if (dst_typenum_t_v != td_ns::typenum_t::BOOL) {
+        throw py::value_error("dst array must have data-type bool");
+    }
+
+    if (needles_nelems == 0) {
+        // Nothing to do
+        return std::make_pair(sycl::event{}, sycl::event{});
+    }
+
+    // if all inputs are contiguous call contiguous implementations
+    // otherwise call strided implementation
+    const bool hay_is_c_contig = hay.is_c_contiguous();
+    const bool hay_is_f_contig = hay.is_f_contiguous();
+
+    const bool needles_is_c_contig = needles.is_c_contiguous();
+    const bool needles_is_f_contig = needles.is_f_contiguous();
+
+    const bool dst_is_c_contig = dst.is_c_contiguous();
+    const bool dst_is_f_contig = dst.is_f_contiguous();
+
+    const bool all_c_contig =
+        (hay_is_c_contig && needles_is_c_contig && dst_is_c_contig);
+    const bool all_f_contig =
+        (hay_is_f_contig && needles_is_f_contig && dst_is_f_contig);
+
+    const char *hay_data = hay.get_data();
+    const char *needles_data = needles.get_data();
+
+    char *dst_data = dst.get_data();
+
+    if (all_c_contig || all_f_contig) {
+        auto fn = detail::isin_contig_impl_dispatch_vector[hay_typeid];
+
+        constexpr py::ssize_t zero_offset(0);
+
+        sycl::event comp_ev = fn(exec_q, invert, hay_nelems, needles_nelems,
+                                 hay_data, zero_offset, needles_data,
+                                 zero_offset, dst_data, zero_offset, depends);
+
+        return std::make_pair(dpctl::utils::keep_args_alive(
+                                  exec_q, {hay, needles, dst}, {comp_ev}),
+                              comp_ev);
+    }
+
+    // strided case
+
+    const auto &needles_strides = needles.get_strides_vector();
+    const auto &dst_strides = dst.get_strides_vector();
+
+    int simplified_nd = needles_nd;
+
+    using shT = std::vector<py::ssize_t>;
+    shT simplified_common_shape;
+    shT simplified_needles_strides;
+    shT simplified_dst_strides;
+    py::ssize_t needles_offset(0);
+    py::ssize_t dst_offset(0);
+
+    if (simplified_nd == 0) {
+        // needles and dst have same nd
+        simplified_nd = 1;
+        simplified_common_shape.push_back(1);
+        simplified_needles_strides.push_back(0);
+        simplified_dst_strides.push_back(0);
+    }
+    else {
+        dpctl::tensor::py_internal::simplify_iteration_space(
+            // modified by refernce
+            simplified_nd,
+            // read-only inputs
+            needles_shape_ptr, needles_strides, dst_strides,
+            // output, modified by reference
+            simplified_common_shape, simplified_needles_strides,
+            simplified_dst_strides, needles_offset, dst_offset);
+    }
+    std::vector<sycl::event> host_task_events;
+    host_task_events.reserve(2);
+
+    using dpctl::tensor::offset_utils::device_allocate_and_pack;
+
+    auto ptr_size_event_tuple = device_allocate_and_pack<py::ssize_t>(
+        exec_q, host_task_events,
+        // vectors being packed
+        simplified_common_shape, simplified_needles_strides,
+        simplified_dst_strides);
+    auto packed_shape_strides_owner =
+        std::move(std::get<0>(ptr_size_event_tuple));
+    const sycl::event &copy_shape_strides_ev =
+        std::get<2>(ptr_size_event_tuple);
+    const py::ssize_t *packed_shape_strides = packed_shape_strides_owner.get();
+
+    std::vector<sycl::event> all_deps;
+    all_deps.reserve(depends.size() + 1);
+    all_deps.insert(all_deps.end(), depends.begin(), depends.end());
+    all_deps.push_back(copy_shape_strides_ev);
+
+    auto strided_fn = detail::isin_strided_impl_dispatch_vector[hay_typeid];
+
+    if (!strided_fn) {
+        throw std::runtime_error(
+            "No implementation for data types of input arrays");
+    }
+
+    constexpr py::ssize_t zero_offset(0);
+    py::ssize_t hay_step = hay.get_strides_vector()[0];
+
+    const sycl::event &comp_ev = strided_fn(
+        exec_q, invert, hay_nelems, needles_nelems, hay_data, zero_offset,
+        hay_step, needles_data, needles_offset, dst_data, dst_offset,
+        simplified_nd, packed_shape_strides, all_deps);
+
+    // free packed temporaries
+    sycl::event temporaries_cleanup_ev =
+        dpctl::tensor::alloc_utils::async_smart_free(
+            exec_q, {comp_ev}, packed_shape_strides_owner);
+
+    host_task_events.push_back(temporaries_cleanup_ev);
+    const sycl::event &ht_ev = dpctl::utils::keep_args_alive(
+        exec_q, {hay, needles, dst}, host_task_events);
+
+    return std::make_pair(ht_ev, comp_ev);
+}
+
+void init_isin_functions(py::module_ m)
+{
+    dpctl::tensor::py_internal::detail::init_isin_dispatch_vector();
+
+    using dpctl::tensor::py_internal::py_isin;
+    m.def("_isin", &py_isin, py::arg("needles"), py::arg("hay"), py::arg("dst"),
+          py::arg("sycl_queue"), py::arg("invert"),
+          py::arg("depends") = py::list());
+}
+
+} // end of namespace py_internal
+} // end of namespace tensor
+} // namespace dpctl

--- a/dpctl/tensor/libtensor/source/sorting/isin.cpp
+++ b/dpctl/tensor/libtensor/source/sorting/isin.cpp
@@ -217,7 +217,7 @@ py_isin(const dpctl::tensor::usm_ndarray &needles,
     if (all_c_contig || all_f_contig) {
         auto fn = detail::isin_contig_impl_dispatch_vector[hay_typeid];
 
-        constexpr py::ssize_t zero_offset(0);
+        static constexpr py::ssize_t zero_offset(0);
 
         sycl::event comp_ev = fn(exec_q, invert, hay_nelems, needles_nelems,
                                  hay_data, zero_offset, needles_data,
@@ -287,7 +287,7 @@ py_isin(const dpctl::tensor::usm_ndarray &needles,
             "No implementation for data types of input arrays");
     }
 
-    constexpr py::ssize_t zero_offset(0);
+    static constexpr py::ssize_t zero_offset(0);
     py::ssize_t hay_step = hay.get_strides_vector()[0];
 
     const sycl::event &comp_ev = strided_fn(

--- a/dpctl/tensor/libtensor/source/sorting/isin.hpp
+++ b/dpctl/tensor/libtensor/source/sorting/isin.hpp
@@ -1,0 +1,42 @@
+//
+//                      Data Parallel Control (dpctl)
+//
+// Copyright 2020-2025 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+//===--------------------------------------------------------------------===//
+///
+/// \file
+/// This file defines functions of dpctl.tensor._tensor_sorting_impl
+/// extension.
+//===--------------------------------------------------------------------===//
+
+#pragma once
+
+#include <pybind11/pybind11.h>
+
+namespace py = pybind11;
+
+namespace dpctl
+{
+namespace tensor
+{
+namespace py_internal
+{
+
+extern void init_isin_functions(py::module_ m);
+
+} // namespace py_internal
+} // namespace tensor
+} // namespace dpctl

--- a/dpctl/tensor/libtensor/source/sorting/merge_argsort.cpp
+++ b/dpctl/tensor/libtensor/source/sorting/merge_argsort.cpp
@@ -30,11 +30,11 @@
 #include "utils/math_utils.hpp"
 #include "utils/memory_overlap.hpp"
 #include "utils/output_validation.hpp"
+#include "utils/rich_comparisons.hpp"
 #include "utils/type_dispatch.hpp"
 
 #include "kernels/sorting/merge_sort.hpp"
 #include "kernels/sorting/sort_impl_fn_ptr_t.hpp"
-#include "rich_comparisons.hpp"
 
 #include "merge_argsort.hpp"
 #include "py_argsort_common.hpp"
@@ -63,6 +63,7 @@ struct AscendingArgSortContigFactory
         if constexpr (std::is_same_v<IndexTy, std::int64_t> ||
                       std::is_same_v<IndexTy, std::int32_t>)
         {
+            using dpctl::tensor::rich_comparisons::AscendingSorter;
             using Comp = typename AscendingSorter<argTy>::type;
 
             using dpctl::tensor::kernels::stable_argsort_axis1_contig_impl;
@@ -82,6 +83,7 @@ struct DescendingArgSortContigFactory
         if constexpr (std::is_same_v<IndexTy, std::int64_t> ||
                       std::is_same_v<IndexTy, std::int32_t>)
         {
+            using dpctl::tensor::rich_comparisons::DescendingSorter;
             using Comp = typename DescendingSorter<argTy>::type;
 
             using dpctl::tensor::kernels::stable_argsort_axis1_contig_impl;

--- a/dpctl/tensor/libtensor/source/sorting/merge_sort.cpp
+++ b/dpctl/tensor/libtensor/source/sorting/merge_sort.cpp
@@ -31,6 +31,7 @@
 #include "utils/math_utils.hpp"
 #include "utils/memory_overlap.hpp"
 #include "utils/output_validation.hpp"
+#include "utils/rich_comparisons.hpp"
 #include "utils/type_dispatch.hpp"
 
 #include "kernels/sorting/merge_sort.hpp"
@@ -38,7 +39,6 @@
 
 #include "merge_sort.hpp"
 #include "py_sort_common.hpp"
-#include "rich_comparisons.hpp"
 
 namespace td_ns = dpctl::tensor::type_dispatch;
 
@@ -59,6 +59,7 @@ template <typename fnT, typename argTy> struct AscendingSortContigFactory
 {
     fnT get()
     {
+        using dpctl::tensor::rich_comparisons::AscendingSorter;
         using Comp = typename AscendingSorter<argTy>::type;
 
         using dpctl::tensor::kernels::stable_sort_axis1_contig_impl;
@@ -70,7 +71,9 @@ template <typename fnT, typename argTy> struct DescendingSortContigFactory
 {
     fnT get()
     {
+        using dpctl::tensor::rich_comparisons::DescendingSorter;
         using Comp = typename DescendingSorter<argTy>::type;
+
         using dpctl::tensor::kernels::stable_sort_axis1_contig_impl;
         return stable_sort_axis1_contig_impl<argTy, Comp>;
     }

--- a/dpctl/tensor/libtensor/source/sorting/searchsorted.cpp
+++ b/dpctl/tensor/libtensor/source/sorting/searchsorted.cpp
@@ -35,11 +35,11 @@
 #include "kernels/sorting/searchsorted.hpp"
 #include "utils/memory_overlap.hpp"
 #include "utils/output_validation.hpp"
+#include "utils/rich_comparisons.hpp"
 #include "utils/sycl_alloc_utils.hpp"
 #include "utils/type_dispatch.hpp"
 #include "utils/type_utils.hpp"
 
-#include "rich_comparisons.hpp"
 #include "simplify_iteration_space.hpp"
 
 namespace py = pybind11;
@@ -76,6 +76,7 @@ struct LeftSideSearchSortedContigFactory
         {
             static constexpr bool left_side_search(true);
             using dpctl::tensor::kernels::searchsorted_contig_impl;
+            using dpctl::tensor::rich_comparisons::AscendingSorter;
 
             using Compare = typename AscendingSorter<argTy>::type;
 
@@ -99,7 +100,9 @@ struct RightSideSearchSortedContigFactory
                       std::is_same_v<indTy, std::int64_t>)
         {
             static constexpr bool right_side_search(false);
+
             using dpctl::tensor::kernels::searchsorted_contig_impl;
+            using dpctl::tensor::rich_comparisons::AscendingSorter;
 
             using Compare = typename AscendingSorter<argTy>::type;
 
@@ -132,6 +135,7 @@ struct LeftSideSearchSortedStridedFactory
         {
             static constexpr bool left_side_search(true);
             using dpctl::tensor::kernels::searchsorted_strided_impl;
+            using dpctl::tensor::rich_comparisons::AscendingSorter;
 
             using Compare = typename AscendingSorter<argTy>::type;
 
@@ -156,6 +160,7 @@ struct RightSideSearchSortedStridedFactory
         {
             static constexpr bool right_side_search(false);
             using dpctl::tensor::kernels::searchsorted_strided_impl;
+            using dpctl::tensor::rich_comparisons::AscendingSorter;
 
             using Compare = typename AscendingSorter<argTy>::type;
 

--- a/dpctl/tensor/libtensor/source/sorting/topk.cpp
+++ b/dpctl/tensor/libtensor/source/sorting/topk.cpp
@@ -41,10 +41,10 @@
 #include "utils/math_utils.hpp"
 #include "utils/memory_overlap.hpp"
 #include "utils/output_validation.hpp"
+#include "utils/rich_comparisons.hpp"
 #include "utils/type_dispatch.hpp"
 #include "utils/type_utils.hpp"
 
-#include "rich_comparisons.hpp"
 #include "topk.hpp"
 
 namespace dpctl
@@ -110,15 +110,16 @@ sycl::event topk_caller(sycl::queue &exec_q,
         using dpctl::tensor::kernels::topk_merge_impl;
         if (largest) {
             using CompTy =
-                typename dpctl::tensor::py_internal::DescendingSorter<
+                typename dpctl::tensor::rich_comparisons::DescendingSorter<
                     argTy>::type;
             return topk_merge_impl<argTy, IndexTy, CompTy>(
                 exec_q, iter_nelems, axis_nelems, k, arg_cp, vals_cp, inds_cp,
                 depends);
         }
         else {
-            using CompTy = typename dpctl::tensor::py_internal::AscendingSorter<
-                argTy>::type;
+            using CompTy =
+                typename dpctl::tensor::rich_comparisons::AscendingSorter<
+                    argTy>::type;
             return topk_merge_impl<argTy, IndexTy, CompTy>(
                 exec_q, iter_nelems, axis_nelems, k, arg_cp, vals_cp, inds_cp,
                 depends);

--- a/dpctl/tensor/libtensor/source/tensor_sorting.cpp
+++ b/dpctl/tensor/libtensor/source/tensor_sorting.cpp
@@ -25,6 +25,7 @@
 
 #include <pybind11/pybind11.h>
 
+#include "sorting/isin.hpp"
 #include "sorting/merge_argsort.hpp"
 #include "sorting/merge_sort.hpp"
 #include "sorting/radix_argsort.hpp"
@@ -36,6 +37,7 @@ namespace py = pybind11;
 
 PYBIND11_MODULE(_tensor_sorting_impl, m)
 {
+    dpctl::tensor::py_internal::init_isin_functions(m);
     dpctl::tensor::py_internal::init_merge_sort_functions(m);
     dpctl::tensor::py_internal::init_merge_argsort_functions(m);
     dpctl::tensor::py_internal::init_searchsorted_functions(m);

--- a/dpctl/tests/test_tensor_isin.py
+++ b/dpctl/tests/test_tensor_isin.py
@@ -142,6 +142,35 @@ def test_isin_strided_bool():
     assert r2.shape == x_s.shape
 
 
+@pytest.mark.parametrize("dt1", _numeric_dtypes)
+@pytest.mark.parametrize("dt2", _numeric_dtypes)
+def test_isin_dtype_matrix(dt1, dt2):
+    q = get_queue_or_skip()
+    skip_if_dtype_not_supported(dt1, q)
+    skip_if_dtype_not_supported(dt2, q)
+
+    sz = 10
+    x = dpt.asarray([0, 1, 11], dtype=dt1, sycl_queue=q)
+    test1 = dpt.arange(sz, dtype=dt2, sycl_queue=q)
+
+    r1 = dpt.isin(x, test1)
+    assert isinstance(r1, dpt.usm_ndarray)
+    assert r1.dtype == dpt.bool
+    assert r1.shape == x.shape
+    assert not r1[-1]
+    assert dpt.all(r1[0:-1])
+    assert r1.sycl_queue == x.sycl_queue
+
+    test2 = dpt.tile(dpt.asarray([[0, 1]], dtype=dt2, sycl_queue=q).mT, 2)
+    r2 = dpt.isin(x, test2)
+    assert isinstance(r2, dpt.usm_ndarray)
+    assert r2.dtype == dpt.bool
+    assert r2.shape == x.shape
+    assert not r2[-1]
+    assert dpt.all(r1[0:-1])
+    assert r2.sycl_queue == x.sycl_queue
+
+
 def test_isin_empty_inputs():
     get_queue_or_skip()
 

--- a/dpctl/tests/test_tensor_isin.py
+++ b/dpctl/tests/test_tensor_isin.py
@@ -246,3 +246,13 @@ def test_isin_py_scalars(dt):
         assert isinstance(r1, dpt.usm_ndarray)
         r2 = dpt.isin(sc, x)
         assert isinstance(r2, dpt.usm_ndarray)
+
+
+def test_isin_compute_follows_data():
+    q1 = get_queue_or_skip()
+    q2 = get_queue_or_skip()
+
+    x = dpt.ones(10, sycl_queue=q1)
+    test = dpt.ones_like(x, sycl_queue=q2)
+    with pytest.raises(ExecutionPlacementError):
+        dpt.isin(x, test)

--- a/dpctl/tests/test_tensor_isin.py
+++ b/dpctl/tests/test_tensor_isin.py
@@ -1,0 +1,168 @@
+#                      Data Parallel Control (dpctl)
+#
+# Copyright 2020-2025 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+import dpctl.tensor as dpt
+from dpctl.tests.helper import get_queue_or_skip, skip_if_dtype_not_supported
+from dpctl.utils import ExecutionPlacementError
+
+
+@pytest.mark.parametrize(
+    "dtype",
+    [
+        "i1",
+        "u1",
+        "i2",
+        "u2",
+        "i4",
+        "u4",
+        "i8",
+        "u8",
+        "f2",
+        "f4",
+        "f8",
+        "c8",
+        "c16",
+    ],
+)
+def test_isin_basic(dtype):
+    q = get_queue_or_skip()
+    skip_if_dtype_not_supported(dtype, q)
+
+    n = 100
+    x = dpt.arange(n, dtype=dtype)
+    test = dpt.arange(n - 1, dtype=dtype)
+    r1 = dpt.isin(x, test)
+    assert dpt.all(r1[:-1])
+    assert not r1[-1]
+    assert r1.shape == x.shape
+
+    # test with invert keyword
+    r2 = dpt.isin(x, test, invert=True)
+    assert not dpt.all(r2[:-1])
+    assert r2[-1]
+    assert r2.shape == x.shape
+
+
+def test_isin_basic_bool():
+    dt = dpt.bool
+    n = 100
+    x = dpt.zeros(n, dtype=dt)
+    x[-1] = True
+    test = dpt.zeros((), dtype=dt)
+    r1 = dpt.isin(x, test)
+    assert dpt.all(r1[:-1])
+    assert not r1[-1]
+    assert r1.shape == x.shape
+
+    r2 = dpt.isin(x, test, invert=True)
+    assert not dpt.all(r2[:-1])
+    assert r2[-1]
+    assert r2.shape == x.shape
+
+
+@pytest.mark.parametrize(
+    "dtype",
+    [
+        "i1",
+        "u1",
+        "i2",
+        "u2",
+        "i4",
+        "u4",
+        "i8",
+        "u8",
+        "f2",
+        "f4",
+        "f8",
+        "c8",
+        "c16",
+    ],
+)
+def test_isin_strided(dtype):
+    q = get_queue_or_skip()
+    skip_if_dtype_not_supported(dtype, q)
+
+    n, m = 100, 20
+    x = dpt.zeros((n, m), dtype=dtype, order="F")
+    x[:, ::2] = dpt.arange(1, (m / 2) + 1, dtype=dtype)
+    test = dpt.arange(1, (m / 2) + 1, dtype=dtype)
+    r1 = dpt.isin(x, test)
+    assert dpt.all(r1[:, ::2])
+    assert not dpt.all(r1[:, 1::2])
+    assert r1.shape == x.shape
+
+    # test with invert keyword
+    r2 = dpt.isin(x, test, invert=True)
+    assert not dpt.all(r2[:, ::2])
+    assert dpt.all(r2[:, 1::2])
+    assert r2.shape == x.shape
+
+
+def test_isin_strided_bool():
+    dt = dpt.bool
+    n, m = 100, 20
+    x = dpt.ones((n, m), dtype=dt, order="F")
+    x[:, ::2] = False
+    test = dpt.zeros((), dtype=dt)
+    r1 = dpt.isin(x, test)
+    assert dpt.all(r1[:, ::2])
+    assert not dpt.all(r1[:, 1::2])
+    assert r1.shape == x.shape
+
+    # test with invert keyword
+    r2 = dpt.isin(x, test, invert=True)
+    assert not dpt.all(r2[:, ::2])
+    assert dpt.all(r2[:, 1::2])
+    assert r2.shape == x.shape
+
+
+def test_isin_empty_inputs():
+    get_queue_or_skip()
+
+    x = dpt.ones((10, 0, 1), dtype="i4")
+    test = dpt.ones((), dtype="i4")
+    res1 = dpt.isin(x, test)
+    assert isinstance(res1, dpt.usm_ndarray)
+    assert res1.size == 0
+    assert res1.shape == x.shape
+    assert res1.dtype == dpt.bool
+
+    res2 = dpt.isin(x, test, invert=True)
+    assert isinstance(res2, dpt.usm_ndarray)
+    assert res2.size == 0
+    assert res2.shape == x.shape
+    assert res2.dtype == dpt.bool
+
+    x = dpt.ones((3, 3), dtype="i4")
+    test = dpt.ones(0, dtype="i4")
+    res3 = dpt.isin(x, test)
+    assert isinstance(res3, dpt.usm_ndarray)
+    assert res3.shape == x.shape
+    assert res3.dtype == dpt.bool
+    assert not dpt.all(res3)
+
+    res4 = dpt.isin(x, test, invert=True)
+    assert isinstance(res4, dpt.usm_ndarray)
+    assert res4.shape == x.shape
+    assert res4.dtype == dpt.bool
+    assert dpt.all(res4)
+
+
+def test_isin_validation():
+    with pytest.raises(ExecutionPlacementError):
+        dpt.isin(1, 1)

--- a/dpctl/tests/test_tensor_isin.py
+++ b/dpctl/tests/test_tensor_isin.py
@@ -212,7 +212,7 @@ def test_isin_validation():
     with pytest.raises(ExecutionPlacementError):
         dpt.isin(1, 1)
     not_bool = dict()
-    with pytest.raises(ValueError):
+    with pytest.raises(TypeError):
         dpt.isin(dpt.ones([1]), dpt.ones([1]), invert=not_bool)
 
 

--- a/dpctl/tests/test_tensor_isin.py
+++ b/dpctl/tests/test_tensor_isin.py
@@ -173,3 +173,22 @@ def test_isin_empty_inputs():
 def test_isin_validation():
     with pytest.raises(ExecutionPlacementError):
         dpt.isin(1, 1)
+
+
+def test_isin_special_floating_point_vals():
+    get_queue_or_skip()
+
+    # real and complex nans compare false
+    x = dpt.asarray(dpt.nan, dtype="f4")
+    test = dpt.asarray(dpt.nan, dtype="f4")
+    assert not dpt.isin(x, test)
+
+    x = dpt.asarray(dpt.nan, dtype="c8")
+    test = dpt.asarray(dpt.nan, dtype="c8")
+    assert not dpt.isin(x, test)
+
+    # -0.0 compares equal to +0.0
+    x = dpt.asarray(-0.0, dtype="f4")
+    test = dpt.asarray(0.0, dtype="f4")
+    assert dpt.isin(x, test)
+    assert dpt.isin(test, x)

--- a/dpctl/tests/test_tensor_isin.py
+++ b/dpctl/tests/test_tensor_isin.py
@@ -111,6 +111,7 @@ def test_isin_strided(dtype):
     assert not dpt.any(r1[:, -1])
     assert not dpt.any(x[:, 1::2])
     assert r1.shape == x_s.shape
+    assert r1.flags.c_contiguous
 
     # test with invert keyword
     r2 = dpt.isin(x_s, test, invert=True)
@@ -118,6 +119,7 @@ def test_isin_strided(dtype):
     assert dpt.all(r2[:, -1])
     assert not dpt.any(x[:, 1:2])
     assert r2.shape == x_s.shape
+    assert r2.flags.c_contiguous
 
 
 def test_isin_strided_bool():
@@ -133,6 +135,7 @@ def test_isin_strided_bool():
     assert not dpt.any(r1[:, -1])
     assert not dpt.any(x[:, 1::2])
     assert r1.shape == x_s.shape
+    assert r1.flags.c_contiguous
 
     # test with invert keyword
     r2 = dpt.isin(x_s, test, invert=True)
@@ -140,6 +143,7 @@ def test_isin_strided_bool():
     assert dpt.all(r2[:, -1])
     assert not dpt.any(x[:, 1:2])
     assert r2.shape == x_s.shape
+    assert r2.flags.c_contiguous
 
 
 @pytest.mark.parametrize("dt1", _numeric_dtypes)

--- a/dpctl/tests/test_tensor_isin.py
+++ b/dpctl/tests/test_tensor_isin.py
@@ -208,8 +208,12 @@ def test_isin_empty_inputs():
 
 
 def test_isin_validation():
+    get_queue_or_skip()
     with pytest.raises(ExecutionPlacementError):
         dpt.isin(1, 1)
+    not_bool = dict()
+    with pytest.raises(ValueError):
+        dpt.isin(dpt.ones([1]), dpt.ones([1]), invert=not_bool)
 
 
 def test_isin_special_floating_point_vals():


### PR DESCRIPTION
This PR proposes an implementation for `isin`, a function likely coming to a future array API specification, which leverages a similar kernel to the implementation of `searchsorted`

This implementation uses the `searchsorted` kernel to check if the value has a position in the array. If that position is the number of elements in the array, it is not a member. Otherwise, if `arr[pos] == val` for some array `arr` being searched for value `val`, then `val` is a member.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [ ] Have you added your changes to the changelog?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
