### PR TITLE
Backport gh-2112

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -41,6 +41,12 @@ requirements:
         - {{ dep }}
         {% elif dep.startswith('build>=') %}
         - {{ 'python-' ~ dep }}
+        {% elif dep.startswith('cython') %}
+        {% if dep.split(';')[1] == "python_version<'3.13'" %}
+        - {{ dep.split(';')[0] }} # [py<313]
+        {% else %}
+        - {{ dep.split(';')[0] }} # [py>=313]
+        {% endif %}
         {% else %}
         - {{ dep|replace('_','-') }}
         {% endif %}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,8 @@ requires = [
   "scikit-build>=0.17.0",
   "ninja>=1.11.1; platform_system!='Windows'",
   "cmake>=3.29.0",
-  "cython>=3.0.10",
+  "cython>=3.0.10;python_version<'3.13'",
+  "cython>=3.0.10,<3.1.0;python_version>='3.13'",
   "numpy >=1.23",
   # WARNING: check with doc how to upgrade
   "versioneer[toml]==0.29"


### PR DESCRIPTION
This PR backports gh-2112 to maintenance/0.20.x to fix potential test failures due to Cython version when dpctl is used with Python 3.13

- [ ] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [ ] Have you added your changes to the changelog?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
