### PR TITLE
Use work-around for Coverage workflow

### DIFF
--- a/.github/workflows/conda-package.yml
+++ b/.github/workflows/conda-package.yml
@@ -19,7 +19,7 @@ env:
 
 jobs:
   build_linux:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     timeout-minutes: 90
 
     strategy:
@@ -133,8 +133,7 @@ jobs:
         env:
           OVERRIDE_INTEL_IPO: 1   # IPO requires more resources that GH actions VM provides
         run: |
-          # TODO: roll back use of Intel channel when 2025.1 is available on conda-forge
-          conda build --no-test --python ${{ matrix.python }} --numpy 2.0 -c ${{ env.INTEL_CHANNEL }} -c conda-forge --override-channels conda-recipe
+          conda build --no-test --python ${{ matrix.python }} --numpy 2.0 -c conda-forge --override-channels conda-recipe
 
       - name: Upload artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -157,7 +156,7 @@ jobs:
       matrix:
         python: ['3.10', '3.11', '3.12', '3.13', '3.14']
         experimental: [false]
-        runner: [ubuntu-22.04]
+        runner: [ubuntu-latest]
     continue-on-error: ${{ matrix.experimental }}
 
     steps:
@@ -244,7 +243,7 @@ jobs:
 
   test_windows:
     needs: build_windows
-    runs-on:  ${{ matrix.runner }}
+    runs-on: ${{ matrix.runner }}
     timeout-minutes: 60
     defaults:
       run:
@@ -417,7 +416,7 @@ jobs:
     if: |
       (github.repository == 'IntelPython/dpctl') &&
       (github.ref == 'refs/heads/master' || (startsWith(github.ref, 'refs/heads/release') == true) || github.event_name == 'push' && contains(github.ref, 'refs/tags/'))
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     timeout-minutes: 20
     strategy:
       matrix:
@@ -506,12 +505,12 @@ jobs:
 
   test_examples_linux:
     needs: build_linux
-    runs-on:  ${{ matrix.runner }}
+    runs-on: ${{ matrix.runner }}
     strategy:
       matrix:
         python: ['3.11']
         experimental: [false]
-        runner: [ubuntu-22.04]
+        runner: [ubuntu-latest]
     continue-on-error: ${{ matrix.experimental }}
     timeout-minutes: 60
     env:
@@ -572,7 +571,8 @@ jobs:
       - name: Install example requirements
         shell: bash -ex -l {0}
         env:
-          DPCPP_CMPLR: "dpcpp_linux-64>=2025.0"
+          # TODO: unpin when 2026.0 is available on conda-forge
+          DPCPP_CMPLR: "dpcpp_linux-64>=2025.0,<2026.0"
         run: |
           CHANNELS="${{ env.CHANNELS }}"
           . $CONDA/etc/profile.d/conda.sh
@@ -589,7 +589,7 @@ jobs:
               $CHANNELS || exit 1
           echo "IPL installed"
           conda create -y -n ${{ env.BUILD_ENV_NAME }} $CHANNELS gcc_linux-64 gxx_linux-64 \
-              ${{ env.DPCPP_CMPLR }} "${DPCTL_DEPENDS}" \
+              "${{ env.DPCPP_CMPLR }}" "${DPCTL_DEPENDS}" \
               "sysroot_linux-64>=2.28"
           echo "Compiler installed"
           conda list -n ${{ env.BUILD_ENV_NAME }}

--- a/.github/workflows/conda-package.yml
+++ b/.github/workflows/conda-package.yml
@@ -599,7 +599,7 @@ jobs:
           source $CONDA/etc/profile.d/conda.sh
           CHANNELS="-c $GITHUB_WORKSPACE/channel -c dppy/label/dev -c ${{ env.INTEL_CHANNEL }} -c conda-forge --override-channels"
           export PACKAGE_VERSION=$(python -c "${VER_SCRIPT1} ${VER_SCRIPT2}")
-          conda install -n ${{ env.EXAMPLES_ENV_NAME }} -y ${CHANNELS} dpctl=${PACKAGE_VERSION} dpnp || exit 1
+          conda install -n ${{ env.EXAMPLES_ENV_NAME }} -y ${CHANNELS} dpctl=${PACKAGE_VERSION} || exit 1
       - name: Build and run examples of pybind11 extensions
         shell: bash -l {0}
         run: |

--- a/.github/workflows/generate-coverage.yaml
+++ b/.github/workflows/generate-coverage.yaml
@@ -34,7 +34,8 @@ jobs:
 
       - name: Install latest Intel OneAPI
         run: |
-          sudo apt install intel-oneapi-compiler-dpcpp-cpp
+          # TODO: drop 2025.3 requirement when coverage build segfault is resolved
+          sudo apt install intel-oneapi-compiler-dpcpp-cpp-2025.3
           sudo apt install intel-oneapi-tbb
           sudo apt install intel-oneapi-umf
           sudo apt install hwloc

--- a/.github/workflows/generate-coverage.yaml
+++ b/.github/workflows/generate-coverage.yaml
@@ -51,7 +51,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
-          python-version: '3.12'
+          python-version: '3.14'
           architecture: x64
 
       - name: Cache Gtest

--- a/scripts/gen_coverage.py
+++ b/scripts/gen_coverage.py
@@ -158,6 +158,7 @@ def main():
         cxx_compiler=cxx_compiler,
         level_zero=level_zero_enabled,
         verbose=args.verbose,
+        other_opts=args.cmake_opts,
     )
 
     cmake_args += ["-DDPCTL_GENERATE_COVERAGE=ON"]

--- a/scripts/gen_docs.py
+++ b/scripts/gen_docs.py
@@ -135,6 +135,7 @@ def main():
         cxx_compiler=cxx_compiler,
         level_zero=level_zero_enabled,
         verbose=args.verbose,
+        other_opts=args.cmake_opts,
     )
 
     cmake_args += ["-DDPCTL_GENERATE_DOCS=ON"]


### PR DESCRIPTION
Coverage currently segfaults due to segfault when building with oneAPI 2026.0

As a work-around, use 2025.3 until the issue is resolved. Slips in a change bumping coverage workflow to Python 3.14 and making `--cmake-opts` actually work in `gen_coverage` and `gen_docs` scripts, an issue which was observed during reproduction of the crash.

- [X] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [ ] Have you added your changes to the changelog?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
