### PR TITLE
Suppress compiler deprecation warnings on Windows

### DIFF
--- a/cmake/IntelSYCLConfig.cmake
+++ b/cmake/IntelSYCLConfig.cmake
@@ -304,7 +304,9 @@ set_property(TARGET IntelSYCL::SYCL_CXX PROPERTY
 set_property(TARGET IntelSYCL::SYCL_CXX PROPERTY
   INTERFACE_LINK_OPTIONS ${SYCL_LINK_FLAGS})
 set_property(TARGET IntelSYCL::SYCL_CXX PROPERTY
-  INTERFACE_INCLUDE_DIRECTORIES ${SYCL_INCLUDE_DIR})
+  INTERFACE_INCLUDE_DIRECTORIES $<BUILD_INTERFACE:${SYCL_INCLUDE_DIR}>)
+set_property(TARGET IntelSYCL::SYCL_CXX PROPERTY
+  INTERFACE_SYSTEM_INCLUDE_DIRECTORIES ${SYCL_INCLUDE_DIR})
 set_property(TARGET IntelSYCL::SYCL_CXX PROPERTY
   INTERFACE_LINK_DIRECTORIES ${SYCL_LIBRARY_DIR})
 
@@ -343,12 +345,13 @@ Adding sycl to all sources but that may effect compilation times")
     if(NOT SYCL_SOURCES)
       message(WARNING "add_sycl_to_target() does not have sources specified.. Adding sycl to all sources but that may effect compilation times")
       target_compile_options(${SYCL_TARGET} PUBLIC ${__sycl_cxx_options})
-      target_include_directories(${SYCL_TARGET} PUBLIC ${__sycl_cxx_include_directories})
+      target_include_directories(${SYCL_TARGET} SYSTEM PUBLIC ${__sycl_cxx_include_directories})
+    else()
+      target_include_directories(${SYCL_TARGET} SYSTEM PRIVATE ${__sycl_cxx_include_directories})
     endif()
 
     foreach(source ${SYCL_SOURCES})
       set_source_files_properties(${source} PROPERTIES COMPILE_OPTIONS "${__sycl_cxx_options}")
-      set_source_files_properties(${source} PROPERTIES INCLUDE_DIRECTORIES "${__sycl_cxx_include_directories}")
     endforeach()
 
     get_target_property(__sycl_link_options

--- a/libsyclinterface/CMakeLists.txt
+++ b/libsyclinterface/CMakeLists.txt
@@ -314,13 +314,14 @@ if(DPCTL_GENERATE_COVERAGE)
 endif()
 
 target_include_directories(DPCTLSyclInterface
-    # PUBLIC
     PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/include/syclinterface
     ${CMAKE_CURRENT_SOURCE_DIR}/include/syclinterface/Support
     ${CMAKE_CURRENT_SOURCE_DIR}/include/syclinterface/Config
-    # PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/helper/include/
+)
+target_include_directories(DPCTLSyclInterface
+    SYSTEM PRIVATE
     ${SYCL_INCLUDE_DIR}
 )
 
@@ -354,7 +355,7 @@ endif()
 
 if(DPCTL_ENABLE_L0_PROGRAM_CREATION)
     target_include_directories(DPCTLSyclInterface
-        PRIVATE
+        SYSTEM PRIVATE
         ${LEVEL_ZERO_INCLUDE_DIR}
     )
 endif()

--- a/libsyclinterface/tests/CMakeLists.txt
+++ b/libsyclinterface/tests/CMakeLists.txt
@@ -87,6 +87,9 @@ target_include_directories(dpctl_c_api_tests
     PRIVATE
     "${CMAKE_CURRENT_SOURCE_DIR}/../helper/include"
     "${CMAKE_CURRENT_SOURCE_DIR}/../include/syclinterface"
+)
+target_include_directories(dpctl_c_api_tests
+    SYSTEM PRIVATE
     ${LEVEL_ZERO_INCLUDE_DIR}
 )
 


### PR DESCRIPTION
This PR proposes suppressing deprecation warnings from within the compiler on Windows by marking headers as SYSTEM, similar to work done in https://github.com/IntelPython/dpnp/pull/2984

- [ ] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [ ] Have you added your changes to the changelog?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
