### PR TITLE
Fix linting with new clang version

### DIFF
--- a/dpctl/tensor/libtensor/include/kernels/accumulators.hpp
+++ b/dpctl/tensor/libtensor/include/kernels/accumulators.hpp
@@ -114,7 +114,7 @@ public:
         : src_(src), size_(sz), local_scans_(local_scans)
     {
     }
-    ~stack_t(){};
+    ~stack_t() {};
 
     T *get_src_ptr() const { return src_; }
 
@@ -140,7 +140,7 @@ public:
           local_stride_(local_stride)
     {
     }
-    ~stack_strided_t(){};
+    ~stack_strided_t() {};
 
     T *get_src_ptr() const { return src_; }
 

--- a/dpctl/tensor/libtensor/include/utils/offset_utils.hpp
+++ b/dpctl/tensor/libtensor/include/utils/offset_utils.hpp
@@ -51,7 +51,7 @@ namespace detail
 
 struct sink_t
 {
-    sink_t(){};
+    sink_t() {};
     template <class T> sink_t(T &&){};
 };
 

--- a/examples/pybind11/external_usm_allocation/external_usm_allocation/_usm_alloc_example.cpp
+++ b/examples/pybind11/external_usm_allocation/external_usm_allocation/_usm_alloc_example.cpp
@@ -49,7 +49,7 @@ struct DMatrix
         : n_(rows), m_(columns), q_(q), alloc_(q), vec_(n_ * m_, alloc_)
     {
     }
-    ~DMatrix(){};
+    ~DMatrix() {};
     DMatrix(const DMatrix &) = default;
     DMatrix(DMatrix &&) = default;
 


### PR DESCRIPTION
GH CI runners are now using clang-format 18.1.8

A few lines are changed in the codebase to conform

- [ ] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [ ] Have you added your changes to the changelog?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
