### PR TITLE
Backport gh-2191

### DIFF
--- a/dpctl/tensor/__init__.py
+++ b/dpctl/tensor/__init__.py
@@ -213,7 +213,9 @@ from ._type_utils import can_cast, finfo, iinfo, isdtype, result_type
 # deprecation warning for the dpctl.tensor module
 _warnings.warn(
     "dpctl.tensor is deprecated since dpctl 0.21.1 and will be removed in a "
-    "future release. Install dpnp and use 'import dpnp.tensor' instead.",
+    "future release. The functionality will be moved to separate package, dpnp "
+    "(see: https://github.com/IntelPython/dpnp). After that, use "
+    "'import dpnp.tensor' instead.",
     DeprecationWarning,
     stacklevel=2,
 )
@@ -413,8 +415,10 @@ def __getattr__(name: str):  # pragma: no cover
     if name in __all__:
         _warnings.warn(
             f"dpctl.tensor.{name} is deprecated; dpctl.tensor is deprecated "
-            "since dpctl 0.21.1 and will be removed in a future release. "
-            "Install dpnp and use 'import dpnp.tensor' instead.",
+            "since dpctl 0.21.1 and will be removed in a future release. The "
+            "functionality will be moved to separate package, dpnp (see: "
+            "https://github.com/IntelPython/dpnp). After that, use 'import "
+            "dpnp.tensor' instead.",
             DeprecationWarning,
             stacklevel=2,
         )


### PR DESCRIPTION
This PR backports the addition of a deprecation warning for dpctl.tensor module to the maintenance/0.20.x branch as part of the coming 0.20.1 release

- [ ] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [ ] Have you added your changes to the changelog?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
