### PR TITLE
Backport gh-2095

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.20.1] - Jun. 06, 2025
+
+### Fixed
+
+* Fixed missing event dependencies in roll and reshape Python bindings for size-1 input arrays [gh-2095](https://github.com/IntelPython/dpctl/pull/2095)
+
 ## [0.20.0] - Jun. 03, 2025
 
 This release achieves compliance of `dpctl.tensor` with the Python Array API 2024.12 standard.

--- a/dpctl/tensor/libtensor/source/copy_for_reshape.cpp
+++ b/dpctl/tensor/libtensor/source/copy_for_reshape.cpp
@@ -108,7 +108,7 @@ copy_usm_ndarray_for_reshape(const dpctl::tensor::usm_ndarray &src,
         const char *src_data = src.get_data();
         char *dst_data = dst.get_data();
         sycl::event copy_ev =
-            exec_q.copy<char>(src_data, dst_data, src_elemsize);
+            exec_q.copy<char>(src_data, dst_data, src_elemsize, depends);
         return std::make_pair(keep_args_alive(exec_q, {src, dst}, {copy_ev}),
                               copy_ev);
     }

--- a/dpctl/tensor/libtensor/source/copy_for_roll.cpp
+++ b/dpctl/tensor/libtensor/source/copy_for_roll.cpp
@@ -132,7 +132,7 @@ copy_usm_ndarray_for_roll_1d(const dpctl::tensor::usm_ndarray &src,
         const char *src_data = src.get_data();
         char *dst_data = dst.get_data();
         sycl::event copy_ev =
-            exec_q.copy<char>(src_data, dst_data, src_elemsize);
+            exec_q.copy<char>(src_data, dst_data, src_elemsize, depends);
         return std::make_pair(keep_args_alive(exec_q, {src, dst}, {copy_ev}),
                               copy_ev);
     }
@@ -282,7 +282,7 @@ copy_usm_ndarray_for_roll_nd(const dpctl::tensor::usm_ndarray &src,
     // typenames must be the same
     if (src_typenum != dst_typenum) {
         throw py::value_error(
-            "copy_usm_ndarray_for_reshape requires src and dst to "
+            "copy_usm_ndarray_for_roll_nd requires src and dst to "
             "have the same type.");
     }
 
@@ -304,7 +304,7 @@ copy_usm_ndarray_for_roll_nd(const dpctl::tensor::usm_ndarray &src,
         const char *src_data = src.get_data();
         char *dst_data = dst.get_data();
         sycl::event copy_ev =
-            exec_q.copy<char>(src_data, dst_data, src_elemsize);
+            exec_q.copy<char>(src_data, dst_data, src_elemsize, depends);
         return std::make_pair(keep_args_alive(exec_q, {src, dst}, {copy_ev}),
                               copy_ev);
     }


### PR DESCRIPTION
This PR backports the fix in gh-2095 to maintenance/0.20.x and adds 0.20.1 to the changelog, in preparation for an out of cycle release

- [X] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [ ] Have you added your changes to the changelog?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
