### PR TITLE
Fix documentation build warnings and errors

### DIFF
--- a/docs/doc_sources/api_reference/dpctl/index.rst
+++ b/docs/doc_sources/api_reference/dpctl/index.rst
@@ -96,4 +96,5 @@
 .. toctree::
     :hidden:
 
+    constants
     filter_selector_string

--- a/docs/doc_sources/api_reference/dpctl/utils.rst
+++ b/docs/doc_sources/api_reference/dpctl/utils.rst
@@ -7,14 +7,15 @@
 
 .. currentmodule:: dpctl.utils
 
-.. autofunction:: get_execution_queue
-
-.. autofunction:: get_coerced_usm_type
-
-.. autofunction:: validate_usm_type
-
 .. autofunction:: onetrace_enabled
 
 .. autofunction:: intel_device_info
 
-.. autoexception:: ExecutionPlacementError
+.. data:: SequentialOrderManager
+
+    Thread-local instance of
+    :class:`~dpctl.utils._order_manager.SyclQueueToOrderManagerMap` used to
+    ensure sequential ordering of tasks offloaded to a :class:`dpctl.SyclQueue`.
+
+.. autoclass:: dpctl.utils._order_manager.SyclQueueToOrderManagerMap
+    :members:

--- a/docs/doc_sources/api_reference/dpctl/utils.rst
+++ b/docs/doc_sources/api_reference/dpctl/utils.rst
@@ -13,9 +13,5 @@
 
 .. data:: SequentialOrderManager
 
-    Thread-local instance of
-    :class:`~dpctl.utils._order_manager.SyclQueueToOrderManagerMap` used to
-    ensure sequential ordering of tasks offloaded to a :class:`dpctl.SyclQueue`.
-
-.. autoclass:: dpctl.utils._order_manager.SyclQueueToOrderManagerMap
-    :members:
+    Thread-local object mapping each :class:`dpctl.SyclQueue` to an order
+    manager, used to ensure sequential ordering of offloaded tasks.

--- a/docs/doc_sources/api_reference/dpctl_capi.rst
+++ b/docs/doc_sources/api_reference/dpctl_capi.rst
@@ -177,7 +177,7 @@ API for :c:struct:`PySyclKernelObject`
 
 
 API for :c:struct:`PySyclKernelBundleObject`
----------------------------------------
+--------------------------------------------
 
 .. c:function:: DPCTLSyclKernelBundleRef SyclKernelBundle_GetKernelBundleRef(struct PySyclKernelBundleObject *prog)
 

--- a/docs/doc_sources/beginners_guides/installation.rst
+++ b/docs/doc_sources/beginners_guides/installation.rst
@@ -217,6 +217,7 @@ one architecture can be specified at a time.
 To determine the architecture code (``<arch>``) for your AMD GPU, run:
 
 .. code-block:: bash
+
     rocminfo | grep 'Name: *gfx.*'
 
 This will print names like ``gfx90a``, ``gfx1030``, etc.
@@ -225,6 +226,7 @@ You can then use one of them as the argument to ``--target-hip``.
 For example:
 
 .. code-block:: bash
+
     python scripts/build_locally.py --verbose --target-hip=gfx1030
 
 Alternatively, you can use the ``DPCTL_TARGET_HIP`` CMake option:

--- a/docs/doc_sources/user_guides/environment_variables.rst
+++ b/docs/doc_sources/user_guides/environment_variables.rst
@@ -42,7 +42,7 @@ The value of the variable is a bit-mask, with the following supported values:
 .. _env_var_ze_flat_device_hierarchy:
 
 Variable ``ZE_FLAT_DEVICE_HIERARCHY``
---------------------------
+-------------------------------------
 Allows users to define the device hierarchy model exposed by Level Zero driver implementation.
 Keep in mind :py:mod:`dpctl.get_composite_devices` will only work while this is set to ``COMBINED``.
 
@@ -79,7 +79,7 @@ Therefore, we could use the second tile in each of four dual-tile GPUs with ``ZE
 Additional examples to illustrate this are in the detailed documentation for ``ZE_AFFINITY_MASK``, read more about it in `Level Zero Specification <https://oneapi-src.github.io/level-zero-spec/level-zero/latest/core/PROG.html#affinity-mask>`_.
 
 Variable ``ZE_ENABLE_PCI_ID_DEVICE_ORDER``
--------------------------------
+------------------------------------------
 Forces driver to report devices from lowest to highest PCI bus ID.
 
 .. list-table::
@@ -93,7 +93,7 @@ Forces driver to report devices from lowest to highest PCI bus ID.
       - Enabled.
 
 Variable ``ZE_SHARED_FORCE_DEVICE_ALLOC``
--------------------------------
+-----------------------------------------
 Forces all shared allocations into device memory
 
 .. list-table::

--- a/docs/doc_sources/user_guides/environment_variables.rst
+++ b/docs/doc_sources/user_guides/environment_variables.rst
@@ -58,7 +58,7 @@ Keep in mind :py:mod:`dpctl.get_composite_devices` will only work while this is 
     * - ``FLAT``
       - Level Zero devices with multiple tiles will be exposed as a set of root devices, each corresponding to an individual tile. Enabled by default.
 
-Read more about device hierarchy in `Level Zero Specification <https://oneapi-src.github.io/level-zero-spec/level-zero/latest/core/PROG.html#device-hierarchy>`_ and `Intel GPU article <https://www.intel.com/content/www/us/en/developer/articles/technical/flattening-gpu-tile-hierarchy.html>`_.
+Read more about device hierarchy in `Level Zero Specification <https://oneapi-src.github.io/level-zero-spec/level-zero/latest/core/PROG.html#device-hierarchy>`__ and `Intel GPU article <https://www.intel.com/content/www/us/en/developer/articles/technical/flattening-gpu-tile-hierarchy.html>`__.
 
 Variable ``ZE_AFFINITY_MASK``
 -------------------------------
@@ -76,7 +76,7 @@ Therefore, we could use the second tile in each of four dual-tile GPUs with ``ZE
 | **If the exposed tiles belong to different physical devices:**
 | - A composite device is available for each physical device, and the tiles are accessible as component devices of their respective composite device.
 
-Additional examples to illustrate this are in the detailed documentation for ``ZE_AFFINITY_MASK``, read more about it in `Level Zero Specification <https://oneapi-src.github.io/level-zero-spec/level-zero/latest/core/PROG.html#affinity-mask>`_.
+Additional examples to illustrate this are in the detailed documentation for ``ZE_AFFINITY_MASK``, read more about it in `Level Zero Specification <https://oneapi-src.github.io/level-zero-spec/level-zero/latest/core/PROG.html#affinity-mask>`__.
 
 Variable ``ZE_ENABLE_PCI_ID_DEVICE_ORDER``
 ------------------------------------------


### PR DESCRIPTION
The documentation build on `master` was completing with 2 errors and 123 warnings (see [failing-ish run](https://github.com/IntelPython/dpctl/actions/runs/28956617012/job/85917173186)).
Although the job did not fail (Sphinx is not run with `-W`), several of these were silently degrading the published docs — dropping content and leaving empty API entries.

This PR fixes the Python-facing documentation defects. The build now completes with **0 errors and 108 warnings** (the remaining 108 are pre-existing Doxygen/doxyrest C-API cross-reference noise in `libsyclinterface`, tracked separately).

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [x] Have you added documentation for your changes, if necessary?
- [ ] Have you added your changes to the changelog?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
