### PR TITLE
Add a workaround to `custom_inclusive_scan_over_group`

### DIFF
--- a/dpctl/tensor/libtensor/include/utils/sycl_utils.hpp
+++ b/dpctl/tensor/libtensor/include/utils/sycl_utils.hpp
@@ -278,7 +278,7 @@ T custom_inclusive_scan_over_group(GroupT &&wg,
         // The w/s adds SYCL atomic fence, since the explicit memory fence
         // prevents reordering/elimination, while it will add slight overhead.
         T __scan_val = identity;
-        sycl::atomic_fence(sycl::memory_order::seq_cst,
+        sycl::atomic_fence(sycl::memory_order::relaxed,
                            sycl::memory_scope::work_item);
         if (in_bounds) {
             __scan_val = local_mem_acc[(offset + lane_id) * max_sgSize - 1];

--- a/dpctl/tensor/libtensor/include/utils/sycl_utils.hpp
+++ b/dpctl/tensor/libtensor/include/utils/sycl_utils.hpp
@@ -268,9 +268,20 @@ T custom_inclusive_scan_over_group(GroupT &&wg,
         const bool in_range = (lane_id < n_aggregates);
         const bool in_bounds = in_range && (lane_id > 0 || large_wg);
 
-        T __scan_val = (in_bounds)
-                           ? local_mem_acc[(offset + lane_id) * max_sgSize - 1]
-                           : identity;
+        // Here is a bug where IGC incorrectly optimized the below code:
+        // T __scan_val = (in_bounds)
+        //                 ? local_mem_acc[(offset + lane_id) * max_sgSize - 1]
+        //                 : identity;
+        // That causes `__scan_val` is not initialized with `identity` value:
+        //   wgs = 256, max_sgSize = 16   =>   n_aggregates = 16
+        //   wi = 0:   in_range = 1, in_bounds = 0   =>   __scan_val = identity
+        // The w/s adds SYCL atomic fence, since the explicit memory fence
+        // prevents reordering/elimination, while it will add slight overhead.
+        T __scan_val = identity;
+        sycl::atomic_fence(sycl::memory_order::seq_cst, sycl::memory_scope::work_item);
+        if (in_bounds) {
+            __scan_val = local_mem_acc[(offset + lane_id) * max_sgSize - 1];
+        }
         for (std::uint32_t step = 1; step < sgSize; step *= 2) {
             const bool advanced_lane = (lane_id >= step);
             const std::uint32_t src_lane_id =

--- a/dpctl/tensor/libtensor/include/utils/sycl_utils.hpp
+++ b/dpctl/tensor/libtensor/include/utils/sycl_utils.hpp
@@ -278,7 +278,8 @@ T custom_inclusive_scan_over_group(GroupT &&wg,
         // The w/s adds SYCL atomic fence, since the explicit memory fence
         // prevents reordering/elimination, while it will add slight overhead.
         T __scan_val = identity;
-        sycl::atomic_fence(sycl::memory_order::seq_cst, sycl::memory_scope::work_item);
+        sycl::atomic_fence(sycl::memory_order::seq_cst,
+                           sycl::memory_scope::work_item);
         if (in_bounds) {
             __scan_val = local_mem_acc[(offset + lane_id) * max_sgSize - 1];
         }


### PR DESCRIPTION
There is IGC bug identified when using `custom_inclusive_scan_over_group` inside accumulator SYCL kernels on ARL GPU.
The issue is that IGC incorrectly optimized the code, cause work-item=0 initialized `__scan_val` with zero instead of `identity` value.

This PR proposes to implement a workaround which adds SYCL atomic fence. That works since the explicit memory fence prevents reordering/elimination, but leads to slight overhead.

Note, no new test added, since `test_tensor_accumulation.py::test_logcumsumexp_basic` and `test_tensor_accumulation.py::test_cumulative_logsumexp_closed_form[fpdt0]` already cover the issue and failed without the w/a in place.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [ ] Have you added your changes to the changelog?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
