### PR TITLE
Remove `python-gil` requirement and enable free-threaded Python

### DIFF
--- a/.github/workflows/conda-package.yml
+++ b/.github/workflows/conda-package.yml
@@ -224,7 +224,7 @@ jobs:
         run: |
           CHANNELS="-c $GITHUB_WORKSPACE/channel ${{ env.CHANNELS }}"
           export CHANNELS
-          TEST_DEPENDENCIES="pytest pytest-cov cython setuptools"
+          TEST_DEPENDENCIES="pytest cython setuptools"
           export TEST_DEPENDENCIES
           PACKAGE_VERSION=$(python -c "${VER_SCRIPT1} ${VER_SCRIPT2}")
           export PACKAGE_VERSION
@@ -377,7 +377,7 @@ jobs:
           FOR /F "tokens=* USEBACKQ" %%F IN (`python -c "%SCRIPT%"`) DO (
              SET PACKAGE_VERSION=%%F
           )
-          SET TEST_DEPENDENCIES=pytest"<8" pytest-cov cython setuptools
+          SET TEST_DEPENDENCIES=pytest"<8" cython setuptools
           conda install -n ${{ env.TEST_ENV_NAME }} ${{ env.PACKAGE_NAME }}=%PACKAGE_VERSION% %TEST_DEPENDENCIES% python=${{ matrix.python }} -c ${{ env.workdir }}/channel ${{ env.CHANNELS }}
 
       - name: Report content of test environment

--- a/.github/workflows/conda-package.yml
+++ b/.github/workflows/conda-package.yml
@@ -26,6 +26,10 @@ jobs:
     strategy:
       matrix:
         python: ['3.10', '3.11', '3.12', '3.13', '3.14']
+        python_spec: ['']
+        include:
+          - python: '3.14'
+            python_spec: '3.14.* *_cp314'
     steps:
       - name: Cancel Previous Runs
         uses: styfle/cancel-workflow-action@d07a454dad7609a92316b57b23c9ccfd4f59af66 # 0.13.1
@@ -46,9 +50,9 @@ jobs:
         with:
           path: ~/.conda/pkgs
           key:
-            ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}-python-${{ matrix.python }}-${{hashFiles('**/meta.yaml') }}
+            ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}-python-${{ matrix.python }}-spec-${{ matrix.python == '3.14' && matrix.python_spec == '' && 't' || '' }}-${{hashFiles('**/meta.yaml') }}
           restore-keys: |
-            ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}-python-${{ matrix.python }}-
+            ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}-python-${{ matrix.python }}-spec-${{ matrix.python == '3.14' && matrix.python_spec == '' && 't' || '' }}-
             ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}-
       - name: Add conda to system path
         run: echo "$CONDA/bin" >> "$GITHUB_PATH"
@@ -71,16 +75,20 @@ jobs:
       - name: Build conda package
         run: |
           # use bootstrap channel to pull NumPy linked with OpenBLAS
-          conda build --no-test --python ${{ matrix.python }} --numpy 2.0 -c conda-forge --override-channels conda-recipe
+          if [ -n "${{ matrix.python_spec }}" ]; then
+            conda build --no-test --python "${{ matrix.python_spec }}" --numpy 2.0 -c conda-forge --override-channels conda-recipe
+          else
+            conda build --no-test --python ${{ matrix.python }} --numpy 2.0 -c conda-forge --override-channels conda-recipe
+          fi
       - name: Upload artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: ${{ env.PACKAGE_NAME }} ${{ runner.os }} Python ${{ matrix.python }}
+          name: ${{ env.PACKAGE_NAME }} ${{ runner.os }} Python ${{ matrix.python == '3.14' && (matrix.python_spec != '' && '3.14' || '3.14t') || matrix.python }}
           path: /usr/share/miniconda/conda-bld/linux-64/${{ env.PACKAGE_NAME }}-*.conda
       - name: Upload wheels artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: ${{ env.PACKAGE_NAME }} ${{ runner.os }} Wheels Python ${{ matrix.python }}
+          name: ${{ env.PACKAGE_NAME }} ${{ runner.os }} Wheels Python ${{ matrix.python == '3.14' && (matrix.python_spec != '' && '3.14' || '3.14t') || matrix.python }}
           path: ${{ env.WHEELS_OUTPUT_FOLDER }}${{ env.PACKAGE_NAME }}-*.whl
 
   build_windows:
@@ -93,6 +101,10 @@ jobs:
     strategy:
       matrix:
         python: ['3.10', '3.11', '3.12', '3.13', '3.14']
+        python_spec: ['']
+        include:
+          - python: '3.14'
+            python_spec: '3.14.* *_cp314'
     steps:
       - name: Cancel Previous Runs
         uses: styfle/cancel-workflow-action@d07a454dad7609a92316b57b23c9ccfd4f59af66 # 0.13.1
@@ -118,9 +130,9 @@ jobs:
         with:
           path: /home/runner/conda_pkgs_dir
           key:
-            ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}-python-${{ matrix.python }}-${{hashFiles('**/meta.yaml') }}
+            ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}-python-${{ matrix.python }}-spec-${{ matrix.python == '3.14' && matrix.python_spec == '' && 't' || '' }}-${{hashFiles('**/meta.yaml') }}
           restore-keys: |
-            ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}-python-${{ matrix.python }}-
+            ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}-python-${{ matrix.python }}-spec-${{ matrix.python == '3.14' && matrix.python_spec == '' && 't' || '' }}-
             ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}-
       - name: Store conda paths as envs
         shell: bash -l {0}
@@ -137,18 +149,23 @@ jobs:
         env:
           OVERRIDE_INTEL_IPO: 1   # IPO requires more resources that GH actions VM provides
         run: |
-          conda build --no-test --python ${{ matrix.python }} --numpy 2.0 -c conda-forge --override-channels conda-recipe
+          set "PYTHON_VER=${{ matrix.python_spec }}"
+          if "%PYTHON_VER%" NEQ "" (
+            conda build --no-test --python "%PYTHON_VER%" --numpy 2.0 -c conda-forge --override-channels conda-recipe
+          ) else (
+            conda build --no-test --python ${{ matrix.python }} --numpy 2.0 -c conda-forge --override-channels conda-recipe
+          )
 
       - name: Upload artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: ${{ env.PACKAGE_NAME }} ${{ runner.os }} Python ${{ matrix.python }}
+          name: ${{ env.PACKAGE_NAME }} ${{ runner.os }} Python ${{ matrix.python == '3.14' && (matrix.python_spec != '' && '3.14' || '3.14t') || matrix.python }}
           path: ${{ env.CONDA_BLD }}${{ env.PACKAGE_NAME }}-*.conda
 
       - name: Upload wheels artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: ${{ env.PACKAGE_NAME }} ${{ runner.os }} Wheels Python ${{ matrix.python }}
+          name: ${{ env.PACKAGE_NAME }} ${{ runner.os }} Wheels Python ${{ matrix.python == '3.14' && (matrix.python_spec != '' && '3.14' || '3.14t') || matrix.python }}
           path: ${{ env.WHEELS_OUTPUT_FOLDER }}${{ env.PACKAGE_NAME }}-*.whl
 
   test_linux:
@@ -159,6 +176,10 @@ jobs:
     strategy:
       matrix:
         python: ['3.10', '3.11', '3.12', '3.13', '3.14']
+        python_spec: ['']
+        include:
+          - python: '3.14'
+            python_spec: '3.14.* *_cp314'
         experimental: [false]
         runner: [ubuntu-latest]
     continue-on-error: ${{ matrix.experimental }}
@@ -173,7 +194,7 @@ jobs:
       - name: Download artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          name: ${{ env.PACKAGE_NAME }} ${{ runner.os }} Python ${{ matrix.python }}
+          name: ${{ env.PACKAGE_NAME }} ${{ runner.os }} Python ${{ matrix.python == '3.14' && (matrix.python_spec != '' && '3.14' || '3.14t') || matrix.python }}
       - name: Add conda to system path
         run: echo "$CONDA/bin" >> "$GITHUB_PATH"
       - name: Update conda
@@ -202,9 +223,13 @@ jobs:
           CHANNELS="-c $GITHUB_WORKSPACE/channel ${{ env.CHANNELS }}"
           export CHANNELS
           PACKAGE_VERSION=$(python -c "${VER_SCRIPT1} ${VER_SCRIPT2}")
-            export PACKAGE_VERSION
-            # shellcheck disable=SC2086
-          conda create -n ${{ env.TEST_ENV_NAME }} ${{ env.PACKAGE_NAME }}=${PACKAGE_VERSION} python=${{ matrix.python }} $CHANNELS --only-deps --dry-run > lockfile
+          export PACKAGE_VERSION
+          PYTHON_VER="${{ matrix.python_spec }}"
+          if [ -z "${PYTHON_VER}" ]; then
+            PYTHON_VER="${{ matrix.python }}"
+          fi
+          # shellcheck disable=SC2086
+          conda create -n ${{ env.TEST_ENV_NAME }} ${{ env.PACKAGE_NAME }}=${PACKAGE_VERSION} python="${PYTHON_VER}" $CHANNELS --only-deps --dry-run > lockfile
           cat lockfile
       - name: Set pkgs_dirs
         run: |
@@ -216,9 +241,9 @@ jobs:
         with:
           path: ~/.conda/pkgs
           key:
-            ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}-python-${{ matrix.python }}-${{hashFiles('lockfile') }}
+            ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}-python-${{ matrix.python }}-spec-${{ matrix.python == '3.14' && matrix.python_spec == '' && 't' || '' }}-${{hashFiles('lockfile') }}
           restore-keys: |
-            ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}-python-${{ matrix.python }}-
+            ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}-python-${{ matrix.python }}-spec-${{ matrix.python == '3.14' && matrix.python_spec == '' && 't' || '' }}-
             ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}-
       - name: Install dpctl
         run: |
@@ -227,9 +252,13 @@ jobs:
           TEST_DEPENDENCIES="pytest cython setuptools"
           export TEST_DEPENDENCIES
           PACKAGE_VERSION=$(python -c "${VER_SCRIPT1} ${VER_SCRIPT2}")
+          PYTHON_VER="${{ matrix.python_spec }}"
+          if [ -z "${PYTHON_VER}" ]; then
+            PYTHON_VER="${{ matrix.python }}"
+          fi
           export PACKAGE_VERSION
           # shellcheck disable=SC2086
-          conda create -n ${{ env.TEST_ENV_NAME }} ${{ env.PACKAGE_NAME }}=${PACKAGE_VERSION} $TEST_DEPENDENCIES python=${{ matrix.python }} $CHANNELS
+          conda create -n ${{ env.TEST_ENV_NAME }} ${{ env.PACKAGE_NAME }}=${PACKAGE_VERSION} $TEST_DEPENDENCIES python="${PYTHON_VER}" $CHANNELS
           # Test installed packages
           conda list -n "${{ env.TEST_ENV_NAME }}"
       - name: Smoke test
@@ -260,6 +289,10 @@ jobs:
     strategy:
       matrix:
         python: ['3.10', '3.11', '3.12', '3.13', '3.14']
+        python_spec: ['']
+        include:
+          - python: '3.14'
+            python_spec: '3.14.* *_cp314'
         experimental: [false]
         runner: [windows-latest]
     continue-on-error: ${{ matrix.experimental }}
@@ -279,7 +312,7 @@ jobs:
       - name: Download artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          name: ${{ env.PACKAGE_NAME }} ${{ runner.os }} Python ${{ matrix.python }}
+          name: ${{ env.PACKAGE_NAME }} ${{ runner.os }} Python ${{ matrix.python == '3.14' && (matrix.python_spec != '' && '3.14' || '3.14t') || matrix.python }}
 
       - uses: conda-incubator/setup-miniconda@8ee1f361103df19b6f8c8655fd3967a8ecb162d5 # v4.0.1
         with:
@@ -344,7 +377,9 @@ jobs:
           FOR /F "tokens=* USEBACKQ" %%F IN (`python -c "%SCRIPT%"`) DO (
              SET PACKAGE_VERSION=%%F
           )
-          conda install -n ${{ env.TEST_ENV_NAME }} ${{ env.PACKAGE_NAME }}=%PACKAGE_VERSION% python=${{ matrix.python }} -c ${{ env.workdir }}/channel ${{ env.CHANNELS }} --only-deps --dry-run > lockfile
+           SET "PYTHON_VER=${{ matrix.python_spec }}"
+           IF "%PYTHON_VER%"=="" SET "PYTHON_VER=${{ matrix.python }}"
+          conda install -n ${{ env.TEST_ENV_NAME }} ${{ env.PACKAGE_NAME }}=%PACKAGE_VERSION% python="%PYTHON_VER%" -c ${{ env.workdir }}/channel ${{ env.CHANNELS }} --only-deps --dry-run > lockfile
 
       - name: Display lockfile content
         shell: pwsh
@@ -357,9 +392,9 @@ jobs:
         with:
           path: /home/runner/conda_pkgs_dir
           key:
-            ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}-python-${{ matrix.python }}-${{hashFiles('lockfile') }}
+            ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}-python-${{ matrix.python }}-spec-${{ matrix.python == '3.14' && matrix.python_spec == '' && 't' || '' }}-${{hashFiles('lockfile') }}
           restore-keys: |
-            ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}-python-${{ matrix.python }}-
+            ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}-python-${{ matrix.python }}-spec-${{ matrix.python == '3.14' && matrix.python_spec == '' && 't' || '' }}-
             ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}-
 
       - name: Install opencl_rt
@@ -377,8 +412,10 @@ jobs:
           FOR /F "tokens=* USEBACKQ" %%F IN (`python -c "%SCRIPT%"`) DO (
              SET PACKAGE_VERSION=%%F
           )
+           SET "PYTHON_VER=${{ matrix.python_spec }}"
+           IF "%PYTHON_VER%"=="" SET "PYTHON_VER=${{ matrix.python }}"
           SET TEST_DEPENDENCIES=pytest"<8" cython setuptools
-          conda install -n ${{ env.TEST_ENV_NAME }} ${{ env.PACKAGE_NAME }}=%PACKAGE_VERSION% %TEST_DEPENDENCIES% python=${{ matrix.python }} -c ${{ env.workdir }}/channel ${{ env.CHANNELS }}
+           conda install -n ${{ env.TEST_ENV_NAME }} ${{ env.PACKAGE_NAME }}=%PACKAGE_VERSION% %TEST_DEPENDENCIES% python="%PYTHON_VER%" -c ${{ env.workdir }}/channel ${{ env.CHANNELS }}
 
       - name: Report content of test environment
         shell: cmd /C CALL {0}
@@ -439,16 +476,20 @@ jobs:
     strategy:
       matrix:
         python: ['3.10', '3.11', '3.12', '3.13', '3.14']
+        python_spec: ['']
+        include:
+          - python: '3.14'
+            python_spec: '3.14.* *_cp314'
     steps:
       - name: Download conda artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          name: ${{ env.PACKAGE_NAME }} ${{ runner.os }} Python ${{ matrix.python }}
+          name: ${{ env.PACKAGE_NAME }} ${{ runner.os }} Python ${{ matrix.python == '3.14' && (matrix.python_spec != '' && '3.14' || '3.14t') || matrix.python }}
 
       - name: Download wheel artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          name: ${{ env.PACKAGE_NAME }} ${{ runner.os }} Wheels Python ${{ matrix.python }}
+          name: ${{ env.PACKAGE_NAME }} ${{ runner.os }} Wheels Python ${{ matrix.python == '3.14' && (matrix.python_spec != '' && '3.14' || '3.14t') || matrix.python }}
 
       - name: Install anaconda-client
         run: conda install anaconda-client -c conda-forge --override-channels
@@ -482,16 +523,20 @@ jobs:
     strategy:
       matrix:
         python: ['3.10', '3.11', '3.12', '3.13', '3.14']
+        python_spec: ['']
+        include:
+          - python: '3.14'
+            python_spec: '3.14.* *_cp314'
     steps:
       - name: Download artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          name: ${{ env.PACKAGE_NAME }} ${{ runner.os }} Python ${{ matrix.python }}
+          name: ${{ env.PACKAGE_NAME }} ${{ runner.os }} Python ${{ matrix.python == '3.14' && (matrix.python_spec != '' && '3.14' || '3.14t') || matrix.python }}
 
       - name: Download wheel artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          name: ${{ env.PACKAGE_NAME }} ${{ runner.os }} Wheels Python ${{ matrix.python }}
+          name: ${{ env.PACKAGE_NAME }} ${{ runner.os }} Wheels Python ${{ matrix.python == '3.14' && (matrix.python_spec != '' && '3.14' || '3.14t') || matrix.python }}
 
       - uses: conda-incubator/setup-miniconda@8ee1f361103df19b6f8c8655fd3967a8ecb162d5 # v4.0.1
         with:

--- a/.github/workflows/conda-package.yml
+++ b/.github/workflows/conda-package.yml
@@ -17,6 +17,7 @@ env:
   VER_SCRIPT3: "print(' '.join(map(lambda s: chr(34) + s + chr(34), [comp for comp in d['depends'] if 'dpcpp' in comp][1:])))"
   INTEL_CHANNEL: "https://software.repos.intel.com/python/conda/"
   CONDA_BUILD_VERSION: 26.3.0
+  CONDA_INDEX_VERSION: 0.11.0
 
 jobs:
   build_linux:
@@ -204,7 +205,7 @@ jobs:
           conda update -n base --all
       - name: Install conda-index
         run: |
-          conda install -n base conda-index"<0.12.0" -c conda-forge --override-channels
+          conda install -n base conda-index=${{ env.CONDA_INDEX_VERSION }} -c conda-forge --override-channels
       - name: Show Conda info
         run: |
           conda info --all
@@ -597,7 +598,7 @@ jobs:
         # Needed to be able to run conda index
         run: |
           conda update -n base --all
-          conda install conda-index"<0.12.0" -c conda-forge --override-channels
+          conda install conda-index=${{ env.CONDA_INDEX_VERSION }} -c conda-forge --override-channels
       - name: Checkout dpctl repo
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:

--- a/.github/workflows/conda-package.yml
+++ b/.github/workflows/conda-package.yml
@@ -572,8 +572,14 @@ jobs:
     strategy:
       matrix:
         python: ['3.14']
+        python_spec: ['']
         experimental: [false]
         runner: [ubuntu-latest]
+        include:
+          - python: '3.14'
+            python_spec: '3.14.* *_cp314'
+            experimental: false
+            runner: ubuntu-latest
     continue-on-error: ${{ matrix.experimental }}
     timeout-minutes: 60
     env:
@@ -599,7 +605,7 @@ jobs:
       - name: Download artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          name: ${{ env.PACKAGE_NAME }} ${{ runner.os }} Python ${{ matrix.python }}
+          name: ${{ env.PACKAGE_NAME }} ${{ runner.os }} Python ${{ matrix.python == '3.14' && (matrix.python_spec != '' && '3.14' || '3.14t') || matrix.python }}
       - name: Add conda to system path
         run: echo "$CONDA/bin" >> "$GITHUB_PATH"
       - name: Create conda channel
@@ -617,8 +623,13 @@ jobs:
           export CHANNELS
           PACKAGE_VERSION=$(python -c "${VER_SCRIPT1} ${VER_SCRIPT2}")
           export PACKAGE_VERSION
+          PYTHON_VER="${{ matrix.python_spec }}"
+          if [ -z "${PYTHON_VER}" ]; then
+            PYTHON_VER="${{ matrix.python }}"
+          fi
+          export PYTHON_VER
           # shellcheck disable=SC2086
-          conda create -n ${{ env.EXAMPLES_ENV_NAME }} ${{ env.PACKAGE_NAME }}=${PACKAGE_VERSION} python=${{ matrix.python }} $CHANNELS --only-deps --dry-run > lockfile
+          conda create -n ${{ env.EXAMPLES_ENV_NAME }} ${{ env.PACKAGE_NAME }}=${PACKAGE_VERSION} python="${PYTHON_VER}" $CHANNELS --only-deps --dry-run > lockfile
           cat lockfile
       - name: Set pkgs_dirs
         run: |
@@ -630,9 +641,9 @@ jobs:
         with:
           path: ~/.conda/pkgs
           key:
-            ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}-python-${{ matrix.python }}-${{hashFiles('lockfile') }}
+            ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}-python-${{ matrix.python }}-spec-${{ matrix.python == '3.14' && matrix.python_spec == '' && 't' || '' }}-${{hashFiles('lockfile') }}
           restore-keys: |
-            ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}-python-${{ matrix.python }}-
+            ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}-python-${{ matrix.python }}-spec-${{ matrix.python == '3.14' && matrix.python_spec == '' && 't' || '' }}-
             ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}-
       - name: Install example requirements
         shell: bash -ex -l {0}
@@ -644,8 +655,12 @@ jobs:
           DPCTL_DEPENDS="$(python -c "${VER_SCRIPT1} ${VER_SCRIPT3}")"
           export DPCTL_DEPENDS
           echo "Dpctl dependencies: ${DPCTL_DEPENDS}"
+          PYTHON_VER="${{ matrix.python_spec }}"
+          if [ -z "${PYTHON_VER}" ]; then
+            PYTHON_VER="${{ matrix.python }}"
+          fi
           # shellcheck disable=SC2086
-          conda create -n ${{ env.EXAMPLES_ENV_NAME }} -y pytest python=${{ matrix.python }} "setuptools<72.2.0" $CHANNELS
+          conda create -n ${{ env.EXAMPLES_ENV_NAME }} -y pytest python="${PYTHON_VER}" "setuptools<72.2.0" $CHANNELS
           echo "Environment created"
           # shellcheck disable=SC2086
           conda install -n ${{ env.EXAMPLES_ENV_NAME }} -y cmake ninja $CHANNELS || exit 1

--- a/.github/workflows/conda-package.yml
+++ b/.github/workflows/conda-package.yml
@@ -204,7 +204,7 @@ jobs:
           conda update -n base --all
       - name: Install conda-index
         run: |
-          conda install -n base conda-index -c conda-forge --override-channels
+          conda install -n base conda-index"<0.12.0" -c conda-forge --override-channels
       - name: Show Conda info
         run: |
           conda info --all
@@ -597,7 +597,7 @@ jobs:
         # Needed to be able to run conda index
         run: |
           conda update -n base --all
-          conda install conda-index -c conda-forge --override-channels
+          conda install conda-index"<0.12.0" -c conda-forge --override-channels
       - name: Checkout dpctl repo
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:

--- a/.github/workflows/conda-package.yml
+++ b/.github/workflows/conda-package.yml
@@ -180,6 +180,8 @@ jobs:
         include:
           - python: '3.14'
             python_spec: '3.14.* *_cp314'
+            experimental: false
+            runner: ubuntu-22.04
         experimental: [false]
         runner: [ubuntu-latest]
     continue-on-error: ${{ matrix.experimental }}
@@ -293,6 +295,8 @@ jobs:
         include:
           - python: '3.14'
             python_spec: '3.14.* *_cp314'
+            experimental: false
+            runner: windows-latest
         experimental: [false]
         runner: [windows-latest]
     continue-on-error: ${{ matrix.experimental }}

--- a/.github/workflows/run-tests-from-dppy-bits.yaml
+++ b/.github/workflows/run-tests-from-dppy-bits.yaml
@@ -47,7 +47,7 @@ jobs:
 
       - name: Install dpctl
         run: |
-          conda create -n "${{ env.TEST_ENV_NAME }}" -c dppy/label/dev "${{ env.CHANNELS }}" dpctl pytest pytest-cov cython setuptools c-compiler cxx-compiler
+          conda create -n "${{ env.TEST_ENV_NAME }}" -c dppy/label/dev "${{ env.CHANNELS }}" dpctl pytest cython setuptools c-compiler cxx-compiler
 
       - name: Smoke test
         run: |
@@ -106,7 +106,7 @@ jobs:
 
       - name: Install dpctl
         run: |
-          conda install -n ${{ env.TEST_ENV_NAME }} -c dppy/label/dev ${{ env.CHANNELS }} dpctl pytest pytest-cov cython setuptools c-compiler cxx-compiler
+          conda install -n ${{ env.TEST_ENV_NAME }} -c dppy/label/dev ${{ env.CHANNELS }} dpctl pytest cython setuptools c-compiler cxx-compiler
 
       # intel-opencl-rt is not being installed when running conda install dpctl, so do it manually
       - name: Install intel-opencl-rt

--- a/.github/workflows/run-tests-from-dppy-bits.yaml
+++ b/.github/workflows/run-tests-from-dppy-bits.yaml
@@ -28,6 +28,10 @@ jobs:
     strategy:
       matrix:
         python: ['3.10', '3.11', '3.12', '3.13', '3.14']
+        python_spec: ['']
+        include:
+          - python: '3.14'
+            python_spec: '3.14.* *_cp314'
         experimental: [false]
         runner: [ubuntu-22.04, ubuntu-24.04]
     continue-on-error: ${{ matrix.experimental }}
@@ -47,7 +51,11 @@ jobs:
 
       - name: Install dpctl
         run: |
-          conda create -n "${{ env.TEST_ENV_NAME }}" -c dppy/label/dev "${{ env.CHANNELS }}" dpctl pytest cython setuptools c-compiler cxx-compiler
+          PYTHON_SPEC="${{ matrix.python_spec }}"
+          if [ -z "${PYTHON_SPEC}" ]; then
+            PYTHON_SPEC="${{ matrix.python }}"
+          fi
+          conda create -n "${{ env.TEST_ENV_NAME }}" -c dppy/label/dev "${{ env.CHANNELS }}" dpctl pytest cython setuptools c-compiler cxx-compiler python="${PYTHON_SPEC}"
 
       - name: Smoke test
         run: |
@@ -79,6 +87,10 @@ jobs:
     strategy:
       matrix:
         python: ['3.10', '3.11', '3.12', '3.13', '3.14']
+        python_spec: ['']
+        include:
+          - python: '3.14'
+            python_spec: '3.14.* *_cp314'
         experimental: [false]
         runner: [windows-latest]
 
@@ -106,7 +118,9 @@ jobs:
 
       - name: Install dpctl
         run: |
-          conda install -n ${{ env.TEST_ENV_NAME }} -c dppy/label/dev ${{ env.CHANNELS }} dpctl pytest cython setuptools c-compiler cxx-compiler
+          SET "PYTHON_SPEC=${{ matrix.python_spec }}"
+          IF "%PYTHON_SPEC%"=="" SET "PYTHON_SPEC=${{ matrix.python }}"
+          conda install -n ${{ env.TEST_ENV_NAME }} -c dppy/label/dev ${{ env.CHANNELS }} dpctl pytest cython setuptools c-compiler cxx-compiler python="%PYTHON_SPEC%"
 
       # intel-opencl-rt is not being installed when running conda install dpctl, so do it manually
       - name: Install intel-opencl-rt

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -28,7 +28,6 @@ requirements:
         - {{ compiler('dpcpp') }} >={{ required_compiler_version }}
     host:
         - python
-        - python-gil     # [py>=314]
         - pip >=24.0
         - level-zero-devel >=1.16
         - pybind11 >=2.12
@@ -52,7 +51,6 @@ requirements:
         - tomli # [py<311]
     run:
         - python
-        - python-gil     # [py>=314]
         - {{ pin_compatible('intel-sycl-rt', min_pin='x.x', max_pin='x') }}
         - {{ pin_compatible('intel-cmplr-lib-rt', min_pin='x.x', max_pin='x') }}
         - numpy

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -63,7 +63,6 @@ test:
         - cython
         - setuptools
         - pytest
-        - pytest-cov
 
 about:
     home: https://github.com/IntelPython/dpctl.git

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -30,7 +30,7 @@ requirements:
         - python
         - pip >=24.0
         - level-zero-devel >=1.16
-        - pybind11 >=2.12
+        - pybind11 >=2.13
         - {{ pin_compatible('intel-sycl-rt', min_pin='x.x', max_pin='x') }}
         - {{ pin_compatible('intel-cmplr-lib-rt', min_pin='x.x', max_pin='x') }}
         # Ensure we are using latest version of setuptools, since we don't need

--- a/conda-recipe/run_test.sh
+++ b/conda-recipe/run_test.sh
@@ -4,11 +4,4 @@ set -e
 
 ${PYTHON} -c "import dpctl; print(dpctl.__version__)"
 ${PYTHON} -m dpctl -f
-# don't use coverage for Python 3.13 due to crashes related to
-# Cython >= 3.1.0 and Python >= 3.13
-# TODO: remove if crash is triaged
-if ${PYTHON} --version 2>&1 | grep -q '^Python 3\.13'; then
-    ${PYTHON} -m pytest -q -ra --disable-warnings --pyargs dpctl -vv
-else
-    ${PYTHON} -m pytest -q -ra --disable-warnings --cov dpctl --cov-report term-missing --pyargs dpctl -vv
-fi
+${PYTHON} -m pytest -q -ra --disable-warnings --pyargs dpctl -vv

--- a/docs/doc_sources/api_reference/dpctl_pybind11.rst
+++ b/docs/doc_sources/api_reference/dpctl_pybind11.rst
@@ -19,7 +19,7 @@ pybind11 API
         return dev.get_info<sycl::info::device::name>();
     }
 
-    PYBIND11_MODULE(_example, m) {
+    PYBIND11_MODULE(_example, m, py::mod_gil_not_used()) {
         m.def("get_device_name", &get_device_name);
     }
 

--- a/dpctl/_diagnostics.pyx
+++ b/dpctl/_diagnostics.pyx
@@ -17,6 +17,7 @@
 # distutils: language = c++
 # cython: language_level=3
 # cython: linetrace=True
+# cython: freethreading_compatible = True
 
 """ Implements developer utilities.
 """

--- a/dpctl/_diagnostics.pyx
+++ b/dpctl/_diagnostics.pyx
@@ -61,6 +61,10 @@ def _shutdown_logger():
 def syclinterface_diagnostics(verbosity="warning", log_dir=None):
     """Context manager that activate verbosity of DPCTLSyclInterface
     function calls.
+
+    .. warning::
+        This context manager modifies the ``DPCTL_VERBOSITY`` environment
+        variable and should only be used from a single thread.
     """
     _allowed_verbosity = ["warning", "error"]
     if verbosity not in _allowed_verbosity:

--- a/dpctl/_sycl_context.pyx
+++ b/dpctl/_sycl_context.pyx
@@ -17,6 +17,7 @@
 # distutils: language = c++
 # cython: language_level=3
 # cython: linetrace=True
+# cython: freethreading_compatible = True
 
 """ Implements SyclContext Cython extension type.
 """

--- a/dpctl/_sycl_device.pyx
+++ b/dpctl/_sycl_device.pyx
@@ -17,6 +17,7 @@
 # distutils: language = c++
 # cython: language_level=3
 # cython: linetrace=True
+# cython: freethreading_compatible = True
 
 """ Implements SyclDevice Cython extension type.
 """

--- a/dpctl/_sycl_device_factory.pyx
+++ b/dpctl/_sycl_device_factory.pyx
@@ -17,6 +17,7 @@
 # distutils: language = c++
 # cython: language_level=3
 # cython: linetrace=True
+# cython: freethreading_compatible = True
 
 """ This module implements several device creation helper functions:
 

--- a/dpctl/_sycl_device_factory.pyx
+++ b/dpctl/_sycl_device_factory.pyx
@@ -19,7 +19,8 @@
 # cython: linetrace=True
 # cython: freethreading_compatible = True
 
-""" This module implements several device creation helper functions:
+"""
+This module implements several device creation helper functions:
 
   - wrapper functions to create a SyclDevice from the standard SYCL
     device selector classes.
@@ -47,7 +48,7 @@ from ._backend cimport (  # noqa: E211
     _device_type,
 )
 
-from contextvars import ContextVar
+import threading
 
 from ._sycl_device import SyclDeviceCreationError
 from .enum_types import backend_type
@@ -289,7 +290,8 @@ cpdef int get_num_devices(
 
 
 cpdef cpp_bool has_cpu_devices():
-    """ A helper function to check if there are any SYCL CPU devices available.
+    """
+    A helper function to check if there are any SYCL CPU devices available.
 
     Returns:
         bool:
@@ -301,7 +303,8 @@ cpdef cpp_bool has_cpu_devices():
 
 
 cpdef cpp_bool has_gpu_devices():
-    """ A helper function to check if there are any SYCL GPU devices available.
+    """
+    A helper function to check if there are any SYCL GPU devices available.
 
     Returns:
         bool:
@@ -313,7 +316,8 @@ cpdef cpp_bool has_gpu_devices():
 
 
 cpdef cpp_bool has_accelerator_devices():
-    """ A helper function to check if there are any SYCL Accelerator devices
+    """
+    A helper function to check if there are any SYCL Accelerator devices
     available.
 
     Returns:
@@ -328,7 +332,8 @@ cpdef cpp_bool has_accelerator_devices():
 
 
 cpdef SyclDevice select_accelerator_device():
-    """A wrapper for ``sycl::device{sycl::accelerator_selector_v}`` constructor.
+    """
+    A wrapper for ``sycl::device{sycl::accelerator_selector_v}`` constructor.
 
     Returns:
         dpctl.SyclDevice:
@@ -350,7 +355,8 @@ cpdef SyclDevice select_accelerator_device():
 
 
 cpdef SyclDevice select_cpu_device():
-    """A wrapper for ``sycl::device{sycl::cpu_selector_v}`` constructor.
+    """
+    A wrapper for ``sycl::device{sycl::cpu_selector_v}`` constructor.
 
     Returns:
         dpctl.SyclDevice:
@@ -372,7 +378,8 @@ cpdef SyclDevice select_cpu_device():
 
 
 cpdef SyclDevice select_default_device():
-    """A wrapper for ``sycl::device{sycl::default_selector_v}`` constructor.
+    """
+    A wrapper for ``sycl::device{sycl::default_selector_v}`` constructor.
 
     Returns:
         dpctl.SyclDevice:
@@ -394,7 +401,8 @@ cpdef SyclDevice select_default_device():
 
 
 cpdef SyclDevice select_gpu_device():
-    """A wrapper for ``sycl::device{sycl::gpu_selector_v}`` constructor.
+    """
+    A wrapper for ``sycl::device{sycl::gpu_selector_v}`` constructor.
 
     Returns:
         dpctl.SyclDevice:
@@ -417,21 +425,23 @@ cpdef SyclDevice select_gpu_device():
 
 cdef class _DefaultDeviceCache:
     cdef dict __device_map__
+    cdef object _cache_lock
 
     def __cinit__(self):
         self.__device_map__ = {}
+        self._cache_lock = threading.Lock()
 
-    cdef get_or_create(self):
-        """Return instance of SyclDevice and indicator if cache
-        has been modified"""
-        key = 0
-        if key in self.__device_map__:
-            return self.__device_map__[key], False
-        dev = select_default_device()
-        self.__device_map__[key] = dev
-        return dev, True
+    def get_or_create(self):
+        """Return cached default SyclDevice, creating it if needed."""
+        with self._cache_lock:
+            key = 0
+            if key in self.__device_map__:
+                return self.__device_map__[key]
+            dev = select_default_device()
+            self.__device_map__[key] = dev
+            return dev
 
-    cdef _update_map(self, dev_map):
+    def _update_map(self, dev_map):
         self.__device_map__.update(dev_map)
 
     def __copy__(self):
@@ -441,37 +451,17 @@ cdef class _DefaultDeviceCache:
         return _copy
 
 
-# no default, as would share a single mutable instance across threads and
-# concurrent access to the cache would not be thread-safe. Using ContextVar
-# without a default ensures each context gets its own instance.
-_global_default_device_cache = ContextVar(
-    "global_default_device_cache",
-)
-
-
-cdef _DefaultDeviceCache _get_default_device_cache():
-    """
-    Factory function to get or create a default device cache for the current
-    context
-    """
-    try:
-        return _global_default_device_cache.get()
-    except LookupError:
-        cache = _DefaultDeviceCache()
-        _global_default_device_cache.set(cache)
-        return cache
+# all threads share the same cached default
+_global_default_device_cache = _DefaultDeviceCache()
 
 
 cpdef SyclDevice _cached_default_device():
-    """Returns a cached device selected by default selector.
+    """
+    Returns a cached device selected by default selector.
 
     Returns:
         dpctl.SyclDevice:
             A cached default-selected SYCL device.
 
     """
-    cdef _DefaultDeviceCache _cache = _get_default_device_cache()
-    d_, changed_ = _cache.get_or_create()
-    if changed_:
-        _global_default_device_cache.set(_cache)
-    return d_
+    return _global_default_device_cache.get_or_create()

--- a/dpctl/_sycl_device_factory.pyx
+++ b/dpctl/_sycl_device_factory.pyx
@@ -447,7 +447,9 @@ cdef class _DefaultDeviceCache:
     def __copy__(self):
         cdef _DefaultDeviceCache _copy = _DefaultDeviceCache.__new__(
             _DefaultDeviceCache)
-        _copy._update_map(self.__device_map__)
+        # lock must be held to avoid race conditions on map state
+        with self._cache_lock:
+            _copy._update_map(self.__device_map__.copy())
         return _copy
 
 

--- a/dpctl/_sycl_device_factory.pyx
+++ b/dpctl/_sycl_device_factory.pyx
@@ -441,10 +441,25 @@ cdef class _DefaultDeviceCache:
         return _copy
 
 
+# no default, as would share a single mutable instance across threads and
+# concurrent access to the cache would not be thread-safe. Using ContextVar
+# without a default ensures each context gets its own instance.
 _global_default_device_cache = ContextVar(
     "global_default_device_cache",
-    default=_DefaultDeviceCache()
 )
+
+
+cdef _DefaultDeviceCache _get_default_device_cache():
+    """
+    Factory function to get or create a default device cache for the current
+    context
+    """
+    try:
+        return _global_default_device_cache.get()
+    except LookupError:
+        cache = _DefaultDeviceCache()
+        _global_default_device_cache.set(cache)
+        return cache
 
 
 cpdef SyclDevice _cached_default_device():
@@ -455,7 +470,7 @@ cpdef SyclDevice _cached_default_device():
             A cached default-selected SYCL device.
 
     """
-    cdef _DefaultDeviceCache _cache = _global_default_device_cache.get()
+    cdef _DefaultDeviceCache _cache = _get_default_device_cache()
     d_, changed_ = _cache.get_or_create()
     if changed_:
         _global_default_device_cache.set(_cache)

--- a/dpctl/_sycl_event.pyx
+++ b/dpctl/_sycl_event.pyx
@@ -17,6 +17,7 @@
 # distutils: language = c++
 # cython: language_level=3
 # cython: linetrace=True
+# cython: freethreading_compatible = True
 
 """ Implements SyclEvent Cython extension type.
 """

--- a/dpctl/_sycl_platform.pyx
+++ b/dpctl/_sycl_platform.pyx
@@ -17,6 +17,7 @@
 # distutils: language = c++
 # cython: language_level=3
 # cython: linetrace=True
+# cython: freethreading_compatible = True
 
 """ Implements SyclPlatform Cython extension type.
 """

--- a/dpctl/_sycl_queue.pxd
+++ b/dpctl/_sycl_queue.pxd
@@ -43,6 +43,7 @@ cdef public api class _SyclQueue [
     cdef DPCTLSyclQueueRef _queue_ref
     cdef SyclContext _context
     cdef SyclDevice _device
+    cdef object __weakref__
 
 
 cdef public api class SyclQueue (_SyclQueue) [

--- a/dpctl/_sycl_queue.pxd
+++ b/dpctl/_sycl_queue.pxd
@@ -43,7 +43,6 @@ cdef public api class _SyclQueue [
     cdef DPCTLSyclQueueRef _queue_ref
     cdef SyclContext _context
     cdef SyclDevice _device
-    cdef object __weakref__
 
 
 cdef public api class SyclQueue (_SyclQueue) [

--- a/dpctl/_sycl_queue.pyx
+++ b/dpctl/_sycl_queue.pyx
@@ -17,6 +17,7 @@
 # distutils: language = c++
 # cython: language_level=3
 # cython: linetrace=True
+# cython: freethreading_compatible = True
 
 """ Implements SyclQueue Cython extension type.
 """

--- a/dpctl/_sycl_queue_manager.pyx
+++ b/dpctl/_sycl_queue_manager.pyx
@@ -17,6 +17,7 @@
 # distutils: language = c++
 # cython: language_level=3
 # cython: linetrace=True
+# cython: freethreading_compatible = True
 
 import logging
 from contextvars import ContextVar

--- a/dpctl/_sycl_queue_manager.pyx
+++ b/dpctl/_sycl_queue_manager.pyx
@@ -75,10 +75,25 @@ cdef class _DeviceDefaultQueueCache:
         return _copy
 
 
+# no default, as would share a single mutable instance across threads and
+# concurrent access to the cache would not be thread-safe. Using ContextVar
+# without a default ensures each context gets its own instance.
 _global_device_queue_cache = ContextVar(
     "global_device_queue_cache",
-    default=_DeviceDefaultQueueCache()
 )
+
+
+cdef _DeviceDefaultQueueCache _get_device_queue_cache():
+    """
+    Factory function to get or create a default device queue cache for the
+    current context
+    """
+    try:
+        return _global_device_queue_cache.get()
+    except LookupError:
+        cache = _DeviceDefaultQueueCache()
+        _global_device_queue_cache.set(cache)
+        return cache
 
 
 cpdef object get_device_cached_queue(object key):
@@ -97,7 +112,7 @@ cpdef object get_device_cached_queue(object key):
         TypeError: If the input key is not one of the accepted types.
 
     """
-    _cache = _global_device_queue_cache.get()
+    _cache = _get_device_queue_cache()
     q_, changed_ = _cache.get_or_create(key)
     if changed_:
         _global_device_queue_cache.set(_cache)

--- a/dpctl/_sycl_queue_manager.pyx
+++ b/dpctl/_sycl_queue_manager.pyx
@@ -73,7 +73,9 @@ cdef class _DeviceDefaultQueueCache:
         cdef _DeviceDefaultQueueCache _copy = _DeviceDefaultQueueCache.__new__(
             _DeviceDefaultQueueCache
         )
-        _copy._update_map(self.__device_queue_map__)
+        # lock must be held to avoid race conditions on map state
+        with self._cache_lock:
+            _copy._update_map(self.__device_queue_map__.copy())
         return _copy
 
 

--- a/dpctl/_sycl_queue_manager.pyx
+++ b/dpctl/_sycl_queue_manager.pyx
@@ -20,7 +20,7 @@
 # cython: freethreading_compatible = True
 
 import logging
-from contextvars import ContextVar
+import threading
 from ._sycl_context cimport SyclContext
 from ._sycl_device cimport SyclDevice
 
@@ -34,13 +34,14 @@ _logger = logging.getLogger(__name__)
 
 cdef class _DeviceDefaultQueueCache:
     cdef dict __device_queue_map__
+    cdef object _cache_lock
 
     def __cinit__(self):
         self.__device_queue_map__ = {}
+        self._cache_lock = threading.Lock()
 
     def get_or_create(self, key):
-        """Return instance of SyclQueue and indicator if cache
-        has been modified"""
+        """Return cached SyclQueue for given key, creating it if needed."""
         if (
             isinstance(key, tuple)
             and len(key) == 2
@@ -57,14 +58,15 @@ cdef class _DeviceDefaultQueueCache:
             ctx_dev = q.sycl_context, q.sycl_device
         else:
             raise TypeError
-        if ctx_dev in self.__device_queue_map__:
-            return self.__device_queue_map__[ctx_dev], False
-        if q is None:
-            q = SyclQueue(*ctx_dev)
-        self.__device_queue_map__[ctx_dev] = q
-        return q, True
+        with self._cache_lock:
+            if ctx_dev in self.__device_queue_map__:
+                return self.__device_queue_map__[ctx_dev]
+            if q is None:
+                q = SyclQueue(*ctx_dev)
+            self.__device_queue_map__[ctx_dev] = q
+            return q
 
-    cdef _update_map(self, dev_queue_map):
+    def _update_map(self, dev_queue_map):
         self.__device_queue_map__.update(dev_queue_map)
 
     def __copy__(self):
@@ -75,29 +77,13 @@ cdef class _DeviceDefaultQueueCache:
         return _copy
 
 
-# no default, as would share a single mutable instance across threads and
-# concurrent access to the cache would not be thread-safe. Using ContextVar
-# without a default ensures each context gets its own instance.
-_global_device_queue_cache = ContextVar(
-    "global_device_queue_cache",
-)
-
-
-cdef _DeviceDefaultQueueCache _get_device_queue_cache():
-    """
-    Factory function to get or create a default device queue cache for the
-    current context
-    """
-    try:
-        return _global_device_queue_cache.get()
-    except LookupError:
-        cache = _DeviceDefaultQueueCache()
-        _global_device_queue_cache.set(cache)
-        return cache
+# all threads share the same cached default
+_global_device_queue_cache = _DeviceDefaultQueueCache()
 
 
 cpdef object get_device_cached_queue(object key):
-    """Returns a cached queue associated with given device.
+    """
+    Returns a cached queue associated with given device.
 
     Args:
         key : Either a 2-tuple consisting of a :class:`dpctl.SyclContext` and
@@ -112,8 +98,4 @@ cpdef object get_device_cached_queue(object key):
         TypeError: If the input key is not one of the accepted types.
 
     """
-    _cache = _get_device_queue_cache()
-    q_, changed_ = _cache.get_or_create(key)
-    if changed_:
-        _global_device_queue_cache.set(_cache)
-    return q_
+    return _global_device_queue_cache.get_or_create(key)

--- a/dpctl/apis/include/dpctl4pybind11.hpp
+++ b/dpctl/apis/include/dpctl4pybind11.hpp
@@ -141,7 +141,9 @@ public:
 
         static std::mutex init_mtx;
 
-        // release gil while holding lock
+        // initialization requires calls into Python C-API, so initializing
+        // thread must hold the GIL, while other threads must not block on the
+        // mutex while holding the GIL, as this creates a deadlock
         py::gil_scoped_release release;
         std::lock_guard<std::mutex> lock(init_mtx);
 

--- a/dpctl/apis/include/dpctl4pybind11.hpp
+++ b/dpctl/apis/include/dpctl4pybind11.hpp
@@ -26,9 +26,12 @@
 #pragma once
 
 #include "dpctl_capi.h"
+
+#include <atomic>
 #include <complex>
 #include <cstddef> // for std::size_t for C++ linkage
 #include <memory>
+#include <mutex>
 #include <pybind11/pybind11.h>
 #include <stddef.h> // for size_t for C linkage
 #include <stdexcept>
@@ -128,8 +131,33 @@ public:
 
     static auto &get()
     {
-        static dpctl_capi api{};
-        return api;
+        static std::atomic<dpctl_capi *> global_capi{nullptr};
+        dpctl_capi *capi_ptr = global_capi.load(std::memory_order_acquire);
+
+        // fast path
+        if (capi_ptr) {
+            return *capi_ptr;
+        }
+
+        static std::mutex init_mtx;
+
+        // release gil while holding lock
+        py::gil_scoped_release release;
+        std::lock_guard<std::mutex> lock(init_mtx);
+
+        // double check after acquiring lock
+        capi_ptr = global_capi.load(std::memory_order_relaxed);
+
+        if (!capi_ptr) {
+            // acquire gil to safely call into Python C API
+            py::gil_scoped_acquire acquire;
+
+            capi_ptr = new dpctl_capi();
+
+            global_capi.store(capi_ptr, std::memory_order_release);
+        }
+
+        return *capi_ptr;
     }
 
     py::object default_sycl_queue_pyobj() { return *default_sycl_queue_; }

--- a/dpctl/apis/include/dpctl4pybind11.hpp
+++ b/dpctl/apis/include/dpctl4pybind11.hpp
@@ -154,6 +154,8 @@ public:
             // acquire gil to safely call into Python C API
             py::gil_scoped_acquire acquire;
 
+            // initialize C-API singleton
+            // not freed, as it's kept until process termination
             capi_ptr = new dpctl_capi();
 
             global_capi.store(capi_ptr, std::memory_order_release);

--- a/dpctl/memory/_memory.pyx
+++ b/dpctl/memory/_memory.pyx
@@ -17,6 +17,7 @@
 # distutils: language = c++
 # cython: language_level=3
 # cython: linetrace=True
+# cython: freethreading_compatible = True
 
 """This file implements Python buffer protocol using Sycl USM shared and host
 allocators. The USM device allocator is also exposed through this module for

--- a/dpctl/program/_program.pyx
+++ b/dpctl/program/_program.pyx
@@ -17,6 +17,7 @@
 # distutils: language = c++
 # cython: language_level=3
 # cython: linetrace=True
+# cython: freethreading_compatible = True
 
 """Implements a Python interface for SYCL's kernel bundle and kernel runtime
 classes.

--- a/dpctl/tests/_cython_api.pyx
+++ b/dpctl/tests/_cython_api.pyx
@@ -16,6 +16,7 @@
 
 # cython: language=c++
 # cython: language_level=3
+# cython: freethreading_compatible = True
 
 cimport dpctl as c_dpctl
 

--- a/dpctl/tests/test_sycl_queue_manager.py
+++ b/dpctl/tests/test_sycl_queue_manager.py
@@ -24,8 +24,10 @@ import dpctl
 def test__DeviceDefaultQueueCache():
     import copy
 
-    from dpctl._sycl_queue_manager import _global_device_queue_cache as cache
-    from dpctl._sycl_queue_manager import get_device_cached_queue
+    from dpctl._sycl_queue_manager import (
+        _global_device_queue_cache,
+        get_device_cached_queue,
+    )
 
     try:
         d = dpctl.SyclDevice()
@@ -33,10 +35,9 @@ def test__DeviceDefaultQueueCache():
         pytest.skip("Could not create default device")
 
     q1 = get_device_cached_queue(d)
-    cache_copy = copy.copy(cache.get())
-    q2, changed = cache_copy.get_or_create(d)
+    cache_copy = copy.copy(_global_device_queue_cache)
+    q2 = cache_copy.get_or_create(d)
 
-    assert not changed
     assert q1 == q2
     q3 = get_device_cached_queue(d.filter_string)
     assert q3 == q1

--- a/dpctl/tests/test_sycl_usm.py
+++ b/dpctl/tests/test_sycl_usm.py
@@ -59,7 +59,7 @@ def test_memory_create(memory_ctor):
     assert mobj.sycl_queue == queue
     assert type(repr(mobj)) is str
     assert type(bytes(mobj)) is bytes
-    assert sys.getsizeof(mobj) > nbytes
+    assert sys.getsizeof(mobj) >= nbytes
 
 
 def test_memory_create_with_np():

--- a/dpctl/utils/_order_manager.py
+++ b/dpctl/utils/_order_manager.py
@@ -1,6 +1,6 @@
+import threading
 import weakref
 from collections import defaultdict
-from contextvars import ContextVar
 
 from .._sycl_event import SyclEvent
 from .._sycl_queue import SyclQueue
@@ -65,26 +65,28 @@ class _SequentialOrderManager:
 
 
 class SyclQueueToOrderManagerMap:
-    """Utility class used to ensure sequential ordering of offloaded tasks
-    when passed to order manager."""
+    """
+    Utility class used to ensure sequential ordering of offloaded tasks
+    when passed to order manager.
+
+    Maintains a thread-local dictionary mapping SyclQueue instances to
+    _SequentialOrderManager instances.
+    """
 
     def __init__(self):
-        self._map = ContextVar(
-            "global_order_manager_map",
-            # no default to avoid sharing a single defaultdict
-            # across threads
-        )
+        # each thread gets its own dictionary of order managers
+        self._tls = threading.local()
 
     def _get_map(self):
         """
-        Factory method to get or create a default device queue cache for the
-        current context
+        Factory method to get or create an order manager map for the
+        current thread.
         """
         try:
-            return self._map.get()
-        except LookupError:
+            return self._tls.order_manager_map
+        except AttributeError:
             m = defaultdict(_SequentialOrderManager)
-            self._map.set(m)
+            self._tls.order_manager_map = m
             return m
 
     def __getitem__(self, q: SyclQueue) -> _SequentialOrderManager:

--- a/dpctl/utils/_order_manager.py
+++ b/dpctl/utils/_order_manager.py
@@ -1,3 +1,4 @@
+import sys
 import threading
 import weakref
 from collections import defaultdict
@@ -17,6 +18,8 @@ class _SequentialOrderManager:
         self._state = _OrderManager(16)
 
     def __del__(self):
+        if sys.is_finalizing():
+            return
         _local = self._state
         SyclEvent.wait_for(_local.get_submitted_events())
         SyclEvent.wait_for(_local.get_host_task_events())

--- a/dpctl/utils/src/device_queries.cpp
+++ b/dpctl/utils/src/device_queries.cpp
@@ -132,7 +132,7 @@ std::uint32_t py_intel_memory_bus_width(const sycl::device &d)
 
 }; // namespace
 
-PYBIND11_MODULE(_device_queries, m)
+PYBIND11_MODULE(_device_queries, m, py::mod_gil_not_used())
 {
     m.def("intel_device_info_device_id", &py_intel_device_id,
           "Get ext_intel_device_id for the device, zero if not an intel device",

--- a/dpctl/utils/src/order_keeper.cpp
+++ b/dpctl/utils/src/order_keeper.cpp
@@ -6,7 +6,7 @@
 #include "sequential_order_keeper.hpp"
 #include <sycl/sycl.hpp>
 
-PYBIND11_MODULE(_seq_order_keeper, m)
+PYBIND11_MODULE(_seq_order_keeper, m, py::mod_gil_not_used())
 {
     py::class_<SequentialOrder>(m, "_OrderManager")
         .def(py::init<std::size_t>())

--- a/dpctl/utils/src/sequential_order_keeper.hpp
+++ b/dpctl/utils/src/sequential_order_keeper.hpp
@@ -3,6 +3,7 @@
 
 #include <algorithm>
 #include <cstddef>
+#include <mutex>
 #include <vector>
 
 namespace
@@ -21,10 +22,12 @@ inline bool is_event_complete(const sycl::event &e)
 class SequentialOrder
 {
 private:
+    mutable std::mutex mu_events;
     std::vector<sycl::event> host_task_events;
     std::vector<sycl::event> submitted_events;
 
-    void prune_complete()
+    // only called with mu_events held
+    void prune_complete_nolock()
     {
         const auto &ht_it =
             std::remove_if(host_task_events.begin(), host_task_events.end(),
@@ -46,76 +49,78 @@ public:
     }
 
     SequentialOrder(const SequentialOrder &other)
-        : host_task_events(other.host_task_events),
-          submitted_events(other.submitted_events)
     {
-        prune_complete();
+        std::lock_guard<std::mutex> lock(other.mu_events);
+        host_task_events = other.host_task_events;
+        submitted_events = other.submitted_events;
+        prune_complete_nolock();
     }
     SequentialOrder(SequentialOrder &&other)
         : host_task_events{}, submitted_events{}
     {
+        std::lock_guard<std::mutex> lock(other.mu_events);
         host_task_events = std::move(other.host_task_events);
         submitted_events = std::move(other.submitted_events);
-        prune_complete();
+        prune_complete_nolock();
     }
 
     SequentialOrder &operator=(const SequentialOrder &other)
     {
-        host_task_events = other.host_task_events;
-        submitted_events = other.submitted_events;
-
-        prune_complete();
+        if (this != &other) {
+            std::scoped_lock lock(mu_events, other.mu_events);
+            host_task_events = other.host_task_events;
+            submitted_events = other.submitted_events;
+            prune_complete_nolock();
+        }
         return *this;
     }
 
     SequentialOrder &operator=(SequentialOrder &&other)
     {
         if (this != &other) {
+            std::scoped_lock lock(mu_events, other.mu_events);
             host_task_events = std::move(other.host_task_events);
             submitted_events = std::move(other.submitted_events);
-            prune_complete();
+            prune_complete_nolock();
         }
         return *this;
     }
 
     std::size_t get_num_submitted_events() const
     {
+        std::lock_guard<std::mutex> lock(mu_events);
         return submitted_events.size();
     }
 
-    const std::vector<sycl::event> &get_host_task_events()
+    // returns a copy to avoid returning a reference that
+    // could be modified after the lock is released
+    std::vector<sycl::event> get_host_task_events()
     {
-        prune_complete();
+        std::lock_guard<std::mutex> lock(mu_events);
+        prune_complete_nolock();
         return host_task_events;
     }
 
-    /*
-        const std::vector<sycl::event> & get_host_task_events() const {
-            return host_task_events;
-        }
-    */
-
     std::size_t get_num_host_task_events() const
     {
+        std::lock_guard<std::mutex> lock(mu_events);
         return host_task_events.size();
     }
 
-    const std::vector<sycl::event> &get_submitted_events()
+    // returns a copy to avoid returning a reference that
+    // could be modified after the lock is released
+    std::vector<sycl::event> get_submitted_events()
     {
-        prune_complete();
+        std::lock_guard<std::mutex> lock(mu_events);
+        prune_complete_nolock();
         return submitted_events;
     }
-
-    /*
-        const std::vector<sycl::event> & get_submitted_events() const {
-            return submitted_events;
-        }
-    */
 
     void add_to_both_events(const sycl::event &ht_ev,
                             const sycl::event &comp_ev)
     {
-        prune_complete();
+        std::lock_guard<std::mutex> lock(mu_events);
+        prune_complete_nolock();
         if (!is_event_complete(ht_ev))
             host_task_events.push_back(ht_ev);
         if (!is_event_complete(comp_ev))
@@ -125,7 +130,8 @@ public:
     void add_vector_to_both_events(const std::vector<sycl::event> &ht_evs,
                                    const std::vector<sycl::event> &comp_evs)
     {
-        prune_complete();
+        std::lock_guard<std::mutex> lock(mu_events);
+        prune_complete_nolock();
         for (const auto &e : ht_evs) {
             if (!is_event_complete(e))
                 host_task_events.push_back(e);
@@ -138,7 +144,8 @@ public:
 
     void add_to_host_task_events(const sycl::event &ht_ev)
     {
-        prune_complete();
+        std::lock_guard<std::mutex> lock(mu_events);
+        prune_complete_nolock();
         if (!is_event_complete(ht_ev)) {
             host_task_events.push_back(ht_ev);
         }
@@ -146,7 +153,8 @@ public:
 
     void add_to_submitted_events(const sycl::event &comp_ev)
     {
-        prune_complete();
+        std::lock_guard<std::mutex> lock(mu_events);
+        prune_complete_nolock();
         if (!is_event_complete(comp_ev)) {
             submitted_events.push_back(comp_ev);
         }
@@ -155,7 +163,8 @@ public:
     template <std::size_t num>
     void add_list_to_host_task_events(const sycl::event (&ht_events)[num])
     {
-        prune_complete();
+        std::lock_guard<std::mutex> lock(mu_events);
+        prune_complete_nolock();
         for (std::size_t i = 0; i < num; ++i) {
             const auto &e = ht_events[i];
             if (!is_event_complete(e))
@@ -166,7 +175,8 @@ public:
     template <std::size_t num>
     void add_list_to_submitted_events(const sycl::event (&comp_events)[num])
     {
-        prune_complete();
+        std::lock_guard<std::mutex> lock(mu_events);
+        prune_complete_nolock();
         for (std::size_t i = 0; i < num; ++i) {
             const auto &e = comp_events[i];
             if (!is_event_complete(e))
@@ -176,8 +186,20 @@ public:
 
     void wait()
     {
-        sycl::event::wait(submitted_events);
-        sycl::event::wait(host_task_events);
-        prune_complete();
+        // snapeshot events outside of mutex to avoid
+        // calling wait inside mutex
+        std::vector<sycl::event> sub_copy;
+        std::vector<sycl::event> ht_copy;
+        {
+            std::lock_guard<std::mutex> lock(mu_events);
+            sub_copy = submitted_events;
+            ht_copy = host_task_events;
+        }
+        sycl::event::wait(sub_copy);
+        sycl::event::wait(ht_copy);
+        {
+            std::lock_guard<std::mutex> lock(mu_events);
+            prune_complete_nolock();
+        }
     }
 };

--- a/dpctl/utils/src/sequential_order_keeper.hpp
+++ b/dpctl/utils/src/sequential_order_keeper.hpp
@@ -4,6 +4,7 @@
 #include <algorithm>
 #include <cstddef>
 #include <mutex>
+#include <utility>
 #include <vector>
 
 namespace

--- a/dpctl/utils/src/sequential_order_keeper.hpp
+++ b/dpctl/utils/src/sequential_order_keeper.hpp
@@ -186,7 +186,7 @@ public:
 
     void wait()
     {
-        // snapeshot events outside of mutex to avoid
+        // snapshot events outside of mutex to avoid
         // calling wait inside mutex
         std::vector<sycl::event> sub_copy;
         std::vector<sycl::event> ht_copy;

--- a/examples/c/py_sycl_ls/src/py_sycl-ls.c
+++ b/examples/c/py_sycl_ls/src/py_sycl-ls.c
@@ -63,25 +63,35 @@ static PyMethodDef SyclLSMethods[] = {
     {NULL, NULL, 0, NULL} /* Sentinel */
 };
 
+static int syclls_module_exec(PyObject *m)
+{
+    (void)(m);
+    import_dpctl();
+    if (PyErr_Occurred()) {
+        return -1;
+    }
+    return 0;
+}
+
+static PyModuleDef_Slot syclls_module_slots[] = {
+    {Py_mod_exec, syclls_module_exec},
+#if PY_VERSION_HEX >= 0x030D0000
+    {Py_mod_gil, Py_MOD_GIL_NOT_USED},
+#endif
+    {0, NULL}};
+
 static struct PyModuleDef syclls_module = {
     PyModuleDef_HEAD_INIT,
     "_py_sycl_ls", /* name of module */
     "",            /* module documentation, may be NULL */
-    -1,            /* size of per-interpreter state of the module,
-                      or -1 if the module keeps state in global variables. */
+    0,             /* size of per-interpreter state of the module */
     SyclLSMethods,
-    NULL,
+    syclls_module_slots,
     NULL,
     NULL,
     NULL};
 
 PyMODINIT_FUNC PyInit__py_sycl_ls(void)
 {
-    PyObject *m;
-
-    import_dpctl();
-
-    m = PyModule_Create(&syclls_module);
-
-    return m;
+    return PyModuleDef_Init(&syclls_module);
 }

--- a/examples/cython/sycl_buffer/syclbuffer/_syclbuffer.pyx
+++ b/examples/cython/sycl_buffer/syclbuffer/_syclbuffer.pyx
@@ -16,6 +16,7 @@
 
 # distutils: language = c++
 # cython: language_level=3
+# cython: freethreading_compatible = True
 
 cimport cython
 

--- a/examples/cython/use_dpctl_sycl/use_dpctl_sycl/_cython_api.pyx
+++ b/examples/cython/use_dpctl_sycl/use_dpctl_sycl/_cython_api.pyx
@@ -17,6 +17,7 @@
 # distutils: language = c++
 # cython: language_level=3
 # cython: linetrace=True
+# cython: freethreading_compatible = True
 
 cimport libcpp.string
 

--- a/examples/pybind11/external_usm_allocation/external_usm_allocation/_usm_alloc_example.cpp
+++ b/examples/pybind11/external_usm_allocation/external_usm_allocation/_usm_alloc_example.cpp
@@ -141,7 +141,7 @@ dpctl::memory::usm_memory make_zeroed_device_memory(size_t nbytes,
     return dpctl::memory::usm_memory(data, nbytes, q, shptr);
 }
 
-PYBIND11_MODULE(_external_usm_alloc, m)
+PYBIND11_MODULE(_external_usm_alloc, m, py::mod_gil_not_used())
 {
     py::class_<DMatrix> dm(m, "DMatrix");
     dm.def(py::init(&create_matrix),

--- a/examples/pybind11/onemkl_gemv/sycl_gemm/_onemkl.cpp
+++ b/examples/pybind11/onemkl_gemv/sycl_gemm/_onemkl.cpp
@@ -521,7 +521,7 @@ int py_cg_solve(sycl::queue exec_q,
     }
 }
 
-PYBIND11_MODULE(_onemkl, m)
+PYBIND11_MODULE(_onemkl, m, py::mod_gil_not_used())
 {
     m.def("gemv", &py_gemv, "Uses oneMKL to compute dot(matrix, vector)",
           py::arg("exec_queue"), py::arg("Amatrix"), py::arg("xvec"),

--- a/examples/pybind11/use_dpctl_sycl_kernel/use_kernel/_example.cpp
+++ b/examples/pybind11/use_dpctl_sycl_kernel/use_kernel/_example.cpp
@@ -75,7 +75,7 @@ void submit_custom_kernel(sycl::queue &q,
     return;
 }
 
-PYBIND11_MODULE(_use_kernel, m)
+PYBIND11_MODULE(_use_kernel, m, py::mod_gil_not_used())
 {
     m.def("submit_custom_kernel", &submit_custom_kernel,
           "Submit given kernel with arguments (int *, int *) to queue",

--- a/examples/pybind11/use_dpctl_sycl_queue/use_queue_device/_example.cpp
+++ b/examples/pybind11/use_dpctl_sycl_queue/use_queue_device/_example.cpp
@@ -95,7 +95,7 @@ std::uint32_t get_partition_max_sub_devices(const sycl::device &d)
     return d.get_info<sycl::info::device::partition_max_sub_devices>();
 }
 
-PYBIND11_MODULE(_use_queue_device, m)
+PYBIND11_MODULE(_use_queue_device, m, py::mod_gil_not_used())
 {
     m.def(
         "get_max_compute_units",

--- a/examples/python/_runner.py
+++ b/examples/python/_runner.py
@@ -20,7 +20,7 @@ import inspect
 
 def has_nondefault_params(sgn):
     for v in sgn.parameters.values():
-        if v.default is inspect._empty:
+        if v.default is inspect.Parameter.empty:
             return True
     return False
 

--- a/examples/python/using_order_manager.py
+++ b/examples/python/using_order_manager.py
@@ -1,0 +1,199 @@
+# Copyright 2020-2025 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Demonstrates using the SequentialOrderManager with USM and the Python threading
+module.
+"""
+
+import concurrent.futures
+
+import numpy as np
+
+import dpctl
+import dpctl.memory as dpmem
+from dpctl.utils import SequentialOrderManager
+
+
+def _memset_async(q, usm_buf, fill_byte, om):
+    """
+    Fill ``usm_buf`` with ``fill_byte`` asynchronously and track in ``om``.
+
+    ``_submit_keep_args_alive`` prevents the buffer and the target from being
+    garbage-collected while the device is still reading/writing.
+    """
+    n = usm_buf.nbytes
+    data = np.full(n, fill_byte, dtype=np.uint8)
+
+    comp_ev = q.memcpy_async(usm_buf, data, n, dEvents=om.submitted_events)
+    # keep Python objects alive until the copy finishes
+    ht_ev = q._submit_keep_args_alive((usm_buf, data), [comp_ev])
+    om.add_event_pair(ht_ev, comp_ev)
+    return comp_ev
+
+
+def independent_threads():
+    """
+    Each thread fills and reads back its own USM buffer independently, with
+    each thread operating on separate memory, with separate order managers.
+    """
+    nbytes = 1024
+    q = dpctl.SyclQueue()
+    n_threads = 2
+
+    def worker(thread_id):
+        om = SequentialOrderManager[q]
+        buf = dpmem.MemoryUSMShared(nbytes, queue=q)
+        fill_value = thread_id + 1
+
+        _memset_async(q, buf, fill_value, om)
+
+        om.wait()
+
+        arr = np.frombuffer(buf.copy_to_host(), dtype=np.uint8)
+        return int(arr[0])
+
+    with concurrent.futures.ThreadPoolExecutor(
+        max_workers=n_threads
+    ) as executor:
+        results = list(executor.map(worker, range(n_threads)))
+
+    assert results == [1, 2], f"Unexpected results: {results}"
+    print(f"independent_threads got what we expected: {results}")
+
+
+def fork_join():
+    """
+    The main thread allocates, then each child thread creates a device buffer,
+    then fills it via ``memcpy_async``, and waits.  After ``thread.join()``,
+    the main thread copies each child's buffer into a single shared result
+    buffer and verifies the contents.
+    """
+    nbytes = 1024
+    q = dpctl.SyclQueue()
+    n_threads = 2
+    chunk = nbytes // n_threads
+
+    def child_fill(thread_id):
+        child_om = SequentialOrderManager[q]
+        fill_val = (thread_id + 1) * 10
+
+        host_data = np.full(chunk, fill_val, dtype=np.uint8)
+        usm_data = dpmem.MemoryUSMShared(chunk, queue=q)
+        usm_data.copy_from_host(host_data)
+
+        usm_chunk = dpmem.MemoryUSMDevice(chunk, queue=q)
+
+        comp_ev = q.memcpy_async(
+            usm_chunk,
+            usm_data,
+            chunk,
+            dEvents=child_om.submitted_events,
+        )
+        ht_ev = q._submit_keep_args_alive((usm_chunk, usm_data), [comp_ev])
+        child_om.add_event_pair(ht_ev, comp_ev)
+
+        child_om.wait()
+        return usm_chunk
+
+    with concurrent.futures.ThreadPoolExecutor(
+        max_workers=n_threads
+    ) as executor:
+        child_bufs = list(executor.map(child_fill, range(n_threads)))
+
+    main_om = SequentialOrderManager[q]
+    result_parts = []
+
+    for child_buf in child_bufs:
+        part = dpmem.MemoryUSMShared(chunk, queue=q)
+        comp_ev = q.memcpy_async(
+            part, child_buf, chunk, dEvents=main_om.submitted_events
+        )
+        ht_ev = q._submit_keep_args_alive((part, child_buf), [comp_ev])
+        main_om.add_event_pair(ht_ev, comp_ev)
+        result_parts.append(part)
+    main_om.wait()
+
+    arr = np.concatenate(
+        [np.frombuffer(p.copy_to_host(), dtype=np.uint8) for p in result_parts]
+    )
+    assert np.all(
+        arr[0:chunk] == 10
+    ), f"Expected all values in first chunk to be 10, got {arr[0:chunk]}"
+    assert np.all(
+        arr[chunk:] == 20
+    ), f"Expected all values in second chunk to be 20, got {arr[chunk:]}"
+    print(f"fork-join got what we expected: [{arr[0]}, ..., {arr[chunk]}, ...]")
+
+
+def explicit_event_passing():
+    """
+    Each child thread performs an async fill and gives its tracked events.
+    The main thread adds those events to its own order manager so that a
+    subsequent ``memcpy_async`` depends on the child work completing first.
+    """
+    nbytes = 1024
+    q = dpctl.SyclQueue()
+    n_threads = 2
+
+    def child_prepare(thread_id):
+        child_om = SequentialOrderManager[q]
+        buf = dpmem.MemoryUSMShared(nbytes, queue=q)
+        fill_val = (thread_id + 1) * 42  # 42 or 84
+
+        _memset_async(q, buf, fill_val, child_om)
+
+        return buf, child_om.host_task_events, child_om.submitted_events
+
+    with concurrent.futures.ThreadPoolExecutor(
+        max_workers=n_threads
+    ) as executor:
+        futures_results = list(executor.map(child_prepare, range(n_threads)))
+
+    child_buffers = []
+    collected_ht_events = []
+    collected_comp_events = []
+    for buf, ht_events, comp_events in futures_results:
+        child_buffers.append(buf)
+        collected_ht_events.extend(ht_events)
+        collected_comp_events.extend(comp_events)
+
+    main_om = SequentialOrderManager[q]
+    main_om.add_event_pair(collected_ht_events, collected_comp_events)
+
+    results = []
+    for buf in child_buffers:
+        out = dpmem.MemoryUSMShared(nbytes, queue=q)
+        comp_ev = q.memcpy_async(
+            out, buf, nbytes, dEvents=main_om.submitted_events
+        )
+        ht_ev = q._submit_keep_args_alive((out, buf), [comp_ev])
+        main_om.add_event_pair(ht_ev, comp_ev)
+        results.append(out)
+
+    main_om.wait()
+
+    values = [
+        int(np.frombuffer(r.copy_to_host(), dtype=np.uint8)[0]) for r in results
+    ]
+    assert values == [42, 84], f"Unexpected: {values}"
+    print(f"explicit_event_passing got what we expected: {values}")
+
+
+if __name__ == "__main__":
+    import _runner as runner
+
+    runner.run_examples(
+        "Examples for working with SequentialOrderManager in dpctl.", globals()
+    )

--- a/examples/python/using_order_manager.py
+++ b/examples/python/using_order_manager.py
@@ -134,7 +134,7 @@ def fork_join():
     assert np.all(
         arr[chunk:] == 20
     ), f"Expected all values in second chunk to be 20, got {arr[chunk:]}"
-    print(f"fork-join got what we expected: [{arr[0]}, ..., {arr[chunk]}, ...]")
+    print(f"fork_join got what we expected: [{arr[0]}, ..., {arr[chunk]}, ...]")
 
 
 def explicit_event_passing():

--- a/examples/python/using_order_manager.py
+++ b/examples/python/using_order_manager.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2025 Intel Corporation
+# Copyright 2026 Intel Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/libsyclinterface/helper/source/dpctl_error_handlers.cpp
+++ b/libsyclinterface/helper/source/dpctl_error_handlers.cpp
@@ -26,6 +26,7 @@
 #include "dpctl_error_handlers.h"
 #include "dpctl_service.h"
 #include <cstring>
+#include <iostream>
 #include <sstream>
 #ifdef _WIN32
 #include <cstdlib>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ classifiers = [
   "Programming Language :: Python :: 3.13",
   "Programming Language :: Python :: 3.14",
   "Programming Language :: Python :: Implementation :: CPython",
+  "Programming Language :: Python :: Free Threading :: 2 - Beta",
   "Topic :: Software Development",
   "Topic :: Scientific/Engineering",
   "Operating System :: Microsoft :: Windows",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,7 @@ readme = {file = "README.md", content-type = "text/markdown"}
 requires-python = ">=3.10"
 
 [project.optional-dependencies]
-coverage = ["Cython", "pytest", "pytest-cov", "coverage", "tomli"]
+coverage = ["Cython", "pytest", "coverage", "tomli"]
 docs = [
   "Cython",
   "graphviz",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -129,12 +129,13 @@ use_parentheses = true
 [tool.pytest.ini_options]
 addopts = [
   "--junitxml=junit.xml",
-  "--ignore setup.py",
-  "--ignore run_test.py",
-  "--tb native",
+  "--ignore=setup.py",
+  "--ignore=run_test.py",
+  "--tb=native",
   "--strict",
   "--durations=20",
-  "-q -ra"
+  "-q",
+  "-ra"
 ]
 markers = [
   "broken_complex: mark a test that is skipped due to complex implementation issues in DPC++ compiler"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -132,7 +132,7 @@ addopts = [
   "--ignore=setup.py",
   "--ignore=run_test.py",
   "--tb=native",
-  "--strict",
+  "--strict-markers",
   "--durations=20",
   "-q",
   "-ra"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -131,7 +131,6 @@ addopts = [
   "--junitxml=junit.xml",
   "--ignore setup.py",
   "--ignore run_test.py",
-  "--cov-report term-missing",
   "--tb native",
   "--strict",
   "--durations=20",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ requires = [
   "scikit-build>=0.17.0",
   "ninja>=1.11.1; platform_system!='Windows'",
   "cmake>=3.29.0",
-  "cython>=3.0.10",
+  "cython>=3.1.0",
   "numpy >=1.26.0",
   # WARNING: check with doc how to upgrade
   "versioneer[toml]==0.29"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,9 +61,9 @@ readme = {file = "README.md", content-type = "text/markdown"}
 requires-python = ">=3.10"
 
 [project.optional-dependencies]
-coverage = ["Cython", "pytest", "coverage", "tomli"]
+coverage = ["Cython>=3.1.0", "pytest", "coverage", "tomli"]
 docs = [
-  "Cython",
+  "Cython>=3.1.0",
   "graphviz",
   "pydot",
   "furo",
@@ -126,7 +126,7 @@ multi_line_output = 3
 skip = ["dpctl/_version.py"]
 use_parentheses = true
 
-[tool.pytest.ini.options]
+[tool.pytest.ini_options]
 addopts = [
   "--junitxml=junit.xml",
   "--ignore setup.py",


### PR DESCRIPTION
This PR removes the required `python-gil` dependency from the dpctl conda package workflow and enables free-threaded Python in extension modules

Adjustments are made to the `SequentialOrderManager` class such that the class is safe in free-threaded, including mutexes in the C++ class as a fall-back in case of (not recommended) simultaneous access to its members and methods

SequentialOrderManager now maintains thread-local storage for individual queue-to-manager-maps, such that each thread has its own manager per queue.

Queue and device caching, meanwhile, are global, to create a concept of default queues and devices that allows operations in extensions like dpnp (which rely on queues being the same for compute follows data) to operate on data passed between threads without copy.

In the futue, per-thread-queues and devices may prove more efficient, in which case, extensions will be asked to be made more robust (checking that context and device are the same, not using queue as a shortcut).

This PR builds on top of work already done removing the tensor submodule, which is pending migration to dpnp

- [X] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [ ] Have you added your changes to the changelog?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
