### PR TITLE
[MAINT] Fix uploading dev package on Linux

### DIFF
--- a/.github/workflows/conda-package.yml
+++ b/.github/workflows/conda-package.yml
@@ -445,12 +445,17 @@ jobs:
       - name: Upload
         env:
           ANACONDA_TOKEN: ${{ secrets.ANACONDA_TOKEN }}
+          # remove when anaconda-client 1.13.1 is available
+          ANACONDA_CLIENT_FORCE_STANDALONE: true
+        if: ${{ env.ANACONDA_TOKEN != '' }}
         run: |
-          anaconda --token $ANACONDA_TOKEN upload --user dppy --label dev ${PACKAGE_NAME}-*.conda
+          anaconda --token ${{ env.ANACONDA_TOKEN }} upload --user dppy --label dev ${PACKAGE_NAME}-*.conda
 
       - name: Upload Wheels
         env:
           ANACONDA_TOKEN: ${{ secrets.ANACONDA_TOKEN }}
+          # remove when anaconda-client 1.13.1 is available
+          ANACONDA_CLIENT_FORCE_STANDALONE: true
         run: anaconda --token ${{ env.ANACONDA_TOKEN }} upload --user dppy --label dev ${{ env.PACKAGE_NAME }}-*.whl --version ${{ env.PACKAGE_VERSION }}
 
   upload_windows:


### PR DESCRIPTION
anaconda-client and anaconda-auth seem to have a bug which was allegedly fixed in 1.13.1 (not available on conda-forge)

setting ANACONDA_CLIENT_FORCE_STANDALONE: true on Linux seems to have resolved the issue

- [X] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [ ] Have you added your changes to the changelog?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
