### PR TITLE
Fix CMake error in OS compiler workflow

### DIFF
--- a/libsyclinterface/cmake/modules/FindIntelSyclCompiler.cmake
+++ b/libsyclinterface/cmake/modules/FindIntelSyclCompiler.cmake
@@ -102,13 +102,13 @@ if(${clangxx_result} MATCHES "0")
             # Match 'clang version xx.x.x'
             string(REGEX MATCH "^.*clang version [0-9]+\\.[0-9]+\\.[0-9]+.*$" _clang_match "${X}")
             if(_clang_match)
-                string(REGEX REPLACE "^.*clang version ([0-9]+\\.[0-9]+\\.[0-9]+).*$" "\\1" IntelSyclCompiler_VERSION "${X}")
+                string(REGEX REPLACE "^.*clang version ([0-9]+\\.[0-9]+\\.[0-9]+).*$" "\\1" IntelSyclCompiler_VERSION "${_clang_match}")
             endif()
 
             # Match 'Intel(R) oneAPI DPC++/C++ Compiler xxxx.x.x (...)'
             string(REGEX MATCH "^.*Intel\\(R\\) oneAPI DPC\\+\\+\\/C\\+\\+ Compiler [0-9]+\\.[0-9]+\\.[0-9]+.*$" _oneapi_match "${X}")
             if(_oneapi_match)
-                string(REGEX REPLACE "^.*Intel\\(R\\) oneAPI DPC\\+\\+\\/C\\+\\+ Compiler ([0-9]+\\.[0-9]+\\.[0-9]+).*$" "\\1" IntelSyclCompiler_VERSION "${X}")
+                string(REGEX REPLACE "^.*Intel\\(R\\) oneAPI DPC\\+\\+\\/C\\+\\+ Compiler ([0-9]+\\.[0-9]+\\.[0-9]+).*$" "\\1" IntelSyclCompiler_VERSION "${_oneapi_match}")
             endif()
         endif()
         math(EXPR IDX "${IDX}+1")


### PR DESCRIPTION
This PR fixes the failing OS compiler workflow, which has been throwing a CMake error

OS compiler versioning output changed, so the Clang version is preceded by another string giving the date and specifying the compiler is the SYCL nightly compiler

This PR modifies dpctl CMake to check if the "Intel SYCL Compiler Nightly" string is in the version string. If so, the next member of the list, containing the Clang version, is used instead

- [ ] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [ ] Have you added your changes to the changelog?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
