### PR TITLE
[MAINT] Make error checks in `.bat` files more general

### DIFF
--- a/conda-recipe/bld.bat
+++ b/conda-recipe/bld.bat
@@ -1,4 +1,3 @@
-
 REM A workaround for activate-dpcpp.bat issue to be addressed in 2021.4
 set "LIB=%BUILD_PREFIX%\Library\lib;%BUILD_PREFIX%\compiler\lib;%LIB%"
 set "INCLUDE=%BUILD_PREFIX%\include;%INCLUDE%"
@@ -65,5 +64,5 @@ for /f %%f in ('dir /b /S .\dist') do (
 :: Copy wheel package
 if NOT "%WHEELS_OUTPUT_FOLDER%"=="" (
     copy dist\dpctl*.whl %WHEELS_OUTPUT_FOLDER%
-    if errorlevel 1 exit 1
+    if %ERRORLEVEL% neq 0 exit 1
 )

--- a/conda-recipe/bld.bat
+++ b/conda-recipe/bld.bat
@@ -25,9 +25,9 @@ rem fix the issue with IntelLLVM integration with cmake on Windows
 if EXIST "%PLATFORM_DIR%" (
   dir "%PLATFORM_DIR%\%FN%"
   copy /Y "%PLATFORM_DIR%\%FN%" .
-  if errorlevel 1 exit 1
+  if %ERRORLEVEL% neq 0 exit 1
   copy /Y ".github\workflows\Windows-IntelLLVM_%PATCHED_CMAKE_VERSION%.cmake" "%PLATFORM_DIR%\%FN%"
-  if errorlevel 1 exit 1
+  if %ERRORLEVEL% neq 0 exit 1
 )
 
 set "CC=icx"

--- a/conda-recipe/run_test.bat
+++ b/conda-recipe/run_test.bat
@@ -1,10 +1,10 @@
 @echo on
 
 "%PYTHON%" -c "import dpctl; print(dpctl.__version__)"
-if errorlevel 1 exit 1
+if %ERRORLEVEL% neq 0 exit 1
 
 "%PYTHON%" -m dpctl -f
-if errorlevel 1 exit 1
+if %ERRORLEVEL% neq 0 exit 1
 
 python -m pytest -q -ra --disable-warnings --pyargs dpctl -vv
-if errorlevel 1 exit 1
+if %ERRORLEVEL% neq 0 exit 1

--- a/libsyclinterface/dbg_build.bat
+++ b/libsyclinterface/dbg_build.bat
@@ -3,7 +3,7 @@ dpcpp.exe --version >nul 2>&1
 if errorlevel 1 (
     set ERRORLEVEL=
     call "%ONEAPI_ROOT%\compiler\latest\env\vars.bat"
-    if errorlevel 1 exit 1
+    if %ERRORLEVEL% neq 0 exit 1
 )
 @REM conda uses %ERRORLEVEL% but FPGA scripts can set it. So it should be reseted.
 set ERRORLEVEL=
@@ -31,13 +31,13 @@ cmake -G Ninja ^
     "-DCMAKE_LINKER:PATH=%DPCPP_HOME%\bin\lld-link.exe" ^
     "-DDPCTL_BUILD_CAPI_TESTS=ON" ^
     ".."
-if errorlevel 1 exit 1
+if %ERRORLEVEL% neq 0 exit 1
 
 ninja -n
-if errorlevel 1 exit 1
+if %ERRORLEVEL% neq 0 exit 1
 @REM ninja check
 @REM IF %ERRORLEVEL% NEQ 0 exit /b 1
 ninja install
-if errorlevel 1 exit 1
+if %ERRORLEVEL% neq 0 exit 1
 
 cd ..


### PR DESCRIPTION
This PR proposes using `if %ERRORLEVEL% neq 0 exit 1` in bld.bat wheel copying, which is more general than `if errorlevel 1 exit 1`

A similar change was suggested when adding the recipe to conda-forge

- [X] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [ ] Have you added your changes to the changelog?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
