### PR TITLE
[MAINT] Unpin compiler in `test_examples` workflow step

### DIFF
--- a/.github/workflows/conda-package.yml
+++ b/.github/workflows/conda-package.yml
@@ -561,8 +561,7 @@ jobs:
       - name: Install example requirements
         shell: bash -ex -l {0}
         env:
-          # TODO: unpin when 2026.0 is available on conda-forge
-          DPCPP_CMPLR: "dpcpp_linux-64>=2025.0,<2026.0"
+          DPCPP_CMPLR: "dpcpp_linux-64>=2026.0"
         run: |
           export CHANNELS="${{ env.CHANNELS }}"
           . "$CONDA/etc/profile.d/conda.sh"


### PR DESCRIPTION
As 2026.0 compiler is now on conda-forge, we can unpin here

- [X] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [ ] Have you added your changes to the changelog?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
