### PR TITLE
Add project root folder to include_dirs in _cython_api setup script

### DIFF
--- a/dpctl/tests/setup_cython_api.py
+++ b/dpctl/tests/setup_cython_api.py
@@ -14,15 +14,26 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os.path
+
 import setuptools
 from Cython.Build import build_ext
 
 import dpctl
 
+
+def get_includes():
+    # path to dpctl/include
+    dpctl_incl_dir = dpctl.get_include()
+    # path to folder where __init__.pxd resides
+    dpctl_pxd_dir = os.path.dirname(os.path.dirname(dpctl_incl_dir))
+    return [dpctl_incl_dir, dpctl_pxd_dir]
+
+
 ext = setuptools.Extension(
     "_cython_api",
     ["_cython_api.pyx"],
-    include_dirs=[dpctl.get_include()],
+    include_dirs=get_includes(),
     language="c++",
 )
 


### PR DESCRIPTION
Add project root folder to `include_dirs` in the `"setup_cython_api.py"` so that Cython can find `dpctl/__init__.pxd`

This resolves gh-2146 for me locally with Cython 3.1.3

- [x] Have you provided a meaningful PR description?
- [x] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [ ] Have you added your changes to the changelog?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
