### PR TITLE
Fix `dpt.repeat()` regression for 1D repeats array

### DIFF
--- a/dpctl/tensor/_manipulation_functions.py
+++ b/dpctl/tensor/_manipulation_functions.py
@@ -829,7 +829,12 @@ def repeat(x, repeats, /, *, axis=None):
         if repeats.size == 1:
             scalar = True
             # bring the single element to the host
-            repeats = int(repeats)
+            if repeats.ndim == 0:
+                repeats = int(repeats)
+            else:
+                # Get the single element explicitly
+                # since non-0D arrays can not be converted to scalars
+                repeats = int(repeats[0])
             if repeats < 0:
                 raise ValueError("`repeats` elements must be positive")
         else:

--- a/dpctl/tests/test_usm_ndarray_manipulation.py
+++ b/dpctl/tests/test_usm_ndarray_manipulation.py
@@ -1342,6 +1342,21 @@ def test_repeat_strided_repeats():
     assert dpt.all(res == x)
 
 
+def test_repeat_size1_repeats():
+    get_queue_or_skip()
+
+    x = dpt.arange(5, dtype="i4")
+    expected_res = dpt.repeat(x, 2)
+    # 0D repeats
+    reps_0d = dpt.asarray(2, dtype="i8")
+    res = dpt.repeat(x, reps_0d)
+    assert dpt.all(res == expected_res)
+    # 1D repeats
+    reps_1d = dpt.asarray([2], dtype="i8")
+    res = dpt.repeat(x, reps_1d)
+    assert dpt.all(res == expected_res)
+
+
 def test_repeat_arg_validation():
     get_queue_or_skip()
 


### PR DESCRIPTION
After #2223 `dpt.repeat()` started raising an error when `repeats` is as 1D `usm_ndarray` 
```
import dpctl.tensor as dpt

a = dpt.arange(8)
dpt.repeat(a, ind)

# repeats = int(repeats)
# TypeError: only 0-dimensional arrays can be converted to Python scalars

```
Previously this worked because `int(repeats)` was implicitly allowed for 1D usm_ndarrays

This PR updates `dpt.repeat()` to explicitly extract the single element from size-1 1D usm_ndarray repeats before converting it to a Python scalar and extends tests to cover both 0D and 1D repeats cases


- [X] Have you provided a meaningful PR description?
- [X] Have you added a test, reproducer or referred to an issue with a reproducer?
- [X] Have you tested your changes locally for CPU and GPU devices?
- [X] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [ ] Have you added your changes to the changelog?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
