### PR TITLE
Update empty Python data structure constructors

### DIFF
--- a/docs/doc_sources/conf.py.in
+++ b/docs/doc_sources/conf.py.in
@@ -134,14 +134,14 @@ if generate_multiversion == "ON":
     try:
         html_context
     except NameError:
-        html_context = dict()
+        html_context = {}
     html_context["display_lower_left"] = True
     templates_path = ["_templates"]
     html_context["current_version"] = release
     html_context["version"] = version
 
     # POPULATE LINKS TO OTHER VERSIONS
-    html_context["versions"] = list()
+    html_context["versions"] = []
 
     # Populate the list of documented versions from the doc_versions.txt
     versions = []

--- a/dpctl/_sycl_device.pyx
+++ b/dpctl/_sycl_device.pyx
@@ -1210,7 +1210,7 @@ cdef class SyclDevice(_SyclDevice):
         sg_sizes = DPCTLDevice_GetSubGroupSizes(
             self._device_ref, &sg_sizes_len)
         if (sg_sizes is not NULL and sg_sizes_len > 0):
-            res = list()
+            res = []
             for i in range(sg_sizes_len):
                 res.append(sg_sizes[i])
             DPCTLSize_t_Array_Delete(sg_sizes)

--- a/dpctl/_sycl_device_factory.pyx
+++ b/dpctl/_sycl_device_factory.pyx
@@ -416,7 +416,7 @@ cdef class _DefaultDeviceCache:
     cdef dict __device_map__
 
     def __cinit__(self):
-        self.__device_map__ = dict()
+        self.__device_map__ = {}
 
     cdef get_or_create(self):
         """Return instance of SyclDevice and indicator if cache

--- a/dpctl/_sycl_queue_manager.pyx
+++ b/dpctl/_sycl_queue_manager.pyx
@@ -35,7 +35,7 @@ cdef class _DeviceDefaultQueueCache:
     cdef dict __device_queue_map__
 
     def __cinit__(self):
-        self.__device_queue_map__ = dict()
+        self.__device_queue_map__ = {}
 
     def get_or_create(self, key):
         """Return instance of SyclQueue and indicator if cache

--- a/dpctl/_sycl_timer.py
+++ b/dpctl/_sycl_timer.py
@@ -190,7 +190,7 @@ class SyclTimer:
         self.queue = None
         self.host_times = []
         self.bracketing_events = []
-        self._context_data = list()
+        self._context_data = []
         if device_timer is None:
             device_timer = "queue_barrier"
         if device_timer == "queue_barrier":

--- a/dpctl/tests/helper/_helper.py
+++ b/dpctl/tests/helper/_helper.py
@@ -43,7 +43,7 @@ def create_invalid_capsule():
     return ctor(id(ctor), b"invalid", 0)
 
 
-def get_queue_or_skip(args=tuple()):
+def get_queue_or_skip(args=()):
     try:
         q = dpctl.SyclQueue(*args)
     except dpctl.SyclQueueCreationError:

--- a/dpctl/tests/test_sycl_device.py
+++ b/dpctl/tests/test_sycl_device.py
@@ -405,7 +405,7 @@ def test_peer_device_arg_validation(method):
         dev = dpctl.SyclDevice()
     except dpctl.SyclDeviceCreationError:
         pytest.skip("No default device available")
-    bad_dev = dict()
+    bad_dev = {}
     callable = getattr(dev, method)
     with pytest.raises(TypeError):
         callable(bad_dev)

--- a/dpctl/tests/test_sycl_event.py
+++ b/dpctl/tests/test_sycl_event.py
@@ -70,7 +70,7 @@ def test_create_event_from_capsule():
 
 def test_invalid_constructor_arg():
     with pytest.raises(TypeError):
-        dpctl.SyclEvent(list())
+        dpctl.SyclEvent([])
 
 
 def test_wait_with_event():

--- a/dpctl/tests/test_sycl_queue.py
+++ b/dpctl/tests/test_sycl_queue.py
@@ -209,7 +209,7 @@ def test_queue_invalid_property():
     with pytest.raises(ValueError):
         dpctl.SyclQueue(property=4.5)
     with pytest.raises(ValueError):
-        dpctl.SyclQueue(property=["abc", tuple()])
+        dpctl.SyclQueue(property=["abc", ()])
 
 
 def test_queue_capsule():
@@ -345,13 +345,13 @@ def test_queue_memops():
     q.prefetch(m1, 512)
     q.mem_advise(m1, 512, 0)
     with pytest.raises(TypeError):
-        q.memcpy(m1, list(), 512)
+        q.memcpy(m1, [], 512)
     with pytest.raises(TypeError):
-        q.memcpy(list(), m2, 512)
+        q.memcpy([], m2, 512)
     with pytest.raises(TypeError):
-        q.prefetch(list(), 512)
+        q.prefetch([], 512)
     with pytest.raises(TypeError):
-        q.mem_advise(list(), 512, 0)
+        q.mem_advise([], 512, 0)
 
 
 @pytest.fixture(scope="session")

--- a/dpctl/tests/test_sycl_usm.py
+++ b/dpctl/tests/test_sycl_usm.py
@@ -265,7 +265,7 @@ def test_usm_type_exceptions():
     with pytest.raises(TypeError):
         m.get_usm_type(syclobj=Ellipsis)
     with pytest.raises(TypeError):
-        m.get_usm_type_enum(syclobj=list())
+        m.get_usm_type_enum(syclobj=[])
 
 
 def test_sycl_usm_array_interface(memory_ctor):
@@ -419,7 +419,7 @@ def test_suai_invalid_suai():
     # data validation
     def invalid_data(suai_iface):
         "Set data to invalid"
-        suai_iface["data"] = tuple()
+        suai_iface["data"] = ()
         return suai_iface
 
     v = View(

--- a/dpctl/tests/test_utils.py
+++ b/dpctl/tests/test_utils.py
@@ -61,7 +61,7 @@ def test_intel_device_info():
 
 
 def test_intel_device_info_validation():
-    invalid_device = dict()
+    invalid_device = {}
     with pytest.raises(TypeError):
         dpctl.utils.intel_device_info(invalid_device)
 

--- a/dpctl/utils/_intel_device_info.py
+++ b/dpctl/utils/_intel_device_info.py
@@ -105,7 +105,7 @@ def intel_device_info(dev, /):
         if mbw:
             res["memory_bus_width"] = mbw
         return res
-    return dict()
+    return {}
 
 
 __all__ = [


### PR DESCRIPTION
This PR updates and makes consistent formatting in the project, by opting to replace all calls to the named constructors of empty Python data structures (`list()`, `dict()`, and `tuple()`) with their simpler constructors (`[]`, `{}`, `()`).

- [X] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [X] Have you tested your changes locally for CPU and GPU devices?
- [X] Have you made sure that new changes do not introduce compiler warnings?
- [X] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [ ] Have you added your changes to the changelog?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
