### PR TITLE
Extend build_locally.py with `--target-cuda` and `--target-hip` arguments

### DIFF
--- a/docs/doc_sources/beginners_guides/installation.rst
+++ b/docs/doc_sources/beginners_guides/installation.rst
@@ -192,12 +192,11 @@ Compute Capabilities can be found in the official
 AMD build
 ~~~~~~~~~
 
-``dpctl`` can be built for AMD devices using the ``DPCTL_TARGET_HIP`` CMake option,
-which requires specifying a compute architecture string:
+``dpctl`` can be built for AMD devices using the  ``--target-hip`` argument.
 
 .. code-block:: bash
 
-    python scripts/build_locally.py --verbose --cmake-opts="-DDPCTL_TARGET_HIP=<arch>"
+    python scripts/build_locally.py --verbose --target-hip=<arch>
 
 Note that the `oneAPI for AMD GPUs` plugin requires the architecture be specified and only
 one architecture can be specified at a time.
@@ -208,12 +207,12 @@ To determine the architecture code (``<arch>``) for your AMD GPU, run:
     rocminfo | grep 'Name: *gfx.*'
 
 This will print names like ``gfx90a``, ``gfx1030``, etc.
-You can then use one of them as the argument to ``-DDPCTL_TARGET_HIP``.
+You can then use one of them as the argument to ``--target-hip``.
 
 For example:
 
 .. code-block:: bash
-    python scripts/build_locally.py --verbose --cmake-opts="-DDPCTL_TARGET_HIP=gfx1030"
+    python scripts/build_locally.py --verbose --target-hip=gfx1030
 
 Multi-target build
 ~~~~~~~~~~~~~~~~~~
@@ -225,7 +224,7 @@ devices at the same time:
 
 .. code-block:: bash
 
-    python scripts/build_locally.py --verbose --target-cuda --cmake-opts="-DDPCTL_TARGET_HIP=gfx1030"
+    python scripts/build_locally.py --verbose --target-cuda --target-hip=gfx1030
 
 Running Examples and Tests
 ==========================

--- a/docs/doc_sources/beginners_guides/installation.rst
+++ b/docs/doc_sources/beginners_guides/installation.rst
@@ -166,19 +166,19 @@ A full list of available SYCL alias targets is available in the
 CUDA build
 ~~~~~~~~~~
 
-``dpctl`` can be built for CUDA devices using the ``DPCTL_TARGET_CUDA`` CMake option,
-which accepts a specific compute architecture string:
+``dpctl`` can be built for CUDA devices using the  ``--target-cuda`` argument.
+
+To target a specific architecture (e.g., ``sm_80``):
 
 .. code-block:: bash
 
-    python scripts/build_locally.py --verbose --cmake-opts="-DDPCTL_TARGET_CUDA=sm_80"
+    python scripts/build_locally.py --verbose --target-cuda=sm_80
 
-To use the default architecture (``sm_50``),
-set ``DPCTL_TARGET_CUDA`` to a value such as ``ON``, ``TRUE``, ``YES``, ``Y``, or ``1``:
+To use the default architecture (``sm_50``), omit the value:
 
 .. code-block:: bash
 
-    python scripts/build_locally.py --verbose --cmake-opts="-DDPCTL_TARGET_CUDA=ON"
+    python scripts/build_locally.py --verbose --target-cuda
 
 Note that kernels are built for the default architecture (``sm_50``), allowing them to work on a
 wider range of architectures, but limiting the usage of more recent CUDA features.
@@ -225,8 +225,7 @@ devices at the same time:
 
 .. code-block:: bash
 
-    python scripts/build_locally.py --verbose --cmake-opts="-DDPCTL_TARGET_CUDA=ON \
-    -DDPCTL_TARGET_HIP=gfx1030"
+    python scripts/build_locally.py --verbose --target-cuda --cmake-opts="-DDPCTL_TARGET_HIP=gfx1030"
 
 Running Examples and Tests
 ==========================

--- a/scripts/build_locally.py
+++ b/scripts/build_locally.py
@@ -30,6 +30,7 @@ def run(
     use_glog=False,
     verbose=False,
     cmake_opts="",
+    target_cuda=None,
 ):
     build_system = None
 
@@ -65,6 +66,15 @@ def run(
         ]
     if cmake_opts:
         cmake_args += cmake_opts.split()
+    if target_cuda is not None:
+        if not target_cuda.strip():
+            raise ValueError(
+                "--target-cuda can not be an empty string. "
+                "Use --target-cuda=<arch> or --target-cuda"
+            )
+        cmake_args += [
+            f"-DDPCTL_TARGET_CUDA={target_cuda}",
+        ]
     subprocess.check_call(
         cmake_args, shell=False, cwd=setup_dir, env=os.environ
     )
@@ -131,6 +141,15 @@ if __name__ == "__main__":
         default="",
         type=str,
     )
+    driver.add_argument(
+        "--target-cuda",
+        nargs="?",
+        const="ON",
+        help="Enable CUDA target for build; "
+        "optionally specify architecture (e.g., --target-cuda=sm_80)",
+        default=None,
+        type=str,
+    )
     args = parser.parse_args()
 
     args_to_validate = [
@@ -186,4 +205,5 @@ if __name__ == "__main__":
         use_glog=args.glog,
         verbose=args.verbose,
         cmake_opts=args.cmake_opts,
+        target_cuda=args.target_cuda,
     )

--- a/scripts/build_locally.py
+++ b/scripts/build_locally.py
@@ -31,6 +31,7 @@ def run(
     verbose=False,
     cmake_opts="",
     target_cuda=None,
+    target_hip=None,
 ):
     build_system = None
 
@@ -74,6 +75,14 @@ def run(
             )
         cmake_args += [
             f"-DDPCTL_TARGET_CUDA={target_cuda}",
+        ]
+    if target_hip is not None:
+        if not target_hip.strip():
+            raise ValueError(
+                "--target-hip requires an architecture (e.g., gfx90a)"
+            )
+        cmake_args += [
+            f"-DDPCTL_TARGET_HIP={target_hip}",
         ]
     subprocess.check_call(
         cmake_args, shell=False, cwd=setup_dir, env=os.environ
@@ -150,6 +159,13 @@ if __name__ == "__main__":
         default=None,
         type=str,
     )
+    driver.add_argument(
+        "--target-hip",
+        required=False,
+        help="Enable HIP target for build. "
+        "Must specify HIP architecture (e.g., --target-hip=gfx90a)",
+        type=str,
+    )
     args = parser.parse_args()
 
     args_to_validate = [
@@ -206,4 +222,5 @@ if __name__ == "__main__":
         verbose=args.verbose,
         cmake_opts=args.cmake_opts,
         target_cuda=args.target_cuda,
+        target_hip=args.target_hip,
     )


### PR DESCRIPTION
This PR suggests extending `build_locally.py` script by adding `--target-cuda` and `--target-hip` arguments
to simplify configuration of CUDA and AMD targets without manually passing CMake options.

```
python scripts/build_locally.py --target-cuda --target-hip=gfx1030
```

Also updates the documentation to reflect the new changes

- [X] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [X] Have you tested your changes locally for CPU and GPU devices?
- [X] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [X] Have you added documentation for your changes, if necessary?
- [ ] Have you added your changes to the changelog?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
