### PR TITLE
Remove remaining anonymous namespaces from headers

### DIFF
--- a/dpctl/memory/_opaque_smart_ptr.hpp
+++ b/dpctl/memory/_opaque_smart_ptr.hpp
@@ -39,7 +39,7 @@
 #include <exception>
 #include <iostream>
 
-namespace
+namespace detail
 {
 
 class USMDeleter
@@ -65,11 +65,11 @@ private:
     ::sycl::context _context;
 };
 
-} // end of anonymous namespace
+} // namespace detail
 
 void *OpaqueSmartPtr_Make(void *usm_ptr, const sycl::queue &q)
 {
-    USMDeleter _deleter(q);
+    detail::USMDeleter _deleter(q);
     auto sptr = new std::shared_ptr<void>(usm_ptr, std::move(_deleter));
 
     return reinterpret_cast<void *>(sptr);

--- a/dpctl/tensor/libtensor/source/sorting/rich_comparisons.hpp
+++ b/dpctl/tensor/libtensor/source/sorting/rich_comparisons.hpp
@@ -34,7 +34,7 @@ namespace tensor
 namespace py_internal
 {
 
-namespace
+namespace detail
 {
 template <typename fpT> struct ExtendedRealFPLess
 {
@@ -103,30 +103,30 @@ inline constexpr bool is_fp_v =
     (std::is_same_v<T, sycl::half> || std::is_same_v<T, float> ||
      std::is_same_v<T, double>);
 
-} // end of anonymous namespace
+} // end of namespace detail
 
 template <typename argTy> struct AscendingSorter
 {
-    using type = std::conditional_t<is_fp_v<argTy>,
-                                    ExtendedRealFPLess<argTy>,
+    using type = std::conditional_t<detail::is_fp_v<argTy>,
+                                    detail::ExtendedRealFPLess<argTy>,
                                     std::less<argTy>>;
 };
 
 template <typename T> struct AscendingSorter<std::complex<T>>
 {
-    using type = ExtendedComplexFPLess<std::complex<T>>;
+    using type = detail::ExtendedComplexFPLess<std::complex<T>>;
 };
 
 template <typename argTy> struct DescendingSorter
 {
-    using type = std::conditional_t<is_fp_v<argTy>,
-                                    ExtendedRealFPGreater<argTy>,
+    using type = std::conditional_t<detail::is_fp_v<argTy>,
+                                    detail::ExtendedRealFPGreater<argTy>,
                                     std::greater<argTy>>;
 };
 
 template <typename T> struct DescendingSorter<std::complex<T>>
 {
-    using type = ExtendedComplexFPGreater<std::complex<T>>;
+    using type = detail::ExtendedComplexFPGreater<std::complex<T>>;
 };
 
 } // end of namespace py_internal


### PR DESCRIPTION
This PR proposes removing two anonymous namespaces from headers

This will reduce possible binary size bloating, and prevents potential undefined behavior

- [X] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [ ] Have you added your changes to the changelog?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
