### PR TITLE
Technical debt clean-up in test suite

### DIFF
--- a/.github/workflows/conda-package.yml
+++ b/.github/workflows/conda-package.yml
@@ -221,15 +221,6 @@ jobs:
           . $CONDA/etc/profile.d/conda.sh
           conda activate ${{ env.TEST_ENV_NAME }}
           python -c "import dpctl; dpctl.lsplatform(verbosity=2)"
-      - name: Install gdb
-        run: |
-          sudo apt-get update --fix-missing
-          sudo apt-get install -y gdb
-      - name: Run test_elementwise under gdb
-        run: |
-          . $CONDA/etc/profile.d/conda.sh
-          conda activate ${{ env.TEST_ENV_NAME }}
-          gdb --batch -ex r -ex 'info sharedlibrary' -ex 'set print elements 1000' -ex bt --args ${CONDA_PREFIX}/bin/python -m pytest -q -ra --disable-warnings --pyargs dpctl.tests.elementwise.test_trigonometric::test_trig_order -vv || true
       - name: Create test temp dir
         # create temporary empty folder to runs tests from
         # https://github.com/pytest-dev/pytest/issues/11904

--- a/dpctl/tests/elementwise/test_abs.py
+++ b/dpctl/tests/elementwise/test_abs.py
@@ -23,7 +23,7 @@ import pytest
 import dpctl.tensor as dpt
 from dpctl.tests.helper import get_queue_or_skip, skip_if_dtype_not_supported
 
-from .utils import _all_dtypes, _complex_fp_dtypes, _real_fp_dtypes, _usm_types
+from .utils import _all_dtypes, _complex_fp_dtypes, _real_fp_dtypes
 
 
 @pytest.mark.parametrize("dtype", _all_dtypes)
@@ -49,25 +49,6 @@ def test_abs_out_type(dtype):
         r = dpt.empty_like(X, dtype=arg_dt)
         dpt.abs(X, out=r)
         assert np.allclose(dpt.asnumpy(r), dpt.asnumpy(dpt.abs(X)))
-
-
-@pytest.mark.parametrize("usm_type", _usm_types)
-def test_abs_usm_type(usm_type):
-    q = get_queue_or_skip()
-
-    arg_dt = np.dtype("i4")
-    input_shape = (10, 10, 10, 10)
-    X = dpt.empty(input_shape, dtype=arg_dt, usm_type=usm_type, sycl_queue=q)
-    X[..., 0::2] = 1
-    X[..., 1::2] = 0
-
-    Y = dpt.abs(X)
-    assert Y.usm_type == X.usm_type
-    assert Y.sycl_queue == X.sycl_queue
-    assert Y.flags.c_contiguous
-
-    expected_Y = dpt.asnumpy(X)
-    assert np.allclose(dpt.asnumpy(Y), expected_Y)
 
 
 def test_abs_types_property():

--- a/dpctl/tests/elementwise/test_add.py
+++ b/dpctl/tests/elementwise/test_add.py
@@ -250,19 +250,12 @@ def test_add_types_property():
 
 
 def test_add_errors():
-    get_queue_or_skip()
-    try:
-        gpu_queue = dpctl.SyclQueue("gpu")
-    except dpctl.SyclQueueCreationError:
-        pytest.skip("SyclQueue('gpu') failed, skipping")
-    try:
-        cpu_queue = dpctl.SyclQueue("cpu")
-    except dpctl.SyclQueueCreationError:
-        pytest.skip("SyclQueue('cpu') failed, skipping")
+    q1 = get_queue_or_skip()
+    q2 = dpctl.SyclQueue()
 
-    ar1 = dpt.ones(2, dtype="float32", sycl_queue=gpu_queue)
-    ar2 = dpt.ones_like(ar1, sycl_queue=gpu_queue)
-    y = dpt.empty_like(ar1, sycl_queue=cpu_queue)
+    ar1 = dpt.ones(2, dtype="float32", sycl_queue=q1)
+    ar2 = dpt.ones_like(ar1, sycl_queue=q1)
+    y = dpt.empty_like(ar1, sycl_queue=q2)
     with pytest.raises(ExecutionPlacementError) as excinfo:
         dpt.add(ar1, ar2, out=y)
     assert "Input and output allocation queues are not compatible" in str(
@@ -294,17 +287,8 @@ def test_add_errors():
         dpt.add(ar1, ar2, out=y)
     assert "output array must be of usm_ndarray type" in str(excinfo.value)
 
-
-@pytest.mark.parametrize("dtype", _all_dtypes)
-def test_add_dtype_error(
-    dtype,
-):
-    q = get_queue_or_skip()
-    skip_if_dtype_not_supported(dtype, q)
-
-    ar1 = dpt.ones(5, dtype=dtype)
+    ar1 = dpt.ones(5, dtype="f4")
     ar2 = dpt.ones_like(ar1, dtype="f4")
-
     y = dpt.zeros_like(ar1, dtype="int8")
     with pytest.raises(ValueError) as excinfo:
         dpt.add(ar1, ar2, out=y)
@@ -436,18 +420,11 @@ def test_add_inplace_operator_mutual_broadcast():
 
 
 def test_add_inplace_errors():
-    get_queue_or_skip()
-    try:
-        gpu_queue = dpctl.SyclQueue("gpu")
-    except dpctl.SyclQueueCreationError:
-        pytest.skip("SyclQueue('gpu') failed, skipping")
-    try:
-        cpu_queue = dpctl.SyclQueue("cpu")
-    except dpctl.SyclQueueCreationError:
-        pytest.skip("SyclQueue('cpu') failed, skipping")
+    q1 = get_queue_or_skip()
+    q2 = dpctl.SyclQueue()
 
-    ar1 = dpt.ones(2, dtype="float32", sycl_queue=gpu_queue)
-    ar2 = dpt.ones_like(ar1, sycl_queue=cpu_queue)
+    ar1 = dpt.ones(2, dtype="float32", sycl_queue=q1)
+    ar2 = dpt.ones_like(ar1, sycl_queue=q2)
     with pytest.raises(ExecutionPlacementError):
         dpt.add(ar1, ar2, out=ar1)
 

--- a/dpctl/tests/elementwise/test_add.py
+++ b/dpctl/tests/elementwise/test_add.py
@@ -26,7 +26,7 @@ from dpctl.tensor._type_utils import _can_cast
 from dpctl.tests.helper import get_queue_or_skip, skip_if_dtype_not_supported
 from dpctl.utils import ExecutionPlacementError
 
-from .utils import _all_dtypes, _compare_dtypes, _usm_types
+from .utils import _all_dtypes, _compare_dtypes
 
 
 @pytest.mark.parametrize("op1_dtype", _all_dtypes)
@@ -69,23 +69,6 @@ def test_add_dtype_matrix(op1_dtype, op2_dtype):
     r2 = dpt.empty_like(ar1, dtype=r.dtype)
     dpt.add(ar3[::-1], ar4[::2], out=r2)
     assert (dpt.asnumpy(r2) == np.full(r2.shape, 2, dtype=r2.dtype)).all()
-
-
-@pytest.mark.parametrize("op1_usm_type", _usm_types)
-@pytest.mark.parametrize("op2_usm_type", _usm_types)
-def test_add_usm_type_matrix(op1_usm_type, op2_usm_type):
-    get_queue_or_skip()
-
-    sz = 128
-    ar1 = dpt.ones(sz, dtype="i4", usm_type=op1_usm_type)
-    ar2 = dpt.ones_like(ar1, dtype="i4", usm_type=op2_usm_type)
-
-    r = dpt.add(ar1, ar2)
-    assert isinstance(r, dpt.usm_ndarray)
-    expected_usm_type = dpctl.utils.get_coerced_usm_type(
-        (op1_usm_type, op2_usm_type)
-    )
-    assert r.usm_type == expected_usm_type
 
 
 def test_add_order():

--- a/dpctl/tests/elementwise/test_atan2.py
+++ b/dpctl/tests/elementwise/test_atan2.py
@@ -14,8 +14,6 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-import ctypes
-
 import numpy as np
 import pytest
 from numpy.testing import assert_allclose
@@ -66,26 +64,6 @@ def test_atan2_dtype_matrix(op1_dtype, op2_dtype):
         dpt.finfo(r.dtype).resolution, dpt.finfo(expected.dtype).resolution
     )
     assert_allclose(dpt.asnumpy(r), expected, atol=tol, rtol=tol)
-
-
-@pytest.mark.parametrize("arr_dt", _no_complex_dtypes[1:])
-def test_atan2_python_scalar(arr_dt):
-    q = get_queue_or_skip()
-    skip_if_dtype_not_supported(arr_dt, q)
-
-    X = dpt.ones((10, 10), dtype=arr_dt, sycl_queue=q)
-    py_ones = (
-        bool(1),
-        int(1),
-        float(1),
-        np.float32(1),
-        ctypes.c_int(1),
-    )
-    for sc in py_ones:
-        R = dpt.atan2(X, sc)
-        assert isinstance(R, dpt.usm_ndarray)
-        R = dpt.atan2(sc, X)
-        assert isinstance(R, dpt.usm_ndarray)
 
 
 @pytest.mark.parametrize("dt", ["f2", "f4", "f8"])
@@ -194,7 +172,7 @@ def test_atan2_special_case_pzero_and_nzero(dt):
 
 
 @pytest.mark.parametrize("dt", ["f2", "f4", "f8"])
-def test_atan2_special_case_pzero_and_negatvie(dt):
+def test_atan2_special_case_pzero_and_negative(dt):
     """
     If x1_i is +0 and x2_i is less than 0, the result
     is an approximation to +pi.

--- a/dpctl/tests/elementwise/test_bitwise_and.py
+++ b/dpctl/tests/elementwise/test_bitwise_and.py
@@ -25,7 +25,7 @@ from .utils import _integral_dtypes
 
 
 @pytest.mark.parametrize("op_dtype", _integral_dtypes)
-def test_bitwise_and_dtype_matrix_contig(op_dtype):
+def test_bitwise_and_dtype_matrix(op_dtype):
     q = get_queue_or_skip()
     skip_if_dtype_not_supported(op_dtype, q)
 
@@ -50,32 +50,6 @@ def test_bitwise_and_dtype_matrix_contig(op_dtype):
     assert (r_np == dpt.asnumpy(r)).all()
 
 
-@pytest.mark.parametrize("op_dtype", _integral_dtypes)
-def test_bitwise_and_dtype_matrix_strided(op_dtype):
-    q = get_queue_or_skip()
-    skip_if_dtype_not_supported(op_dtype, q)
-
-    sz = 11
-    n = 2 * sz
-    dt1 = dpt.dtype(op_dtype)
-    dt2 = dpt.dtype(op_dtype)
-
-    x1_range_begin = -sz if dpt.iinfo(dt1).min < 0 else 0
-    x1 = dpt.arange(x1_range_begin, x1_range_begin + n, dtype=dt1)[::2]
-
-    x2_range_begin = -(sz // 2) if dpt.iinfo(dt2).min < 0 else 0
-    x2 = dpt.arange(x2_range_begin, x2_range_begin + n, dtype=dt1)[::-2]
-
-    r = dpt.bitwise_and(x1, x2)
-    assert isinstance(r, dpt.usm_ndarray)
-
-    x1_np = np.arange(x1_range_begin, x1_range_begin + n, dtype=op_dtype)[::2]
-    x2_np = np.arange(x2_range_begin, x2_range_begin + n, dtype=op_dtype)[::-2]
-    r_np = np.bitwise_and(x1_np, x2_np)
-
-    assert (r_np == dpt.asnumpy(r)).all()
-
-
 def test_bitwise_and_bool():
     get_queue_or_skip()
 
@@ -86,18 +60,6 @@ def test_bitwise_and_bool():
     r_lo = dpt.logical_and(x1[:, dpt.newaxis], x2[dpt.newaxis])
 
     assert dpt.all(dpt.equal(r_bw, r_lo))
-
-
-@pytest.mark.parametrize("dtype", ["?"] + _integral_dtypes)
-def test_bitwise_and_inplace_python_scalar(dtype):
-    q = get_queue_or_skip()
-    skip_if_dtype_not_supported(dtype, q)
-    X = dpt.zeros((10, 10), dtype=dtype, sycl_queue=q)
-    dt_kind = X.dtype.kind
-    if dt_kind == "b":
-        X &= False
-    else:
-        X &= int(0)
 
 
 @pytest.mark.parametrize("op1_dtype", ["?"] + _integral_dtypes)

--- a/dpctl/tests/elementwise/test_bitwise_invert.py
+++ b/dpctl/tests/elementwise/test_bitwise_invert.py
@@ -20,7 +20,7 @@ import pytest
 import dpctl.tensor as dpt
 from dpctl.tests.helper import get_queue_or_skip, skip_if_dtype_not_supported
 
-from .utils import _compare_dtypes, _integral_dtypes, _usm_types
+from .utils import _compare_dtypes, _integral_dtypes
 
 
 @pytest.mark.parametrize(
@@ -71,52 +71,6 @@ def test_bitwise_invert_dtype_matrix(op_dtype):
     r3 = dpt.empty_like(r, dtype=r.dtype)
     dpt.bitwise_invert(ar2[::-1], out=r3)
     assert dpt.all(dpt.equal(r, r3))
-
-
-@pytest.mark.parametrize("op_usm_type", _usm_types)
-def test_bitwise_invert_usm_type_matrix(op_usm_type):
-    get_queue_or_skip()
-
-    sz = 128
-    ar1 = dpt.asarray(
-        np.random.randint(0, 2, sz), dtype="i4", usm_type=op_usm_type
-    )
-
-    r = dpt.bitwise_invert(ar1)
-    assert isinstance(r, dpt.usm_ndarray)
-    assert r.usm_type == op_usm_type
-
-
-def test_bitwise_invert_order():
-    get_queue_or_skip()
-
-    ar1 = dpt.ones((20, 20), dtype="i4", order="C")
-    r1 = dpt.bitwise_invert(ar1, order="C")
-    assert r1.flags.c_contiguous
-    r2 = dpt.bitwise_invert(ar1, order="F")
-    assert r2.flags.f_contiguous
-    r3 = dpt.bitwise_invert(ar1, order="A")
-    assert r3.flags.c_contiguous
-    r4 = dpt.bitwise_invert(ar1, order="K")
-    assert r4.flags.c_contiguous
-
-    ar1 = dpt.zeros((20, 20), dtype="i4", order="F")
-    r1 = dpt.bitwise_invert(ar1, order="C")
-    assert r1.flags.c_contiguous
-    r2 = dpt.bitwise_invert(ar1, order="F")
-    assert r2.flags.f_contiguous
-    r3 = dpt.bitwise_invert(ar1, order="A")
-    assert r3.flags.f_contiguous
-    r4 = dpt.bitwise_invert(ar1, order="K")
-    assert r4.flags.f_contiguous
-
-    ar1 = dpt.ones((40, 40), dtype="i4", order="C")[:20, ::-2]
-    r4 = dpt.bitwise_invert(ar1, order="K")
-    assert r4.strides == (20, -1)
-
-    ar1 = dpt.zeros((40, 40), dtype="i4", order="C")[:20, ::-2].mT
-    r4 = dpt.bitwise_invert(ar1, order="K")
-    assert r4.strides == (-1, 20)
 
 
 def test_bitwise_invert_large_boolean():

--- a/dpctl/tests/elementwise/test_bitwise_left_shift.py
+++ b/dpctl/tests/elementwise/test_bitwise_left_shift.py
@@ -26,7 +26,7 @@ from .utils import _integral_dtypes
 
 @pytest.mark.parametrize("op1_dtype", _integral_dtypes)
 @pytest.mark.parametrize("op2_dtype", _integral_dtypes)
-def test_bitwise_left_shift_dtype_matrix_contig(op1_dtype, op2_dtype):
+def test_bitwise_left_shift_dtype_matrix(op1_dtype, op2_dtype):
     q = get_queue_or_skip()
     skip_if_dtype_not_supported(op1_dtype, q)
     skip_if_dtype_not_supported(op2_dtype, q)
@@ -56,38 +56,6 @@ def test_bitwise_left_shift_dtype_matrix_contig(op1_dtype, op2_dtype):
     assert (dpt.asnumpy(r) == r_np).all()
 
 
-@pytest.mark.parametrize("op1_dtype", _integral_dtypes)
-@pytest.mark.parametrize("op2_dtype", _integral_dtypes)
-def test_bitwise_left_shift_dtype_matrix_strided(op1_dtype, op2_dtype):
-    q = get_queue_or_skip()
-    skip_if_dtype_not_supported(op1_dtype, q)
-    skip_if_dtype_not_supported(op2_dtype, q)
-
-    if op1_dtype != op2_dtype and "u8" in [op1_dtype, op2_dtype]:
-        return
-
-    sz = 11
-    n = 2 * sz
-    dt1 = dpt.dtype(op1_dtype)
-    dt2 = dpt.dtype(op2_dtype)
-
-    x1_range_begin = -sz if dpt.iinfo(dt1).min < 0 else 0
-    x1 = dpt.arange(x1_range_begin, x1_range_begin + n, dtype=dt1)[::-2]
-    x2 = dpt.arange(0, n, dtype=dt2)[::2]
-
-    r = dpt.bitwise_left_shift(x1, x2)
-    assert isinstance(r, dpt.usm_ndarray)
-    assert r.sycl_queue == x1.sycl_queue
-    assert r.sycl_queue == x2.sycl_queue
-
-    x1_np = np.arange(x1_range_begin, x1_range_begin + n, dtype=dt1)[::-2]
-    x2_np = np.arange(0, n, dtype=dt2)[::2]
-    r_np = np.left_shift(x1_np, x2_np)
-
-    assert r.dtype == r_np.dtype
-    assert (dpt.asnumpy(r) == r_np).all()
-
-
 @pytest.mark.parametrize("op_dtype", _integral_dtypes)
 def test_bitwise_left_shift_range(op_dtype):
     q = get_queue_or_skip()
@@ -98,14 +66,6 @@ def test_bitwise_left_shift_range(op_dtype):
 
     z = dpt.bitwise_left_shift(x, y)
     assert dpt.all(dpt.equal(z, 0))
-
-
-@pytest.mark.parametrize("dtype", _integral_dtypes)
-def test_bitwise_left_shift_inplace_python_scalar(dtype):
-    q = get_queue_or_skip()
-    skip_if_dtype_not_supported(dtype, q)
-    X = dpt.zeros((10, 10), dtype=dtype, sycl_queue=q)
-    X <<= int(0)
 
 
 @pytest.mark.parametrize("op1_dtype", _integral_dtypes)

--- a/dpctl/tests/elementwise/test_bitwise_or.py
+++ b/dpctl/tests/elementwise/test_bitwise_or.py
@@ -25,7 +25,7 @@ from .utils import _integral_dtypes
 
 
 @pytest.mark.parametrize("op_dtype", _integral_dtypes)
-def test_bitwise_or_dtype_matrix_contig(op_dtype):
+def test_bitwise_or_dtype_matrix(op_dtype):
     q = get_queue_or_skip()
     skip_if_dtype_not_supported(op_dtype, q)
 
@@ -50,32 +50,6 @@ def test_bitwise_or_dtype_matrix_contig(op_dtype):
     assert (r_np == dpt.asnumpy(r)).all()
 
 
-@pytest.mark.parametrize("op_dtype", _integral_dtypes)
-def test_bitwise_or_dtype_matrix_strided(op_dtype):
-    q = get_queue_or_skip()
-    skip_if_dtype_not_supported(op_dtype, q)
-
-    sz = 11
-    n = 2 * sz
-    dt1 = dpt.dtype(op_dtype)
-    dt2 = dpt.dtype(op_dtype)
-
-    x1_range_begin = -sz if dpt.iinfo(dt1).min < 0 else 0
-    x1 = dpt.arange(x1_range_begin, x1_range_begin + n, dtype=dt1)[::2]
-
-    x2_range_begin = -(sz // 2) if dpt.iinfo(dt2).min < 0 else 0
-    x2 = dpt.arange(x2_range_begin, x2_range_begin + n, dtype=dt1)[::-2]
-
-    r = dpt.bitwise_or(x1, x2)
-    assert isinstance(r, dpt.usm_ndarray)
-
-    x1_np = np.arange(x1_range_begin, x1_range_begin + n, dtype=op_dtype)[::2]
-    x2_np = np.arange(x2_range_begin, x2_range_begin + n, dtype=op_dtype)[::-2]
-    r_np = np.bitwise_or(x1_np, x2_np)
-
-    assert (r_np == dpt.asnumpy(r)).all()
-
-
 def test_bitwise_or_bool():
     get_queue_or_skip()
 
@@ -86,18 +60,6 @@ def test_bitwise_or_bool():
     r_lo = dpt.logical_or(x1[:, dpt.newaxis], x2[dpt.newaxis])
 
     assert dpt.all(dpt.equal(r_bw, r_lo))
-
-
-@pytest.mark.parametrize("dtype", ["?"] + _integral_dtypes)
-def test_bitwise_or_inplace_python_scalar(dtype):
-    q = get_queue_or_skip()
-    skip_if_dtype_not_supported(dtype, q)
-    X = dpt.zeros((10, 10), dtype=dtype, sycl_queue=q)
-    dt_kind = X.dtype.kind
-    if dt_kind == "b":
-        X |= False
-    else:
-        X |= int(0)
 
 
 @pytest.mark.parametrize("op1_dtype", ["?"] + _integral_dtypes)

--- a/dpctl/tests/elementwise/test_bitwise_right_shift.py
+++ b/dpctl/tests/elementwise/test_bitwise_right_shift.py
@@ -26,7 +26,7 @@ from .utils import _integral_dtypes
 
 @pytest.mark.parametrize("op1_dtype", _integral_dtypes)
 @pytest.mark.parametrize("op2_dtype", _integral_dtypes)
-def test_bitwise_right_shift_dtype_matrix_contig(op1_dtype, op2_dtype):
+def test_bitwise_right_shift_dtype_matrix(op1_dtype, op2_dtype):
     q = get_queue_or_skip()
     skip_if_dtype_not_supported(op1_dtype, q)
     skip_if_dtype_not_supported(op2_dtype, q)
@@ -54,58 +54,6 @@ def test_bitwise_right_shift_dtype_matrix_contig(op1_dtype, op2_dtype):
 
     assert r.dtype == r_np.dtype
     assert (dpt.asnumpy(r) == r_np).all()
-
-
-@pytest.mark.parametrize("op1_dtype", _integral_dtypes)
-@pytest.mark.parametrize("op2_dtype", _integral_dtypes)
-def test_bitwise_right_shift_dtype_matrix_strided(op1_dtype, op2_dtype):
-    q = get_queue_or_skip()
-    skip_if_dtype_not_supported(op1_dtype, q)
-    skip_if_dtype_not_supported(op2_dtype, q)
-
-    if op1_dtype != op2_dtype and "u8" in [op1_dtype, op2_dtype]:
-        return
-
-    sz = 11
-    n = 2 * sz
-    dt1 = dpt.dtype(op1_dtype)
-    dt2 = dpt.dtype(op2_dtype)
-
-    x1_range_begin = -sz if dpt.iinfo(dt1).min < 0 else 0
-    x1 = dpt.arange(x1_range_begin, x1_range_begin + n, dtype=dt1)[::-2]
-    x2 = dpt.arange(0, n, dtype=dt2)[::2]
-
-    r = dpt.bitwise_right_shift(x1, x2)
-    assert isinstance(r, dpt.usm_ndarray)
-    assert r.sycl_queue == x1.sycl_queue
-    assert r.sycl_queue == x2.sycl_queue
-
-    x1_np = np.arange(x1_range_begin, x1_range_begin + n, dtype=dt1)[::-2]
-    x2_np = np.arange(0, n, dtype=dt2)[::2]
-    r_np = np.right_shift(x1_np, x2_np)
-
-    assert r.dtype == r_np.dtype
-    assert (dpt.asnumpy(r) == r_np).all()
-
-
-@pytest.mark.parametrize("op_dtype", _integral_dtypes)
-def test_bitwise_right_shift_range(op_dtype):
-    q = get_queue_or_skip()
-    skip_if_dtype_not_supported(op_dtype, q)
-
-    x = dpt.ones(255, dtype=op_dtype)
-    y = dpt.asarray(64, dtype=op_dtype)
-
-    z = dpt.bitwise_right_shift(x, y)
-    assert dpt.all(dpt.equal(z, 0))
-
-
-@pytest.mark.parametrize("dtype", _integral_dtypes)
-def test_bitwise_right_shift_inplace_python_scalar(dtype):
-    q = get_queue_or_skip()
-    skip_if_dtype_not_supported(dtype, q)
-    X = dpt.zeros((10, 10), dtype=dtype, sycl_queue=q)
-    X >>= int(0)
 
 
 @pytest.mark.parametrize("op1_dtype", _integral_dtypes)

--- a/dpctl/tests/elementwise/test_bitwise_xor.py
+++ b/dpctl/tests/elementwise/test_bitwise_xor.py
@@ -25,7 +25,7 @@ from .utils import _integral_dtypes
 
 
 @pytest.mark.parametrize("op_dtype", _integral_dtypes)
-def test_bitwise_xor_dtype_matrix_contig(op_dtype):
+def test_bitwise_xor_dtype_matrix(op_dtype):
     q = get_queue_or_skip()
     skip_if_dtype_not_supported(op_dtype, q)
 
@@ -50,32 +50,6 @@ def test_bitwise_xor_dtype_matrix_contig(op_dtype):
     assert (r_np == dpt.asnumpy(r)).all()
 
 
-@pytest.mark.parametrize("op_dtype", _integral_dtypes)
-def test_bitwise_xor_dtype_matrix_strided(op_dtype):
-    q = get_queue_or_skip()
-    skip_if_dtype_not_supported(op_dtype, q)
-
-    sz = 11
-    n = 2 * sz
-    dt1 = dpt.dtype(op_dtype)
-    dt2 = dpt.dtype(op_dtype)
-
-    x1_range_begin = -sz if dpt.iinfo(dt1).min < 0 else 0
-    x1 = dpt.arange(x1_range_begin, x1_range_begin + n, dtype=dt1)[::2]
-
-    x2_range_begin = -(sz // 2) if dpt.iinfo(dt2).min < 0 else 0
-    x2 = dpt.arange(x2_range_begin, x2_range_begin + n, dtype=dt1)[::-2]
-
-    r = dpt.bitwise_xor(x1, x2)
-    assert isinstance(r, dpt.usm_ndarray)
-
-    x1_np = np.arange(x1_range_begin, x1_range_begin + n, dtype=op_dtype)[::2]
-    x2_np = np.arange(x2_range_begin, x2_range_begin + n, dtype=op_dtype)[::-2]
-    r_np = np.bitwise_xor(x1_np, x2_np)
-
-    assert (r_np == dpt.asnumpy(r)).all()
-
-
 def test_bitwise_xor_bool():
     get_queue_or_skip()
 
@@ -86,18 +60,6 @@ def test_bitwise_xor_bool():
     r_lo = dpt.logical_xor(x1[:, dpt.newaxis], x2[dpt.newaxis])
 
     assert dpt.all(dpt.equal(r_bw, r_lo))
-
-
-@pytest.mark.parametrize("dtype", ["?"] + _integral_dtypes)
-def test_bitwise_xor_inplace_python_scalar(dtype):
-    q = get_queue_or_skip()
-    skip_if_dtype_not_supported(dtype, q)
-    X = dpt.zeros((10, 10), dtype=dtype, sycl_queue=q)
-    dt_kind = X.dtype.kind
-    if dt_kind == "b":
-        X ^= False
-    else:
-        X ^= int(0)
 
 
 @pytest.mark.parametrize("op1_dtype", ["?"] + _integral_dtypes)

--- a/dpctl/tests/elementwise/test_cbrt.py
+++ b/dpctl/tests/elementwise/test_cbrt.py
@@ -36,29 +36,13 @@ def test_cbrt_out_type(dtype):
 
 
 @pytest.mark.parametrize("dtype", _real_fp_dtypes)
-def test_cbrt_output_contig(dtype):
+def test_cbrt_basic(dtype):
     q = get_queue_or_skip()
     skip_if_dtype_not_supported(dtype, q)
 
     n_seq = 1027
 
     X = dpt.linspace(0, 13, num=n_seq, dtype=dtype, sycl_queue=q)
-    Xnp = dpt.asnumpy(X)
-
-    Y = dpt.cbrt(X)
-    tol = 8 * dpt.finfo(Y.dtype).resolution
-
-    assert_allclose(dpt.asnumpy(Y), np.cbrt(Xnp), atol=tol, rtol=tol)
-
-
-@pytest.mark.parametrize("dtype", _real_fp_dtypes)
-def test_cbrt_output_strided(dtype):
-    q = get_queue_or_skip()
-    skip_if_dtype_not_supported(dtype, q)
-
-    n_seq = 2054
-
-    X = dpt.linspace(0, 13, num=n_seq, dtype=dtype, sycl_queue=q)[::-2]
     Xnp = dpt.asnumpy(X)
 
     Y = dpt.cbrt(X)

--- a/dpctl/tests/elementwise/test_complex.py
+++ b/dpctl/tests/elementwise/test_complex.py
@@ -24,7 +24,7 @@ from numpy.testing import assert_allclose
 import dpctl.tensor as dpt
 from dpctl.tests.helper import get_queue_or_skip, skip_if_dtype_not_supported
 
-from .utils import _all_dtypes, _map_to_device_dtype, _usm_types
+from .utils import _all_dtypes, _map_to_device_dtype
 
 
 @pytest.mark.parametrize("dtype", _all_dtypes)
@@ -73,56 +73,6 @@ def test_complex_output(np_call, dpt_call, dtype):
     assert_allclose(dpt.asnumpy(Z), np_call(Xnp), atol=tol, rtol=tol)
 
 
-@pytest.mark.parametrize(
-    "np_call, dpt_call",
-    [(np.real, dpt.real), (np.imag, dpt.imag), (np.conj, dpt.conj)],
-)
-@pytest.mark.parametrize("usm_type", _usm_types)
-def test_complex_usm_type(np_call, dpt_call, usm_type):
-    q = get_queue_or_skip()
-
-    arg_dt = np.dtype("c8")
-    input_shape = (10, 10, 10, 10)
-    X = dpt.empty(input_shape, dtype=arg_dt, usm_type=usm_type, sycl_queue=q)
-    X[..., 0::2] = np.pi / 6 + 1j * np.pi / 3
-    X[..., 1::2] = np.pi / 3 + 1j * np.pi / 6
-
-    Y = dpt_call(X)
-    assert Y.usm_type == X.usm_type
-    assert Y.sycl_queue == X.sycl_queue
-    assert Y.flags.c_contiguous
-
-    expected_Y = np.empty(input_shape, dtype=arg_dt)
-    expected_Y[..., 0::2] = np_call(np.complex64(np.pi / 6 + 1j * np.pi / 3))
-    expected_Y[..., 1::2] = np_call(np.complex64(np.pi / 3 + 1j * np.pi / 6))
-    tol = 8 * dpt.finfo(Y.dtype).resolution
-
-    assert_allclose(dpt.asnumpy(Y), expected_Y, atol=tol, rtol=tol)
-
-
-@pytest.mark.parametrize(
-    "np_call, dpt_call",
-    [(np.real, dpt.real), (np.imag, dpt.imag), (np.conj, dpt.conj)],
-)
-@pytest.mark.parametrize("dtype", _all_dtypes)
-def test_complex_order(np_call, dpt_call, dtype):
-    q = get_queue_or_skip()
-    skip_if_dtype_not_supported(dtype, q)
-
-    arg_dt = np.dtype(dtype)
-    input_shape = (10, 10, 10, 10)
-    X = dpt.empty(input_shape, dtype=arg_dt, sycl_queue=q)
-    X[..., 0::2] = np.pi / 6 + 1j * np.pi / 3
-    X[..., 1::2] = np.pi / 3 + 1j * np.pi / 6
-
-    for perms in itertools.permutations(range(4)):
-        U = dpt.permute_dims(X[:, ::-1, ::-1, :], perms)
-        expected_Y = np_call(dpt.asnumpy(U))
-        for ord in ["C", "F", "A", "K"]:
-            Y = dpt_call(U, order=ord)
-            assert_allclose(dpt.asnumpy(Y), expected_Y)
-
-
 @pytest.mark.parametrize("dtype", ["c8", "c16"])
 def test_projection_complex(dtype):
     q = get_queue_or_skip()
@@ -159,37 +109,6 @@ def test_projection(dtype):
 
     tol = 8 * dpt.finfo(Yf.dtype).resolution
     assert_allclose(dpt.asnumpy(dpt.proj(Xf)), Yf, atol=tol, rtol=tol)
-
-
-@pytest.mark.parametrize(
-    "np_call, dpt_call",
-    [(np.real, dpt.real), (np.imag, dpt.imag), (np.conj, dpt.conj)],
-)
-@pytest.mark.parametrize("dtype", ["c8", "c16"])
-def test_complex_strided(np_call, dpt_call, dtype):
-    q = get_queue_or_skip()
-    skip_if_dtype_not_supported(dtype, q)
-
-    np.random.seed(42)
-    strides = np.array([-4, -3, -2, -1, 1, 2, 3, 4])
-    sizes = [2, 4, 6, 8, 9, 24, 72]
-    tol = 8 * dpt.finfo(dtype).resolution
-
-    low = -1000.0
-    high = 1000.0
-    for ii in sizes:
-        x1 = np.random.uniform(low=low, high=high, size=ii)
-        x2 = np.random.uniform(low=low, high=high, size=ii)
-        Xnp = np.array([complex(v1, v2) for v1, v2 in zip(x1, x2)], dtype=dtype)
-        X = dpt.asarray(Xnp)
-        Ynp = np_call(Xnp)
-        for jj in strides:
-            assert_allclose(
-                dpt.asnumpy(dpt_call(X[::jj])),
-                Ynp[::jj],
-                atol=tol,
-                rtol=tol,
-            )
 
 
 @pytest.mark.parametrize("dtype", ["c8", "c16"])

--- a/dpctl/tests/elementwise/test_copysign.py
+++ b/dpctl/tests/elementwise/test_copysign.py
@@ -14,8 +14,6 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-import ctypes
-
 import numpy as np
 import pytest
 
@@ -57,26 +55,6 @@ def test_copysign_dtype_matrix(op1_dtype, op2_dtype):
     assert _compare_dtypes(r.dtype, expected.dtype, sycl_queue=q)
     assert r.shape == ar3.shape
     assert (dpt.asnumpy(r) == expected.astype(r.dtype)).all()
-
-
-@pytest.mark.parametrize("arr_dt", _real_fp_dtypes)
-def test_copysign_python_scalar(arr_dt):
-    q = get_queue_or_skip()
-    skip_if_dtype_not_supported(arr_dt, q)
-
-    X = dpt.ones((10, 10), dtype=arr_dt, sycl_queue=q)
-    py_ones = (
-        bool(1),
-        int(1),
-        float(1),
-        np.float32(1),
-        ctypes.c_int(1),
-    )
-    for sc in py_ones:
-        R = dpt.copysign(X, sc)
-        assert isinstance(R, dpt.usm_ndarray)
-        R = dpt.copysign(sc, X)
-        assert isinstance(R, dpt.usm_ndarray)
 
 
 @pytest.mark.parametrize("dt", _real_fp_dtypes)

--- a/dpctl/tests/elementwise/test_divide.py
+++ b/dpctl/tests/elementwise/test_divide.py
@@ -14,25 +14,16 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-import ctypes
-
 import numpy as np
 import pytest
 
-import dpctl
 import dpctl.tensor as dpt
 from dpctl.tensor._tensor_elementwise_impl import _divide_by_scalar
 from dpctl.tensor._type_utils import _can_cast
 from dpctl.tests.helper import get_queue_or_skip, skip_if_dtype_not_supported
 from dpctl.utils import SequentialOrderManager
 
-from .utils import (
-    _all_dtypes,
-    _compare_dtypes,
-    _complex_fp_dtypes,
-    _real_fp_dtypes,
-    _usm_types,
-)
+from .utils import _all_dtypes, _compare_dtypes
 
 
 @pytest.mark.parametrize("op1_dtype", _all_dtypes)
@@ -67,147 +58,6 @@ def test_divide_dtype_matrix(op1_dtype, op2_dtype):
     assert _compare_dtypes(r.dtype, expected.dtype, sycl_queue=q)
     assert r.shape == ar3.shape
     assert (dpt.asnumpy(r) == expected.astype(r.dtype)).all()
-
-
-@pytest.mark.parametrize("op1_usm_type", _usm_types)
-@pytest.mark.parametrize("op2_usm_type", _usm_types)
-def test_divide_usm_type_matrix(op1_usm_type, op2_usm_type):
-    get_queue_or_skip()
-
-    sz = 128
-    ar1 = dpt.ones(sz, dtype="i4", usm_type=op1_usm_type)
-    ar2 = dpt.ones_like(ar1, dtype="i4", usm_type=op2_usm_type)
-
-    r = dpt.divide(ar1, ar2)
-    assert isinstance(r, dpt.usm_ndarray)
-    expected_usm_type = dpctl.utils.get_coerced_usm_type(
-        (op1_usm_type, op2_usm_type)
-    )
-    assert r.usm_type == expected_usm_type
-
-
-def test_divide_order():
-    get_queue_or_skip()
-
-    ar1 = dpt.ones((20, 20), dtype="i4", order="C")
-    ar2 = dpt.ones((20, 20), dtype="i4", order="C")
-    r1 = dpt.divide(ar1, ar2, order="C")
-    assert r1.flags.c_contiguous
-    r2 = dpt.divide(ar1, ar2, order="F")
-    assert r2.flags.f_contiguous
-    r3 = dpt.divide(ar1, ar2, order="A")
-    assert r3.flags.c_contiguous
-    r4 = dpt.divide(ar1, ar2, order="K")
-    assert r4.flags.c_contiguous
-
-    ar1 = dpt.ones((20, 20), dtype="i4", order="F")
-    ar2 = dpt.ones((20, 20), dtype="i4", order="F")
-    r1 = dpt.divide(ar1, ar2, order="C")
-    assert r1.flags.c_contiguous
-    r2 = dpt.divide(ar1, ar2, order="F")
-    assert r2.flags.f_contiguous
-    r3 = dpt.divide(ar1, ar2, order="A")
-    assert r3.flags.f_contiguous
-    r4 = dpt.divide(ar1, ar2, order="K")
-    assert r4.flags.f_contiguous
-
-    ar1 = dpt.ones((40, 40), dtype="i4", order="C")[:20, ::-2]
-    ar2 = dpt.ones((40, 40), dtype="i4", order="C")[:20, ::-2]
-    r4 = dpt.divide(ar1, ar2, order="K")
-    assert r4.strides == (20, -1)
-
-    ar1 = dpt.ones((40, 40), dtype="i4", order="C")[:20, ::-2].mT
-    ar2 = dpt.ones((40, 40), dtype="i4", order="C")[:20, ::-2].mT
-    r4 = dpt.divide(ar1, ar2, order="K")
-    assert r4.strides == (-1, 20)
-
-
-def test_divide_broadcasting():
-    get_queue_or_skip()
-
-    m = dpt.ones((100, 5), dtype="i4")
-    v = dpt.arange(1, 6, dtype="i4")
-
-    r = dpt.divide(m, v)
-
-    expected = np.divide(
-        np.ones((100, 5), dtype="i4"), np.arange(1, 6, dtype="i4")
-    )
-    assert (dpt.asnumpy(r) == expected.astype(r.dtype)).all()
-
-    r2 = dpt.divide(v, m)
-    expected2 = np.divide(
-        np.arange(1, 6, dtype="i4"), np.ones((100, 5), dtype="i4")
-    )
-    assert (dpt.asnumpy(r2) == expected2.astype(r2.dtype)).all()
-
-
-@pytest.mark.parametrize("arr_dt", _all_dtypes)
-def test_divide_python_scalar(arr_dt):
-    q = get_queue_or_skip()
-    skip_if_dtype_not_supported(arr_dt, q)
-
-    X = dpt.ones((10, 10), dtype=arr_dt, sycl_queue=q)
-    py_ones = (
-        bool(1),
-        int(1),
-        float(1),
-        complex(1),
-        np.float32(1),
-        ctypes.c_int(1),
-    )
-    for sc in py_ones:
-        R = dpt.divide(X, sc)
-        assert isinstance(R, dpt.usm_ndarray)
-        R = dpt.divide(sc, X)
-        assert isinstance(R, dpt.usm_ndarray)
-
-
-class MockArray:
-    def __init__(self, arr):
-        self.data_ = arr
-
-    @property
-    def __sycl_usm_array_interface__(self):
-        return self.data_.__sycl_usm_array_interface__
-
-
-def test_divide_mock_array():
-    get_queue_or_skip()
-    a = dpt.arange(10)
-    b = dpt.ones(10)
-    c = MockArray(b)
-    r = dpt.divide(a, c)
-    assert isinstance(r, dpt.usm_ndarray)
-
-
-def test_divide_canary_mock_array():
-    get_queue_or_skip()
-    a = dpt.arange(10)
-
-    class Canary:
-        def __init__(self):
-            pass
-
-        @property
-        def __sycl_usm_array_interface__(self):
-            return None
-
-    c = Canary()
-    with pytest.raises(ValueError):
-        dpt.divide(a, c)
-
-
-@pytest.mark.parametrize("dtype", _real_fp_dtypes + _complex_fp_dtypes)
-def test_divide_inplace_python_scalar(dtype):
-    q = get_queue_or_skip()
-    skip_if_dtype_not_supported(dtype, q)
-    X = dpt.zeros((10, 10), dtype=dtype, sycl_queue=q)
-    dt_kind = X.dtype.kind
-    if dt_kind == "f":
-        X /= float(1)
-    elif dt_kind == "c":
-        X /= complex(1)
 
 
 @pytest.mark.parametrize("op1_dtype", _all_dtypes)

--- a/dpctl/tests/elementwise/test_divide.py
+++ b/dpctl/tests/elementwise/test_divide.py
@@ -14,6 +14,8 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
+import ctypes
+
 import numpy as np
 import pytest
 
@@ -58,6 +60,27 @@ def test_divide_dtype_matrix(op1_dtype, op2_dtype):
     assert _compare_dtypes(r.dtype, expected.dtype, sycl_queue=q)
     assert r.shape == ar3.shape
     assert (dpt.asnumpy(r) == expected.astype(r.dtype)).all()
+
+
+@pytest.mark.parametrize("arr_dt", _all_dtypes)
+def test_divide_python_scalar(arr_dt):
+    q = get_queue_or_skip()
+    skip_if_dtype_not_supported(arr_dt, q)
+
+    X = dpt.ones((10, 10), dtype=arr_dt, sycl_queue=q)
+    py_ones = (
+        bool(1),
+        int(1),
+        float(1),
+        complex(1),
+        np.float32(1),
+        ctypes.c_int(1),
+    )
+    for sc in py_ones:
+        R = dpt.divide(X, sc)
+        assert isinstance(R, dpt.usm_ndarray)
+        R = dpt.divide(sc, X)
+        assert isinstance(R, dpt.usm_ndarray)
 
 
 @pytest.mark.parametrize("op1_dtype", _all_dtypes)

--- a/dpctl/tests/elementwise/test_equal.py
+++ b/dpctl/tests/elementwise/test_equal.py
@@ -14,16 +14,13 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-import ctypes
-
 import numpy as np
 import pytest
 
-import dpctl
 import dpctl.tensor as dpt
 from dpctl.tests.helper import get_queue_or_skip, skip_if_dtype_not_supported
 
-from .utils import _all_dtypes, _compare_dtypes, _usm_types
+from .utils import _all_dtypes, _compare_dtypes
 
 
 @pytest.mark.parametrize("op1_dtype", _all_dtypes)
@@ -60,101 +57,6 @@ def test_equal_dtype_matrix(op1_dtype, op2_dtype):
     assert (dpt.asnumpy(r) == np.full(r.shape, True, dtype=r.dtype)).all()
 
 
-@pytest.mark.parametrize("op1_usm_type", _usm_types)
-@pytest.mark.parametrize("op2_usm_type", _usm_types)
-def test_equal_usm_type_matrix(op1_usm_type, op2_usm_type):
-    get_queue_or_skip()
-
-    sz = 128
-    ar1 = dpt.ones(sz, dtype="i4", usm_type=op1_usm_type)
-    ar2 = dpt.ones_like(ar1, dtype="i4", usm_type=op2_usm_type)
-
-    r = dpt.equal(ar1, ar2)
-    assert isinstance(r, dpt.usm_ndarray)
-    expected_usm_type = dpctl.utils.get_coerced_usm_type(
-        (op1_usm_type, op2_usm_type)
-    )
-    assert r.usm_type == expected_usm_type
-
-
-def test_equal_order():
-    get_queue_or_skip()
-
-    ar1 = dpt.ones((20, 20), dtype="i4", order="C")
-    ar2 = dpt.ones((20, 20), dtype="i4", order="C")
-    r1 = dpt.equal(ar1, ar2, order="C")
-    assert r1.flags.c_contiguous
-    r2 = dpt.equal(ar1, ar2, order="F")
-    assert r2.flags.f_contiguous
-    r3 = dpt.equal(ar1, ar2, order="A")
-    assert r3.flags.c_contiguous
-    r4 = dpt.equal(ar1, ar2, order="K")
-    assert r4.flags.c_contiguous
-
-    ar1 = dpt.ones((20, 20), dtype="i4", order="F")
-    ar2 = dpt.ones((20, 20), dtype="i4", order="F")
-    r1 = dpt.equal(ar1, ar2, order="C")
-    assert r1.flags.c_contiguous
-    r2 = dpt.equal(ar1, ar2, order="F")
-    assert r2.flags.f_contiguous
-    r3 = dpt.equal(ar1, ar2, order="A")
-    assert r3.flags.f_contiguous
-    r4 = dpt.equal(ar1, ar2, order="K")
-    assert r4.flags.f_contiguous
-
-    ar1 = dpt.ones((40, 40), dtype="i4", order="C")[:20, ::-2]
-    ar2 = dpt.ones((40, 40), dtype="i4", order="C")[:20, ::-2]
-    r4 = dpt.equal(ar1, ar2, order="K")
-    assert r4.strides == (20, -1)
-
-    ar1 = dpt.ones((40, 40), dtype="i4", order="C")[:20, ::-2].mT
-    ar2 = dpt.ones((40, 40), dtype="i4", order="C")[:20, ::-2].mT
-    r4 = dpt.equal(ar1, ar2, order="K")
-    assert r4.strides == (-1, 20)
-
-
-def test_equal_broadcasting():
-    get_queue_or_skip()
-
-    m = dpt.ones((100, 5), dtype="i4")
-    v = dpt.arange(5, dtype="i4")
-
-    r = dpt.equal(m, v)
-    expected = np.full((100, 5), [False, True, False, False, False], dtype="?")
-
-    assert (dpt.asnumpy(r) == expected).all()
-
-    r2 = dpt.equal(v, m)
-    assert (dpt.asnumpy(r2) == expected).all()
-
-    r3 = dpt.empty_like(m, dtype="?")
-    dpt.equal(m, v, out=r3)
-    assert (dpt.asnumpy(r3) == expected).all()
-
-
-@pytest.mark.parametrize("arr_dt", _all_dtypes)
-def test_equal_python_scalar(arr_dt):
-    q = get_queue_or_skip()
-    skip_if_dtype_not_supported(arr_dt, q)
-
-    X = dpt.zeros((10, 10), dtype=arr_dt, sycl_queue=q)
-    py_zeros = (
-        bool(0),
-        int(0),
-        float(0),
-        complex(0),
-        np.float32(0),
-        ctypes.c_int(0),
-    )
-    for sc in py_zeros:
-        R = dpt.equal(X, sc)
-        assert isinstance(R, dpt.usm_ndarray)
-        assert dpt.all(R)
-        R = dpt.equal(sc, X)
-        assert isinstance(R, dpt.usm_ndarray)
-        assert dpt.all(R)
-
-
 class MockArray:
     def __init__(self, arr):
         self.data_ = arr
@@ -162,29 +64,3 @@ class MockArray:
     @property
     def __sycl_usm_array_interface__(self):
         return self.data_.__sycl_usm_array_interface__
-
-
-def test_equal_mock_array():
-    get_queue_or_skip()
-    a = dpt.arange(10)
-    b = dpt.ones(10)
-    c = MockArray(b)
-    r = dpt.equal(a, c)
-    assert isinstance(r, dpt.usm_ndarray)
-
-
-def test_equal_canary_mock_array():
-    get_queue_or_skip()
-    a = dpt.arange(10)
-
-    class Canary:
-        def __init__(self):
-            pass
-
-        @property
-        def __sycl_usm_array_interface__(self):
-            return None
-
-    c = Canary()
-    with pytest.raises(ValueError):
-        dpt.equal(a, c)

--- a/dpctl/tests/elementwise/test_exp.py
+++ b/dpctl/tests/elementwise/test_exp.py
@@ -23,7 +23,7 @@ from numpy.testing import assert_allclose, assert_array_equal
 import dpctl.tensor as dpt
 from dpctl.tests.helper import get_queue_or_skip, skip_if_dtype_not_supported
 
-from .utils import _all_dtypes, _map_to_device_dtype, _usm_types
+from .utils import _all_dtypes, _map_to_device_dtype
 
 
 @pytest.mark.parametrize("dtype", _all_dtypes)
@@ -38,7 +38,7 @@ def test_exp_out_type(dtype):
 
 
 @pytest.mark.parametrize("dtype", ["f2", "f4", "f8"])
-def test_exp_real_contig(dtype):
+def test_exp_real(dtype):
     q = get_queue_or_skip()
     skip_if_dtype_not_supported(dtype, q)
 
@@ -60,7 +60,7 @@ def test_exp_real_contig(dtype):
 
 
 @pytest.mark.parametrize("dtype", ["c8", "c16"])
-def test_exp_complex_contig(dtype):
+def test_exp_complex(dtype):
     q = get_queue_or_skip()
     skip_if_dtype_not_supported(dtype, q)
 
@@ -86,52 +86,6 @@ def test_exp_complex_contig(dtype):
     assert_allclose(
         dpt.asnumpy(Z), np.repeat(np.exp(Xnp), n_rep), atol=tol, rtol=tol
     )
-
-
-@pytest.mark.parametrize("usm_type", _usm_types)
-def test_exp_usm_type(usm_type):
-    q = get_queue_or_skip()
-
-    arg_dt = np.dtype("f4")
-    input_shape = (10, 10, 10, 10)
-    X = dpt.empty(input_shape, dtype=arg_dt, usm_type=usm_type, sycl_queue=q)
-    X[..., 0::2] = 16.0
-    X[..., 1::2] = 23.0
-
-    Y = dpt.exp(X)
-    assert Y.usm_type == X.usm_type
-    assert Y.sycl_queue == X.sycl_queue
-    assert Y.flags.c_contiguous
-
-    expected_Y = np.empty(input_shape, dtype=arg_dt)
-    expected_Y[..., 0::2] = np.exp(np.float32(16.0))
-    expected_Y[..., 1::2] = np.exp(np.float32(23.0))
-    tol = 8 * dpt.finfo(Y.dtype).resolution
-
-    assert_allclose(dpt.asnumpy(Y), expected_Y, atol=tol, rtol=tol)
-
-
-@pytest.mark.parametrize("dtype", _all_dtypes)
-def test_exp_order(dtype):
-    q = get_queue_or_skip()
-    skip_if_dtype_not_supported(dtype, q)
-
-    arg_dt = np.dtype(dtype)
-    input_shape = (10, 10, 10, 10)
-    X = dpt.empty(input_shape, dtype=arg_dt, sycl_queue=q)
-    X[..., 0::2] = 8.0
-    X[..., 1::2] = 11.0
-
-    for perms in itertools.permutations(range(4)):
-        U = dpt.permute_dims(X[:, ::-1, ::-1, :], perms)
-        expected_Y = np.exp(dpt.asnumpy(U))
-        for ord in ["C", "F", "A", "K"]:
-            Y = dpt.exp(U, order=ord)
-            tol = 8 * max(
-                dpt.finfo(Y.dtype).resolution,
-                np.finfo(expected_Y.dtype).resolution,
-            )
-            assert_allclose(dpt.asnumpy(Y), expected_Y, atol=tol, rtol=tol)
 
 
 @pytest.mark.parametrize("dtype", ["f2", "f4", "f8"])
@@ -161,57 +115,6 @@ def test_exp_real_special_cases(dtype):
     Ynp = np.exp(Xnp)
     assert_allclose(Y, Ynp, atol=tol, rtol=tol)
     assert_array_equal(np.signbit(Y), np.signbit(Ynp))
-
-
-@pytest.mark.parametrize("dtype", ["f2", "f4", "f8"])
-def test_exp_real_strided(dtype):
-    q = get_queue_or_skip()
-    skip_if_dtype_not_supported(dtype, q)
-
-    np.random.seed(42)
-    strides = np.array([-4, -3, -2, -1, 1, 2, 3, 4])
-    sizes = [2, 4, 6, 8, 9, 24, 72]
-    tol = 8 * dpt.finfo(dtype).resolution
-
-    for ii in sizes:
-        Xnp = np.random.uniform(low=0.01, high=88.1, size=ii)
-        Xnp.astype(dtype)
-        X = dpt.asarray(Xnp)
-        Ynp = np.exp(Xnp)
-        for jj in strides:
-            assert_allclose(
-                dpt.asnumpy(dpt.exp(X[::jj])),
-                Ynp[::jj],
-                atol=tol,
-                rtol=tol,
-            )
-
-
-@pytest.mark.parametrize("dtype", ["c8", "c16"])
-def test_exp_complex_strided(dtype):
-    q = get_queue_or_skip()
-    skip_if_dtype_not_supported(dtype, q)
-
-    np.random.seed(42)
-    strides = np.array([-4, -3, -2, -1, 1, 2, 3, 4])
-    sizes = [2, 4, 6, 8, 9, 24, 72]
-    tol = 8 * dpt.finfo(dtype).resolution
-
-    low = -88.0
-    high = 88.0
-    for ii in sizes:
-        x1 = np.random.uniform(low=low, high=high, size=ii)
-        x2 = np.random.uniform(low=low, high=high, size=ii)
-        Xnp = np.array([complex(v1, v2) for v1, v2 in zip(x1, x2)], dtype=dtype)
-        X = dpt.asarray(Xnp)
-        Ynp = np.exp(Xnp)
-        for jj in strides:
-            assert_allclose(
-                dpt.asnumpy(dpt.exp(X[::jj])),
-                Ynp[::jj],
-                atol=tol,
-                rtol=tol,
-            )
 
 
 @pytest.mark.parametrize("dtype", ["c8", "c16"])

--- a/dpctl/tests/elementwise/test_exp2.py
+++ b/dpctl/tests/elementwise/test_exp2.py
@@ -14,8 +14,6 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-import itertools
-
 import numpy as np
 import pytest
 from numpy.testing import assert_allclose
@@ -23,7 +21,7 @@ from numpy.testing import assert_allclose
 import dpctl.tensor as dpt
 from dpctl.tests.helper import get_queue_or_skip, skip_if_dtype_not_supported
 
-from .utils import _all_dtypes, _map_to_device_dtype, _usm_types
+from .utils import _all_dtypes, _map_to_device_dtype
 
 
 @pytest.mark.parametrize("dtype", _all_dtypes)
@@ -38,7 +36,7 @@ def test_exp2_out_type(dtype):
 
 
 @pytest.mark.parametrize("dtype", ["f2", "f4", "f8", "c8", "c16"])
-def test_exp2_output_contig(dtype):
+def test_exp2_basic(dtype):
     q = get_queue_or_skip()
     skip_if_dtype_not_supported(dtype, q)
 
@@ -51,68 +49,6 @@ def test_exp2_output_contig(dtype):
     tol = 8 * dpt.finfo(Y.dtype).resolution
 
     assert_allclose(dpt.asnumpy(Y), np.exp2(Xnp), atol=tol, rtol=tol)
-
-
-@pytest.mark.parametrize("dtype", ["f2", "f4", "f8", "c8", "c16"])
-def test_exp2_output_strided(dtype):
-    q = get_queue_or_skip()
-    skip_if_dtype_not_supported(dtype, q)
-
-    n_seq = 2 * 1027
-
-    X = dpt.linspace(1, 5, num=n_seq, dtype=dtype, sycl_queue=q)[::-2]
-    Xnp = dpt.asnumpy(X)
-
-    Y = dpt.exp2(X)
-    tol = 8 * dpt.finfo(Y.dtype).resolution
-
-    assert_allclose(dpt.asnumpy(Y), np.exp2(Xnp), atol=tol, rtol=tol)
-
-
-@pytest.mark.parametrize("usm_type", _usm_types)
-def test_exp2_usm_type(usm_type):
-    q = get_queue_or_skip()
-
-    arg_dt = np.dtype("f4")
-    input_shape = (10, 10, 10, 10)
-    X = dpt.empty(input_shape, dtype=arg_dt, usm_type=usm_type, sycl_queue=q)
-    X[..., 0::2] = 1 / 4
-    X[..., 1::2] = 1 / 2
-
-    Y = dpt.exp2(X)
-    assert Y.usm_type == X.usm_type
-    assert Y.sycl_queue == X.sycl_queue
-    assert Y.flags.c_contiguous
-
-    expected_Y = np.empty(input_shape, dtype=arg_dt)
-    expected_Y[..., 0::2] = np.exp2(np.float32(1 / 4))
-    expected_Y[..., 1::2] = np.exp2(np.float32(1 / 2))
-    tol = 8 * dpt.finfo(Y.dtype).resolution
-
-    assert_allclose(dpt.asnumpy(Y), expected_Y, atol=tol, rtol=tol)
-
-
-@pytest.mark.parametrize("dtype", _all_dtypes)
-def test_exp2_order(dtype):
-    q = get_queue_or_skip()
-    skip_if_dtype_not_supported(dtype, q)
-
-    arg_dt = np.dtype(dtype)
-    input_shape = (10, 10, 10, 10)
-    X = dpt.empty(input_shape, dtype=arg_dt, sycl_queue=q)
-    X[..., 0::2] = 1 / 4
-    X[..., 1::2] = 1 / 2
-
-    for perms in itertools.permutations(range(4)):
-        U = dpt.permute_dims(X[:, ::-1, ::-1, :], perms)
-        expected_Y = np.exp2(dpt.asnumpy(U))
-        for ord in ["C", "F", "A", "K"]:
-            Y = dpt.exp2(U, order=ord)
-            tol = 8 * max(
-                dpt.finfo(Y.dtype).resolution,
-                np.finfo(expected_Y.dtype).resolution,
-            )
-            assert_allclose(dpt.asnumpy(Y), expected_Y, atol=tol, rtol=tol)
 
 
 def test_exp2_special_cases():

--- a/dpctl/tests/elementwise/test_expm1.py
+++ b/dpctl/tests/elementwise/test_expm1.py
@@ -14,8 +14,6 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-import itertools
-
 import numpy as np
 import pytest
 from numpy.testing import assert_allclose
@@ -23,7 +21,7 @@ from numpy.testing import assert_allclose
 import dpctl.tensor as dpt
 from dpctl.tests.helper import get_queue_or_skip, skip_if_dtype_not_supported
 
-from .utils import _all_dtypes, _map_to_device_dtype, _usm_types
+from .utils import _all_dtypes, _map_to_device_dtype
 
 
 @pytest.mark.parametrize("dtype", _all_dtypes)
@@ -38,7 +36,7 @@ def test_expm1_out_type(dtype):
 
 
 @pytest.mark.parametrize("dtype", ["f2", "f4", "f8", "c8", "c16"])
-def test_expm1_output_contig(dtype):
+def test_expm1_basic(dtype):
     q = get_queue_or_skip()
     skip_if_dtype_not_supported(dtype, q)
 
@@ -51,68 +49,6 @@ def test_expm1_output_contig(dtype):
     tol = 8 * dpt.finfo(Y.dtype).resolution
 
     assert_allclose(dpt.asnumpy(Y), np.expm1(Xnp), atol=tol, rtol=tol)
-
-
-@pytest.mark.parametrize("dtype", ["f2", "f4", "f8", "c8", "c16"])
-def test_expm1_output_strided(dtype):
-    q = get_queue_or_skip()
-    skip_if_dtype_not_supported(dtype, q)
-
-    n_seq = 2 * 1027
-
-    X = dpt.linspace(-2, 2, num=n_seq, dtype=dtype, sycl_queue=q)[::-2]
-    Xnp = dpt.asnumpy(X)
-
-    Y = dpt.expm1(X)
-    tol = 8 * dpt.finfo(Y.dtype).resolution
-
-    assert_allclose(dpt.asnumpy(Y), np.expm1(Xnp), atol=tol, rtol=tol)
-
-
-@pytest.mark.parametrize("usm_type", _usm_types)
-def test_expm1_usm_type(usm_type):
-    q = get_queue_or_skip()
-
-    arg_dt = np.dtype("f4")
-    input_shape = (10, 10, 10, 10)
-    X = dpt.empty(input_shape, dtype=arg_dt, usm_type=usm_type, sycl_queue=q)
-    X[..., 0::2] = 1 / 50
-    X[..., 1::2] = 1 / 25
-
-    Y = dpt.expm1(X)
-    assert Y.usm_type == X.usm_type
-    assert Y.sycl_queue == X.sycl_queue
-    assert Y.flags.c_contiguous
-
-    expected_Y = np.empty(input_shape, dtype=arg_dt)
-    expected_Y[..., 0::2] = np.expm1(np.float32(1 / 50))
-    expected_Y[..., 1::2] = np.expm1(np.float32(1 / 25))
-    tol = 8 * dpt.finfo(Y.dtype).resolution
-
-    assert_allclose(dpt.asnumpy(Y), expected_Y, atol=tol, rtol=tol)
-
-
-@pytest.mark.parametrize("dtype", _all_dtypes)
-def test_expm1_order(dtype):
-    q = get_queue_or_skip()
-    skip_if_dtype_not_supported(dtype, q)
-
-    arg_dt = np.dtype(dtype)
-    input_shape = (10, 10, 10, 10)
-    X = dpt.empty(input_shape, dtype=arg_dt, sycl_queue=q)
-    X[..., 0::2] = 1 / 50
-    X[..., 1::2] = 1 / 25
-
-    for perms in itertools.permutations(range(4)):
-        U = dpt.permute_dims(X[:, ::-1, ::-1, :], perms)
-        expected_Y = np.expm1(dpt.asnumpy(U))
-        for ord in ["C", "F", "A", "K"]:
-            Y = dpt.expm1(U, order=ord)
-            tol = 8 * max(
-                dpt.finfo(Y.dtype).resolution,
-                np.finfo(expected_Y.dtype).resolution,
-            )
-            assert_allclose(dpt.asnumpy(Y), expected_Y, atol=tol, rtol=tol)
 
 
 def test_expm1_special_cases():

--- a/dpctl/tests/elementwise/test_floor_divide.py
+++ b/dpctl/tests/elementwise/test_floor_divide.py
@@ -14,22 +14,14 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-import ctypes
-
 import numpy as np
 import pytest
 
-import dpctl
 import dpctl.tensor as dpt
 from dpctl.tensor._type_utils import _can_cast
 from dpctl.tests.helper import get_queue_or_skip, skip_if_dtype_not_supported
 
-from .utils import (
-    _compare_dtypes,
-    _integral_dtypes,
-    _no_complex_dtypes,
-    _usm_types,
-)
+from .utils import _compare_dtypes, _integral_dtypes, _no_complex_dtypes
 
 
 @pytest.mark.parametrize("op1_dtype", _no_complex_dtypes[1:])
@@ -64,134 +56,6 @@ def test_floor_divide_dtype_matrix(op1_dtype, op2_dtype):
     assert _compare_dtypes(r.dtype, expected.dtype, sycl_queue=q)
     assert r.shape == ar3.shape
     assert (dpt.asnumpy(r) == expected.astype(r.dtype)).all()
-
-
-@pytest.mark.parametrize("op1_usm_type", _usm_types)
-@pytest.mark.parametrize("op2_usm_type", _usm_types)
-def test_floor_divide_usm_type_matrix(op1_usm_type, op2_usm_type):
-    get_queue_or_skip()
-
-    sz = 128
-    ar1 = dpt.ones(sz, dtype="i4", usm_type=op1_usm_type)
-    ar2 = dpt.ones_like(ar1, dtype="i4", usm_type=op2_usm_type)
-
-    r = dpt.floor_divide(ar1, ar2)
-    assert isinstance(r, dpt.usm_ndarray)
-    expected_usm_type = dpctl.utils.get_coerced_usm_type(
-        (op1_usm_type, op2_usm_type)
-    )
-    assert r.usm_type == expected_usm_type
-
-
-def test_floor_divide_order():
-    get_queue_or_skip()
-
-    ar1 = dpt.ones((20, 20), dtype="i4", order="C")
-    ar2 = dpt.ones((20, 20), dtype="i4", order="C")
-    r1 = dpt.floor_divide(ar1, ar2, order="C")
-    assert r1.flags.c_contiguous
-    r2 = dpt.floor_divide(ar1, ar2, order="F")
-    assert r2.flags.f_contiguous
-    r3 = dpt.floor_divide(ar1, ar2, order="A")
-    assert r3.flags.c_contiguous
-    r4 = dpt.floor_divide(ar1, ar2, order="K")
-    assert r4.flags.c_contiguous
-
-    ar1 = dpt.ones((20, 20), dtype="i4", order="F")
-    ar2 = dpt.ones((20, 20), dtype="i4", order="F")
-    r1 = dpt.floor_divide(ar1, ar2, order="C")
-    assert r1.flags.c_contiguous
-    r2 = dpt.floor_divide(ar1, ar2, order="F")
-    assert r2.flags.f_contiguous
-    r3 = dpt.floor_divide(ar1, ar2, order="A")
-    assert r3.flags.f_contiguous
-    r4 = dpt.floor_divide(ar1, ar2, order="K")
-    assert r4.flags.f_contiguous
-
-    ar1 = dpt.ones((40, 40), dtype="i4", order="C")[:20, ::-2]
-    ar2 = dpt.ones((40, 40), dtype="i4", order="C")[:20, ::-2]
-    r4 = dpt.floor_divide(ar1, ar2, order="K")
-    assert r4.strides == (20, -1)
-
-    ar1 = dpt.ones((40, 40), dtype="i4", order="C")[:20, ::-2].mT
-    ar2 = dpt.ones((40, 40), dtype="i4", order="C")[:20, ::-2].mT
-    r4 = dpt.floor_divide(ar1, ar2, order="K")
-    assert r4.strides == (-1, 20)
-
-
-def test_floor_divide_broadcasting():
-    get_queue_or_skip()
-
-    m = dpt.ones((100, 5), dtype="i4")
-    v = dpt.arange(1, 6, dtype="i4")
-
-    r = dpt.floor_divide(m, v)
-
-    expected = np.floor_divide(
-        np.ones((100, 5), dtype="i4"), np.arange(1, 6, dtype="i4")
-    )
-    assert (dpt.asnumpy(r) == expected.astype(r.dtype)).all()
-
-    r2 = dpt.floor_divide(v, m)
-    expected2 = np.floor_divide(
-        np.arange(1, 6, dtype="i4"), np.ones((100, 5), dtype="i4")
-    )
-    assert (dpt.asnumpy(r2) == expected2.astype(r2.dtype)).all()
-
-
-@pytest.mark.parametrize("arr_dt", _no_complex_dtypes[1:])
-def test_floor_divide_python_scalar(arr_dt):
-    q = get_queue_or_skip()
-    skip_if_dtype_not_supported(arr_dt, q)
-
-    X = dpt.ones((10, 10), dtype=arr_dt, sycl_queue=q)
-    py_ones = (
-        bool(1),
-        int(1),
-        float(1),
-        np.float32(1),
-        ctypes.c_int(1),
-    )
-    for sc in py_ones:
-        R = dpt.floor_divide(X, sc)
-        assert isinstance(R, dpt.usm_ndarray)
-        R = dpt.floor_divide(sc, X)
-        assert isinstance(R, dpt.usm_ndarray)
-
-
-class MockArray:
-    def __init__(self, arr):
-        self.data_ = arr
-
-    @property
-    def __sycl_usm_array_interface__(self):
-        return self.data_.__sycl_usm_array_interface__
-
-
-def test_floor_divide_mock_array():
-    get_queue_or_skip()
-    a = dpt.arange(10)
-    b = dpt.ones(10)
-    c = MockArray(b)
-    r = dpt.floor_divide(a, c)
-    assert isinstance(r, dpt.usm_ndarray)
-
-
-def test_floor_divide_canary_mock_array():
-    get_queue_or_skip()
-    a = dpt.arange(10)
-
-    class Canary:
-        def __init__(self):
-            pass
-
-        @property
-        def __sycl_usm_array_interface__(self):
-            return None
-
-    c = Canary()
-    with pytest.raises(ValueError):
-        dpt.floor_divide(a, c)
 
 
 def test_floor_divide_gh_1247():
@@ -261,18 +125,6 @@ def test_floor_divide_special_cases():
     res = dpt.floor_divide(x, y)
     res_np = np.floor_divide(dpt.asnumpy(x), dpt.asnumpy(y))
     np.testing.assert_array_equal(dpt.asnumpy(res), res_np)
-
-
-@pytest.mark.parametrize("dtype", _no_complex_dtypes[1:])
-def test_divide_inplace_python_scalar(dtype):
-    q = get_queue_or_skip()
-    skip_if_dtype_not_supported(dtype, q)
-    X = dpt.zeros((10, 10), dtype=dtype, sycl_queue=q)
-    dt_kind = X.dtype.kind
-    if dt_kind in "ui":
-        X //= int(1)
-    elif dt_kind == "f":
-        X //= float(1)
 
 
 @pytest.mark.parametrize("op1_dtype", _no_complex_dtypes[1:])

--- a/dpctl/tests/elementwise/test_greater_equal.py
+++ b/dpctl/tests/elementwise/test_greater_equal.py
@@ -14,16 +14,13 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-import ctypes
-
 import numpy as np
 import pytest
 
-import dpctl
 import dpctl.tensor as dpt
 from dpctl.tests.helper import get_queue_or_skip, skip_if_dtype_not_supported
 
-from .utils import _all_dtypes, _compare_dtypes, _usm_types
+from .utils import _all_dtypes, _compare_dtypes
 
 
 @pytest.mark.parametrize("op1_dtype", _all_dtypes)
@@ -132,135 +129,6 @@ def test_greater_equal_complex_float():
             r3 = dpt.greater_equal(ar3, ar1)
             expected3 = np.greater_equal(ar3_np, ar1_np)
             assert (dpt.asnumpy(r3) == expected3).all()
-
-
-@pytest.mark.parametrize("op1_usm_type", _usm_types)
-@pytest.mark.parametrize("op2_usm_type", _usm_types)
-def test_greater_equal_usm_type_matrix(op1_usm_type, op2_usm_type):
-    get_queue_or_skip()
-
-    sz = 128
-    ar1 = dpt.ones(sz, dtype="i4", usm_type=op1_usm_type)
-    ar2 = dpt.ones_like(ar1, dtype="i4", usm_type=op2_usm_type)
-
-    r = dpt.greater_equal(ar1, ar2)
-    assert isinstance(r, dpt.usm_ndarray)
-    expected_usm_type = dpctl.utils.get_coerced_usm_type(
-        (op1_usm_type, op2_usm_type)
-    )
-    assert r.usm_type == expected_usm_type
-
-
-def test_greater_equal_order():
-    get_queue_or_skip()
-
-    ar1 = dpt.ones((20, 20), dtype="i4", order="C")
-    ar2 = dpt.ones((20, 20), dtype="i4", order="C")
-    r1 = dpt.greater_equal(ar1, ar2, order="C")
-    assert r1.flags.c_contiguous
-    r2 = dpt.greater_equal(ar1, ar2, order="F")
-    assert r2.flags.f_contiguous
-    r3 = dpt.greater_equal(ar1, ar2, order="A")
-    assert r3.flags.c_contiguous
-    r4 = dpt.greater_equal(ar1, ar2, order="K")
-    assert r4.flags.c_contiguous
-
-    ar1 = dpt.ones((20, 20), dtype="i4", order="F")
-    ar2 = dpt.ones((20, 20), dtype="i4", order="F")
-    r1 = dpt.greater_equal(ar1, ar2, order="C")
-    assert r1.flags.c_contiguous
-    r2 = dpt.greater_equal(ar1, ar2, order="F")
-    assert r2.flags.f_contiguous
-    r3 = dpt.greater_equal(ar1, ar2, order="A")
-    assert r3.flags.f_contiguous
-    r4 = dpt.greater_equal(ar1, ar2, order="K")
-    assert r4.flags.f_contiguous
-
-    ar1 = dpt.ones((40, 40), dtype="i4", order="C")[:20, ::-2]
-    ar2 = dpt.ones((40, 40), dtype="i4", order="C")[:20, ::-2]
-    r4 = dpt.greater_equal(ar1, ar2, order="K")
-    assert r4.strides == (20, -1)
-
-    ar1 = dpt.ones((40, 40), dtype="i4", order="C")[:20, ::-2].mT
-    ar2 = dpt.ones((40, 40), dtype="i4", order="C")[:20, ::-2].mT
-    r4 = dpt.greater_equal(ar1, ar2, order="K")
-    assert r4.strides == (-1, 20)
-
-
-def test_greater_equal_broadcasting():
-    get_queue_or_skip()
-
-    m = dpt.ones((100, 5), dtype="i4")
-    v = dpt.arange(1, 6, dtype="i4")
-
-    r = dpt.greater_equal(m, v)
-
-    expected = np.greater_equal(
-        np.ones((100, 5), dtype="i4"), np.arange(1, 6, dtype="i4")
-    )
-    assert (dpt.asnumpy(r) == expected.astype(r.dtype)).all()
-
-    r2 = dpt.greater_equal(v, m)
-    expected2 = np.greater_equal(
-        np.arange(1, 6, dtype="i4"), np.ones((100, 5), dtype="i4")
-    )
-    assert (dpt.asnumpy(r2) == expected2.astype(r2.dtype)).all()
-
-
-@pytest.mark.parametrize("arr_dt", _all_dtypes)
-def test_greater_equal_python_scalar(arr_dt):
-    q = get_queue_or_skip()
-    skip_if_dtype_not_supported(arr_dt, q)
-
-    X = dpt.ones((10, 10), dtype=arr_dt, sycl_queue=q)
-    py_ones = (
-        bool(1),
-        int(1),
-        float(1),
-        complex(1),
-        np.float32(1),
-        ctypes.c_int(1),
-    )
-    for sc in py_ones:
-        R = dpt.greater_equal(X, sc)
-        assert isinstance(R, dpt.usm_ndarray)
-        R = dpt.greater_equal(sc, X)
-        assert isinstance(R, dpt.usm_ndarray)
-
-
-class MockArray:
-    def __init__(self, arr):
-        self.data_ = arr
-
-    @property
-    def __sycl_usm_array_interface__(self):
-        return self.data_.__sycl_usm_array_interface__
-
-
-def test_greater_equal_mock_array():
-    get_queue_or_skip()
-    a = dpt.arange(10)
-    b = dpt.ones(10)
-    c = MockArray(b)
-    r = dpt.greater_equal(a, c)
-    assert isinstance(r, dpt.usm_ndarray)
-
-
-def test_greater_equal_canary_mock_array():
-    get_queue_or_skip()
-    a = dpt.arange(10)
-
-    class Canary:
-        def __init__(self):
-            pass
-
-        @property
-        def __sycl_usm_array_interface__(self):
-            return None
-
-    c = Canary()
-    with pytest.raises(ValueError):
-        dpt.greater_equal(a, c)
 
 
 def test_greater_equal_mixed_integer_kinds():

--- a/dpctl/tests/elementwise/test_hyperbolic.py
+++ b/dpctl/tests/elementwise/test_hyperbolic.py
@@ -48,7 +48,7 @@ def test_hyper_out_type(np_call, dpt_call, dtype):
 
 @pytest.mark.parametrize("np_call, dpt_call", _all_funcs)
 @pytest.mark.parametrize("dtype", ["f2", "f4", "f8"])
-def test_hyper_real_contig(np_call, dpt_call, dtype):
+def test_hyper_basic(np_call, dpt_call, dtype):
     q = get_queue_or_skip()
     skip_if_dtype_not_supported(dtype, q)
 
@@ -79,7 +79,7 @@ def test_hyper_real_contig(np_call, dpt_call, dtype):
 
 @pytest.mark.parametrize("np_call, dpt_call", _all_funcs)
 @pytest.mark.parametrize("dtype", ["c8", "c16"])
-def test_hyper_complex_contig(np_call, dpt_call, dtype):
+def test_hyper_complex(np_call, dpt_call, dtype):
     q = get_queue_or_skip()
     skip_if_dtype_not_supported(dtype, q)
 
@@ -105,68 +105,6 @@ def test_hyper_complex_contig(np_call, dpt_call, dtype):
     assert_allclose(
         dpt.asnumpy(Z), np.repeat(np_call(Xnp), n_rep), atol=tol, rtol=tol
     )
-
-
-@pytest.mark.parametrize("np_call, dpt_call", _all_funcs)
-@pytest.mark.parametrize("dtype", ["f2", "f4", "f8"])
-def test_hyper_real_strided(np_call, dpt_call, dtype):
-    q = get_queue_or_skip()
-    skip_if_dtype_not_supported(dtype, q)
-
-    np.random.seed(42)
-    strides = np.array([-4, -3, -2, -1, 1, 2, 3, 4])
-    sizes = [2, 4, 6, 8, 9, 24, 72]
-    tol = 8 * dpt.finfo(dtype).resolution
-
-    low = -10.0
-    high = 10.0
-    if np_call == np.arctanh:
-        low = -0.9
-        high = 0.9
-    elif np_call == np.arccosh:
-        low = 1.01
-        high = 100.0
-
-    for ii in sizes:
-        Xnp = np.random.uniform(low=low, high=high, size=ii)
-        Xnp.astype(dtype)
-        X = dpt.asarray(Xnp)
-        Ynp = np_call(Xnp)
-        for jj in strides:
-            assert_allclose(
-                dpt.asnumpy(dpt_call(X[::jj])),
-                Ynp[::jj],
-                atol=tol,
-                rtol=tol,
-            )
-
-
-@pytest.mark.parametrize("np_call, dpt_call", _all_funcs)
-@pytest.mark.parametrize("dtype", ["c8", "c16"])
-def test_hyper_complex_strided(np_call, dpt_call, dtype):
-    q = get_queue_or_skip()
-    skip_if_dtype_not_supported(dtype, q)
-
-    np.random.seed(42)
-    strides = np.array([-4, -3, -2, -1, 1, 2, 3, 4])
-    sizes = [2, 4, 6, 8, 9, 24, 72]
-    tol = 50 * dpt.finfo(dtype).resolution
-
-    low = -8.0
-    high = 8.0
-    for ii in sizes:
-        x1 = np.random.uniform(low=low, high=high, size=ii)
-        x2 = np.random.uniform(low=low, high=high, size=ii)
-        Xnp = np.array([complex(v1, v2) for v1, v2 in zip(x1, x2)], dtype=dtype)
-        X = dpt.asarray(Xnp)
-        Ynp = np_call(Xnp)
-        for jj in strides:
-            assert_allclose(
-                dpt.asnumpy(dpt_call(X[::jj])),
-                Ynp[::jj],
-                atol=tol,
-                rtol=tol,
-            )
 
 
 @pytest.mark.parametrize("np_call, dpt_call", _all_funcs)

--- a/dpctl/tests/elementwise/test_hypot.py
+++ b/dpctl/tests/elementwise/test_hypot.py
@@ -14,16 +14,13 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-import ctypes
-
 import numpy as np
 import pytest
 
-import dpctl
 import dpctl.tensor as dpt
 from dpctl.tests.helper import get_queue_or_skip, skip_if_dtype_not_supported
 
-from .utils import _compare_dtypes, _no_complex_dtypes, _usm_types
+from .utils import _compare_dtypes, _no_complex_dtypes
 
 
 @pytest.mark.parametrize("op1_dtype", _no_complex_dtypes[1:])
@@ -58,136 +55,3 @@ def test_hypot_dtype_matrix(op1_dtype, op2_dtype):
     assert _compare_dtypes(r.dtype, expected.dtype, sycl_queue=q)
     assert r.shape == ar3.shape
     assert (dpt.asnumpy(r) == expected.astype(r.dtype)).all()
-
-
-@pytest.mark.parametrize("op1_usm_type", _usm_types)
-@pytest.mark.parametrize("op2_usm_type", _usm_types)
-def test_hypot_usm_type_matrix(op1_usm_type, op2_usm_type):
-    get_queue_or_skip()
-
-    sz = 128
-    ar1 = dpt.ones(sz, dtype="i4", usm_type=op1_usm_type)
-    ar2 = dpt.ones_like(ar1, dtype="i4", usm_type=op2_usm_type)
-
-    r = dpt.hypot(ar1, ar2)
-    assert isinstance(r, dpt.usm_ndarray)
-    expected_usm_type = dpctl.utils.get_coerced_usm_type(
-        (op1_usm_type, op2_usm_type)
-    )
-    assert r.usm_type == expected_usm_type
-
-
-def test_hypot_order():
-    get_queue_or_skip()
-
-    ar1 = dpt.ones((20, 20), dtype="i4", order="C")
-    ar2 = dpt.ones((20, 20), dtype="i4", order="C")
-    r1 = dpt.hypot(ar1, ar2, order="C")
-    assert r1.flags.c_contiguous
-    r2 = dpt.hypot(ar1, ar2, order="F")
-    assert r2.flags.f_contiguous
-    r3 = dpt.hypot(ar1, ar2, order="A")
-    assert r3.flags.c_contiguous
-    r4 = dpt.hypot(ar1, ar2, order="K")
-    assert r4.flags.c_contiguous
-
-    ar1 = dpt.ones((20, 20), dtype="i4", order="F")
-    ar2 = dpt.ones((20, 20), dtype="i4", order="F")
-    r1 = dpt.hypot(ar1, ar2, order="C")
-    assert r1.flags.c_contiguous
-    r2 = dpt.hypot(ar1, ar2, order="F")
-    assert r2.flags.f_contiguous
-    r3 = dpt.hypot(ar1, ar2, order="A")
-    assert r3.flags.f_contiguous
-    r4 = dpt.hypot(ar1, ar2, order="K")
-    assert r4.flags.f_contiguous
-
-    ar1 = dpt.ones((40, 40), dtype="i4", order="C")[:20, ::-2]
-    ar2 = dpt.ones((40, 40), dtype="i4", order="C")[:20, ::-2]
-    r4 = dpt.hypot(ar1, ar2, order="K")
-    assert r4.strides == (20, -1)
-
-    ar1 = dpt.ones((40, 40), dtype="i4", order="C")[:20, ::-2].mT
-    ar2 = dpt.ones((40, 40), dtype="i4", order="C")[:20, ::-2].mT
-    r4 = dpt.hypot(ar1, ar2, order="K")
-    assert r4.strides == (-1, 20)
-
-
-def test_hypot_broadcasting():
-    get_queue_or_skip()
-
-    m = dpt.ones((100, 5), dtype="i4")
-    v = dpt.arange(1, 6, dtype="i4")
-
-    r = dpt.hypot(m, v)
-
-    expected = np.hypot(
-        np.ones((100, 5), dtype="i4"), np.arange(1, 6, dtype="i4")
-    )
-    tol = 8 * np.finfo(r.dtype).resolution
-    assert np.allclose(
-        dpt.asnumpy(r), expected.astype(r.dtype), atol=tol, rtol=tol
-    )
-
-    r2 = dpt.hypot(v, m)
-    expected2 = np.hypot(
-        np.arange(1, 6, dtype="i4"), np.ones((100, 5), dtype="i4")
-    )
-    assert np.allclose(
-        dpt.asnumpy(r2), expected2.astype(r2.dtype), atol=tol, rtol=tol
-    )
-
-
-@pytest.mark.parametrize("arr_dt", _no_complex_dtypes[1:])
-def test_hypot_python_scalar(arr_dt):
-    q = get_queue_or_skip()
-    skip_if_dtype_not_supported(arr_dt, q)
-
-    X = dpt.ones((10, 10), dtype=arr_dt, sycl_queue=q)
-    py_ones = (
-        bool(1),
-        int(1),
-        float(1),
-        np.float32(1),
-        ctypes.c_int(1),
-    )
-    for sc in py_ones:
-        R = dpt.hypot(X, sc)
-        assert isinstance(R, dpt.usm_ndarray)
-        R = dpt.hypot(sc, X)
-        assert isinstance(R, dpt.usm_ndarray)
-
-
-class MockArray:
-    def __init__(self, arr):
-        self.data_ = arr
-
-    @property
-    def __sycl_usm_array_interface__(self):
-        return self.data_.__sycl_usm_array_interface__
-
-
-def test_hypot_mock_array():
-    get_queue_or_skip()
-    a = dpt.arange(10)
-    b = dpt.ones(10)
-    c = MockArray(b)
-    r = dpt.hypot(a, c)
-    assert isinstance(r, dpt.usm_ndarray)
-
-
-def test_hypot_canary_mock_array():
-    get_queue_or_skip()
-    a = dpt.arange(10)
-
-    class Canary:
-        def __init__(self):
-            pass
-
-        @property
-        def __sycl_usm_array_interface__(self):
-            return None
-
-    c = Canary()
-    with pytest.raises(ValueError):
-        dpt.hypot(a, c)

--- a/dpctl/tests/elementwise/test_isfinite.py
+++ b/dpctl/tests/elementwise/test_isfinite.py
@@ -14,11 +14,8 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-import itertools
-
 import numpy as np
 import pytest
-from numpy.testing import assert_allclose
 
 import dpctl.tensor as dpt
 from dpctl.tests.helper import get_queue_or_skip, skip_if_dtype_not_supported
@@ -80,20 +77,3 @@ def test_isfinite_floats(dtype):
         r = dpt.empty_like(Y, dtype="bool")
         dpt.isfinite(Y, out=r)
         assert np.array_equal(dpt.asnumpy(r)[()], np.isfinite(Ynp))
-
-
-@pytest.mark.parametrize("dtype", _all_dtypes)
-def test_isfinite_order(dtype):
-    q = get_queue_or_skip()
-    skip_if_dtype_not_supported(dtype, q)
-
-    arg_dt = np.dtype(dtype)
-    input_shape = (10, 10, 10, 10)
-    X = dpt.ones(input_shape, dtype=arg_dt, sycl_queue=q)
-
-    for perms in itertools.permutations(range(4)):
-        U = dpt.permute_dims(X[::2, ::-1, ::-1, ::5], perms)
-        expected_Y = np.full(U.shape, fill_value=True, dtype=dpt.bool)
-        for ord in ["C", "F", "A", "K"]:
-            Y = dpt.isfinite(U, order=ord)
-            assert_allclose(dpt.asnumpy(Y), expected_Y)

--- a/dpctl/tests/elementwise/test_isinf.py
+++ b/dpctl/tests/elementwise/test_isinf.py
@@ -14,11 +14,8 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-import itertools
-
 import numpy as np
 import pytest
-from numpy.testing import assert_allclose
 
 import dpctl.tensor as dpt
 from dpctl.tests.helper import get_queue_or_skip, skip_if_dtype_not_supported
@@ -74,20 +71,3 @@ def test_isinf_floats(dtype):
         Ynp = np.repeat(np.array([y1, y2, y3, y4], dtype=dtype), mult)
         Y = dpt.asarray(Ynp, sycl_queue=q)
         assert np.array_equal(dpt.asnumpy(dpt.isinf(Y)), np.isinf(Ynp))
-
-
-@pytest.mark.parametrize("dtype", _all_dtypes)
-def test_isinf_order(dtype):
-    q = get_queue_or_skip()
-    skip_if_dtype_not_supported(dtype, q)
-
-    arg_dt = np.dtype(dtype)
-    input_shape = (10, 10, 10, 10)
-    X = dpt.ones(input_shape, dtype=arg_dt, sycl_queue=q)
-
-    for perms in itertools.permutations(range(4)):
-        U = dpt.permute_dims(X[::2, ::-1, ::-1, ::5], perms)
-        expected_Y = np.full(U.shape, fill_value=False, dtype=dpt.bool)
-        for ord in ["C", "F", "A", "K"]:
-            Y = dpt.isinf(U, order=ord)
-            assert_allclose(dpt.asnumpy(Y), expected_Y)

--- a/dpctl/tests/elementwise/test_isnan.py
+++ b/dpctl/tests/elementwise/test_isnan.py
@@ -14,8 +14,6 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-import itertools
-
 import numpy as np
 import pytest
 
@@ -79,20 +77,3 @@ def test_isnan_floats(dtype):
         r = dpt.empty_like(Y, dtype="bool")
         dpt.isnan(Y, out=r)
         assert np.array_equal(dpt.asnumpy(r)[()], np.isnan(Ynp))
-
-
-@pytest.mark.parametrize("dtype", _all_dtypes)
-def test_isnan_order(dtype):
-    q = get_queue_or_skip()
-    skip_if_dtype_not_supported(dtype, q)
-
-    arg_dt = np.dtype(dtype)
-    input_shape = (10, 10, 10, 10)
-    X = dpt.ones(input_shape, dtype=arg_dt, sycl_queue=q)
-
-    for perms in itertools.permutations(range(4)):
-        U = dpt.permute_dims(X[::2, ::-1, ::-1, ::5], perms)
-        expected_Y = np.full(U.shape, fill_value=False, dtype=dpt.bool)
-        for ord in ["C", "F", "A", "K"]:
-            Y = dpt.isnan(U, order=ord)
-            assert np.allclose(dpt.asnumpy(Y), expected_Y)

--- a/dpctl/tests/elementwise/test_less.py
+++ b/dpctl/tests/elementwise/test_less.py
@@ -14,16 +14,13 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-import ctypes
-
 import numpy as np
 import pytest
 
-import dpctl
 import dpctl.tensor as dpt
 from dpctl.tests.helper import get_queue_or_skip, skip_if_dtype_not_supported
 
-from .utils import _all_dtypes, _compare_dtypes, _usm_types
+from .utils import _all_dtypes, _compare_dtypes
 
 
 @pytest.mark.parametrize("op1_dtype", _all_dtypes)
@@ -134,135 +131,6 @@ def test_less_complex_float():
             r3 = dpt.less(ar3, ar1)
             expected3 = np.less(ar3_np, ar1_np)
             assert (dpt.asnumpy(r3) == expected3).all()
-
-
-@pytest.mark.parametrize("op1_usm_type", _usm_types)
-@pytest.mark.parametrize("op2_usm_type", _usm_types)
-def test_less_usm_type_matrix(op1_usm_type, op2_usm_type):
-    get_queue_or_skip()
-
-    sz = 128
-    ar1 = dpt.ones(sz, dtype="i4", usm_type=op1_usm_type)
-    ar2 = dpt.ones_like(ar1, dtype="i4", usm_type=op2_usm_type)
-
-    r = dpt.less(ar1, ar2)
-    assert isinstance(r, dpt.usm_ndarray)
-    expected_usm_type = dpctl.utils.get_coerced_usm_type(
-        (op1_usm_type, op2_usm_type)
-    )
-    assert r.usm_type == expected_usm_type
-
-
-def test_less_order():
-    get_queue_or_skip()
-
-    ar1 = dpt.ones((20, 20), dtype="i4", order="C")
-    ar2 = dpt.ones((20, 20), dtype="i4", order="C")
-    r1 = dpt.less(ar1, ar2, order="C")
-    assert r1.flags.c_contiguous
-    r2 = dpt.less(ar1, ar2, order="F")
-    assert r2.flags.f_contiguous
-    r3 = dpt.less(ar1, ar2, order="A")
-    assert r3.flags.c_contiguous
-    r4 = dpt.less(ar1, ar2, order="K")
-    assert r4.flags.c_contiguous
-
-    ar1 = dpt.ones((20, 20), dtype="i4", order="F")
-    ar2 = dpt.ones((20, 20), dtype="i4", order="F")
-    r1 = dpt.less(ar1, ar2, order="C")
-    assert r1.flags.c_contiguous
-    r2 = dpt.less(ar1, ar2, order="F")
-    assert r2.flags.f_contiguous
-    r3 = dpt.less(ar1, ar2, order="A")
-    assert r3.flags.f_contiguous
-    r4 = dpt.less(ar1, ar2, order="K")
-    assert r4.flags.f_contiguous
-
-    ar1 = dpt.ones((40, 40), dtype="i4", order="C")[:20, ::-2]
-    ar2 = dpt.ones((40, 40), dtype="i4", order="C")[:20, ::-2]
-    r4 = dpt.less(ar1, ar2, order="K")
-    assert r4.strides == (20, -1)
-
-    ar1 = dpt.ones((40, 40), dtype="i4", order="C")[:20, ::-2].mT
-    ar2 = dpt.ones((40, 40), dtype="i4", order="C")[:20, ::-2].mT
-    r4 = dpt.less(ar1, ar2, order="K")
-    assert r4.strides == (-1, 20)
-
-
-def test_less_broadcasting():
-    get_queue_or_skip()
-
-    m = dpt.ones((100, 5), dtype="i4")
-    v = dpt.arange(1, 6, dtype="i4")
-
-    r = dpt.less(m, v)
-
-    expected = np.less(
-        np.ones((100, 5), dtype="i4"), np.arange(1, 6, dtype="i4")
-    )
-    assert (dpt.asnumpy(r) == expected.astype(r.dtype)).all()
-
-    r2 = dpt.less(v, m)
-    expected2 = np.less(
-        np.arange(1, 6, dtype="i4"), np.ones((100, 5), dtype="i4")
-    )
-    assert (dpt.asnumpy(r2) == expected2.astype(r2.dtype)).all()
-
-
-@pytest.mark.parametrize("arr_dt", _all_dtypes)
-def test_less_python_scalar(arr_dt):
-    q = get_queue_or_skip()
-    skip_if_dtype_not_supported(arr_dt, q)
-
-    X = dpt.ones((10, 10), dtype=arr_dt, sycl_queue=q)
-    py_ones = (
-        bool(1),
-        int(1),
-        float(1),
-        complex(1),
-        np.float32(1),
-        ctypes.c_int(1),
-    )
-    for sc in py_ones:
-        R = dpt.less(X, sc)
-        assert isinstance(R, dpt.usm_ndarray)
-        R = dpt.less(sc, X)
-        assert isinstance(R, dpt.usm_ndarray)
-
-
-class MockArray:
-    def __init__(self, arr):
-        self.data_ = arr
-
-    @property
-    def __sycl_usm_array_interface__(self):
-        return self.data_.__sycl_usm_array_interface__
-
-
-def test_less_mock_array():
-    get_queue_or_skip()
-    a = dpt.arange(10)
-    b = dpt.ones(10)
-    c = MockArray(b)
-    r = dpt.less(a, c)
-    assert isinstance(r, dpt.usm_ndarray)
-
-
-def test_less_canary_mock_array():
-    get_queue_or_skip()
-    a = dpt.arange(10)
-
-    class Canary:
-        def __init__(self):
-            pass
-
-        @property
-        def __sycl_usm_array_interface__(self):
-            return None
-
-    c = Canary()
-    with pytest.raises(ValueError):
-        dpt.less(a, c)
 
 
 def test_less_mixed_integer_kinds():

--- a/dpctl/tests/elementwise/test_less_equal.py
+++ b/dpctl/tests/elementwise/test_less_equal.py
@@ -14,16 +14,13 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-import ctypes
-
 import numpy as np
 import pytest
 
-import dpctl
 import dpctl.tensor as dpt
 from dpctl.tests.helper import get_queue_or_skip, skip_if_dtype_not_supported
 
-from .utils import _all_dtypes, _compare_dtypes, _usm_types
+from .utils import _all_dtypes, _compare_dtypes
 
 
 @pytest.mark.parametrize("op1_dtype", _all_dtypes)
@@ -133,135 +130,6 @@ def test_less_equal_complex_float():
             r3 = dpt.less_equal(ar3, ar1)
             expected3 = np.less_equal(ar3_np, ar1_np)
             assert (dpt.asnumpy(r3) == expected3).all()
-
-
-@pytest.mark.parametrize("op1_usm_type", _usm_types)
-@pytest.mark.parametrize("op2_usm_type", _usm_types)
-def test_less_equal_usm_type_matrix(op1_usm_type, op2_usm_type):
-    get_queue_or_skip()
-
-    sz = 128
-    ar1 = dpt.ones(sz, dtype="i4", usm_type=op1_usm_type)
-    ar2 = dpt.ones_like(ar1, dtype="i4", usm_type=op2_usm_type)
-
-    r = dpt.less_equal(ar1, ar2)
-    assert isinstance(r, dpt.usm_ndarray)
-    expected_usm_type = dpctl.utils.get_coerced_usm_type(
-        (op1_usm_type, op2_usm_type)
-    )
-    assert r.usm_type == expected_usm_type
-
-
-def test_less_equal_order():
-    get_queue_or_skip()
-
-    ar1 = dpt.ones((20, 20), dtype="i4", order="C")
-    ar2 = dpt.ones((20, 20), dtype="i4", order="C")
-    r1 = dpt.less_equal(ar1, ar2, order="C")
-    assert r1.flags.c_contiguous
-    r2 = dpt.less_equal(ar1, ar2, order="F")
-    assert r2.flags.f_contiguous
-    r3 = dpt.less_equal(ar1, ar2, order="A")
-    assert r3.flags.c_contiguous
-    r4 = dpt.less_equal(ar1, ar2, order="K")
-    assert r4.flags.c_contiguous
-
-    ar1 = dpt.ones((20, 20), dtype="i4", order="F")
-    ar2 = dpt.ones((20, 20), dtype="i4", order="F")
-    r1 = dpt.less_equal(ar1, ar2, order="C")
-    assert r1.flags.c_contiguous
-    r2 = dpt.less_equal(ar1, ar2, order="F")
-    assert r2.flags.f_contiguous
-    r3 = dpt.less_equal(ar1, ar2, order="A")
-    assert r3.flags.f_contiguous
-    r4 = dpt.less_equal(ar1, ar2, order="K")
-    assert r4.flags.f_contiguous
-
-    ar1 = dpt.ones((40, 40), dtype="i4", order="C")[:20, ::-2]
-    ar2 = dpt.ones((40, 40), dtype="i4", order="C")[:20, ::-2]
-    r4 = dpt.less_equal(ar1, ar2, order="K")
-    assert r4.strides == (20, -1)
-
-    ar1 = dpt.ones((40, 40), dtype="i4", order="C")[:20, ::-2].mT
-    ar2 = dpt.ones((40, 40), dtype="i4", order="C")[:20, ::-2].mT
-    r4 = dpt.less_equal(ar1, ar2, order="K")
-    assert r4.strides == (-1, 20)
-
-
-def test_less_equal_broadcasting():
-    get_queue_or_skip()
-
-    m = dpt.ones((100, 5), dtype="i4")
-    v = dpt.arange(1, 6, dtype="i4")
-
-    r = dpt.less_equal(m, v)
-
-    expected = np.less_equal(
-        np.ones((100, 5), dtype="i4"), np.arange(1, 6, dtype="i4")
-    )
-    assert (dpt.asnumpy(r) == expected.astype(r.dtype)).all()
-
-    r2 = dpt.less_equal(v, m)
-    expected2 = np.less_equal(
-        np.arange(1, 6, dtype="i4"), np.ones((100, 5), dtype="i4")
-    )
-    assert (dpt.asnumpy(r2) == expected2.astype(r2.dtype)).all()
-
-
-@pytest.mark.parametrize("arr_dt", _all_dtypes)
-def test_less_equal_python_scalar(arr_dt):
-    q = get_queue_or_skip()
-    skip_if_dtype_not_supported(arr_dt, q)
-
-    X = dpt.ones((10, 10), dtype=arr_dt, sycl_queue=q)
-    py_ones = (
-        bool(1),
-        int(1),
-        float(1),
-        complex(1),
-        np.float32(1),
-        ctypes.c_int(1),
-    )
-    for sc in py_ones:
-        R = dpt.less_equal(X, sc)
-        assert isinstance(R, dpt.usm_ndarray)
-        R = dpt.less_equal(sc, X)
-        assert isinstance(R, dpt.usm_ndarray)
-
-
-class MockArray:
-    def __init__(self, arr):
-        self.data_ = arr
-
-    @property
-    def __sycl_usm_array_interface__(self):
-        return self.data_.__sycl_usm_array_interface__
-
-
-def test_less_equal_mock_array():
-    get_queue_or_skip()
-    a = dpt.arange(10)
-    b = dpt.ones(10)
-    c = MockArray(b)
-    r = dpt.less_equal(a, c)
-    assert isinstance(r, dpt.usm_ndarray)
-
-
-def test_less_equal_canary_mock_array():
-    get_queue_or_skip()
-    a = dpt.arange(10)
-
-    class Canary:
-        def __init__(self):
-            pass
-
-        @property
-        def __sycl_usm_array_interface__(self):
-            return None
-
-    c = Canary()
-    with pytest.raises(ValueError):
-        dpt.less_equal(a, c)
 
 
 def test_less_equal_mixed_integer_kinds():

--- a/dpctl/tests/elementwise/test_log.py
+++ b/dpctl/tests/elementwise/test_log.py
@@ -14,8 +14,6 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-import itertools
-
 import numpy as np
 import pytest
 from numpy.testing import assert_allclose, assert_equal
@@ -23,7 +21,7 @@ from numpy.testing import assert_allclose, assert_equal
 import dpctl.tensor as dpt
 from dpctl.tests.helper import get_queue_or_skip, skip_if_dtype_not_supported
 
-from .utils import _all_dtypes, _map_to_device_dtype, _usm_types
+from .utils import _all_dtypes, _map_to_device_dtype
 
 
 @pytest.mark.parametrize("dtype", _all_dtypes)
@@ -38,7 +36,7 @@ def test_log_out_type(dtype):
 
 
 @pytest.mark.parametrize("dtype", ["f2", "f4", "f8", "c8", "c16"])
-def test_log_output_contig(dtype):
+def test_log_basic(dtype):
     q = get_queue_or_skip()
     skip_if_dtype_not_supported(dtype, q)
 
@@ -51,68 +49,6 @@ def test_log_output_contig(dtype):
     tol = 8 * dpt.finfo(Y.dtype).resolution
 
     assert_allclose(dpt.asnumpy(Y), np.log(Xnp), atol=tol, rtol=tol)
-
-
-@pytest.mark.parametrize("dtype", ["f2", "f4", "f8", "c8", "c16"])
-def test_log_output_strided(dtype):
-    q = get_queue_or_skip()
-    skip_if_dtype_not_supported(dtype, q)
-
-    n_seq = 2 * 1027
-
-    X = dpt.linspace(1, 13, num=n_seq, dtype=dtype, sycl_queue=q)[::-2]
-    Xnp = dpt.asnumpy(X)
-
-    Y = dpt.log(X)
-    tol = 8 * dpt.finfo(Y.dtype).resolution
-
-    assert_allclose(dpt.asnumpy(Y), np.log(Xnp), atol=tol, rtol=tol)
-
-
-@pytest.mark.parametrize("usm_type", _usm_types)
-def test_log_usm_type(usm_type):
-    q = get_queue_or_skip()
-
-    arg_dt = np.dtype("f4")
-    input_shape = (10, 10, 10, 10)
-    X = dpt.empty(input_shape, dtype=arg_dt, usm_type=usm_type, sycl_queue=q)
-    X[..., 0::2] = 4 * dpt.e
-    X[..., 1::2] = 10 * dpt.e
-
-    Y = dpt.log(X)
-    assert Y.usm_type == X.usm_type
-    assert Y.sycl_queue == X.sycl_queue
-    assert Y.flags.c_contiguous
-
-    expected_Y = np.empty(input_shape, dtype=arg_dt)
-    expected_Y[..., 0::2] = np.log(np.float32(4 * dpt.e))
-    expected_Y[..., 1::2] = np.log(np.float32(10 * dpt.e))
-    tol = 8 * dpt.finfo(Y.dtype).resolution
-
-    assert_allclose(dpt.asnumpy(Y), expected_Y, atol=tol, rtol=tol)
-
-
-@pytest.mark.parametrize("dtype", _all_dtypes)
-def test_log_order(dtype):
-    q = get_queue_or_skip()
-    skip_if_dtype_not_supported(dtype, q)
-
-    arg_dt = np.dtype(dtype)
-    input_shape = (10, 10, 10, 10)
-    X = dpt.empty(input_shape, dtype=arg_dt, sycl_queue=q)
-    X[..., 0::2] = 4 * dpt.e
-    X[..., 1::2] = 10 * dpt.e
-
-    for perms in itertools.permutations(range(4)):
-        U = dpt.permute_dims(X[:, ::-1, ::-1, :], perms)
-        expected_Y = np.log(dpt.asnumpy(U))
-        for ord in ["C", "F", "A", "K"]:
-            Y = dpt.log(U, order=ord)
-            tol = 8 * max(
-                dpt.finfo(Y.dtype).resolution,
-                np.finfo(expected_Y.dtype).resolution,
-            )
-            assert_allclose(dpt.asnumpy(Y), expected_Y, atol=tol, rtol=tol)
 
 
 def test_log_special_cases():

--- a/dpctl/tests/elementwise/test_log10.py
+++ b/dpctl/tests/elementwise/test_log10.py
@@ -14,8 +14,6 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-import itertools
-
 import numpy as np
 import pytest
 from numpy.testing import assert_equal
@@ -23,7 +21,7 @@ from numpy.testing import assert_equal
 import dpctl.tensor as dpt
 from dpctl.tests.helper import get_queue_or_skip, skip_if_dtype_not_supported
 
-from .utils import _all_dtypes, _map_to_device_dtype, _usm_types
+from .utils import _all_dtypes, _map_to_device_dtype
 
 
 @pytest.mark.parametrize("dtype", _all_dtypes)
@@ -38,7 +36,7 @@ def test_log_out_type(dtype):
 
 
 @pytest.mark.parametrize("dtype", ["f2", "f4", "f8", "c8", "c16"])
-def test_log_output_contig(dtype):
+def test_log_basic(dtype):
     q = get_queue_or_skip()
     skip_if_dtype_not_supported(dtype, q)
 
@@ -53,72 +51,6 @@ def test_log_output_contig(dtype):
     np.testing.assert_allclose(
         dpt.asnumpy(Y), np.log10(Xnp), atol=tol, rtol=tol
     )
-
-
-@pytest.mark.parametrize("dtype", ["f2", "f4", "f8", "c8", "c16"])
-def test_log_output_strided(dtype):
-    q = get_queue_or_skip()
-    skip_if_dtype_not_supported(dtype, q)
-
-    n_seq = 2 * 1027
-
-    X = dpt.linspace(1, 13, num=n_seq, dtype=dtype, sycl_queue=q)[::-2]
-    Xnp = dpt.asnumpy(X)
-
-    Y = dpt.log10(X)
-    tol = 8 * dpt.finfo(Y.dtype).resolution
-
-    np.testing.assert_allclose(
-        dpt.asnumpy(Y), np.log10(Xnp), atol=tol, rtol=tol
-    )
-
-
-@pytest.mark.parametrize("usm_type", _usm_types)
-def test_log_usm_type(usm_type):
-    q = get_queue_or_skip()
-
-    arg_dt = np.dtype("f4")
-    input_shape = (10, 10, 10, 10)
-    X = dpt.empty(input_shape, dtype=arg_dt, usm_type=usm_type, sycl_queue=q)
-    X[..., 0::2] = 4 * dpt.e
-    X[..., 1::2] = 10 * dpt.e
-
-    Y = dpt.log10(X)
-    assert Y.usm_type == X.usm_type
-    assert Y.sycl_queue == X.sycl_queue
-    assert Y.flags.c_contiguous
-
-    expected_Y = np.empty(input_shape, dtype=arg_dt)
-    expected_Y[..., 0::2] = np.log10(np.float32(4 * dpt.e))
-    expected_Y[..., 1::2] = np.log10(np.float32(10 * dpt.e))
-    tol = 8 * dpt.finfo(Y.dtype).resolution
-
-    np.testing.assert_allclose(dpt.asnumpy(Y), expected_Y, atol=tol, rtol=tol)
-
-
-@pytest.mark.parametrize("dtype", _all_dtypes)
-def test_log_order(dtype):
-    q = get_queue_or_skip()
-    skip_if_dtype_not_supported(dtype, q)
-
-    arg_dt = np.dtype(dtype)
-    input_shape = (10, 10, 10, 10)
-    X = dpt.empty(input_shape, dtype=arg_dt, sycl_queue=q)
-    X[..., 0::2] = 4 * dpt.e
-    X[..., 1::2] = 10 * dpt.e
-
-    for perms in itertools.permutations(range(4)):
-        U = dpt.permute_dims(X[:, ::-1, ::-1, :], perms)
-        expected_Y = np.log10(dpt.asnumpy(U))
-        for ord in ["C", "F", "A", "K"]:
-            Y = dpt.log10(U, order=ord)
-            tol = 8 * max(
-                dpt.finfo(Y.dtype).resolution,
-                np.finfo(expected_Y.dtype).resolution,
-            )
-            np.testing.assert_allclose(
-                dpt.asnumpy(Y), expected_Y, atol=tol, rtol=tol
-            )
 
 
 def test_log_special_cases():

--- a/dpctl/tests/elementwise/test_log1p.py
+++ b/dpctl/tests/elementwise/test_log1p.py
@@ -14,8 +14,6 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-import itertools
-
 import numpy as np
 import pytest
 from numpy.testing import assert_allclose
@@ -23,7 +21,7 @@ from numpy.testing import assert_allclose
 import dpctl.tensor as dpt
 from dpctl.tests.helper import get_queue_or_skip, skip_if_dtype_not_supported
 
-from .utils import _all_dtypes, _map_to_device_dtype, _usm_types
+from .utils import _all_dtypes, _map_to_device_dtype
 
 
 @pytest.mark.parametrize("dtype", _all_dtypes)
@@ -38,7 +36,7 @@ def test_log1p_out_type(dtype):
 
 
 @pytest.mark.parametrize("dtype", ["f2", "f4", "f8", "c8", "c16"])
-def test_log1p_output_contig(dtype):
+def test_log1p_basic(dtype):
     q = get_queue_or_skip()
     skip_if_dtype_not_supported(dtype, q)
 
@@ -51,68 +49,6 @@ def test_log1p_output_contig(dtype):
     tol = 8 * dpt.finfo(Y.dtype).resolution
 
     assert_allclose(dpt.asnumpy(Y), np.log1p(Xnp), atol=tol, rtol=tol)
-
-
-@pytest.mark.parametrize("dtype", ["f2", "f4", "f8", "c8", "c16"])
-def test_log1p_output_strided(dtype):
-    q = get_queue_or_skip()
-    skip_if_dtype_not_supported(dtype, q)
-
-    n_seq = 2 * 1027
-
-    X = dpt.linspace(0, 2, num=n_seq, dtype=dtype, sycl_queue=q)[::-2]
-    Xnp = dpt.asnumpy(X)
-
-    Y = dpt.log1p(X)
-    tol = 8 * dpt.finfo(Y.dtype).resolution
-
-    assert_allclose(dpt.asnumpy(Y), np.log1p(Xnp), atol=tol, rtol=tol)
-
-
-@pytest.mark.parametrize("usm_type", _usm_types)
-def test_log1p_usm_type(usm_type):
-    q = get_queue_or_skip()
-
-    arg_dt = np.dtype("f4")
-    input_shape = (10, 10, 10, 10)
-    X = dpt.empty(input_shape, dtype=arg_dt, usm_type=usm_type, sycl_queue=q)
-    X[..., 0::2] = dpt.e / 1000
-    X[..., 1::2] = dpt.e / 100
-
-    Y = dpt.log1p(X)
-    assert Y.usm_type == X.usm_type
-    assert Y.sycl_queue == X.sycl_queue
-    assert Y.flags.c_contiguous
-
-    expected_Y = np.empty(input_shape, dtype=arg_dt)
-    expected_Y[..., 0::2] = np.log1p(np.float32(dpt.e / 1000))
-    expected_Y[..., 1::2] = np.log1p(np.float32(dpt.e / 100))
-    tol = 8 * dpt.finfo(Y.dtype).resolution
-
-    assert_allclose(dpt.asnumpy(Y), expected_Y, atol=tol, rtol=tol)
-
-
-@pytest.mark.parametrize("dtype", _all_dtypes)
-def test_log1p_order(dtype):
-    q = get_queue_or_skip()
-    skip_if_dtype_not_supported(dtype, q)
-
-    arg_dt = np.dtype(dtype)
-    input_shape = (10, 10, 10, 10)
-    X = dpt.empty(input_shape, dtype=arg_dt, sycl_queue=q)
-    X[..., 0::2] = dpt.e / 1000
-    X[..., 1::2] = dpt.e / 100
-
-    for perms in itertools.permutations(range(4)):
-        U = dpt.permute_dims(X[:, ::-1, ::-1, :], perms)
-        expected_Y = np.log1p(dpt.asnumpy(U))
-        for ord in ["C", "F", "A", "K"]:
-            Y = dpt.log1p(U, order=ord)
-            tol = 8 * max(
-                dpt.finfo(Y.dtype).resolution,
-                np.finfo(expected_Y.dtype).resolution,
-            )
-            assert_allclose(dpt.asnumpy(Y), expected_Y, atol=tol, rtol=tol)
 
 
 def test_log1p_special_cases():

--- a/dpctl/tests/elementwise/test_log2.py
+++ b/dpctl/tests/elementwise/test_log2.py
@@ -14,8 +14,6 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-import itertools
-
 import numpy as np
 import pytest
 from numpy.testing import assert_equal
@@ -23,7 +21,7 @@ from numpy.testing import assert_equal
 import dpctl.tensor as dpt
 from dpctl.tests.helper import get_queue_or_skip, skip_if_dtype_not_supported
 
-from .utils import _all_dtypes, _map_to_device_dtype, _usm_types
+from .utils import _all_dtypes, _map_to_device_dtype
 
 
 @pytest.mark.parametrize("dtype", _all_dtypes)
@@ -38,7 +36,7 @@ def test_log_out_type(dtype):
 
 
 @pytest.mark.parametrize("dtype", ["f2", "f4", "f8", "c8", "c16"])
-def test_log_output_contig(dtype):
+def test_log_basic(dtype):
     q = get_queue_or_skip()
     skip_if_dtype_not_supported(dtype, q)
 
@@ -51,70 +49,6 @@ def test_log_output_contig(dtype):
     tol = 8 * dpt.finfo(Y.dtype).resolution
 
     np.testing.assert_allclose(dpt.asnumpy(Y), np.log2(Xnp), atol=tol, rtol=tol)
-
-
-@pytest.mark.parametrize("dtype", ["f2", "f4", "f8", "c8", "c16"])
-def test_log_output_strided(dtype):
-    q = get_queue_or_skip()
-    skip_if_dtype_not_supported(dtype, q)
-
-    n_seq = 2 * 1027
-
-    X = dpt.linspace(1, 13, num=n_seq, dtype=dtype, sycl_queue=q)[::-2]
-    Xnp = dpt.asnumpy(X)
-
-    Y = dpt.log2(X)
-    tol = 8 * dpt.finfo(Y.dtype).resolution
-
-    np.testing.assert_allclose(dpt.asnumpy(Y), np.log2(Xnp), atol=tol, rtol=tol)
-
-
-@pytest.mark.parametrize("usm_type", _usm_types)
-def test_log_usm_type(usm_type):
-    q = get_queue_or_skip()
-
-    arg_dt = np.dtype("f4")
-    input_shape = (10, 10, 10, 10)
-    X = dpt.empty(input_shape, dtype=arg_dt, usm_type=usm_type, sycl_queue=q)
-    X[..., 0::2] = 4 * dpt.e
-    X[..., 1::2] = 10 * dpt.e
-
-    Y = dpt.log2(X)
-    assert Y.usm_type == X.usm_type
-    assert Y.sycl_queue == X.sycl_queue
-    assert Y.flags.c_contiguous
-
-    expected_Y = np.empty(input_shape, dtype=arg_dt)
-    expected_Y[..., 0::2] = np.log2(np.float32(4 * dpt.e))
-    expected_Y[..., 1::2] = np.log2(np.float32(10 * dpt.e))
-    tol = 8 * dpt.finfo(Y.dtype).resolution
-
-    np.testing.assert_allclose(dpt.asnumpy(Y), expected_Y, atol=tol, rtol=tol)
-
-
-@pytest.mark.parametrize("dtype", _all_dtypes)
-def test_log_order(dtype):
-    q = get_queue_or_skip()
-    skip_if_dtype_not_supported(dtype, q)
-
-    arg_dt = np.dtype(dtype)
-    input_shape = (10, 10, 10, 10)
-    X = dpt.empty(input_shape, dtype=arg_dt, sycl_queue=q)
-    X[..., 0::2] = 4 * dpt.e
-    X[..., 1::2] = 10 * dpt.e
-
-    for perms in itertools.permutations(range(4)):
-        U = dpt.permute_dims(X[:, ::-1, ::-1, :], perms)
-        expected_Y = np.log2(dpt.asnumpy(U))
-        for ord in ["C", "F", "A", "K"]:
-            Y = dpt.log2(U, order=ord)
-            tol = 8 * max(
-                dpt.finfo(Y.dtype).resolution,
-                np.finfo(expected_Y.dtype).resolution,
-            )
-            np.testing.assert_allclose(
-                dpt.asnumpy(Y), expected_Y, atol=tol, rtol=tol
-            )
 
 
 def test_log_special_cases():

--- a/dpctl/tests/elementwise/test_logaddexp.py
+++ b/dpctl/tests/elementwise/test_logaddexp.py
@@ -14,18 +14,16 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-import ctypes
 import re
 
 import numpy as np
 import pytest
 from numpy.testing import assert_allclose
 
-import dpctl
 import dpctl.tensor as dpt
 from dpctl.tests.helper import get_queue_or_skip, skip_if_dtype_not_supported
 
-from .utils import _compare_dtypes, _no_complex_dtypes, _usm_types
+from .utils import _compare_dtypes, _no_complex_dtypes
 
 
 @pytest.mark.parametrize("op1_dtype", _no_complex_dtypes)
@@ -65,117 +63,12 @@ def test_logaddexp_dtype_matrix(op1_dtype, op2_dtype):
     )
 
 
-@pytest.mark.parametrize("op1_usm_type", _usm_types)
-@pytest.mark.parametrize("op2_usm_type", _usm_types)
-def test_logaddexp_usm_type_matrix(op1_usm_type, op2_usm_type):
-    get_queue_or_skip()
-
-    sz = 128
-    ar1 = dpt.ones(sz, dtype="i4", usm_type=op1_usm_type)
-    ar2 = dpt.ones_like(ar1, dtype="i4", usm_type=op2_usm_type)
-
-    r = dpt.logaddexp(ar1, ar2)
-    assert isinstance(r, dpt.usm_ndarray)
-    expected_usm_type = dpctl.utils.get_coerced_usm_type(
-        (op1_usm_type, op2_usm_type)
-    )
-    assert r.usm_type == expected_usm_type
-
-
-def test_logaddexp_order():
-    get_queue_or_skip()
-
-    test_shape = (
-        20,
-        20,
-    )
-    test_shape2 = tuple(2 * dim for dim in test_shape)
-    n = test_shape[-1]
-
-    for dt1, dt2 in zip(["i4", "i4", "f4"], ["i4", "f4", "i4"]):
-        ar1 = dpt.ones(test_shape, dtype=dt1, order="C")
-        ar2 = dpt.ones(test_shape, dtype=dt2, order="C")
-        r1 = dpt.logaddexp(ar1, ar2, order="C")
-        assert r1.flags.c_contiguous
-        r2 = dpt.logaddexp(ar1, ar2, order="F")
-        assert r2.flags.f_contiguous
-        r3 = dpt.logaddexp(ar1, ar2, order="A")
-        assert r3.flags.c_contiguous
-        r4 = dpt.logaddexp(ar1, ar2, order="K")
-        assert r4.flags.c_contiguous
-
-        ar1 = dpt.ones(test_shape, dtype=dt1, order="F")
-        ar2 = dpt.ones(test_shape, dtype=dt2, order="F")
-        r1 = dpt.logaddexp(ar1, ar2, order="C")
-        assert r1.flags.c_contiguous
-        r2 = dpt.logaddexp(ar1, ar2, order="F")
-        assert r2.flags.f_contiguous
-        r3 = dpt.logaddexp(ar1, ar2, order="A")
-        assert r3.flags.f_contiguous
-        r4 = dpt.logaddexp(ar1, ar2, order="K")
-        assert r4.flags.f_contiguous
-
-        ar1 = dpt.ones(test_shape2, dtype=dt1, order="C")[:20, ::-2]
-        ar2 = dpt.ones(test_shape2, dtype=dt2, order="C")[:20, ::-2]
-        r4 = dpt.logaddexp(ar1, ar2, order="K")
-        assert r4.strides == (n, -1)
-        r5 = dpt.logaddexp(ar1, ar2, order="C")
-        assert r5.strides == (n, 1)
-
-        ar1 = dpt.ones(test_shape2, dtype=dt1, order="C")[:20, ::-2].mT
-        ar2 = dpt.ones(test_shape2, dtype=dt2, order="C")[:20, ::-2].mT
-        r4 = dpt.logaddexp(ar1, ar2, order="K")
-        assert r4.strides == (-1, n)
-        r5 = dpt.logaddexp(ar1, ar2, order="C")
-        assert r5.strides == (n, 1)
-
-
-def test_logaddexp_broadcasting():
-    get_queue_or_skip()
-
-    m = dpt.ones((100, 5), dtype="i4")
-    v = dpt.arange(1, 6, dtype="i4")
-
-    r = dpt.logaddexp(m, v)
-
-    expected = np.logaddexp(
-        np.ones((100, 5), dtype="i4"), np.arange(1, 6, dtype="i4")
-    )
-    assert (dpt.asnumpy(r) == expected.astype(r.dtype)).all()
-
-    r2 = dpt.logaddexp(v, m)
-    expected2 = np.logaddexp(
-        np.arange(1, 6, dtype="i4"), np.ones((100, 5), dtype="i4")
-    )
-    assert (dpt.asnumpy(r2) == expected2.astype(r2.dtype)).all()
-
-
 def test_logaddexp_broadcasting_error():
     get_queue_or_skip()
     m = dpt.ones((10, 10), dtype="i4")
     v = dpt.ones((3,), dtype="i4")
     with pytest.raises(ValueError):
         dpt.logaddexp(m, v)
-
-
-@pytest.mark.parametrize("arr_dt", _no_complex_dtypes)
-def test_logaddexp_python_scalar(arr_dt):
-    q = get_queue_or_skip()
-    skip_if_dtype_not_supported(arr_dt, q)
-
-    X = dpt.zeros((10, 10), dtype=arr_dt, sycl_queue=q)
-    py_zeros = (
-        bool(0),
-        int(0),
-        float(0),
-        np.float32(0),
-        ctypes.c_int(0),
-    )
-    for sc in py_zeros:
-        R = dpt.logaddexp(X, sc)
-        assert isinstance(R, dpt.usm_ndarray)
-        R = dpt.logaddexp(sc, X)
-        assert isinstance(R, dpt.usm_ndarray)
 
 
 @pytest.mark.parametrize("dtype", _no_complex_dtypes)

--- a/dpctl/tests/elementwise/test_logical_and.py
+++ b/dpctl/tests/elementwise/test_logical_and.py
@@ -14,16 +14,13 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-import ctypes
-
 import numpy as np
 import pytest
 
-import dpctl
 import dpctl.tensor as dpt
 from dpctl.tests.helper import get_queue_or_skip, skip_if_dtype_not_supported
 
-from .utils import _all_dtypes, _compare_dtypes, _usm_types
+from .utils import _all_dtypes, _compare_dtypes
 
 
 @pytest.mark.parametrize("op1_dtype", _all_dtypes)
@@ -157,148 +154,3 @@ def test_logical_and_complex_float():
             r3 = dpt.logical_and(ar3, ar1)
             expected3 = np.logical_and(ar3_np, ar1_np)
             assert (dpt.asnumpy(r3) == expected3).all()
-
-
-@pytest.mark.parametrize("op1_usm_type", _usm_types)
-@pytest.mark.parametrize("op2_usm_type", _usm_types)
-def test_logical_and_usm_type_matrix(op1_usm_type, op2_usm_type):
-    get_queue_or_skip()
-
-    sz = 128
-    ar1 = dpt.asarray(
-        np.random.randint(0, 2, sz), dtype="i4", usm_type=op1_usm_type
-    )
-    ar2 = dpt.asarray(
-        np.random.randint(0, 2, sz), dtype=ar1.dtype, usm_type=op2_usm_type
-    )
-
-    r = dpt.logical_and(ar1, ar2)
-    assert isinstance(r, dpt.usm_ndarray)
-    expected_usm_type = dpctl.utils.get_coerced_usm_type(
-        (op1_usm_type, op2_usm_type)
-    )
-    assert r.usm_type == expected_usm_type
-
-
-def test_logical_and_order():
-    get_queue_or_skip()
-
-    ar1 = dpt.ones((20, 20), dtype="i4", order="C")
-    ar2 = dpt.ones((20, 20), dtype="i4", order="C")
-    r1 = dpt.logical_and(ar1, ar2, order="C")
-    assert r1.flags.c_contiguous
-    r2 = dpt.logical_and(ar1, ar2, order="F")
-    assert r2.flags.f_contiguous
-    r3 = dpt.logical_and(ar1, ar2, order="A")
-    assert r3.flags.c_contiguous
-    r4 = dpt.logical_and(ar1, ar2, order="K")
-    assert r4.flags.c_contiguous
-
-    ar1 = dpt.ones((20, 20), dtype="i4", order="F")
-    ar2 = dpt.ones((20, 20), dtype="i4", order="F")
-    r1 = dpt.logical_and(ar1, ar2, order="C")
-    assert r1.flags.c_contiguous
-    r2 = dpt.logical_and(ar1, ar2, order="F")
-    assert r2.flags.f_contiguous
-    r3 = dpt.logical_and(ar1, ar2, order="A")
-    assert r3.flags.f_contiguous
-    r4 = dpt.logical_and(ar1, ar2, order="K")
-    assert r4.flags.f_contiguous
-
-    ar1 = dpt.ones((40, 40), dtype="i4", order="C")[:20, ::-2]
-    ar2 = dpt.ones((40, 40), dtype="i4", order="C")[:20, ::-2]
-    r4 = dpt.logical_and(ar1, ar2, order="K")
-    assert r4.strides == (20, -1)
-
-    ar1 = dpt.ones((40, 40), dtype="i4", order="C")[:20, ::-2].mT
-    ar2 = dpt.ones((40, 40), dtype="i4", order="C")[:20, ::-2].mT
-    r4 = dpt.logical_and(ar1, ar2, order="K")
-    assert r4.strides == (-1, 20)
-
-
-def test_logical_and_broadcasting():
-    get_queue_or_skip()
-
-    m = dpt.asarray(np.random.randint(0, 2, (100, 5)), dtype="i4")
-    v = dpt.arange(1, 6, dtype="i4")
-
-    r = dpt.logical_and(m, v)
-
-    expected = np.logical_and(dpt.asnumpy(m), dpt.asnumpy(v))
-    assert (dpt.asnumpy(r) == expected).all()
-
-    r2 = dpt.logical_and(v, m)
-    expected2 = np.logical_and(dpt.asnumpy(v), dpt.asnumpy(m))
-    assert (dpt.asnumpy(r2) == expected2).all()
-
-    r3 = dpt.empty_like(r)
-    dpt.logical_and(m, v, out=r3)
-    assert (dpt.asnumpy(r3) == expected).all()
-
-    r4 = dpt.empty_like(r)
-    dpt.logical_and(v, m, out=r4)
-    assert (dpt.asnumpy(r4) == expected).all()
-
-
-@pytest.mark.parametrize("arr_dt", _all_dtypes)
-@pytest.mark.parametrize("scalar_val", [0, 1])
-def test_logical_and_python_scalar(arr_dt, scalar_val):
-    q = get_queue_or_skip()
-    skip_if_dtype_not_supported(arr_dt, q)
-
-    X = dpt.asarray(
-        np.random.randint(0, 2, (10, 10)), dtype=arr_dt, sycl_queue=q
-    )
-    py_ones = (
-        bool(scalar_val),
-        int(scalar_val),
-        float(scalar_val),
-        complex(scalar_val),
-        np.float32(scalar_val),
-        ctypes.c_int(scalar_val),
-    )
-    for sc in py_ones:
-        R = dpt.logical_and(X, sc)
-        assert isinstance(R, dpt.usm_ndarray)
-        E = np.logical_and(dpt.asnumpy(X), sc)
-        assert (dpt.asnumpy(R) == E).all()
-
-        R = dpt.logical_and(sc, X)
-        assert isinstance(R, dpt.usm_ndarray)
-        E = np.logical_and(sc, dpt.asnumpy(X))
-        assert (dpt.asnumpy(R) == E).all()
-
-
-class MockArray:
-    def __init__(self, arr):
-        self.data_ = arr
-
-    @property
-    def __sycl_usm_array_interface__(self):
-        return self.data_.__sycl_usm_array_interface__
-
-
-def test_logical_and_mock_array():
-    get_queue_or_skip()
-    a = dpt.arange(10)
-    b = dpt.ones(10)
-    c = MockArray(b)
-    r = dpt.logical_and(a, c)
-    assert isinstance(r, dpt.usm_ndarray)
-
-
-def test_logical_and_canary_mock_array():
-    get_queue_or_skip()
-    a = dpt.arange(10)
-
-    class Canary:
-        def __init__(self):
-            pass
-
-        @property
-        def __sycl_usm_array_interface__(self):
-            return None
-
-    c = Canary()
-    with pytest.raises(ValueError):
-        dpt.logical_and(a, c)

--- a/dpctl/tests/elementwise/test_logical_not.py
+++ b/dpctl/tests/elementwise/test_logical_not.py
@@ -20,7 +20,7 @@ import pytest
 import dpctl.tensor as dpt
 from dpctl.tests.helper import get_queue_or_skip, skip_if_dtype_not_supported
 
-from .utils import _all_dtypes, _compare_dtypes, _usm_types
+from .utils import _all_dtypes, _compare_dtypes
 
 
 @pytest.mark.parametrize("op_dtype", _all_dtypes)
@@ -131,49 +131,3 @@ def test_logical_not_complex_float():
             r2 = dpt.logical_not(ar2)
             expected2 = np.logical_not(dpt.asnumpy(ar2))
             assert (dpt.asnumpy(r2) == expected2).all()
-
-
-@pytest.mark.parametrize("op_usm_type", _usm_types)
-def test_logical_not_usm_type_matrix(op_usm_type):
-    get_queue_or_skip()
-
-    sz = 128
-    ar1 = dpt.asarray(
-        np.random.randint(0, 2, sz), dtype="i4", usm_type=op_usm_type
-    )
-
-    r = dpt.logical_not(ar1)
-    assert isinstance(r, dpt.usm_ndarray)
-    assert r.usm_type == op_usm_type
-
-
-def test_logical_not_order():
-    get_queue_or_skip()
-
-    ar1 = dpt.ones((20, 20), dtype="i4", order="C")
-    r1 = dpt.logical_not(ar1, order="C")
-    assert r1.flags.c_contiguous
-    r2 = dpt.logical_not(ar1, order="F")
-    assert r2.flags.f_contiguous
-    r3 = dpt.logical_not(ar1, order="A")
-    assert r3.flags.c_contiguous
-    r4 = dpt.logical_not(ar1, order="K")
-    assert r4.flags.c_contiguous
-
-    ar1 = dpt.zeros((20, 20), dtype="i4", order="F")
-    r1 = dpt.logical_not(ar1, order="C")
-    assert r1.flags.c_contiguous
-    r2 = dpt.logical_not(ar1, order="F")
-    assert r2.flags.f_contiguous
-    r3 = dpt.logical_not(ar1, order="A")
-    assert r3.flags.f_contiguous
-    r4 = dpt.logical_not(ar1, order="K")
-    assert r4.flags.f_contiguous
-
-    ar1 = dpt.ones((40, 40), dtype="i4", order="C")[:20, ::-2]
-    r4 = dpt.logical_not(ar1, order="K")
-    assert r4.strides == (20, -1)
-
-    ar1 = dpt.zeros((40, 40), dtype="i4", order="C")[:20, ::-2].mT
-    r4 = dpt.logical_not(ar1, order="K")
-    assert r4.strides == (-1, 20)

--- a/dpctl/tests/elementwise/test_logical_or.py
+++ b/dpctl/tests/elementwise/test_logical_or.py
@@ -14,16 +14,13 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-import ctypes
-
 import numpy as np
 import pytest
 
-import dpctl
 import dpctl.tensor as dpt
 from dpctl.tests.helper import get_queue_or_skip, skip_if_dtype_not_supported
 
-from .utils import _all_dtypes, _compare_dtypes, _usm_types
+from .utils import _all_dtypes, _compare_dtypes
 
 
 @pytest.mark.parametrize("op1_dtype", _all_dtypes)
@@ -158,148 +155,3 @@ def test_logical_or_complex_float():
             r3 = dpt.logical_or(ar3, ar1)
             expected3 = np.logical_or(ar3_np, ar1_np)
             assert (dpt.asnumpy(r3) == expected3).all()
-
-
-@pytest.mark.parametrize("op1_usm_type", _usm_types)
-@pytest.mark.parametrize("op2_usm_type", _usm_types)
-def test_logical_or_usm_type_matrix(op1_usm_type, op2_usm_type):
-    get_queue_or_skip()
-
-    sz = 128
-    ar1 = dpt.asarray(
-        np.random.randint(0, 2, sz), dtype="i4", usm_type=op1_usm_type
-    )
-    ar2 = dpt.asarray(
-        np.random.randint(0, 2, sz), dtype=ar1.dtype, usm_type=op2_usm_type
-    )
-
-    r = dpt.logical_or(ar1, ar2)
-    assert isinstance(r, dpt.usm_ndarray)
-    expected_usm_type = dpctl.utils.get_coerced_usm_type(
-        (op1_usm_type, op2_usm_type)
-    )
-    assert r.usm_type == expected_usm_type
-
-
-def test_logical_or_order():
-    get_queue_or_skip()
-
-    ar1 = dpt.ones((20, 20), dtype="i4", order="C")
-    ar2 = dpt.ones((20, 20), dtype="i4", order="C")
-    r1 = dpt.logical_or(ar1, ar2, order="C")
-    assert r1.flags.c_contiguous
-    r2 = dpt.logical_or(ar1, ar2, order="F")
-    assert r2.flags.f_contiguous
-    r3 = dpt.logical_or(ar1, ar2, order="A")
-    assert r3.flags.c_contiguous
-    r4 = dpt.logical_or(ar1, ar2, order="K")
-    assert r4.flags.c_contiguous
-
-    ar1 = dpt.ones((20, 20), dtype="i4", order="F")
-    ar2 = dpt.ones((20, 20), dtype="i4", order="F")
-    r1 = dpt.logical_or(ar1, ar2, order="C")
-    assert r1.flags.c_contiguous
-    r2 = dpt.logical_or(ar1, ar2, order="F")
-    assert r2.flags.f_contiguous
-    r3 = dpt.logical_or(ar1, ar2, order="A")
-    assert r3.flags.f_contiguous
-    r4 = dpt.logical_or(ar1, ar2, order="K")
-    assert r4.flags.f_contiguous
-
-    ar1 = dpt.ones((40, 40), dtype="i4", order="C")[:20, ::-2]
-    ar2 = dpt.ones((40, 40), dtype="i4", order="C")[:20, ::-2]
-    r4 = dpt.logical_or(ar1, ar2, order="K")
-    assert r4.strides == (20, -1)
-
-    ar1 = dpt.ones((40, 40), dtype="i4", order="C")[:20, ::-2].mT
-    ar2 = dpt.ones((40, 40), dtype="i4", order="C")[:20, ::-2].mT
-    r4 = dpt.logical_or(ar1, ar2, order="K")
-    assert r4.strides == (-1, 20)
-
-
-def test_logical_or_broadcasting():
-    get_queue_or_skip()
-
-    m = dpt.asarray(np.random.randint(0, 2, (100, 5)), dtype="i4")
-    v = dpt.arange(1, 6, dtype="i4")
-
-    r = dpt.logical_or(m, v)
-
-    expected = np.logical_or(dpt.asnumpy(m), dpt.asnumpy(v))
-    assert (dpt.asnumpy(r) == expected).all()
-
-    r2 = dpt.logical_or(v, m)
-    expected2 = np.logical_or(dpt.asnumpy(v), dpt.asnumpy(m))
-    assert (dpt.asnumpy(r2) == expected2).all()
-
-    r3 = dpt.empty_like(r)
-    dpt.logical_or(m, v, out=r3)
-    assert (dpt.asnumpy(r3) == expected).all()
-
-    r4 = dpt.empty_like(r)
-    dpt.logical_or(v, m, out=r4)
-    assert (dpt.asnumpy(r4) == expected).all()
-
-
-@pytest.mark.parametrize("arr_dt", _all_dtypes)
-@pytest.mark.parametrize("scalar_val", [0, 1])
-def test_logical_or_python_scalar(arr_dt, scalar_val):
-    q = get_queue_or_skip()
-    skip_if_dtype_not_supported(arr_dt, q)
-
-    X = dpt.asarray(
-        np.random.randint(0, 2, (10, 10)), dtype=arr_dt, sycl_queue=q
-    )
-    py_ones = (
-        bool(scalar_val),
-        int(scalar_val),
-        float(scalar_val),
-        complex(scalar_val),
-        np.float32(scalar_val),
-        ctypes.c_int(scalar_val),
-    )
-    for sc in py_ones:
-        R = dpt.logical_or(X, sc)
-        assert isinstance(R, dpt.usm_ndarray)
-        E = np.logical_or(dpt.asnumpy(X), sc)
-        assert (dpt.asnumpy(R) == E).all()
-
-        R = dpt.logical_or(sc, X)
-        assert isinstance(R, dpt.usm_ndarray)
-        E = np.logical_or(sc, dpt.asnumpy(X))
-        assert (dpt.asnumpy(R) == E).all()
-
-
-class MockArray:
-    def __init__(self, arr):
-        self.data_ = arr
-
-    @property
-    def __sycl_usm_array_interface__(self):
-        return self.data_.__sycl_usm_array_interface__
-
-
-def test_logical_or_mock_array():
-    get_queue_or_skip()
-    a = dpt.arange(10)
-    b = dpt.ones(10)
-    c = MockArray(b)
-    r = dpt.logical_or(a, c)
-    assert isinstance(r, dpt.usm_ndarray)
-
-
-def test_logical_or_canary_mock_array():
-    get_queue_or_skip()
-    a = dpt.arange(10)
-
-    class Canary:
-        def __init__(self):
-            pass
-
-        @property
-        def __sycl_usm_array_interface__(self):
-            return None
-
-    c = Canary()
-    with pytest.raises(ValueError):
-        dpt.logical_or(a, c)

--- a/dpctl/tests/elementwise/test_logical_xor.py
+++ b/dpctl/tests/elementwise/test_logical_xor.py
@@ -14,16 +14,13 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-import ctypes
-
 import numpy as np
 import pytest
 
-import dpctl
 import dpctl.tensor as dpt
 from dpctl.tests.helper import get_queue_or_skip, skip_if_dtype_not_supported
 
-from .utils import _all_dtypes, _compare_dtypes, _usm_types
+from .utils import _all_dtypes, _compare_dtypes
 
 
 @pytest.mark.parametrize("op1_dtype", _all_dtypes)
@@ -159,148 +156,3 @@ def test_logical_xor_complex_float():
             r3 = dpt.logical_xor(ar3, ar1)
             expected3 = np.logical_xor(ar3_np, ar1_np)
             assert (dpt.asnumpy(r3) == expected3).all()
-
-
-@pytest.mark.parametrize("op1_usm_type", _usm_types)
-@pytest.mark.parametrize("op2_usm_type", _usm_types)
-def test_logical_xor_usm_type_matrix(op1_usm_type, op2_usm_type):
-    get_queue_or_skip()
-
-    sz = 128
-    ar1 = dpt.asarray(
-        np.random.randint(0, 2, sz), dtype="i4", usm_type=op1_usm_type
-    )
-    ar2 = dpt.asarray(
-        np.random.randint(0, 2, sz), dtype=ar1.dtype, usm_type=op2_usm_type
-    )
-
-    r = dpt.logical_xor(ar1, ar2)
-    assert isinstance(r, dpt.usm_ndarray)
-    expected_usm_type = dpctl.utils.get_coerced_usm_type(
-        (op1_usm_type, op2_usm_type)
-    )
-    assert r.usm_type == expected_usm_type
-
-
-def test_logical_xor_order():
-    get_queue_or_skip()
-
-    ar1 = dpt.ones((20, 20), dtype="i4", order="C")
-    ar2 = dpt.ones((20, 20), dtype="i4", order="C")
-    r1 = dpt.logical_xor(ar1, ar2, order="C")
-    assert r1.flags.c_contiguous
-    r2 = dpt.logical_xor(ar1, ar2, order="F")
-    assert r2.flags.f_contiguous
-    r3 = dpt.logical_xor(ar1, ar2, order="A")
-    assert r3.flags.c_contiguous
-    r4 = dpt.logical_xor(ar1, ar2, order="K")
-    assert r4.flags.c_contiguous
-
-    ar1 = dpt.ones((20, 20), dtype="i4", order="F")
-    ar2 = dpt.ones((20, 20), dtype="i4", order="F")
-    r1 = dpt.logical_xor(ar1, ar2, order="C")
-    assert r1.flags.c_contiguous
-    r2 = dpt.logical_xor(ar1, ar2, order="F")
-    assert r2.flags.f_contiguous
-    r3 = dpt.logical_xor(ar1, ar2, order="A")
-    assert r3.flags.f_contiguous
-    r4 = dpt.logical_xor(ar1, ar2, order="K")
-    assert r4.flags.f_contiguous
-
-    ar1 = dpt.ones((40, 40), dtype="i4", order="C")[:20, ::-2]
-    ar2 = dpt.ones((40, 40), dtype="i4", order="C")[:20, ::-2]
-    r4 = dpt.logical_xor(ar1, ar2, order="K")
-    assert r4.strides == (20, -1)
-
-    ar1 = dpt.ones((40, 40), dtype="i4", order="C")[:20, ::-2].mT
-    ar2 = dpt.ones((40, 40), dtype="i4", order="C")[:20, ::-2].mT
-    r4 = dpt.logical_xor(ar1, ar2, order="K")
-    assert r4.strides == (-1, 20)
-
-
-def test_logical_xor_broadcasting():
-    get_queue_or_skip()
-
-    m = dpt.asarray(np.random.randint(0, 2, (100, 5)), dtype="i4")
-    v = dpt.arange(1, 6, dtype="i4")
-
-    r = dpt.logical_xor(m, v)
-
-    expected = np.logical_xor(dpt.asnumpy(m), dpt.asnumpy(v))
-    assert (dpt.asnumpy(r) == expected).all()
-
-    r2 = dpt.logical_xor(v, m)
-    expected2 = np.logical_xor(dpt.asnumpy(v), dpt.asnumpy(m))
-    assert (dpt.asnumpy(r2) == expected2).all()
-
-    r3 = dpt.empty_like(r)
-    dpt.logical_xor(m, v, out=r3)
-    assert (dpt.asnumpy(r3) == expected).all()
-
-    r4 = dpt.empty_like(r)
-    dpt.logical_xor(v, m, out=r4)
-    assert (dpt.asnumpy(r4) == expected).all()
-
-
-@pytest.mark.parametrize("arr_dt", _all_dtypes)
-@pytest.mark.parametrize("scalar_val", [0, 1])
-def test_logical_xor_python_scalar(arr_dt, scalar_val):
-    q = get_queue_or_skip()
-    skip_if_dtype_not_supported(arr_dt, q)
-
-    X = dpt.asarray(
-        np.random.randint(0, 2, (10, 10)), dtype=arr_dt, sycl_queue=q
-    )
-    py_ones = (
-        bool(scalar_val),
-        int(scalar_val),
-        float(scalar_val),
-        complex(scalar_val),
-        np.float32(scalar_val),
-        ctypes.c_int(scalar_val),
-    )
-    for sc in py_ones:
-        R = dpt.logical_xor(X, sc)
-        assert isinstance(R, dpt.usm_ndarray)
-        E = np.logical_xor(dpt.asnumpy(X), sc)
-        assert (dpt.asnumpy(R) == E).all()
-
-        R = dpt.logical_xor(sc, X)
-        assert isinstance(R, dpt.usm_ndarray)
-        E = np.logical_xor(sc, dpt.asnumpy(X))
-        assert (dpt.asnumpy(R) == E).all()
-
-
-class MockArray:
-    def __init__(self, arr):
-        self.data_ = arr
-
-    @property
-    def __sycl_usm_array_interface__(self):
-        return self.data_.__sycl_usm_array_interface__
-
-
-def test_logical_xor_mock_array():
-    get_queue_or_skip()
-    a = dpt.arange(10)
-    b = dpt.ones(10)
-    c = MockArray(b)
-    r = dpt.logical_xor(a, c)
-    assert isinstance(r, dpt.usm_ndarray)
-
-
-def test_logical_xor_canary_mock_array():
-    get_queue_or_skip()
-    a = dpt.arange(10)
-
-    class Canary:
-        def __init__(self):
-            pass
-
-        @property
-        def __sycl_usm_array_interface__(self):
-            return None
-
-    c = Canary()
-    with pytest.raises(ValueError):
-        dpt.logical_xor(a, c)

--- a/dpctl/tests/elementwise/test_maximum_minimum.py
+++ b/dpctl/tests/elementwise/test_maximum_minimum.py
@@ -14,18 +14,16 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-import ctypes
 import itertools
 
 import numpy as np
 import pytest
 from numpy.testing import assert_array_equal
 
-import dpctl
 import dpctl.tensor as dpt
 from dpctl.tests.helper import get_queue_or_skip, skip_if_dtype_not_supported
 
-from .utils import _all_dtypes, _compare_dtypes, _usm_types
+from .utils import _all_dtypes, _compare_dtypes
 
 
 @pytest.mark.parametrize("op1_dtype", _all_dtypes)
@@ -172,143 +170,3 @@ def test_maximum_minimum_complex_special_cases(dtype):
     Rnp = np.minimum(Xnp, Ynp)
     assert_array_equal(dpt.asnumpy(dpt.real(R)), np.real(Rnp))
     assert_array_equal(dpt.asnumpy(dpt.imag(R)), np.imag(Rnp))
-
-
-@pytest.mark.parametrize("op1_usm_type", _usm_types)
-@pytest.mark.parametrize("op2_usm_type", _usm_types)
-def test_maximum_minimum_usm_type_matrix(op1_usm_type, op2_usm_type):
-    get_queue_or_skip()
-
-    sz = 128
-    ar1_np = np.arange(sz, dtype="i4")
-    np.random.shuffle(ar1_np)
-    ar1 = dpt.asarray(ar1_np, usm_type=op1_usm_type)
-    ar2_np = np.arange(sz, dtype="i4")
-    np.random.shuffle(ar2_np)
-    ar2 = dpt.asarray(ar2_np, usm_type=op2_usm_type)
-
-    r = dpt.maximum(ar1, ar2)
-    assert isinstance(r, dpt.usm_ndarray)
-    expected_usm_type = dpctl.utils.get_coerced_usm_type(
-        (op1_usm_type, op2_usm_type)
-    )
-    assert r.usm_type == expected_usm_type
-
-    r = dpt.minimum(ar1, ar2)
-    assert isinstance(r, dpt.usm_ndarray)
-    expected_usm_type = dpctl.utils.get_coerced_usm_type(
-        (op1_usm_type, op2_usm_type)
-    )
-    assert r.usm_type == expected_usm_type
-
-
-def test_maximum_minimum_order():
-    get_queue_or_skip()
-
-    ar1_np = np.arange(20 * 20, dtype="i4").reshape(20, 20)
-    np.random.shuffle(ar1_np)
-    ar1 = dpt.asarray(ar1_np, order="C")
-    ar2_np = np.arange(20 * 20, dtype="i4").reshape(20, 20)
-    np.random.shuffle(ar2_np)
-    ar2 = dpt.asarray(ar2_np, order="C")
-
-    r1 = dpt.maximum(ar1, ar2, order="C")
-    assert r1.flags.c_contiguous
-    r2 = dpt.maximum(ar1, ar2, order="F")
-    assert r2.flags.f_contiguous
-    r3 = dpt.maximum(ar1, ar2, order="A")
-    assert r3.flags.c_contiguous
-    r4 = dpt.maximum(ar1, ar2, order="K")
-    assert r4.flags.c_contiguous
-
-    ar1 = dpt.asarray(ar1_np, order="F")
-    ar2 = dpt.asarray(ar2_np, order="F")
-    r1 = dpt.maximum(ar1, ar2, order="C")
-    assert r1.flags.c_contiguous
-    r2 = dpt.maximum(ar1, ar2, order="F")
-    assert r2.flags.f_contiguous
-    r3 = dpt.maximum(ar1, ar2, order="A")
-    assert r3.flags.f_contiguous
-    r4 = dpt.maximum(ar1, ar2, order="K")
-    assert r4.flags.f_contiguous
-
-    ar1_np = np.arange(40 * 40, dtype="i4").reshape(40, 40)
-    np.random.shuffle(ar1_np)
-    ar1 = dpt.asarray(ar1_np, order="C")[:20, ::-2]
-    ar2_np = np.arange(40 * 40, dtype="i4").reshape(40, 40)
-    np.random.shuffle(ar2_np)
-    ar2 = dpt.asarray(ar2_np, order="C")[:20, ::-2]
-    r4 = dpt.maximum(ar1, ar2, order="K")
-    assert r4.strides == (20, -1)
-
-    ar1 = dpt.asarray(ar1_np, order="C")[:20, ::-2].mT
-    ar2 = dpt.asarray(ar2_np, order="C")[:20, ::-2].mT
-    r4 = dpt.maximum(ar1, ar2, order="K")
-    assert r4.strides == (-1, 20)
-
-
-@pytest.mark.parametrize("arr_dt", _all_dtypes)
-def test_maximum_minimum_python_scalar(arr_dt):
-    q = get_queue_or_skip()
-    skip_if_dtype_not_supported(arr_dt, q)
-
-    X = dpt.zeros((10, 10), dtype=arr_dt, sycl_queue=q)
-    py_ones = (
-        bool(1),
-        int(1),
-        float(1),
-        complex(1),
-        np.float32(1),
-        ctypes.c_int(1),
-    )
-    for sc in py_ones:
-        R = dpt.maximum(X, sc)
-        assert isinstance(R, dpt.usm_ndarray)
-        R = dpt.maximum(sc, X)
-        assert isinstance(R, dpt.usm_ndarray)
-
-        R = dpt.minimum(X, sc)
-        assert isinstance(R, dpt.usm_ndarray)
-        R = dpt.minimum(sc, X)
-        assert isinstance(R, dpt.usm_ndarray)
-
-
-class MockArray:
-    def __init__(self, arr):
-        self.data_ = arr
-
-    @property
-    def __sycl_usm_array_interface__(self):
-        return self.data_.__sycl_usm_array_interface__
-
-
-def test_maximum_minimum_mock_array():
-    get_queue_or_skip()
-    a = dpt.arange(10)
-    b = dpt.ones(10)
-    c = MockArray(b)
-    r = dpt.maximum(a, c)
-    assert isinstance(r, dpt.usm_ndarray)
-
-    r = dpt.minimum(a, c)
-    assert isinstance(r, dpt.usm_ndarray)
-
-
-def test_maximum_canary_mock_array():
-    get_queue_or_skip()
-    a = dpt.arange(10)
-
-    class Canary:
-        def __init__(self):
-            pass
-
-        @property
-        def __sycl_usm_array_interface__(self):
-            return None
-
-    c = Canary()
-    with pytest.raises(ValueError):
-        dpt.maximum(a, c)
-
-    with pytest.raises(ValueError):
-        dpt.minimum(a, c)

--- a/dpctl/tests/elementwise/test_multiply.py
+++ b/dpctl/tests/elementwise/test_multiply.py
@@ -14,17 +14,14 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-import ctypes
-
 import numpy as np
 import pytest
 
-import dpctl
 import dpctl.tensor as dpt
 from dpctl.tensor._type_utils import _can_cast
 from dpctl.tests.helper import get_queue_or_skip, skip_if_dtype_not_supported
 
-from .utils import _all_dtypes, _compare_dtypes, _usm_types
+from .utils import _all_dtypes, _compare_dtypes
 
 
 @pytest.mark.parametrize("op1_dtype", _all_dtypes)
@@ -61,100 +58,6 @@ def test_multiply_dtype_matrix(op1_dtype, op2_dtype):
     assert (dpt.asnumpy(r) == expected.astype(r.dtype)).all()
 
 
-@pytest.mark.parametrize("op1_usm_type", _usm_types)
-@pytest.mark.parametrize("op2_usm_type", _usm_types)
-def test_multiply_usm_type_matrix(op1_usm_type, op2_usm_type):
-    get_queue_or_skip()
-
-    sz = 128
-    ar1 = dpt.ones(sz, dtype="i4", usm_type=op1_usm_type)
-    ar2 = dpt.ones_like(ar1, dtype="i4", usm_type=op2_usm_type)
-
-    r = dpt.multiply(ar1, ar2)
-    assert isinstance(r, dpt.usm_ndarray)
-    expected_usm_type = dpctl.utils.get_coerced_usm_type(
-        (op1_usm_type, op2_usm_type)
-    )
-    assert r.usm_type == expected_usm_type
-
-
-def test_multiply_order():
-    get_queue_or_skip()
-
-    ar1 = dpt.ones((20, 20), dtype="i4", order="C")
-    ar2 = dpt.ones((20, 20), dtype="i4", order="C")
-    r1 = dpt.multiply(ar1, ar2, order="C")
-    assert r1.flags.c_contiguous
-    r2 = dpt.multiply(ar1, ar2, order="F")
-    assert r2.flags.f_contiguous
-    r3 = dpt.multiply(ar1, ar2, order="A")
-    assert r3.flags.c_contiguous
-    r4 = dpt.multiply(ar1, ar2, order="K")
-    assert r4.flags.c_contiguous
-
-    ar1 = dpt.ones((20, 20), dtype="i4", order="F")
-    ar2 = dpt.ones((20, 20), dtype="i4", order="F")
-    r1 = dpt.multiply(ar1, ar2, order="C")
-    assert r1.flags.c_contiguous
-    r2 = dpt.multiply(ar1, ar2, order="F")
-    assert r2.flags.f_contiguous
-    r3 = dpt.multiply(ar1, ar2, order="A")
-    assert r3.flags.f_contiguous
-    r4 = dpt.multiply(ar1, ar2, order="K")
-    assert r4.flags.f_contiguous
-
-    ar1 = dpt.ones((40, 40), dtype="i4", order="C")[:20, ::-2]
-    ar2 = dpt.ones((40, 40), dtype="i4", order="C")[:20, ::-2]
-    r4 = dpt.multiply(ar1, ar2, order="K")
-    assert r4.strides == (20, -1)
-
-    ar1 = dpt.ones((40, 40), dtype="i4", order="C")[:20, ::-2].mT
-    ar2 = dpt.ones((40, 40), dtype="i4", order="C")[:20, ::-2].mT
-    r4 = dpt.multiply(ar1, ar2, order="K")
-    assert r4.strides == (-1, 20)
-
-
-def test_multiply_broadcasting():
-    get_queue_or_skip()
-
-    m = dpt.ones((100, 5), dtype="i4")
-    v = dpt.arange(1, 6, dtype="i4")
-
-    r = dpt.multiply(m, v)
-
-    expected = np.multiply(
-        np.ones((100, 5), dtype="i4"), np.arange(1, 6, dtype="i4")
-    )
-    assert (dpt.asnumpy(r) == expected.astype(r.dtype)).all()
-
-    r2 = dpt.multiply(v, m)
-    expected2 = np.multiply(
-        np.arange(1, 6, dtype="i4"), np.ones((100, 5), dtype="i4")
-    )
-    assert (dpt.asnumpy(r2) == expected2.astype(r2.dtype)).all()
-
-
-@pytest.mark.parametrize("arr_dt", _all_dtypes)
-def test_multiply_python_scalar(arr_dt):
-    q = get_queue_or_skip()
-    skip_if_dtype_not_supported(arr_dt, q)
-
-    X = dpt.ones((10, 10), dtype=arr_dt, sycl_queue=q)
-    py_ones = (
-        bool(1),
-        int(1),
-        float(1),
-        complex(1),
-        np.float32(1),
-        ctypes.c_int(1),
-    )
-    for sc in py_ones:
-        R = dpt.multiply(X, sc)
-        assert isinstance(R, dpt.usm_ndarray)
-        R = dpt.multiply(sc, X)
-        assert isinstance(R, dpt.usm_ndarray)
-
-
 @pytest.mark.parametrize("arr_dt", _all_dtypes)
 @pytest.mark.parametrize("sc", [bool(1), int(1), float(1), complex(1)])
 def test_multiply_python_scalar_gh1219(arr_dt, sc):
@@ -173,22 +76,6 @@ def test_multiply_python_scalar_gh1219(arr_dt, sc):
     R = dpt.multiply(sc, X)
     Rnp = np.multiply(sc, Xnp)
     assert _compare_dtypes(R.dtype, Rnp.dtype, sycl_queue=q)
-
-
-@pytest.mark.parametrize("dtype", _all_dtypes)
-def test_multiply_inplace_python_scalar(dtype):
-    q = get_queue_or_skip()
-    skip_if_dtype_not_supported(dtype, q)
-    X = dpt.ones((10, 10), dtype=dtype, sycl_queue=q)
-    dt_kind = X.dtype.kind
-    if dt_kind in "ui":
-        X *= int(1)
-    elif dt_kind == "f":
-        X *= float(1)
-    elif dt_kind == "c":
-        X *= complex(1)
-    elif dt_kind == "b":
-        X *= bool(1)
 
 
 @pytest.mark.parametrize("op1_dtype", _all_dtypes)

--- a/dpctl/tests/elementwise/test_negative.py
+++ b/dpctl/tests/elementwise/test_negative.py
@@ -14,15 +14,13 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-import itertools
-
 import numpy as np
 import pytest
 
 import dpctl.tensor as dpt
 from dpctl.tests.helper import get_queue_or_skip, skip_if_dtype_not_supported
 
-from .utils import _all_dtypes, _usm_types
+from .utils import _all_dtypes
 
 
 @pytest.mark.parametrize("dtype", _all_dtypes[1:])
@@ -44,43 +42,3 @@ def test_negative_bool():
     x = dpt.ones(64, dtype="?")
     with pytest.raises(ValueError):
         dpt.negative(x)
-
-
-@pytest.mark.parametrize("usm_type", _usm_types)
-def test_negative_usm_type(usm_type):
-    q = get_queue_or_skip()
-
-    arg_dt = np.dtype("i4")
-    input_shape = (10, 10, 10, 10)
-    X = dpt.empty(input_shape, dtype=arg_dt, usm_type=usm_type, sycl_queue=q)
-    X[..., 0::2] = 1
-    X[..., 1::2] = 0
-
-    Y = dpt.negative(X)
-    assert Y.usm_type == X.usm_type
-    assert Y.sycl_queue == X.sycl_queue
-    assert Y.flags.c_contiguous
-
-    expected_Y = np.negative(dpt.asnumpy(X))
-    assert np.allclose(dpt.asnumpy(Y), expected_Y)
-
-
-@pytest.mark.parametrize("dtype", _all_dtypes[1:])
-def test_negative_order(dtype):
-    q = get_queue_or_skip()
-    skip_if_dtype_not_supported(dtype, q)
-
-    arg_dt = np.dtype(dtype)
-    input_shape = (10, 10, 10, 10)
-    X = dpt.empty(input_shape, dtype=arg_dt, sycl_queue=q)
-    X[..., 0::2] = 1
-    X[..., 1::2] = 0
-
-    for perms in itertools.permutations(range(4)):
-        U = dpt.permute_dims(X[:, ::-1, ::-1, :], perms)
-        expected_Y = np.negative(np.ones(U.shape, dtype=U.dtype))
-        expected_Y[..., 1::2] = 0
-        expected_Y = np.transpose(expected_Y, perms)
-        for ord in ["C", "F", "A", "K"]:
-            Y = dpt.negative(U, order=ord)
-            assert np.allclose(dpt.asnumpy(Y), expected_Y)

--- a/dpctl/tests/elementwise/test_nextafter.py
+++ b/dpctl/tests/elementwise/test_nextafter.py
@@ -14,8 +14,6 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-import ctypes
-
 import numpy as np
 import pytest
 
@@ -58,26 +56,6 @@ def test_nextafter_dtype_matrix(op1_dtype, op2_dtype):
     assert _compare_dtypes(r.dtype, expected.dtype, sycl_queue=q)
     assert r.shape == ar3.shape
     assert (dpt.asnumpy(r) == expected.astype(r.dtype)).all()
-
-
-@pytest.mark.parametrize("arr_dt", _no_complex_dtypes[1:])
-def test_nextafter_python_scalar(arr_dt):
-    q = get_queue_or_skip()
-    skip_if_dtype_not_supported(arr_dt, q)
-
-    X = dpt.ones((10, 10), dtype=arr_dt, sycl_queue=q)
-    py_ones = (
-        bool(1),
-        int(1),
-        float(1),
-        np.float32(1),
-        ctypes.c_int(1),
-    )
-    for sc in py_ones:
-        R = dpt.nextafter(X, sc)
-        assert isinstance(R, dpt.usm_ndarray)
-        R = dpt.nextafter(sc, X)
-        assert isinstance(R, dpt.usm_ndarray)
 
 
 @pytest.mark.parametrize("dt", ["f2", "f4", "f8"])

--- a/dpctl/tests/elementwise/test_not_equal.py
+++ b/dpctl/tests/elementwise/test_not_equal.py
@@ -14,16 +14,13 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-import ctypes
-
 import numpy as np
 import pytest
 
-import dpctl
 import dpctl.tensor as dpt
 from dpctl.tests.helper import get_queue_or_skip, skip_if_dtype_not_supported
 
-from .utils import _all_dtypes, _compare_dtypes, _usm_types
+from .utils import _all_dtypes, _compare_dtypes
 
 
 @pytest.mark.parametrize("op1_dtype", _all_dtypes)
@@ -58,136 +55,6 @@ def test_not_equal_dtype_matrix(op1_dtype, op2_dtype):
     assert _compare_dtypes(r.dtype, expected_dtype, sycl_queue=q)
     assert r.shape == ar3.shape
     assert (dpt.asnumpy(r) == np.full(r.shape, False, dtype=r.dtype)).all()
-
-
-@pytest.mark.parametrize("op1_usm_type", _usm_types)
-@pytest.mark.parametrize("op2_usm_type", _usm_types)
-def test_not_equal_usm_type_matrix(op1_usm_type, op2_usm_type):
-    get_queue_or_skip()
-
-    sz = 128
-    ar1 = dpt.ones(sz, dtype="i4", usm_type=op1_usm_type)
-    ar2 = dpt.ones_like(ar1, dtype="i4", usm_type=op2_usm_type)
-
-    r = dpt.not_equal(ar1, ar2)
-    assert isinstance(r, dpt.usm_ndarray)
-    expected_usm_type = dpctl.utils.get_coerced_usm_type(
-        (op1_usm_type, op2_usm_type)
-    )
-    assert r.usm_type == expected_usm_type
-
-
-def test_not_equal_order():
-    get_queue_or_skip()
-
-    ar1 = dpt.ones((20, 20), dtype="i4", order="C")
-    ar2 = dpt.ones((20, 20), dtype="i4", order="C")
-    r1 = dpt.not_equal(ar1, ar2, order="C")
-    assert r1.flags.c_contiguous
-    r2 = dpt.not_equal(ar1, ar2, order="F")
-    assert r2.flags.f_contiguous
-    r3 = dpt.not_equal(ar1, ar2, order="A")
-    assert r3.flags.c_contiguous
-    r4 = dpt.not_equal(ar1, ar2, order="K")
-    assert r4.flags.c_contiguous
-
-    ar1 = dpt.ones((20, 20), dtype="i4", order="F")
-    ar2 = dpt.ones((20, 20), dtype="i4", order="F")
-    r1 = dpt.not_equal(ar1, ar2, order="C")
-    assert r1.flags.c_contiguous
-    r2 = dpt.not_equal(ar1, ar2, order="F")
-    assert r2.flags.f_contiguous
-    r3 = dpt.not_equal(ar1, ar2, order="A")
-    assert r3.flags.f_contiguous
-    r4 = dpt.not_equal(ar1, ar2, order="K")
-    assert r4.flags.f_contiguous
-
-    ar1 = dpt.ones((40, 40), dtype="i4", order="C")[:20, ::-2]
-    ar2 = dpt.ones((40, 40), dtype="i4", order="C")[:20, ::-2]
-    r4 = dpt.not_equal(ar1, ar2, order="K")
-    assert r4.strides == (20, -1)
-
-    ar1 = dpt.ones((40, 40), dtype="i4", order="C")[:20, ::-2].mT
-    ar2 = dpt.ones((40, 40), dtype="i4", order="C")[:20, ::-2].mT
-    r4 = dpt.not_equal(ar1, ar2, order="K")
-    assert r4.strides == (-1, 20)
-
-
-def test_not_equal_broadcasting():
-    get_queue_or_skip()
-
-    m = dpt.ones((100, 5), dtype="i4")
-    v = dpt.arange(5, dtype="i4")
-
-    r = dpt.not_equal(m, v)
-    expected = np.full((100, 5), [True, False, True, True, True], dtype="?")
-
-    assert (dpt.asnumpy(r) == expected).all()
-
-    r2 = dpt.not_equal(v, m)
-    assert (dpt.asnumpy(r2) == expected).all()
-
-    r3 = dpt.empty_like(m, dtype="?")
-    dpt.not_equal(m, v, out=r3)
-    assert (dpt.asnumpy(r3) == expected).all()
-
-
-@pytest.mark.parametrize("arr_dt", _all_dtypes)
-def test_not_equal_python_scalar(arr_dt):
-    q = get_queue_or_skip()
-    skip_if_dtype_not_supported(arr_dt, q)
-
-    X = dpt.zeros((10, 10), dtype=arr_dt, sycl_queue=q)
-    py_zeros = (
-        bool(0),
-        int(0),
-        float(0),
-        complex(0),
-        np.float32(0),
-        ctypes.c_int(0),
-    )
-    for sc in py_zeros:
-        R = dpt.not_equal(X, sc)
-        assert isinstance(R, dpt.usm_ndarray)
-        assert not dpt.all(R)
-        R = dpt.not_equal(sc, X)
-        assert isinstance(R, dpt.usm_ndarray)
-        assert not dpt.all(R)
-
-
-class MockArray:
-    def __init__(self, arr):
-        self.data_ = arr
-
-    @property
-    def __sycl_usm_array_interface__(self):
-        return self.data_.__sycl_usm_array_interface__
-
-
-def test_not_equal_mock_array():
-    get_queue_or_skip()
-    a = dpt.arange(10)
-    b = dpt.ones(10)
-    c = MockArray(b)
-    r = dpt.not_equal(a, c)
-    assert isinstance(r, dpt.usm_ndarray)
-
-
-def test_not_equal_canary_mock_array():
-    get_queue_or_skip()
-    a = dpt.arange(10)
-
-    class Canary:
-        def __init__(self):
-            pass
-
-        @property
-        def __sycl_usm_array_interface__(self):
-            return None
-
-    c = Canary()
-    with pytest.raises(ValueError):
-        dpt.not_equal(a, c)
 
 
 @pytest.mark.parametrize("dtype", _all_dtypes)

--- a/dpctl/tests/elementwise/test_positive.py
+++ b/dpctl/tests/elementwise/test_positive.py
@@ -14,15 +14,13 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-import itertools
-
 import numpy as np
 import pytest
 
 import dpctl.tensor as dpt
 from dpctl.tests.helper import get_queue_or_skip, skip_if_dtype_not_supported
 
-from .utils import _all_dtypes, _usm_types
+from .utils import _all_dtypes
 
 
 @pytest.mark.parametrize("dtype", _all_dtypes[1:])
@@ -37,43 +35,3 @@ def test_positive_out_type(dtype):
     r = dpt.empty_like(X, dtype=arg_dt)
     dpt.positive(X, out=r)
     assert np.allclose(dpt.asnumpy(r), dpt.asnumpy(dpt.positive(X)))
-
-
-@pytest.mark.parametrize("usm_type", _usm_types)
-def test_positive_usm_type(usm_type):
-    q = get_queue_or_skip()
-
-    arg_dt = np.dtype("i4")
-    input_shape = (10, 10, 10, 10)
-    X = dpt.empty(input_shape, dtype=arg_dt, usm_type=usm_type, sycl_queue=q)
-    X[..., 0::2] = 1
-    X[..., 1::2] = 0
-
-    Y = dpt.positive(X)
-    assert Y.usm_type == X.usm_type
-    assert Y.sycl_queue == X.sycl_queue
-    assert Y.flags.c_contiguous
-
-    expected_Y = dpt.asnumpy(X)
-    assert np.allclose(dpt.asnumpy(Y), expected_Y)
-
-
-@pytest.mark.parametrize("dtype", _all_dtypes[1:])
-def test_positive_order(dtype):
-    q = get_queue_or_skip()
-    skip_if_dtype_not_supported(dtype, q)
-
-    arg_dt = np.dtype(dtype)
-    input_shape = (10, 10, 10, 10)
-    X = dpt.empty(input_shape, dtype=arg_dt, sycl_queue=q)
-    X[..., 0::2] = 1
-    X[..., 1::2] = 0
-
-    for perms in itertools.permutations(range(4)):
-        U = dpt.permute_dims(X[:, ::-1, ::-1, :], perms)
-        expected_Y = np.ones(U.shape, dtype=U.dtype)
-        expected_Y[..., 1::2] = 0
-        expected_Y = np.transpose(expected_Y, perms)
-        for ord in ["C", "F", "A", "K"]:
-            Y = dpt.positive(U, order=ord)
-            assert np.allclose(dpt.asnumpy(Y), expected_Y)

--- a/dpctl/tests/elementwise/test_pow.py
+++ b/dpctl/tests/elementwise/test_pow.py
@@ -14,17 +14,14 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-import ctypes
-
 import numpy as np
 import pytest
 
-import dpctl
 import dpctl.tensor as dpt
 from dpctl.tensor._type_utils import _can_cast
 from dpctl.tests.helper import get_queue_or_skip, skip_if_dtype_not_supported
 
-from .utils import _all_dtypes, _compare_dtypes, _usm_types
+from .utils import _all_dtypes, _compare_dtypes
 
 
 @pytest.mark.parametrize("op1_dtype", _all_dtypes[1:])
@@ -59,114 +56,6 @@ def test_power_dtype_matrix(op1_dtype, op2_dtype):
     assert _compare_dtypes(r.dtype, expected.dtype, sycl_queue=q)
     assert r.shape == ar3.shape
     assert (dpt.asnumpy(r) == expected.astype(r.dtype)).all()
-
-
-@pytest.mark.parametrize("op1_usm_type", _usm_types)
-@pytest.mark.parametrize("op2_usm_type", _usm_types)
-def test_power_usm_type_matrix(op1_usm_type, op2_usm_type):
-    get_queue_or_skip()
-
-    sz = 128
-    ar1 = dpt.ones(sz, dtype="i4", usm_type=op1_usm_type)
-    ar2 = dpt.ones_like(ar1, dtype="i4", usm_type=op2_usm_type)
-
-    r = dpt.pow(ar1, ar2)
-    assert isinstance(r, dpt.usm_ndarray)
-    expected_usm_type = dpctl.utils.get_coerced_usm_type(
-        (op1_usm_type, op2_usm_type)
-    )
-    assert r.usm_type == expected_usm_type
-
-
-def test_pow_order():
-    get_queue_or_skip()
-
-    ar1 = dpt.ones((20, 20), dtype="i4", order="C")
-    ar2 = dpt.ones((20, 20), dtype="i4", order="C")
-    r1 = dpt.pow(ar1, ar2, order="C")
-    assert r1.flags.c_contiguous
-    r2 = dpt.pow(ar1, ar2, order="F")
-    assert r2.flags.f_contiguous
-    r3 = dpt.pow(ar1, ar2, order="A")
-    assert r3.flags.c_contiguous
-    r4 = dpt.pow(ar1, ar2, order="K")
-    assert r4.flags.c_contiguous
-
-    ar1 = dpt.ones((20, 20), dtype="i4", order="F")
-    ar2 = dpt.ones((20, 20), dtype="i4", order="F")
-    r1 = dpt.pow(ar1, ar2, order="C")
-    assert r1.flags.c_contiguous
-    r2 = dpt.pow(ar1, ar2, order="F")
-    assert r2.flags.f_contiguous
-    r3 = dpt.pow(ar1, ar2, order="A")
-    assert r3.flags.f_contiguous
-    r4 = dpt.pow(ar1, ar2, order="K")
-    assert r4.flags.f_contiguous
-
-    ar1 = dpt.ones((40, 40), dtype="i4", order="C")[:20, ::-2]
-    ar2 = dpt.ones((40, 40), dtype="i4", order="C")[:20, ::-2]
-    r4 = dpt.pow(ar1, ar2, order="K")
-    assert r4.strides == (20, -1)
-
-    ar1 = dpt.ones((40, 40), dtype="i4", order="C")[:20, ::-2].mT
-    ar2 = dpt.ones((40, 40), dtype="i4", order="C")[:20, ::-2].mT
-    r4 = dpt.pow(ar1, ar2, order="K")
-    assert r4.strides == (-1, 20)
-
-
-def test_pow_broadcasting():
-    get_queue_or_skip()
-
-    v = dpt.arange(1, 6, dtype="i4")
-    m = dpt.full((100, 5), 2, dtype="i4")
-
-    r = dpt.pow(m, v)
-
-    expected = np.power(
-        np.full((100, 5), 2, dtype="i4"), np.arange(1, 6, dtype="i4")
-    )
-    assert (dpt.asnumpy(r) == expected.astype(r.dtype)).all()
-
-    r2 = dpt.pow(v, m)
-    expected2 = np.power(
-        np.arange(1, 6, dtype="i4"), np.full((100, 5), 2, dtype="i4")
-    )
-    assert (dpt.asnumpy(r2) == expected2.astype(r2.dtype)).all()
-
-
-@pytest.mark.parametrize("arr_dt", _all_dtypes)
-def test_pow_python_scalar(arr_dt):
-    q = get_queue_or_skip()
-    skip_if_dtype_not_supported(arr_dt, q)
-
-    X = dpt.ones((10, 10), dtype=arr_dt, sycl_queue=q)
-    py_ones = (
-        bool(1),
-        int(1),
-        float(1),
-        complex(1),
-        np.float32(1),
-        ctypes.c_int(1),
-    )
-    for sc in py_ones:
-        R = dpt.pow(X, sc)
-        assert isinstance(R, dpt.usm_ndarray)
-        R = dpt.pow(sc, X)
-        assert isinstance(R, dpt.usm_ndarray)
-
-
-@pytest.mark.parametrize("dtype", _all_dtypes[1:])
-def test_pow_inplace_python_scalar(dtype):
-    q = get_queue_or_skip()
-    skip_if_dtype_not_supported(dtype, q)
-    X = dpt.ones((10, 10), dtype=dtype, sycl_queue=q)
-    dt_kind = X.dtype.kind
-    if dt_kind in "ui":
-        X **= int(1)
-    elif dt_kind == "f":
-        X **= float(1)
-    elif dt_kind == "c":
-        X **= complex(1)
 
 
 @pytest.mark.parametrize("op1_dtype", _all_dtypes[1:])

--- a/dpctl/tests/elementwise/test_reciprocal.py
+++ b/dpctl/tests/elementwise/test_reciprocal.py
@@ -36,27 +36,13 @@ def test_reciprocal_out_type(dtype):
 
 
 @pytest.mark.parametrize("dtype", _all_dtypes)
-def test_reciprocal_output_contig(dtype):
+def test_reciprocal_basic(dtype):
     q = get_queue_or_skip()
     skip_if_dtype_not_supported(dtype, q)
 
     n_seq = 1027
 
     x = dpt.linspace(1, 13, num=n_seq, dtype=dtype, sycl_queue=q)
-    res = dpt.reciprocal(x)
-    expected = 1 / x
-    tol = 8 * dpt.finfo(res.dtype).resolution
-    assert dpt.allclose(res, expected, atol=tol, rtol=tol)
-
-
-@pytest.mark.parametrize("dtype", _all_dtypes)
-def test_reciprocal_output_strided(dtype):
-    q = get_queue_or_skip()
-    skip_if_dtype_not_supported(dtype, q)
-
-    n_seq = 2054
-
-    x = dpt.linspace(1, 13, num=n_seq, dtype=dtype, sycl_queue=q)[::-2]
     res = dpt.reciprocal(x)
     expected = 1 / x
     tol = 8 * dpt.finfo(res.dtype).resolution

--- a/dpctl/tests/elementwise/test_remainder.py
+++ b/dpctl/tests/elementwise/test_remainder.py
@@ -14,17 +14,14 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-import ctypes
-
 import numpy as np
 import pytest
 
-import dpctl
 import dpctl.tensor as dpt
 from dpctl.tensor._type_utils import _can_cast
 from dpctl.tests.helper import get_queue_or_skip, skip_if_dtype_not_supported
 
-from .utils import _compare_dtypes, _no_complex_dtypes, _usm_types
+from .utils import _compare_dtypes, _no_complex_dtypes
 
 
 @pytest.mark.parametrize("op1_dtype", _no_complex_dtypes)
@@ -59,59 +56,6 @@ def test_remainder_dtype_matrix(op1_dtype, op2_dtype):
     assert _compare_dtypes(r.dtype, expected.dtype, sycl_queue=q)
     assert r.shape == ar3.shape
     assert (dpt.asnumpy(r) == expected.astype(r.dtype)).all()
-
-
-@pytest.mark.parametrize("op1_usm_type", _usm_types)
-@pytest.mark.parametrize("op2_usm_type", _usm_types)
-def test_remainder_usm_type_matrix(op1_usm_type, op2_usm_type):
-    get_queue_or_skip()
-
-    sz = 128
-    ar1 = dpt.ones(sz, dtype="i4", usm_type=op1_usm_type)
-    ar2 = dpt.ones_like(ar1, dtype="i4", usm_type=op2_usm_type)
-
-    r = dpt.remainder(ar1, ar2)
-    assert isinstance(r, dpt.usm_ndarray)
-    expected_usm_type = dpctl.utils.get_coerced_usm_type(
-        (op1_usm_type, op2_usm_type)
-    )
-    assert r.usm_type == expected_usm_type
-
-
-def test_remainder_order():
-    get_queue_or_skip()
-
-    ar1 = dpt.ones((20, 20), dtype="i4", order="C")
-    ar2 = dpt.ones((20, 20), dtype="i4", order="C")
-    r1 = dpt.remainder(ar1, ar2, order="C")
-    assert r1.flags.c_contiguous
-    r2 = dpt.remainder(ar1, ar2, order="F")
-    assert r2.flags.f_contiguous
-    r3 = dpt.remainder(ar1, ar2, order="A")
-    assert r3.flags.c_contiguous
-    r4 = dpt.remainder(ar1, ar2, order="K")
-    assert r4.flags.c_contiguous
-
-    ar1 = dpt.ones((20, 20), dtype="i4", order="F")
-    ar2 = dpt.ones((20, 20), dtype="i4", order="F")
-    r1 = dpt.remainder(ar1, ar2, order="C")
-    assert r1.flags.c_contiguous
-    r2 = dpt.remainder(ar1, ar2, order="F")
-    assert r2.flags.f_contiguous
-    r3 = dpt.remainder(ar1, ar2, order="A")
-    assert r3.flags.f_contiguous
-    r4 = dpt.remainder(ar1, ar2, order="K")
-    assert r4.flags.f_contiguous
-
-    ar1 = dpt.ones((40, 40), dtype="i4", order="C")[:20, ::-2]
-    ar2 = dpt.ones((40, 40), dtype="i4", order="C")[:20, ::-2]
-    r4 = dpt.remainder(ar1, ar2, order="K")
-    assert r4.strides == (20, -1)
-
-    ar1 = dpt.ones((40, 40), dtype="i4", order="C")[:20, ::-2].mT
-    ar2 = dpt.ones((40, 40), dtype="i4", order="C")[:20, ::-2].mT
-    r4 = dpt.remainder(ar1, ar2, order="K")
-    assert r4.strides == (-1, 20)
 
 
 @pytest.mark.parametrize("dt", _no_complex_dtypes[1:8:2])
@@ -187,38 +131,6 @@ def test_remainder_special_cases():
 
     with np.errstate(invalid="ignore"):
         np.allclose(dpt.asnumpy(res), np.remainder(x_np, y_np))
-
-
-@pytest.mark.parametrize("arr_dt", _no_complex_dtypes)
-def test_remainder_python_scalar(arr_dt):
-    q = get_queue_or_skip()
-    skip_if_dtype_not_supported(arr_dt, q)
-
-    X = dpt.ones((10, 10), dtype=arr_dt, sycl_queue=q)
-    py_ones = (
-        bool(1),
-        int(1),
-        float(1),
-        np.float32(1),
-        ctypes.c_int(1),
-    )
-    for sc in py_ones:
-        R = dpt.remainder(X, sc)
-        assert isinstance(R, dpt.usm_ndarray)
-        R = dpt.remainder(sc, X)
-        assert isinstance(R, dpt.usm_ndarray)
-
-
-@pytest.mark.parametrize("dtype", _no_complex_dtypes[1:])
-def test_remainder_inplace_python_scalar(dtype):
-    q = get_queue_or_skip()
-    skip_if_dtype_not_supported(dtype, q)
-    X = dpt.ones((10, 10), dtype=dtype, sycl_queue=q)
-    dt_kind = X.dtype.kind
-    if dt_kind in "ui":
-        X %= int(1)
-    elif dt_kind == "f":
-        X %= float(1)
 
 
 @pytest.mark.parametrize("op1_dtype", _no_complex_dtypes[1:])

--- a/dpctl/tests/elementwise/test_rsqrt.py
+++ b/dpctl/tests/elementwise/test_rsqrt.py
@@ -36,27 +36,13 @@ def test_rsqrt_out_type(dtype):
 
 
 @pytest.mark.parametrize("dtype", _real_fp_dtypes)
-def test_rsqrt_output_contig(dtype):
+def test_rsqrt_basic(dtype):
     q = get_queue_or_skip()
     skip_if_dtype_not_supported(dtype, q)
 
     n_seq = 1027
 
     x = dpt.linspace(1, 13, num=n_seq, dtype=dtype, sycl_queue=q)
-    res = dpt.rsqrt(x)
-    expected = np.reciprocal(np.sqrt(dpt.asnumpy(x), dtype=dtype))
-    tol = 8 * dpt.finfo(res.dtype).resolution
-    assert_allclose(dpt.asnumpy(res), expected, atol=tol, rtol=tol)
-
-
-@pytest.mark.parametrize("dtype", _real_fp_dtypes)
-def test_rsqrt_output_strided(dtype):
-    q = get_queue_or_skip()
-    skip_if_dtype_not_supported(dtype, q)
-
-    n_seq = 2054
-
-    x = dpt.linspace(1, 13, num=n_seq, dtype=dtype, sycl_queue=q)[::-2]
     res = dpt.rsqrt(x)
     expected = np.reciprocal(np.sqrt(dpt.asnumpy(x), dtype=dtype))
     tol = 8 * dpt.finfo(res.dtype).resolution

--- a/dpctl/tests/elementwise/test_sign.py
+++ b/dpctl/tests/elementwise/test_sign.py
@@ -22,7 +22,7 @@ import pytest
 import dpctl.tensor as dpt
 from dpctl.tests.helper import get_queue_or_skip, skip_if_dtype_not_supported
 
-from .utils import _all_dtypes, _no_complex_dtypes, _usm_types
+from .utils import _all_dtypes, _no_complex_dtypes
 
 
 @pytest.mark.parametrize("dtype", _all_dtypes[1:])
@@ -37,47 +37,6 @@ def test_sign_out_type(dtype):
     r = dpt.empty_like(X, dtype=arg_dt)
     dpt.sign(X, out=r)
     assert np.allclose(dpt.asnumpy(r), dpt.asnumpy(dpt.sign(X)))
-
-
-@pytest.mark.parametrize("usm_type", _usm_types)
-def test_sign_usm_type(usm_type):
-    q = get_queue_or_skip()
-
-    arg_dt = np.dtype("i4")
-    input_shape = (10, 10, 10, 10)
-    X = dpt.empty(input_shape, dtype=arg_dt, usm_type=usm_type, sycl_queue=q)
-    X[..., 0::2] = 1
-    X[..., 1::2] = 0
-
-    Y = dpt.sign(X)
-    assert Y.usm_type == X.usm_type
-    assert Y.sycl_queue == X.sycl_queue
-    assert Y.flags.c_contiguous
-
-    expected_Y = dpt.asnumpy(X)
-    assert np.allclose(dpt.asnumpy(Y), expected_Y)
-
-
-@pytest.mark.parametrize("dtype", _all_dtypes[1:])
-def test_sign_order(dtype):
-    q = get_queue_or_skip()
-    skip_if_dtype_not_supported(dtype, q)
-
-    arg_dt = np.dtype(dtype)
-    expected_dt = np.sign(np.ones(tuple(), dtype=arg_dt)).dtype
-    input_shape = (10, 10, 10, 10)
-    X = dpt.empty(input_shape, dtype=arg_dt, sycl_queue=q)
-    X[..., 0::2] = 1
-    X[..., 1::2] = 0
-
-    for perms in itertools.permutations(range(4)):
-        U = dpt.permute_dims(X[:, ::-1, ::-1, :], perms)
-        expected_Y = np.ones(U.shape, dtype=expected_dt)
-        expected_Y[..., 1::2] = 0
-        expected_Y = np.transpose(expected_Y, perms)
-        for ord in ["C", "F", "A", "K"]:
-            Y = dpt.sign(U, order=ord)
-            assert np.allclose(dpt.asnumpy(Y), expected_Y)
 
 
 @pytest.mark.parametrize("dtype", ["c8", "c16"])

--- a/dpctl/tests/elementwise/test_signbit.py
+++ b/dpctl/tests/elementwise/test_signbit.py
@@ -22,7 +22,7 @@ from dpctl.tests.helper import get_queue_or_skip, skip_if_dtype_not_supported
 
 
 @pytest.mark.parametrize("dtype", ["f2", "f4", "f8"])
-def test_signbit_out_type_contig(dtype):
+def test_signbit_out_type(dtype):
     q = get_queue_or_skip()
     skip_if_dtype_not_supported(dtype, q)
 
@@ -39,24 +39,7 @@ def test_signbit_out_type_contig(dtype):
 
 
 @pytest.mark.parametrize("dtype", ["f2", "f4", "f8"])
-def test_signbit_out_type_strided(dtype):
-    q = get_queue_or_skip()
-    skip_if_dtype_not_supported(dtype, q)
-
-    arg_dt = np.dtype(dtype)
-    x = dpt.linspace(1, 10, num=256, dtype=arg_dt)
-    sb = dpt.signbit(x[::-3])
-    assert sb.dtype == dpt.bool
-
-    assert not dpt.any(sb)
-
-    x2 = dpt.linspace(-10, -1, num=256, dtype=arg_dt)
-    sb2 = dpt.signbit(x2[::-3])
-    assert dpt.all(sb2)
-
-
-@pytest.mark.parametrize("dtype", ["f2", "f4", "f8"])
-def test_signbit_special_cases_contig(dtype):
+def test_signbit_special_cases(dtype):
     q = get_queue_or_skip()
     skip_if_dtype_not_supported(dtype, q)
 
@@ -76,32 +59,6 @@ def test_signbit_special_cases_contig(dtype):
             dpt.full(x2.size, True),
             dpt.full(x3.size, False),
             dpt.full(x4.size, False),
-        )
-    )
-
-    assert dpt.all(dpt.equal(actual, expected))
-
-
-@pytest.mark.parametrize("dtype", ["f2", "f4", "f8"])
-def test_signbit_special_cases_strided(dtype):
-    q = get_queue_or_skip()
-    skip_if_dtype_not_supported(dtype, q)
-
-    arg_dt = np.dtype(dtype)
-    x1 = dpt.full(63, -dpt.inf, dtype=arg_dt)
-    x2 = dpt.full(63, -0.0, dtype=arg_dt)
-    x3 = dpt.full(63, 0.0, dtype=arg_dt)
-    x4 = dpt.full(63, dpt.inf, dtype=arg_dt)
-
-    x = dpt.concat((x1, x2, x3, x4))
-    actual = dpt.signbit(x[::-1])
-
-    expected = dpt.concat(
-        (
-            dpt.full(x4.size, False),
-            dpt.full(x3.size, False),
-            dpt.full(x2.size, True),
-            dpt.full(x1.size, True),
         )
     )
 

--- a/dpctl/tests/elementwise/test_sqrt.py
+++ b/dpctl/tests/elementwise/test_sqrt.py
@@ -29,7 +29,6 @@ from .utils import (
     _complex_fp_dtypes,
     _map_to_device_dtype,
     _real_fp_dtypes,
-    _usm_types,
 )
 
 
@@ -45,7 +44,7 @@ def test_sqrt_out_type(dtype):
 
 
 @pytest.mark.parametrize("dtype", ["f2", "f4", "f8", "c8", "c16"])
-def test_sqrt_output_contig(dtype):
+def test_sqrt_basic(dtype):
     q = get_queue_or_skip()
     skip_if_dtype_not_supported(dtype, q)
 
@@ -58,68 +57,6 @@ def test_sqrt_output_contig(dtype):
     tol = 8 * dpt.finfo(Y.dtype).resolution
 
     assert_allclose(dpt.asnumpy(Y), np.sqrt(Xnp), atol=tol, rtol=tol)
-
-
-@pytest.mark.parametrize("dtype", ["f2", "f4", "f8", "c8", "c16"])
-def test_sqrt_output_strided(dtype):
-    q = get_queue_or_skip()
-    skip_if_dtype_not_supported(dtype, q)
-
-    n_seq = 2054
-
-    X = dpt.linspace(0, 13, num=n_seq, dtype=dtype, sycl_queue=q)[::-2]
-    Xnp = dpt.asnumpy(X)
-
-    Y = dpt.sqrt(X)
-    tol = 8 * dpt.finfo(Y.dtype).resolution
-
-    assert_allclose(dpt.asnumpy(Y), np.sqrt(Xnp), atol=tol, rtol=tol)
-
-
-@pytest.mark.parametrize("usm_type", _usm_types)
-def test_sqrt_usm_type(usm_type):
-    q = get_queue_or_skip()
-
-    arg_dt = np.dtype("f4")
-    input_shape = (10, 10, 10, 10)
-    X = dpt.empty(input_shape, dtype=arg_dt, usm_type=usm_type, sycl_queue=q)
-    X[..., 0::2] = 16.0
-    X[..., 1::2] = 23.0
-
-    Y = dpt.sqrt(X)
-    assert Y.usm_type == X.usm_type
-    assert Y.sycl_queue == X.sycl_queue
-    assert Y.flags.c_contiguous
-
-    expected_Y = np.empty(input_shape, dtype=arg_dt)
-    expected_Y[..., 0::2] = np.sqrt(np.float32(16.0))
-    expected_Y[..., 1::2] = np.sqrt(np.float32(23.0))
-    tol = 8 * dpt.finfo(Y.dtype).resolution
-
-    assert_allclose(dpt.asnumpy(Y), expected_Y, atol=tol, rtol=tol)
-
-
-@pytest.mark.parametrize("dtype", _all_dtypes)
-def test_sqrt_order(dtype):
-    q = get_queue_or_skip()
-    skip_if_dtype_not_supported(dtype, q)
-
-    arg_dt = np.dtype(dtype)
-    input_shape = (10, 10, 10, 10)
-    X = dpt.empty(input_shape, dtype=arg_dt, sycl_queue=q)
-    X[..., 0::2] = 16.0
-    X[..., 1::2] = 23.0
-
-    for perms in itertools.permutations(range(4)):
-        U = dpt.permute_dims(X[:, ::-1, ::-1, :], perms)
-        expected_Y = np.sqrt(dpt.asnumpy(U))
-        for ord in ["C", "F", "A", "K"]:
-            Y = dpt.sqrt(U, order=ord)
-            tol = 8 * max(
-                dpt.finfo(Y.dtype).resolution,
-                np.finfo(expected_Y.dtype).resolution,
-            )
-            assert_allclose(dpt.asnumpy(Y), expected_Y, atol=tol, rtol=tol)
 
 
 @pytest.mark.usefixtures("suppress_invalid_numpy_warnings")

--- a/dpctl/tests/elementwise/test_square.py
+++ b/dpctl/tests/elementwise/test_square.py
@@ -14,15 +14,13 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-import itertools
-
 import numpy as np
 import pytest
 
 import dpctl.tensor as dpt
 from dpctl.tests.helper import get_queue_or_skip, skip_if_dtype_not_supported
 
-from .utils import _all_dtypes, _usm_types
+from .utils import _all_dtypes
 
 
 @pytest.mark.parametrize("dtype", _all_dtypes[1:])
@@ -37,46 +35,6 @@ def test_square_out_type(dtype):
     r = dpt.empty_like(X, dtype=arg_dt)
     dpt.square(X, out=r)
     assert np.allclose(dpt.asnumpy(r), dpt.asnumpy(dpt.square(X)))
-
-
-@pytest.mark.parametrize("usm_type", _usm_types)
-def test_square_usm_type(usm_type):
-    q = get_queue_or_skip()
-
-    arg_dt = np.dtype("i4")
-    input_shape = (10, 10, 10, 10)
-    X = dpt.empty(input_shape, dtype=arg_dt, usm_type=usm_type, sycl_queue=q)
-    X[..., 0::2] = 1
-    X[..., 1::2] = 0
-
-    Y = dpt.square(X)
-    assert Y.usm_type == X.usm_type
-    assert Y.sycl_queue == X.sycl_queue
-    assert Y.flags.c_contiguous
-
-    expected_Y = dpt.asnumpy(X)
-    assert np.allclose(dpt.asnumpy(Y), expected_Y)
-
-
-@pytest.mark.parametrize("dtype", _all_dtypes[1:])
-def test_square_order(dtype):
-    q = get_queue_or_skip()
-    skip_if_dtype_not_supported(dtype, q)
-
-    arg_dt = np.dtype(dtype)
-    input_shape = (10, 10, 10, 10)
-    X = dpt.empty(input_shape, dtype=arg_dt, sycl_queue=q)
-    X[..., 0::2] = 2
-    X[..., 1::2] = 0
-
-    for perms in itertools.permutations(range(4)):
-        U = dpt.permute_dims(X[:, ::-1, ::-1, :], perms)
-        expected_Y = np.full(U.shape, 4, dtype=U.dtype)
-        expected_Y[..., 1::2] = 0
-        expected_Y = np.transpose(expected_Y, perms)
-        for ord in ["C", "F", "A", "K"]:
-            Y = dpt.square(U, order=ord)
-            assert np.allclose(dpt.asnumpy(Y), expected_Y)
 
 
 @pytest.mark.parametrize("dtype", ["c8", "c16"])

--- a/dpctl/tests/elementwise/test_subtract.py
+++ b/dpctl/tests/elementwise/test_subtract.py
@@ -14,17 +14,14 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-import ctypes
-
 import numpy as np
 import pytest
 
-import dpctl
 import dpctl.tensor as dpt
 from dpctl.tensor._type_utils import _can_cast
 from dpctl.tests.helper import get_queue_or_skip, skip_if_dtype_not_supported
 
-from .utils import _all_dtypes, _compare_dtypes, _usm_types
+from .utils import _all_dtypes, _compare_dtypes
 
 
 @pytest.mark.parametrize("op1_dtype", _all_dtypes[1:])
@@ -77,123 +74,6 @@ def test_subtract_bool():
         dpt.subtract(ar1, ar2)
 
 
-@pytest.mark.parametrize("op1_usm_type", _usm_types)
-@pytest.mark.parametrize("op2_usm_type", _usm_types)
-def test_subtract_usm_type_matrix(op1_usm_type, op2_usm_type):
-    get_queue_or_skip()
-
-    sz = 128
-    ar1 = dpt.ones(sz, dtype="i4", usm_type=op1_usm_type)
-    ar2 = dpt.ones_like(ar1, dtype="i4", usm_type=op2_usm_type)
-
-    r = dpt.subtract(ar1, ar2)
-    assert isinstance(r, dpt.usm_ndarray)
-    expected_usm_type = dpctl.utils.get_coerced_usm_type(
-        (op1_usm_type, op2_usm_type)
-    )
-    assert r.usm_type == expected_usm_type
-
-
-def test_subtract_order():
-    get_queue_or_skip()
-
-    test_shape = (
-        20,
-        20,
-    )
-    test_shape2 = tuple(2 * dim for dim in test_shape)
-    n = test_shape[-1]
-
-    for dt1, dt2 in zip(["i4", "i4", "f4"], ["i4", "f4", "i4"]):
-        ar1 = dpt.ones(test_shape, dtype=dt1, order="C")
-        ar2 = dpt.ones(test_shape, dtype=dt2, order="C")
-        r1 = dpt.subtract(ar1, ar2, order="C")
-        assert r1.flags.c_contiguous
-        r2 = dpt.subtract(ar1, ar2, order="F")
-        assert r2.flags.f_contiguous
-        r3 = dpt.subtract(ar1, ar2, order="A")
-        assert r3.flags.c_contiguous
-        r4 = dpt.subtract(ar1, ar2, order="K")
-        assert r4.flags.c_contiguous
-
-        ar1 = dpt.ones(test_shape, dtype=dt1, order="F")
-        ar2 = dpt.ones(test_shape, dtype=dt2, order="F")
-        r1 = dpt.subtract(ar1, ar2, order="C")
-        assert r1.flags.c_contiguous
-        r2 = dpt.subtract(ar1, ar2, order="F")
-        assert r2.flags.f_contiguous
-        r3 = dpt.subtract(ar1, ar2, order="A")
-        assert r3.flags.f_contiguous
-        r4 = dpt.subtract(ar1, ar2, order="K")
-        assert r4.flags.f_contiguous
-
-        ar1 = dpt.ones(test_shape2, dtype=dt1, order="C")[:20, ::-2]
-        ar2 = dpt.ones(test_shape2, dtype=dt2, order="C")[:20, ::-2]
-        r4 = dpt.subtract(ar1, ar2, order="K")
-        assert r4.strides == (n, -1)
-        r5 = dpt.subtract(ar1, ar2, order="C")
-        assert r5.strides == (n, 1)
-
-        ar1 = dpt.ones(test_shape2, dtype=dt1, order="C")[:20, ::-2].mT
-        ar2 = dpt.ones(test_shape2, dtype=dt2, order="C")[:20, ::-2].mT
-        r4 = dpt.subtract(ar1, ar2, order="K")
-        assert r4.strides == (-1, n)
-        r5 = dpt.subtract(ar1, ar2, order="C")
-        assert r5.strides == (n, 1)
-
-
-def test_subtract_broadcasting():
-    get_queue_or_skip()
-
-    m = dpt.ones((100, 5), dtype="i4")
-    v = dpt.arange(5, dtype="i4")
-
-    r = dpt.subtract(m, v)
-    assert (
-        dpt.asnumpy(r) == np.arange(1, -4, step=-1, dtype="i4")[np.newaxis, :]
-    ).all()
-
-    r2 = dpt.subtract(v, m)
-    assert (
-        dpt.asnumpy(r2) == np.arange(-1, 4, dtype="i4")[np.newaxis, :]
-    ).all()
-
-
-@pytest.mark.parametrize("arr_dt", _all_dtypes[1:])
-def test_subtract_python_scalar(arr_dt):
-    q = get_queue_or_skip()
-    skip_if_dtype_not_supported(arr_dt, q)
-
-    X = dpt.zeros((10, 10), dtype=arr_dt, sycl_queue=q)
-    py_zeros = (
-        bool(0),
-        int(0),
-        float(0),
-        complex(0),
-        np.float32(0),
-        ctypes.c_int(0),
-    )
-    for sc in py_zeros:
-        R = dpt.subtract(X, sc)
-        assert isinstance(R, dpt.usm_ndarray)
-        R = dpt.subtract(sc, X)
-        assert isinstance(R, dpt.usm_ndarray)
-
-
-@pytest.mark.parametrize("dtype", _all_dtypes[1:])
-def test_subtract_inplace_python_scalar(dtype):
-    q = get_queue_or_skip()
-    skip_if_dtype_not_supported(dtype, q)
-    X = dpt.zeros((10, 10), dtype=dtype, sycl_queue=q)
-    dt_kind = X.dtype.kind
-    if dt_kind in "ui":
-        X -= int(0)
-    elif dt_kind == "f":
-        X -= float(0)
-    elif dt_kind == "c":
-        X -= complex(0)
-
-
 @pytest.mark.parametrize("op1_dtype", _all_dtypes[1:])
 @pytest.mark.parametrize("op2_dtype", _all_dtypes[1:])
 def test_subtract_inplace_dtype_matrix(op1_dtype, op2_dtype):
@@ -221,15 +101,3 @@ def test_subtract_inplace_dtype_matrix(op1_dtype, op2_dtype):
     else:
         with pytest.raises(ValueError):
             ar1 -= ar2
-
-
-def test_subtract_inplace_broadcasting():
-    get_queue_or_skip()
-
-    m = dpt.ones((100, 5), dtype="i4")
-    v = dpt.arange(5, dtype="i4")
-
-    m -= v
-    assert (
-        dpt.asnumpy(m) == np.arange(1, -4, step=-1, dtype="i4")[np.newaxis, :]
-    ).all()

--- a/dpctl/tests/elementwise/test_usm_types.py
+++ b/dpctl/tests/elementwise/test_usm_types.py
@@ -1,0 +1,296 @@
+#                       Data Parallel Control (dpctl)
+#
+#  Copyright 2020-2025 Intel Corporation
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import pytest
+
+import dpctl
+import dpctl.tensor as dpt
+from dpctl.tests.helper import get_queue_or_skip
+
+from .utils import _usm_types
+
+
+@pytest.mark.parametrize("usm_type", _usm_types)
+class TestUnaryUSMType:
+    def unary_elementwise(self, fn, usm_type, dtype="f4"):
+        q = get_queue_or_skip()
+        x = dpt.asarray(
+            [1, 2, 3, 4], dtype=dtype, usm_type=usm_type, sycl_queue=q
+        )
+        return getattr(dpt, fn)(x)
+
+    def test_abs(self, usm_type):
+        self.unary_elementwise("abs", usm_type)
+
+    def test_acos(self, usm_type):
+        self.unary_elementwise("acos", usm_type)
+
+    def test_acosh(self, usm_type):
+        self.unary_elementwise("acosh", usm_type)
+
+    def test_angle(self, usm_type):
+        self.unary_elementwise("angle", usm_type, dtype="c8")
+
+    def test_asin(self, usm_type):
+        self.unary_elementwise("asin", usm_type)
+
+    def test_asinh(self, usm_type):
+        self.unary_elementwise("asinh", usm_type)
+
+    def test_atan(self, usm_type):
+        self.unary_elementwise("atan", usm_type)
+
+    def test_atanh(self, usm_type):
+        self.unary_elementwise("atanh", usm_type)
+
+    def test_bitwise_invert(self, usm_type):
+        self.unary_elementwise("bitwise_invert", usm_type, dtype="i4")
+
+    def test_cbrt(self, usm_type):
+        self.unary_elementwise("cbrt", usm_type)
+
+    def test_ceil(self, usm_type):
+        self.unary_elementwise("ceil", usm_type)
+
+    def test_conj(self, usm_type):
+        self.unary_elementwise("conj", usm_type)
+
+    def test_cos(self, usm_type):
+        self.unary_elementwise("cos", usm_type)
+
+    def test_cosh(self, usm_type):
+        self.unary_elementwise("cosh", usm_type)
+
+    def test_exp(self, usm_type):
+        self.unary_elementwise("exp", usm_type)
+
+    def test_exp2(self, usm_type):
+        self.unary_elementwise("exp2", usm_type)
+
+    def test_expm1(self, usm_type):
+        self.unary_elementwise("expm1", usm_type)
+
+    def test_floor(self, usm_type):
+        self.unary_elementwise("floor", usm_type)
+
+    def test_imag(self, usm_type):
+        self.unary_elementwise("imag", usm_type)
+
+    def test_isfinite(self, usm_type):
+        self.unary_elementwise("isfinite", usm_type)
+
+    def test_isinf(self, usm_type):
+        self.unary_elementwise("isinf", usm_type)
+
+    def test_isnan(self, usm_type):
+        self.unary_elementwise("isnan", usm_type)
+
+    def test_log(self, usm_type):
+        self.unary_elementwise("log", usm_type)
+
+    def test_log1p(self, usm_type):
+        self.unary_elementwise("log1p", usm_type)
+
+    def test_log2(self, usm_type):
+        self.unary_elementwise("log2", usm_type)
+
+    def test_log10(self, usm_type):
+        self.unary_elementwise("log10", usm_type)
+
+    def test_logical_not(self, usm_type):
+        self.unary_elementwise("logical_not", usm_type, dtype="i4")
+
+    def test_negative(self, usm_type):
+        self.unary_elementwise("negative", usm_type)
+
+    def test_positive(self, usm_type):
+        self.unary_elementwise("positive", usm_type)
+
+    def test_proj(self, usm_type):
+        self.unary_elementwise("proj", usm_type, dtype="c8")
+
+    def test_real(self, usm_type):
+        self.unary_elementwise("real", usm_type, dtype="c8")
+
+    def test_reciprocal(self, usm_type):
+        self.unary_elementwise("reciprocal", usm_type)
+
+    def test_round(self, usm_type):
+        self.unary_elementwise("round", usm_type)
+
+    def test_rsqrt(self, usm_type):
+        self.unary_elementwise("rsqrt", usm_type)
+
+    def test_sign(self, usm_type):
+        self.unary_elementwise("sign", usm_type)
+
+    def test_signbit(self, usm_type):
+        self.unary_elementwise("signbit", usm_type)
+
+    def test_sin(self, usm_type):
+        self.unary_elementwise("sin", usm_type)
+
+    def test_sinh(self, usm_type):
+        self.unary_elementwise("sinh", usm_type)
+
+    def test_square(self, usm_type):
+        self.unary_elementwise("square", usm_type)
+
+    def test_sqrt(self, usm_type):
+        self.unary_elementwise("sqrt", usm_type)
+
+    def test_tan(self, usm_type):
+        self.unary_elementwise("tan", usm_type)
+
+    def test_tanh(self, usm_type):
+        self.unary_elementwise("tanh", usm_type)
+
+    def test_trunc(self, usm_type):
+        self.unary_elementwise("trunc", usm_type)
+
+    def test_usm_basic(self, usm_type):
+        q = get_queue_or_skip()
+
+        sz = 128
+        dt = dpt.int32
+        x = dpt.ones(sz, dtype=dt, usm_type=usm_type, sycl_queue=q)
+
+        r = dpt.abs(x)
+        assert isinstance(r, dpt.usm_ndarray)
+        assert r.usm_type == x.usm_type
+
+
+@pytest.mark.parametrize("op1_usm_type", _usm_types)
+@pytest.mark.parametrize("op2_usm_type", _usm_types)
+class TestBinaryUSMType:
+    def binary_elementwise(self, fn, op1_usm_type, op2_usm_type, dtype="f4"):
+        q = get_queue_or_skip()
+        x = dpt.asarray(
+            [1, 2, 3, 4, 5, 6], dtype=dtype, usm_type=op1_usm_type, sycl_queue=q
+        )
+        y = dpt.asarray(
+            [1, 2, 3, 4, 5, 6], dtype=dtype, usm_type=op2_usm_type, sycl_queue=q
+        )
+        return getattr(dpt, fn)(x, y)
+
+    def test_add(self, op1_usm_type, op2_usm_type):
+        self.binary_elementwise("add", op1_usm_type, op2_usm_type)
+
+    def test_atan2(self, op1_usm_type, op2_usm_type):
+        self.binary_elementwise("atan2", op1_usm_type, op2_usm_type)
+
+    def test_bitwise_and(self, op1_usm_type, op2_usm_type):
+        self.binary_elementwise(
+            "bitwise_and", op1_usm_type, op2_usm_type, dtype="i4"
+        )
+
+    def test_bitwise_left_shift(self, op1_usm_type, op2_usm_type):
+        self.binary_elementwise(
+            "bitwise_left_shift", op1_usm_type, op2_usm_type, dtype="i4"
+        )
+
+    def test_bitwise_or(self, op1_usm_type, op2_usm_type):
+        self.binary_elementwise(
+            "bitwise_or", op1_usm_type, op2_usm_type, dtype="i4"
+        )
+
+    def test_bitwise_right_shift(self, op1_usm_type, op2_usm_type):
+        self.binary_elementwise(
+            "bitwise_right_shift", op1_usm_type, op2_usm_type, dtype="i4"
+        )
+
+    def test_bitwise_xor(self, op1_usm_type, op2_usm_type):
+        self.binary_elementwise(
+            "bitwise_xor", op1_usm_type, op2_usm_type, dtype="i4"
+        )
+
+    def test_copysign(self, op1_usm_type, op2_usm_type):
+        self.binary_elementwise("copysign", op1_usm_type, op2_usm_type)
+
+    def test_divide(self, op1_usm_type, op2_usm_type):
+        self.binary_elementwise("divide", op1_usm_type, op2_usm_type)
+
+    def test_equal(self, op1_usm_type, op2_usm_type):
+        self.binary_elementwise("equal", op1_usm_type, op2_usm_type)
+
+    def test_floor_divide(self, op1_usm_type, op2_usm_type):
+        self.binary_elementwise("floor_divide", op1_usm_type, op2_usm_type)
+
+    def test_hypot(self, op1_usm_type, op2_usm_type):
+        self.binary_elementwise("hypot", op1_usm_type, op2_usm_type)
+
+    def test_greater(self, op1_usm_type, op2_usm_type):
+        self.binary_elementwise("greater", op1_usm_type, op2_usm_type)
+
+    def test_greater_equal(self, op1_usm_type, op2_usm_type):
+        self.binary_elementwise("greater_equal", op1_usm_type, op2_usm_type)
+
+    def test_less(self, op1_usm_type, op2_usm_type):
+        self.binary_elementwise("less", op1_usm_type, op2_usm_type)
+
+    def test_less_equal(self, op1_usm_type, op2_usm_type):
+        self.binary_elementwise("less_equal", op1_usm_type, op2_usm_type)
+
+    def test_logaddexp(self, op1_usm_type, op2_usm_type):
+        self.binary_elementwise("logaddexp", op1_usm_type, op2_usm_type)
+
+    def test_logical_and(self, op1_usm_type, op2_usm_type):
+        self.binary_elementwise("logical_and", op1_usm_type, op2_usm_type)
+
+    def test_logical_or(self, op1_usm_type, op2_usm_type):
+        self.binary_elementwise("logical_or", op1_usm_type, op2_usm_type)
+
+    def test_logical_xor(self, op1_usm_type, op2_usm_type):
+        self.binary_elementwise("logical_xor", op1_usm_type, op2_usm_type)
+
+    def test_maximum(self, op1_usm_type, op2_usm_type):
+        self.binary_elementwise("maximum", op1_usm_type, op2_usm_type)
+
+    def test_minimum(self, op1_usm_type, op2_usm_type):
+        self.binary_elementwise("minimum", op1_usm_type, op2_usm_type)
+
+    def test_multiply(self, op1_usm_type, op2_usm_type):
+        self.binary_elementwise("multiply", op1_usm_type, op2_usm_type)
+
+    def test_nextafter(self, op1_usm_type, op2_usm_type):
+        self.binary_elementwise("nextafter", op1_usm_type, op2_usm_type)
+
+    def test_not_equal(self, op1_usm_type, op2_usm_type):
+        self.binary_elementwise("not_equal", op1_usm_type, op2_usm_type)
+
+    def test_pow(self, op1_usm_type, op2_usm_type):
+        self.binary_elementwise("pow", op1_usm_type, op2_usm_type)
+
+    def test_remainder(self, op1_usm_type, op2_usm_type):
+        self.binary_elementwise("remainder", op1_usm_type, op2_usm_type)
+
+    def test_subtract(self, op1_usm_type, op2_usm_type):
+        self.binary_elementwise("subtract", op1_usm_type, op2_usm_type)
+
+    def test_binary_usm_type_coercion(self, op1_usm_type, op2_usm_type):
+        q = get_queue_or_skip()
+
+        sz = 128
+        dt = dpt.int32
+        ar1 = dpt.ones(sz, dtype=dt, usm_type=op1_usm_type, sycl_queue=q)
+        ar2 = dpt.ones_like(ar1, dtype=dt, usm_type=op2_usm_type, sycl_queue=q)
+
+        r = dpt.add(ar1, ar2)
+        assert isinstance(r, dpt.usm_ndarray)
+        expected_usm_type = dpctl.utils.get_coerced_usm_type(
+            (op1_usm_type, op2_usm_type)
+        )
+        assert r.usm_type == expected_usm_type


### PR DESCRIPTION
This PR proposes reducing the scope of the dpctl test suite by redacting tests which are redundant

For example, the dpctl test suite for element-wise functions repeatedly tests for things like `usm_type` of the output array. But the output array `usm_type` is determined in the function which dispatches to the element-wise kernel, and therefore, only needs to be tested once

- [X] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [ ] Have you added your changes to the changelog?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
