### PR TITLE
Accept NumPy arrays in advanced indexing

### DIFF
--- a/dpctl/tensor/_slicing.pxi
+++ b/dpctl/tensor/_slicing.pxi
@@ -17,6 +17,7 @@
 import numbers
 from operator import index
 from cpython.buffer cimport PyObject_CheckBuffer
+from numpy import ndarray
 
 
 cdef bint _is_buffer(object o):
@@ -46,7 +47,7 @@ cdef Py_ssize_t _slice_len(
 
 cdef bint _is_integral(object x) except *:
     """Gives True if x is an integral slice spec"""
-    if isinstance(x, usm_ndarray):
+    if isinstance(x, (ndarray, usm_ndarray)):
         if x.ndim > 0:
             return False
         if x.dtype.kind not in "ui":
@@ -74,7 +75,7 @@ cdef bint _is_integral(object x) except *:
 
 cdef bint _is_boolean(object x) except *:
     """Gives True if x is an integral slice spec"""
-    if isinstance(x, usm_ndarray):
+    if isinstance(x, (ndarray, usm_ndarray)):
         if x.ndim > 0:
             return False
         if x.dtype.kind not in "b":
@@ -185,7 +186,7 @@ def _basic_slice_meta(ind, shape : tuple, strides : tuple, offset : int):
             raise IndexError(
                 "Index {0} is out of range for axes 0 with "
                 "size {1}".format(ind, shape[0]))
-    elif isinstance(ind, usm_ndarray):
+    elif isinstance(ind, (ndarray, usm_ndarray)):
         return (shape, strides, offset, (ind,), 0)
     elif isinstance(ind, tuple):
         axes_referenced = 0
@@ -216,7 +217,7 @@ def _basic_slice_meta(ind, shape : tuple, strides : tuple, offset : int):
                 axes_referenced += 1
                 if not array_streak_started and array_streak_interrupted:
                     explicit_index += 1
-            elif isinstance(i, usm_ndarray):
+            elif isinstance(i, (ndarray, usm_ndarray)):
                 if not seen_arrays_yet:
                     seen_arrays_yet = True
                     array_streak_started = True
@@ -302,7 +303,7 @@ def _basic_slice_meta(ind, shape : tuple, strides : tuple, offset : int):
                     array_streak = False
             elif _is_integral(ind_i):
                 if array_streak:
-                    if not isinstance(ind_i, usm_ndarray):
+                    if not isinstance(ind_i, (ndarray, usm_ndarray)):
                         ind_i = index(ind_i)
                         # integer will be converted to an array,
                         # still raise if OOB
@@ -337,7 +338,7 @@ def _basic_slice_meta(ind, shape : tuple, strides : tuple, offset : int):
                             "Index {0} is out of range for axes "
                             "{1} with size {2}".format(ind_i, k, shape[k])
                         )
-            elif isinstance(ind_i, usm_ndarray):
+            elif isinstance(ind_i, (ndarray, usm_ndarray)):
                 if not array_streak:
                     array_streak = True
                 if not advanced_start_pos_set:

--- a/dpctl/tests/test_usm_ndarray_indexing.py
+++ b/dpctl/tests/test_usm_ndarray_indexing.py
@@ -440,6 +440,28 @@ def test_advanced_slice16():
     assert isinstance(y, dpt.usm_ndarray)
 
 
+def test_integer_indexing_numpy_array():
+    q = get_queue_or_skip()
+    ii = np.asarray([1, 2])
+    x = dpt.arange(10, dtype="i4", sycl_queue=q)
+    y = x[ii]
+    assert isinstance(y, dpt.usm_ndarray)
+    assert y.shape == ii.shape
+    assert dpt.all(dpt.asarray(ii, sycl_queue=q) == y)
+
+
+def test_boolean_indexing_numpy_array():
+    q = get_queue_or_skip()
+    ii = np.asarray(
+        [False, True, True, False, False, False, False, False, False, False]
+    )
+    x = dpt.arange(10, dtype="i4", sycl_queue=q)
+    y = x[ii]
+    assert isinstance(y, dpt.usm_ndarray)
+    assert y.shape == (2,)
+    assert dpt.all(x[1:3] == y)
+
+
 def test_boolean_indexing_validation():
     get_queue_or_skip()
     x = dpt.zeros(10, dtype="i4")

--- a/dpctl/tests/test_usm_ndarray_indexing.py
+++ b/dpctl/tests/test_usm_ndarray_indexing.py
@@ -447,7 +447,7 @@ def test_integer_indexing_numpy_array():
     y = x[ii]
     assert isinstance(y, dpt.usm_ndarray)
     assert y.shape == ii.shape
-    assert dpt.all(dpt.asarray(ii, sycl_queue=q) == y)
+    assert dpt.all(x[1:3] == y)
 
 
 def test_boolean_indexing_numpy_array():


### PR DESCRIPTION
This PR proposes allowing NumPy arrays when indexing `usm_ndarray`

This can be useful where attempting to use `usm_ndarray` in a library which generates indices with NumPy, and which expects to only handle devices implicitly through tensor operations (i.e., a library which can take an arbitrary tensor input, but generates indices with `numpy.random` and expects these indices to work on the input tensor)

Both boolean and integer advanced indices can accept NumPy arrays with these changes 

Closes #2053 

- [X] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [ ] Have you added your changes to the changelog?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
