### PR TITLE
Add implicit NumPy conversion for dpctl.tensor.usm_array types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+* `dpctl.tensor.usm_ndarray` object allows implicit conversions to NumPy array changing implementation from [gh-1964](https://github.com/IntelPython/dpctl/pull/1964) for a more user-friendly behavior.
+
 ### Maintenance
 
 ## [0.20.2] - Jun. 26, 2025

--- a/dpctl/tensor/_copy_utils.py
+++ b/dpctl/tensor/_copy_utils.py
@@ -41,26 +41,7 @@ int32_t_max = 1 + np.iinfo(np.int32).max
 def _copy_to_numpy(ary):
     if not isinstance(ary, dpt.usm_ndarray):
         raise TypeError(f"Expected dpctl.tensor.usm_ndarray, got {type(ary)}")
-    if ary.size == 0:
-        # no data needs to be copied for zero sized array
-        return np.ndarray(ary.shape, dtype=ary.dtype)
-    nb = ary.usm_data.nbytes
-    q = ary.sycl_queue
-    hh = dpm.MemoryUSMHost(nb, queue=q)
-    h = np.ndarray(nb, dtype="u1", buffer=hh).view(ary.dtype)
-    itsz = ary.itemsize
-    strides_bytes = tuple(si * itsz for si in ary.strides)
-    offset = ary._element_offset * itsz
-    # ensure that content of ary.usm_data is final
-    q.wait()
-    hh.copy_from_device(ary.usm_data)
-    return np.ndarray(
-        ary.shape,
-        dtype=ary.dtype,
-        buffer=h,
-        strides=strides_bytes,
-        offset=offset,
-    )
+    return ary.__array__()
 
 
 def _copy_from_numpy(np_ary, usm_type="device", sycl_queue=None):


### PR DESCRIPTION
The functionality introduced in #1964 can be better optimized by moving code from ```_copy_utils``` to the ```usm_array``` itself.  This will make seamless integration into other larger codebases like scikit-learn, where use of ```asarray``` is common.

- [ ] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [ ] Have you added your changes to the changelog?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
