### PR TITLE
Fix for gh-2121

### DIFF
--- a/dpctl/tensor/_copy_utils.py
+++ b/dpctl/tensor/_copy_utils.py
@@ -739,6 +739,9 @@ def astype(
             order=copy_order,
             buffer_ctor_kwargs={"queue": usm_ary.sycl_queue},
         )
+    # see #2121
+    if ary_dtype == dpt.bool:
+        usm_ary = dpt.not_equal(usm_ary, 0, order=order)
     _copy_from_usm_ndarray_to_usm_ndarray(R, usm_ary)
     return R
 

--- a/dpctl/tensor/_copy_utils.py
+++ b/dpctl/tensor/_copy_utils.py
@@ -741,7 +741,7 @@ def astype(
         )
     # see #2121
     if ary_dtype == dpt.bool:
-        usm_ary = dpt.not_equal(usm_ary, 0, order=order)
+        usm_ary = dpt.not_equal(usm_ary, 0, order=copy_order)
     _copy_from_usm_ndarray_to_usm_ndarray(R, usm_ary)
     return R
 

--- a/dpctl/tests/test_usm_ndarray_ctor.py
+++ b/dpctl/tests/test_usm_ndarray_ctor.py
@@ -1541,6 +1541,16 @@ def test_astype_gh_1926():
     assert x is x__
 
 
+def test_astype_gh_2121():
+    get_queue_or_skip()
+
+    x_np = np.asarray([0, 3, 1, 2, 0, 1], dtype="u1").view("?")
+    x = dpt.asarray(x_np)
+    res = dpt.astype(x, dpt.uint8)
+    expected = dpt.asarray([0, 1, 1, 1, 0, 1], dtype="u1")
+    assert dpt.all(res == expected)
+
+
 def test_copy():
     try:
         X = dpt.usm_ndarray((5, 5), "i4")[2:4, 1:4]


### PR DESCRIPTION
This PR proposes a fix for gh-2121, which is caused by underlying memory of a boolean array not necessarily representing only 0s and 1s, in particular when it is a view from a non-boolean array

This PR adds a path to astype that guarantees `astype(a, "?")` will give an output array of only 0 and 1

- [ ] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [ ] Have you added your changes to the changelog?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
