### PR TITLE
Avoid warnings from Unified Runtime Level Zero adapter

### DIFF
--- a/libsyclinterface/source/dpctl_sycl_platform_interface.cpp
+++ b/libsyclinterface/source/dpctl_sycl_platform_interface.cpp
@@ -304,6 +304,15 @@ DPCTLPlatform_GetDevices(__dpctl_keep const DPCTLSyclPlatformRef PRef,
         return wrap<vecTy>(DevicesVectorPtr);
     }
 
+    DPCTLSyclBackendType BTy =
+        DPCTL_SyclBackendToDPCTLBackendType(P->get_backend());
+    if (DTy == DPCTLSyclDeviceType::DPCTL_CUSTOM &&
+        BTy == DPCTLSyclBackendType::DPCTL_LEVEL_ZERO)
+    {
+        // avoid ugly warnings from unified runtime
+        return wrap<vecTy>(DevicesVectorPtr);
+    }
+
     try {
         auto SyclDTy = DPCTL_DPCTLDeviceTypeToSyclDeviceType(DTy);
         auto Devices = P->get_devices(SyclDTy);


### PR DESCRIPTION
This PR proposes adding a backend check in the C API for `SyclPlatform.get_devices`, to avoid a warning from the unified runtime

The warning is raised when `device_type::custom` is requested. The UR LZ adapter has no concept of custom, causing it to warn that the device type is unknown

- [X] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [ ] Have you added your changes to the changelog?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
