### PR TITLE
Bumped versions of OpenCL CPU driver and TBB used in workflow

### DIFF
--- a/.github/workflows/os-llvm-sycl-build.yml
+++ b/.github/workflows/os-llvm-sycl-build.yml
@@ -14,11 +14,11 @@ jobs:
 
     env:
       DOWNLOAD_URL_PREFIX: https://github.com/intel/llvm/releases/download
-      DRIVER_PATH: 2025-WW13
-      OCLCPUEXP_FN: oclcpuexp-2025.19.3.0.17_230222_rel.tar.gz
-      TBB_URL: https://github.com/oneapi-src/oneTBB/releases/download/v2022.1.0/
-      TBB_INSTALL_DIR: oneapi-tbb-2022.1.0
-      TBB_FN: oneapi-tbb-2022.1.0-lin.tgz
+      DRIVER_PATH: 2025-WW27
+      OCLCPUEXP_FN: oclcpuexp-2025.20.6.0.04_224945_rel.tar.gz
+      TBB_URL: https://github.com/oneapi-src/oneTBB/releases/download/v2022.2.0/
+      TBB_INSTALL_DIR: oneapi-tbb-2022.2.0
+      TBB_FN: oneapi-tbb-2022.2.0-lin.tgz
 
     steps:
       - name: Cancel Previous Runs


### PR DESCRIPTION
Given locally non-reproducible test crashes observed in CI, say in https://github.com/IntelPython/dpctl/pull/2147, bump versions of TBB library and OpenCL CPU driver implementation to the one used locally (latest release of open-source DPC++).

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [ ] Have you added your changes to the changelog?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
