### PR TITLE
Remove work-around in `dpctl.SyclPlatform.get_devices` for `custom` and `automatic` device types

### DIFF
--- a/dpctl/_sycl_platform.pyx
+++ b/dpctl/_sycl_platform.pyx
@@ -415,19 +415,27 @@ cdef class SyclPlatform(_SyclPlatform):
                 DTy = _device_type._ACCELERATOR
             elif dty_str == "all":
                 DTy = _device_type._ALL_DEVICES
+            elif dty_str == "automatic":
+                DTy = _device_type._AUTOMATIC
             elif dty_str == "cpu":
                 DTy = _device_type._CPU
+            elif dty_str == "custom":
+                DTy = _device_type._CUSTOM
             elif dty_str == "gpu":
                 DTy = _device_type._GPU
             else:
                 DTy = _device_type._UNKNOWN_DEVICE
         elif isinstance(device_type, device_type_t):
-            if device_type == device_type_t.all:
-                DTy = _device_type._ALL_DEVICES
-            elif device_type == device_type_t.accelerator:
+            if device_type == device_type_t.accelerator:
                 DTy = _device_type._ACCELERATOR
+            elif device_type == device_type_t.all:
+                DTy = _device_type._ALL_DEVICES
+            elif device_type == device_type_t.automatic:
+                DTy = _device_type._AUTOMATIC
             elif device_type == device_type_t.cpu:
                 DTy = _device_type._CPU
+            elif device_type == device_type_t.custom:
+                DTy = _device_type._CUSTOM
             elif device_type == device_type_t.gpu:
                 DTy = _device_type._GPU
             else:

--- a/libsyclinterface/source/dpctl_sycl_platform_interface.cpp
+++ b/libsyclinterface/source/dpctl_sycl_platform_interface.cpp
@@ -300,10 +300,6 @@ DPCTLPlatform_GetDevices(__dpctl_keep const DPCTLSyclPlatformRef PRef,
         return nullptr;
     }
 
-    // handle unknown device
-    // custom and automatic are also treated as unknown
-    // as DPC++ would normally treat as `all`
-    // see CMPLRLLVM-65826
     if (DTy == DPCTLSyclDeviceType::DPCTL_UNKNOWN_DEVICE) {
         return wrap<vecTy>(DevicesVectorPtr);
     }


### PR DESCRIPTION
This PR removes a work-around added to `dpctl.SyclPlatform.get_devices` due to a bug in the implementation, where the device types "automatic" and "custom" would return "all"

To work-around, these were treated as "unknown" and returned an empty list instead of a full list

The work-around is no longer necessary

- [X] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [ ] Have you added your changes to the changelog?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
