### PR TITLE
[MAINT] Remove uses of `format` in strings

### DIFF
--- a/dpctl/_sycl_context.pyx
+++ b/dpctl/_sycl_context.pyx
@@ -321,11 +321,11 @@ cdef class SyclContext(_SyclContext):
                 )
             elif (ret == -6):
                 raise TypeError(
-                    "Input capsule {} contains a null pointer or could not be"
-                    " renamed".format(arg)
+                    f"Input capsule {arg} contains a null pointer or could not "
+                    "be renamed"
                 )
             raise ValueError(
-                "Unrecognized error code ({}) encountered.".format(ret)
+                f"Unrecognized error code ({ret}) encountered."
             )
 
     cdef bool equals(self, SyclContext ctxt):
@@ -471,12 +471,10 @@ cdef class SyclContext(_SyclContext):
         """
         cdef size_t n = self.device_count
         if n == 1:
-            return ("<dpctl." + self.__name__ + " at {}>".format(hex(id(self))))
+            return f"<dpctl.{self.__name__} at {hex(id(self))}>"
         else:
             return (
-                "<dpctl."
-                + self.__name__
-                + " for {} devices at {}>".format(n, hex(id(self)))
+                f"<dpctl.{self.__name__} for {n} devices at {hex(id(self))}>"
             )
 
     def _get_capsule(self):

--- a/dpctl/_sycl_device.pyx
+++ b/dpctl/_sycl_device.pyx
@@ -410,7 +410,7 @@ cdef class SyclDevice(_SyclDevice):
             if ret == -1:
                 raise SyclDeviceCreationError(
                     "Could not create a SyclDevice with the selector string "
-                    "'{selector_string}'".format(selector_string=arg)
+                    f"'{arg}'"
                 )
         elif isinstance(arg, _SyclDevice):
             ret = self._init_from__SyclDevice(arg)
@@ -1577,7 +1577,7 @@ cdef class SyclDevice(_SyclDevice):
             + ", "
             + " "
             + self.name
-            + "] at {}>".format(hex(id(self)))
+            + f"] at {hex(id(self))}>"
         )
 
     def __hash__(self):
@@ -1651,7 +1651,7 @@ cdef class SyclDevice(_SyclDevice):
         counts_buff = <size_t *> malloc((<size_t> ncounts) * sizeof(size_t))
         if counts_buff is NULL:
             raise MemoryError(
-                "Allocation of counts array of size {} failed.".format(ncounts)
+                f"Allocation of counts array of size {ncounts} failed."
             )
         for i in range(ncounts):
             counts_buff[i] = counts[i]
@@ -1714,9 +1714,8 @@ cdef class SyclDevice(_SyclDevice):
                 try:
                     sd = cpu_d.create_sub_devices(partition="numa")
                     print(
-                        "{0} sub-devices were created with respective "
-                        "#EUs being {1}".format(
-                            len(sd), [d.max_compute_units for d in sd]
+                        f"{len(sd)} sub-devices were created with respective "
+                        f"#EUs being {[d.max_compute_units for d in sd]}"
                         )
                     )
                 except Exception:
@@ -1785,9 +1784,7 @@ cdef class SyclDevice(_SyclDevice):
                 )
             else:
                 raise ValueError(
-                    "Partition affinity domain {} is not understood.".format(
-                        partition
-                    )
+                    f"Partition affinity domain {partition} is not understood."
                 )
             return self.create_sub_devices_by_affinity(domain_type)
         elif isinstance(partition, collections.abc.Sized) and isinstance(

--- a/dpctl/_sycl_device.pyx
+++ b/dpctl/_sycl_device.pyx
@@ -1716,7 +1716,6 @@ cdef class SyclDevice(_SyclDevice):
                     print(
                         f"{len(sd)} sub-devices were created with respective "
                         f"#EUs being {[d.max_compute_units for d in sd]}"
-                        )
                     )
                 except Exception:
                     print("Device partitioning by affinity was not successful.")

--- a/dpctl/_sycl_event.pyx
+++ b/dpctl/_sycl_event.pyx
@@ -201,15 +201,15 @@ cdef class SyclEvent(_SyclEvent):
                 raise ValueError("Event failed to be created.")
             elif (ret == -2):
                 raise TypeError(
-                    "Input capsule {} contains a null pointer or could not be"
-                    " renamed".format(arg)
+                    f"Input capsule {arg} contains a null pointer or could not "
+                    "be renamed"
                 )
             elif (ret == -3):
                 raise ValueError(
                     "Internal Error: Could not create a copy of a sycl event."
                 )
             raise ValueError(
-                "Unrecognized error code ({}) encountered.".format(ret)
+                f"Unrecognized error code ({ret}) encountered."
             )
 
     cdef DPCTLSyclEventRef get_event_ref(self):

--- a/dpctl/_sycl_platform.pyx
+++ b/dpctl/_sycl_platform.pyx
@@ -181,7 +181,7 @@ cdef class SyclPlatform(_SyclPlatform):
             + ", "
             + self.vendor
             + ", "
-            + self.version + "] at {}>".format(hex(id(self)))
+            + self.version + f"] at {hex(id(self))}>"
         )
 
     def __cinit__(self, arg=None):

--- a/dpctl/_sycl_queue.pyx
+++ b/dpctl/_sycl_queue.pyx
@@ -431,14 +431,12 @@ cdef int _parse_queue_properties(object prop) except *:
                 res = res | _queue_property_type._DEFAULT_PROPERTY
             else:
                 raise ValueError(
-                    (
-                        "queue property '{}' is not understood, "
-                        "expecting 'in_order', 'enable_profiling', or 'default'"
-                    ).format(prop)
+                    f"queue property '{prop}' is not understood, expecting "
+                    "'in_order', 'enable_profiling', or 'default'"
                 )
         else:
             raise ValueError(
-                "queue property '{}' is not understood.".format(prop)
+                f"queue property '{prop}' is not understood."
             )
     return res
 
@@ -648,7 +646,7 @@ cdef class SyclQueue(_SyclQueue):
         if len(args) > 2:
             raise TypeError(
                 "SyclQueue constructor takes 0, 1, or 2 positinal arguments, "
-                "but {} were given.".format(len(args))
+                f"but {len(args)} were given."
             )
         props = _parse_queue_properties(
             kwargs.pop("property", _queue_property_type._DEFAULT_PROPERTY)
@@ -676,22 +674,22 @@ cdef class SyclQueue(_SyclQueue):
                 status = self._init_queue_from_capsule(arg)
             else:
                 raise TypeError(
-                    "Positional argument {} is not a filter string or a "
-                    "SyclDevice".format(arg)
+                    f"Positional argument {arg} is not a filter string or a "
+                    "SyclDevice"
                 )
         else:
             ctx, dev = args
             if not isinstance(ctx, SyclContext):
                 raise TypeError(
                     "SyclQueue constructor with two positional arguments "
-                    "expected SyclContext as its first argument, but got {}."
-                    .format(type(ctx))
+                    f"expected SyclContext as its first argument, but got "
+                    f"{type(ctx)}."
                 )
             if not isinstance(dev, SyclDevice):
                 raise TypeError(
                     "SyclQueue constructor with two positional arguments "
-                    "expected SyclDevice as its second argument, but got {}."
-                    .format(type(dev))
+                    "expected SyclDevice as its second argument, but got "
+                    f"{type(dev)}."
                 )
             status = self._init_queue_from_context_and_device(
                 <SyclContext>ctx, <SyclDevice>dev, props
@@ -699,8 +697,7 @@ cdef class SyclQueue(_SyclQueue):
         if status < 0:
             if status == -1:
                 raise SyclQueueCreationError(
-                    "Device filter selector string '{}' is not understood."
-                    .format(arg)
+                    f"Device filter selector string '{arg}' is not understood."
                 )
             elif status == -2 or status == -8:
                 default_dev_error = (
@@ -708,24 +705,24 @@ cdef class SyclQueue(_SyclQueue):
                 )
                 raise SyclQueueCreationError(
                     default_dev_error if (len_args == 0) else
-                    "SYCL Device '{}' could not be created.".format(arg)
+                    f"SYCL Device '{arg}' could not be created."
                 )
             elif status == -3 or status == -7:
                 raise SyclQueueCreationError(
                     "SYCL Context could not be created " +
                     "by default constructor" if len_args == 0 else
-                    "from '{}'.".format(arg)
+                    f"from '{arg}'."
                 )
             elif status == -4 or status == -6:
                 if len_args == 2:
                     arg = args
                 raise SyclQueueCreationError(
-                    "SYCL Queue failed to be created from '{}'.".format(arg)
+                    f"SYCL Queue failed to be created from '{arg}'."
                 )
             elif status == -5:
                 raise TypeError(
-                    "Input capsule {} contains a null pointer or could not "
-                    "be renamed".format(arg)
+                    f"Input capsule {arg} contains a null pointer or could not "
+                    "be renamed"
                 )
 
     cdef int _init_queue_from__SyclQueue(self, _SyclQueue other):
@@ -1546,12 +1543,10 @@ cdef class SyclQueue(_SyclQueue):
             if en_prof:
                 prop.append("enable_profiling")
             return (
-                "<dpctl."
-                + self.__name__
-                + " at {}, property={}>".format(hex(id(self)), prop)
+                f"<dpctl.{self.__name__} at {hex(id(self))}, property={prop}>"
             )
         else:
-            return "<dpctl." + self.__name__ + " at {}>".format(hex(id(self)))
+            return f"<dpctl.{self.__name__} at {hex(id(self))}>"
 
     def __hash__(self):
         """

--- a/dpctl/_sycl_queue.pyx
+++ b/dpctl/_sycl_queue.pyx
@@ -682,7 +682,7 @@ cdef class SyclQueue(_SyclQueue):
             if not isinstance(ctx, SyclContext):
                 raise TypeError(
                     "SyclQueue constructor with two positional arguments "
-                    f"expected SyclContext as its first argument, but got "
+                    "expected SyclContext as its first argument, but got "
                     f"{type(ctx)}."
                 )
             if not isinstance(dev, SyclDevice):

--- a/dpctl/memory/_memory.pyx
+++ b/dpctl/memory/_memory.pyx
@@ -787,8 +787,7 @@ cdef class MemoryUSMShared(_Memory):
                         "Zero-copy operation is not possible with "
                         "copy=False. "
                         "Either use copy=True, or use a constructor "
-                        f"appropriate for "
-                        f"type '{self.get_usm_type()}'"
+                        f"appropriate for type '{self.get_usm_type()}'"
                     )
 
     def __getbuffer__(self, Py_buffer *buffer, int flags):

--- a/dpctl/memory/_memory.pyx
+++ b/dpctl/memory/_memory.pyx
@@ -146,8 +146,7 @@ def _to_memory(unsigned char[::1] b, str usm_kind):
         res = MemoryUSMHost(len(b))
     else:
         raise ValueError(
-            "Unrecognized usm_kind={} stored in the "
-            "pickle".format(usm_kind)
+            f"Unrecognized usm_kind={usm_kind} stored in the pickle"
         )
     res.copy_from_host(b)
 
@@ -206,9 +205,8 @@ cdef class _Memory:
                         p = DPCTLmalloc_device(nbytes, QRef)
             else:
                 raise RuntimeError(
-                    "Pointer type '{}' is not recognized".format(
-                        ptr_type.decode("UTF-8")
-                    )
+                    f"Pointer type '{ptr_type.decode('UTF-8')}' is not "
+                    "recognized"
                 )
 
             if (p):
@@ -250,13 +248,13 @@ cdef class _Memory:
                 self.refobj = other
             else:
                 raise ValueError(
-                    "Argument {} does not correctly expose"
-                    "`__sycl_usm_array_interface__`.".format(other)
+                    f"Argument {other} does not correctly expose"
+                    "`__sycl_usm_array_interface__`."
                 )
         else:
             raise ValueError(
-                "Argument {} does not expose "
-                "`__sycl_usm_array_interface__`.".format(other)
+                f"Argument {other} does not expose "
+                "`__sycl_usm_array_interface__`."
             )
 
     def __dealloc__(self):
@@ -350,12 +348,8 @@ cdef class _Memory:
 
     def __repr__(self):
         return (
-            "<SYCL(TM) USM-{} allocation of {} bytes at {}>"
-            .format(
-                self.get_usm_type(),
-                self.nbytes,
-                hex(<object>(<size_t>self._memory_ptr))
-            )
+            f"<SYCL(TM) USM-{self.get_usm_type()} allocation of {self.nbytes} "
+            f"bytes at {hex(<object>(<size_t>self._memory_ptr))}>"
         )
 
     def __len__(self):
@@ -488,8 +482,8 @@ cdef class _Memory:
             host_buf = obj
         elif (<Py_ssize_t>len(host_buf) < self.nbytes):
             raise ValueError(
-                "Destination object is too small to accommodate {} bytes"
-                .format(self.nbytes)
+                f"Destination object is too small to accommodate {self.nbytes} "
+                "bytes"
             )
         # call kernel to copy from
         ERef = DPCTLQueue_Memcpy(
@@ -514,8 +508,8 @@ cdef class _Memory:
 
         if (buf_len > self.nbytes):
             raise ValueError(
-                "Source object is too large to be accommodated in {} bytes "
-                "buffer".format(self.nbytes)
+                "Source object is too large to be accommodated in "
+                f"{self.nbytes} bytes buffer"
             )
         # call kernel to copy from
         ERef = DPCTLQueue_Memcpy(
@@ -551,7 +545,7 @@ cdef class _Memory:
             if (src_buf.nbytes > self.nbytes):
                 raise ValueError(
                     "Source object is too large to "
-                    "be accommondated in {} bytes buffer".format(self.nbytes)
+                    f"be accommondated in {self.nbytes} bytes buffer"
                 )
 
             src_queue = src_buf.queue
@@ -788,13 +782,13 @@ cdef class MemoryUSMShared(_Memory):
                     self.copy_from_device(other)
                 else:
                     raise ValueError(
-                        "USM pointer in the argument {} is not a "
+                        f"USM pointer in the argument {other} is not a "
                         "USM shared pointer. "
                         "Zero-copy operation is not possible with "
                         "copy=False. "
                         "Either use copy=True, or use a constructor "
-                        "appropriate for "
-                        "type '{}'".format(other, self.get_usm_type())
+                        f"appropriate for "
+                        f"type '{self.get_usm_type()}'"
                     )
 
     def __getbuffer__(self, Py_buffer *buffer, int flags):
@@ -840,13 +834,11 @@ cdef class MemoryUSMHost(_Memory):
                     self.copy_from_device(other)
                 else:
                     raise ValueError(
-                        "USM pointer in the argument {} is "
+                        f"USM pointer in the argument {other} is "
                         "not a USM host pointer. "
                         "Zero-copy operation is not possible with copy=False. "
                         "Either use copy=True, or use a constructor "
-                        "appropriate for type '{}'".format(
-                            other, self.get_usm_type()
-                        )
+                        f"appropriate for type '{self.get_usm_type()}'"
                     )
 
     def __getbuffer__(self, Py_buffer *buffer, int flags):
@@ -892,13 +884,11 @@ cdef class MemoryUSMDevice(_Memory):
                     self.copy_from_device(other)
                 else:
                     raise ValueError(
-                        "USM pointer in the argument {} is not "
+                        f"USM pointer in the argument {other} is not "
                         "a USM device pointer. "
                         "Zero-copy operation is not possible with copy=False. "
                         "Either use copy=True, or use a constructor "
-                        "appropriate for type '{}'".format(
-                            other, self.get_usm_type()
-                        )
+                        f"appropriate for type '{self.get_usm_type()}'"
                     )
 
 

--- a/dpctl/memory/_sycl_usm_array_interface_utils.pxi
+++ b/dpctl/memory/_sycl_usm_array_interface_utils.pxi
@@ -165,9 +165,8 @@ cdef class _USMBufferData:
 
         if ary_version != 1:
             raise ValueError(("__sycl_usm_array_interface__ is malformed:"
-                              " dict('version': {}) is unexpected."
-                              " The only recognized version is 1.").format(
-                                  ary_version))
+                              f" dict('version': {ary_version}) is unexpected."
+                              " The only recognized version is 1."))
         if not ary_data_tuple or len(ary_data_tuple) != 2:
             raise ValueError("__sycl_usm_array_interface__ is malformed:"
                              " 'data' field is required, and must be a tuple"
@@ -181,10 +180,9 @@ cdef class _USMBufferData:
         if (QRef is NULL):
             raise ValueError("__sycl_usm_array_interface__ is malformed:"
                              " 'data' field is not consistent with 'syclobj'"
-                             " field, the pointer {} is not bound to"
-                             " SyclContext derived from"
-                             " dict('syclobj': {}).".format(
-                                 hex(arr_data_ptr), ary_syclobj))
+                             f" field, the pointer {hex(arr_data_ptr)} is not "
+                             "bound to SyclContext derived from "
+                             f"dict('syclobj': {ary_syclobj}).")
         # shape must be present
         if ary_shape is None or not (
                 isinstance(ary_shape, collections.abc.Sized) and
@@ -204,7 +202,7 @@ cdef class _USMBufferData:
         except TypeError as e:
             raise ValueError(
                 "__sycl_usm_array_interface__ is malformed:"
-                " dict('typestr': {}) is unexpected. ".format(ary_typestr)
+                f" dict('typestr': {ary_typestr}) is unexpected."
             ) from e
 
         if (ary_strides is None or (

--- a/dpctl/tests/test_sycl_device.py
+++ b/dpctl/tests/test_sycl_device.py
@@ -83,9 +83,7 @@ def test_filter_string(valid_filter):
     dev_id = device.filter_string
     assert (
         dpctl.SyclDevice(dev_id) == device
-    ), "Reconstructed device is different, ({}, {})".format(
-        valid_filter, dev_id
-    )
+    ), f"Reconstructed device is different, ({valid_filter}, {dev_id})"
 
 
 def test_filter_string_property():

--- a/dpctl/tests/test_sycl_kernel_submit.py
+++ b/dpctl/tests/test_sycl_kernel_submit.py
@@ -100,7 +100,7 @@ def test_create_program_from_source(ctype_str, dtype, ctypes_ctor):
         host_dt, device_dt = timer.dt
         assert type(host_dt) is float and type(device_dt) is float
         q.memcpy(c, c_usm, c.nbytes)
-        assert np.allclose(c, ref_c), "Failed for {}".format(r)
+        assert np.allclose(c, ref_c), f"Failed for {r}"
 
     for gr, lr in (
         (
@@ -120,7 +120,7 @@ def test_create_program_from_source(ctype_str, dtype, ctypes_ctor):
         host_dt, device_dt = timer.dt
         assert type(host_dt) is float and type(device_dt) is float
         q.memcpy(c, c_usm, c.nbytes)
-        assert np.allclose(c, ref_c), "Failed for {}, {}".format(gr, lr)
+        assert np.allclose(c, ref_c), f"Failed for {gr}, {lr}"
 
 
 def test_submit_async():

--- a/dpctl/tests/test_sycl_queue.py
+++ b/dpctl/tests/test_sycl_queue.py
@@ -150,7 +150,7 @@ def test_channeling_device_properties(capsys):
     for pr in ["backend", "name", "driver_version"]:
         assert getattr(q, pr) == getattr(
             dev, pr
-        ), "Mismatch found for property {}".format(pr)
+        ), f"Mismatch found for property {pr}"
 
 
 def test_queue_submit_barrier(valid_filter):

--- a/dpctl/tests/test_sycl_usm.py
+++ b/dpctl/tests/test_sycl_usm.py
@@ -314,7 +314,7 @@ def test_suai_non_contig_1D(memory_ctor):
     try:
         buf = memory_ctor(32)
     except Exception:
-        pytest.skip("{} could not be allocated".format(memory_ctor.__name__))
+        pytest.skip(f"{memory_ctor.__name__} could not be allocated")
     host_canary = np.full((buf.nbytes,), 77, dtype="|u1")
     buf.copy_from_host(host_canary)
     n1d = 10
@@ -344,7 +344,7 @@ def test_suai_non_contig_2D(memory_ctor):
     try:
         buf = memory_ctor(20)
     except Exception:
-        pytest.skip("{} could not be allocated".format(memory_ctor.__name__))
+        pytest.skip(f"{memory_ctor.__name__} could not be allocated")
     host_canary = np.arange(20, dtype="|u1")
     buf.copy_from_host(host_canary)
     shape_2d = (2, 2)
@@ -497,7 +497,7 @@ def test_with_constructor(memory_ctor):
     try:
         buf = memory_ctor(64)
     except Exception:
-        pytest.skip("{} could not be allocated".format(memory_ctor.__name__))
+        pytest.skip(f"{memory_ctor.__name__} could not be allocated")
     # reuse queue from buffer's SUAI
     v = View(buf, shape=(64,), strides=(1,), offset=0)
     check_view(v)

--- a/examples/cython/sycl_buffer/scripts/bench.py
+++ b/examples/cython/sycl_buffer/scripts/bench.py
@@ -62,9 +62,9 @@ def run_offload(selector_string, X):
         return Skipped(
             f"Skipping run for {selector_string}, queue could nor be created"
         )
-    return "SYCL({}) result: {}".format(
-        q.sycl_device.name,
-        sb.columnwise_total(X, queue=q),
+    return (
+        f"SYCL({q.sycl_device.name}) result: "
+        f"{sb.columnwise_total(X, queue=q)}"
     )
 
 
@@ -77,16 +77,15 @@ print("=" * 10 + " Executing warm-up " + "=" * 10)
 print("NumPy result: ", X.sum(axis=0))
 
 for ss in ["opencl:cpu", "opencl:gpu", "level_zero:gpu"]:
-    print("Result for '" + ss + "': {}".format(run_offload(ss, X)))
+    print(f"Result for '{ss}': {run_offload(ss, X)}")
 
 print("=" * 10 + " Running bechmarks " + "=" * 10)
 
 for ss in ["opencl:cpu", "opencl:gpu", "level_zero:gpu"]:
-    print("Timing offload to '" + ss + "': {}".format(bench_offload(ss, X)))
+    print(f"Timing offload to '{ss}': {bench_offload(ss, X)}")
 
 
 print(
-    "Times for NumPy: {}".format(
-        timeit.repeat(stmt="X.sum(axis=0)", number=100, globals=globals())
-    )
+    "Times for NumPy: "
+    f"{timeit.repeat(stmt='X.sum(axis=0)', number=100, globals=globals())}"
 )

--- a/examples/pybind11/use_dpctl_sycl_queue/example.py
+++ b/examples/pybind11/use_dpctl_sycl_queue/example.py
@@ -29,9 +29,9 @@ global_mem_size = eg.get_device_global_mem_size(q.sycl_device)
 local_mem_size = eg.get_device_local_mem_size(q.sycl_device)
 
 print(f"EU count returned by Pybind11 extension {eu_count}")
-print("EU count computed by dpctl {}".format(q.sycl_device.max_compute_units))
-print("Device's global memory size:  {} bytes".format(global_mem_size))
-print("Device's local memory size:  {} bytes".format(local_mem_size))
+print(f"EU count computed by dpctl {q.sycl_device.max_compute_units}")
+print(f"Device's global memory size:  {global_mem_size} bytes")
+print(f"Device's local memory size:  {local_mem_size} bytes")
 
 print("")
 print("Computing modular reduction using SYCL on a NumPy array")

--- a/examples/python/subdevices.py
+++ b/examples/python/subdevices.py
@@ -67,10 +67,8 @@ def subdivide_by_affinity(affinity="numa"):
     try:
         sub_devs = cpu_d.create_sub_devices(partition=affinity)
         print(
-            "{0} sub-devices were created with respective "
-            "#EUs being {1}".format(
-                len(sub_devs), [d.max_compute_units for d in sub_devs]
-            )
+            f"{len(sub_devs)} sub-devices were created with respective #EUs "
+            f"being {[d.max_compute_units for d in sub_devs]}"
         )
     except Exception:
         print("Device partitioning by affinity was not successful.")

--- a/examples/python/sycl_queue.py
+++ b/examples/python/sycl_queue.py
@@ -21,7 +21,7 @@ def create_default_queue():
     """Create a queue from default selector."""
     q = dpctl.SyclQueue()
     # Queue is out-of-order by default
-    print("Queue {} is in order: {}".format(q, q.is_in_order))
+    print(f"Queue {q} is in order: {q.is_in_order}")
 
 
 def create_queue_from_filter_selector():
@@ -31,7 +31,7 @@ def create_queue_from_filter_selector():
     Create in-order queue with profiling enabled.
     """
     q = dpctl.SyclQueue("gpu,cpu", property=("in_order", "enable_profiling"))
-    print("Queue {} is in order: {}".format(q, q.is_in_order))
+    print(f"Queue {q} is in order: {q.is_in_order}")
     # display the device used
     print("Device targeted by the queue:")
     q.sycl_device.print_device_info()
@@ -45,8 +45,8 @@ def create_queue_from_device():
     q = dpctl.SyclQueue(cpu_d, property="enable_profiling")
     assert q.sycl_device == cpu_d
     print(
-        "Number of devices in SyclContext " "associated with the queue: ",
-        q.sycl_context.device_count,
+        "Number of devices in SyclContext associated with the queue: "
+        f"{q.sycl_context.device_count}"
     )
 
 
@@ -64,8 +64,8 @@ def create_queue_from_subdevice():
     q = dpctl.SyclQueue(sub_devs[0])
     # a single-device context is created automatically
     print(
-        "Number of devices in SyclContext " "associated with the queue: ",
-        q.sycl_context.device_count,
+        "Number of devices in SyclContext associated with the queue: "
+        f"{q.sycl_context.device_count}"
     )
 
 
@@ -83,8 +83,8 @@ def create_queue_from_subdevice_multidevice_context():
     ctx = dpctl.SyclContext(sub_devs)
     q = dpctl.SyclQueue(ctx, sub_devs[0], property="enable_profiling")
     print(
-        "Number of devices in SyclContext " "associated with the queue: ",
-        q.sycl_context.device_count,
+        "Number of devices in SyclContext associated with the queue: "
+        f"{q.sycl_context.device_count}"
     )
 
 


### PR DESCRIPTION
This PR updates the codebase, removing uses of `format` instead of f strings

f strings are technically slightly faster, and are more readable 

- [X] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [X] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [ ] Have you added your changes to the changelog?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
