### PR TITLE
Fix logic managing dll search path and path when initializing dpctl

### DIFF
--- a/dpctl/__init__.py
+++ b/dpctl/__init__.py
@@ -129,10 +129,6 @@ __all__ += [
     "utils",
 ]
 
-if hasattr(os, "add_dll_directory"):
-    # Include folder containing DPCTLSyclInterface.dll to search path
-    os.add_dll_directory(os.path.dirname(__file__))
-
 
 def get_include():
     r"""

--- a/dpctl/_init_helper.py
+++ b/dpctl/_init_helper.py
@@ -18,20 +18,24 @@ import os
 import os.path
 import sys
 
-is_venv_win32 = (
-    sys.platform == "win32"
-    and sys.base_exec_prefix != sys.exec_prefix
-    and os.path.isfile(os.path.join(sys.exec_prefix, "pyvenv.cfg"))
+is_venv = sys.base_exec_prefix != sys.exec_prefix and os.path.isfile(
+    os.path.join(sys.exec_prefix, "pyvenv.cfg")
 )
 
-if is_venv_win32:  # pragma: no cover
-    # For virtual environments on Windows, add folder
-    # with DPC++ libraries to the DLL search path gh-1745
-    dll_dir = os.path.join(sys.exec_prefix, "Library", "bin")
-    if os.path.isdir(dll_dir):
-        os.add_dll_directory(dll_dir)
+if sys.platform == "win32":  # pragma: no cover
+    # Include folder containing DPCTLSyclInterface.dll to search path
+    os.add_dll_directory(os.path.dirname(__file__))
+    if is_venv:
+        # For virtual environments on Windows, add folder
+        # with DPC++ libraries to the DLL search path gh-1745
+        dll_dir = os.path.join(sys.exec_prefix, "Library", "bin")
+        if os.path.isdir(dll_dir):
+            os.add_dll_directory(dll_dir)
+            os.environ["PATH"] = os.pathsep.join(
+                [os.getenv("PATH", ""), dll_dir]
+            )
 
-del is_venv_win32
+del is_venv
 
 is_linux = sys.platform.startswith("linux")
 


### PR DESCRIPTION
This PR refactors some logic in dpctl managing the DLL search path, also adding the dpctl `__init__.py` directory to the PATH, matching the logic in dpnp, in an attempt to fix dpctl being imported from virtual environments failing to see devices or find SYCL dlls

- [X] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [ ] Have you added your changes to the changelog?
- [X] If this PR is a work in progress, are you opening the PR as a draft?
