### PR TITLE
Fix memory leak in `RawKernelArg`

### DIFF
--- a/dpctl/_sycl_queue.pyx
+++ b/dpctl/_sycl_queue.pyx
@@ -1753,7 +1753,7 @@ cdef class WorkGroupMemory:
 
 
 cdef class _RawKernelArg:
-    def __dealloc(self):
+    def __dealloc__(self):
         if(self._arg_ref):
             DPCTLRawKernelArg_Delete(self._arg_ref)
 


### PR DESCRIPTION
The `__dealloc__` method was written as `__dealloc`, so would not be recognized as the deallocator by Cython, meaning it has been leaking memory from C

- [X] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [ ] Have you added your changes to the changelog?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
