### PR TITLE
fix(ci): build free-threaded 3.14 wheels with cp314t ABI to stop upload collision

### DIFF
--- a/.github/workflows/conda-package.yml
+++ b/.github/workflows/conda-package.yml
@@ -30,7 +30,7 @@ jobs:
         python_spec: ['']
         include:
           - python: '3.14'
-            python_spec: '3.14.* *_cp314'
+            python_spec: '3.14.* *_cp314t'
     steps:
       - name: Cancel Previous Runs
         uses: styfle/cancel-workflow-action@d07a454dad7609a92316b57b23c9ccfd4f59af66 # 0.13.1
@@ -51,9 +51,9 @@ jobs:
         with:
           path: ~/.conda/pkgs
           key:
-            ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}-python-${{ matrix.python }}-spec-${{ matrix.python == '3.14' && matrix.python_spec == '' && 't' || '' }}-${{hashFiles('**/meta.yaml') }}
+            ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}-python-${{ matrix.python }}-spec-${{ matrix.python == '3.14' && contains(matrix.python_spec, 'cp314t') && 't' || '' }}-${{hashFiles('**/meta.yaml') }}
           restore-keys: |
-            ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}-python-${{ matrix.python }}-spec-${{ matrix.python == '3.14' && matrix.python_spec == '' && 't' || '' }}-
+            ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}-python-${{ matrix.python }}-spec-${{ matrix.python == '3.14' && contains(matrix.python_spec, 'cp314t') && 't' || '' }}-
             ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}-
       - name: Add conda to system path
         run: echo "$CONDA/bin" >> "$GITHUB_PATH"
@@ -84,12 +84,12 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: ${{ env.PACKAGE_NAME }} ${{ runner.os }} Python ${{ matrix.python == '3.14' && (matrix.python_spec != '' && '3.14' || '3.14t') || matrix.python }}
+          name: ${{ env.PACKAGE_NAME }} ${{ runner.os }} Python ${{ matrix.python == '3.14' && (contains(matrix.python_spec, 'cp314t') && '3.14t' || '3.14') || matrix.python }}
           path: /usr/share/miniconda/conda-bld/linux-64/${{ env.PACKAGE_NAME }}-*.conda
       - name: Upload wheels artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: ${{ env.PACKAGE_NAME }} ${{ runner.os }} Wheels Python ${{ matrix.python == '3.14' && (matrix.python_spec != '' && '3.14' || '3.14t') || matrix.python }}
+          name: ${{ env.PACKAGE_NAME }} ${{ runner.os }} Wheels Python ${{ matrix.python == '3.14' && (contains(matrix.python_spec, 'cp314t') && '3.14t' || '3.14') || matrix.python }}
           path: ${{ env.WHEELS_OUTPUT_FOLDER }}${{ env.PACKAGE_NAME }}-*.whl
 
   build_windows:
@@ -105,7 +105,7 @@ jobs:
         python_spec: ['']
         include:
           - python: '3.14'
-            python_spec: '3.14.* *_cp314'
+            python_spec: '3.14.* *_cp314t'
     steps:
       - name: Cancel Previous Runs
         uses: styfle/cancel-workflow-action@d07a454dad7609a92316b57b23c9ccfd4f59af66 # 0.13.1
@@ -131,9 +131,9 @@ jobs:
         with:
           path: /home/runner/conda_pkgs_dir
           key:
-            ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}-python-${{ matrix.python }}-spec-${{ matrix.python == '3.14' && matrix.python_spec == '' && 't' || '' }}-${{hashFiles('**/meta.yaml') }}
+            ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}-python-${{ matrix.python }}-spec-${{ matrix.python == '3.14' && contains(matrix.python_spec, 'cp314t') && 't' || '' }}-${{hashFiles('**/meta.yaml') }}
           restore-keys: |
-            ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}-python-${{ matrix.python }}-spec-${{ matrix.python == '3.14' && matrix.python_spec == '' && 't' || '' }}-
+            ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}-python-${{ matrix.python }}-spec-${{ matrix.python == '3.14' && contains(matrix.python_spec, 'cp314t') && 't' || '' }}-
             ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}-
       - name: Store conda paths as envs
         shell: bash -l {0}
@@ -160,13 +160,13 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: ${{ env.PACKAGE_NAME }} ${{ runner.os }} Python ${{ matrix.python == '3.14' && (matrix.python_spec != '' && '3.14' || '3.14t') || matrix.python }}
+          name: ${{ env.PACKAGE_NAME }} ${{ runner.os }} Python ${{ matrix.python == '3.14' && (contains(matrix.python_spec, 'cp314t') && '3.14t' || '3.14') || matrix.python }}
           path: ${{ env.CONDA_BLD }}${{ env.PACKAGE_NAME }}-*.conda
 
       - name: Upload wheels artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: ${{ env.PACKAGE_NAME }} ${{ runner.os }} Wheels Python ${{ matrix.python == '3.14' && (matrix.python_spec != '' && '3.14' || '3.14t') || matrix.python }}
+          name: ${{ env.PACKAGE_NAME }} ${{ runner.os }} Wheels Python ${{ matrix.python == '3.14' && (contains(matrix.python_spec, 'cp314t') && '3.14t' || '3.14') || matrix.python }}
           path: ${{ env.WHEELS_OUTPUT_FOLDER }}${{ env.PACKAGE_NAME }}-*.whl
 
   test_linux:
@@ -180,7 +180,7 @@ jobs:
         python_spec: ['']
         include:
           - python: '3.14'
-            python_spec: '3.14.* *_cp314'
+            python_spec: '3.14.* *_cp314t'
             experimental: false
             runner: ubuntu-22.04
         experimental: [false]
@@ -197,7 +197,7 @@ jobs:
       - name: Download artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          name: ${{ env.PACKAGE_NAME }} ${{ runner.os }} Python ${{ matrix.python == '3.14' && (matrix.python_spec != '' && '3.14' || '3.14t') || matrix.python }}
+          name: ${{ env.PACKAGE_NAME }} ${{ runner.os }} Python ${{ matrix.python == '3.14' && (contains(matrix.python_spec, 'cp314t') && '3.14t' || '3.14') || matrix.python }}
       - name: Add conda to system path
         run: echo "$CONDA/bin" >> "$GITHUB_PATH"
       - name: Update conda
@@ -244,9 +244,9 @@ jobs:
         with:
           path: ~/.conda/pkgs
           key:
-            ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}-python-${{ matrix.python }}-spec-${{ matrix.python == '3.14' && matrix.python_spec == '' && 't' || '' }}-${{hashFiles('lockfile') }}
+            ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}-python-${{ matrix.python }}-spec-${{ matrix.python == '3.14' && contains(matrix.python_spec, 'cp314t') && 't' || '' }}-${{hashFiles('lockfile') }}
           restore-keys: |
-            ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}-python-${{ matrix.python }}-spec-${{ matrix.python == '3.14' && matrix.python_spec == '' && 't' || '' }}-
+            ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}-python-${{ matrix.python }}-spec-${{ matrix.python == '3.14' && contains(matrix.python_spec, 'cp314t') && 't' || '' }}-
             ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}-
       - name: Install dpctl
         run: |
@@ -295,7 +295,7 @@ jobs:
         python_spec: ['']
         include:
           - python: '3.14'
-            python_spec: '3.14.* *_cp314'
+            python_spec: '3.14.* *_cp314t'
             experimental: false
             runner: windows-latest
         experimental: [false]
@@ -317,7 +317,7 @@ jobs:
       - name: Download artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          name: ${{ env.PACKAGE_NAME }} ${{ runner.os }} Python ${{ matrix.python == '3.14' && (matrix.python_spec != '' && '3.14' || '3.14t') || matrix.python }}
+          name: ${{ env.PACKAGE_NAME }} ${{ runner.os }} Python ${{ matrix.python == '3.14' && (contains(matrix.python_spec, 'cp314t') && '3.14t' || '3.14') || matrix.python }}
 
       - uses: conda-incubator/setup-miniconda@8ee1f361103df19b6f8c8655fd3967a8ecb162d5 # v4.0.1
         with:
@@ -397,9 +397,9 @@ jobs:
         with:
           path: /home/runner/conda_pkgs_dir
           key:
-            ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}-python-${{ matrix.python }}-spec-${{ matrix.python == '3.14' && matrix.python_spec == '' && 't' || '' }}-${{hashFiles('lockfile') }}
+            ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}-python-${{ matrix.python }}-spec-${{ matrix.python == '3.14' && contains(matrix.python_spec, 'cp314t') && 't' || '' }}-${{hashFiles('lockfile') }}
           restore-keys: |
-            ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}-python-${{ matrix.python }}-spec-${{ matrix.python == '3.14' && matrix.python_spec == '' && 't' || '' }}-
+            ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}-python-${{ matrix.python }}-spec-${{ matrix.python == '3.14' && contains(matrix.python_spec, 'cp314t') && 't' || '' }}-
             ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}-
 
       - name: Install opencl_rt
@@ -484,17 +484,17 @@ jobs:
         python_spec: ['']
         include:
           - python: '3.14'
-            python_spec: '3.14.* *_cp314'
+            python_spec: '3.14.* *_cp314t'
     steps:
       - name: Download conda artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          name: ${{ env.PACKAGE_NAME }} ${{ runner.os }} Python ${{ matrix.python == '3.14' && (matrix.python_spec != '' && '3.14' || '3.14t') || matrix.python }}
+          name: ${{ env.PACKAGE_NAME }} ${{ runner.os }} Python ${{ matrix.python == '3.14' && (contains(matrix.python_spec, 'cp314t') && '3.14t' || '3.14') || matrix.python }}
 
       - name: Download wheel artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          name: ${{ env.PACKAGE_NAME }} ${{ runner.os }} Wheels Python ${{ matrix.python == '3.14' && (matrix.python_spec != '' && '3.14' || '3.14t') || matrix.python }}
+          name: ${{ env.PACKAGE_NAME }} ${{ runner.os }} Wheels Python ${{ matrix.python == '3.14' && (contains(matrix.python_spec, 'cp314t') && '3.14t' || '3.14') || matrix.python }}
 
       - name: Install anaconda-client
         run: conda install anaconda-client -c conda-forge --override-channels
@@ -531,17 +531,17 @@ jobs:
         python_spec: ['']
         include:
           - python: '3.14'
-            python_spec: '3.14.* *_cp314'
+            python_spec: '3.14.* *_cp314t'
     steps:
       - name: Download artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          name: ${{ env.PACKAGE_NAME }} ${{ runner.os }} Python ${{ matrix.python == '3.14' && (matrix.python_spec != '' && '3.14' || '3.14t') || matrix.python }}
+          name: ${{ env.PACKAGE_NAME }} ${{ runner.os }} Python ${{ matrix.python == '3.14' && (contains(matrix.python_spec, 'cp314t') && '3.14t' || '3.14') || matrix.python }}
 
       - name: Download wheel artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          name: ${{ env.PACKAGE_NAME }} ${{ runner.os }} Wheels Python ${{ matrix.python == '3.14' && (matrix.python_spec != '' && '3.14' || '3.14t') || matrix.python }}
+          name: ${{ env.PACKAGE_NAME }} ${{ runner.os }} Wheels Python ${{ matrix.python == '3.14' && (contains(matrix.python_spec, 'cp314t') && '3.14t' || '3.14') || matrix.python }}
 
       - uses: conda-incubator/setup-miniconda@8ee1f361103df19b6f8c8655fd3967a8ecb162d5 # v4.0.1
         with:
@@ -578,7 +578,7 @@ jobs:
         runner: [ubuntu-latest]
         include:
           - python: '3.14'
-            python_spec: '3.14.* *_cp314'
+            python_spec: '3.14.* *_cp314t'
             experimental: false
             runner: ubuntu-latest
     continue-on-error: ${{ matrix.experimental }}
@@ -606,7 +606,7 @@ jobs:
       - name: Download artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          name: ${{ env.PACKAGE_NAME }} ${{ runner.os }} Python ${{ matrix.python == '3.14' && (matrix.python_spec != '' && '3.14' || '3.14t') || matrix.python }}
+          name: ${{ env.PACKAGE_NAME }} ${{ runner.os }} Python ${{ matrix.python == '3.14' && (contains(matrix.python_spec, 'cp314t') && '3.14t' || '3.14') || matrix.python }}
       - name: Add conda to system path
         run: echo "$CONDA/bin" >> "$GITHUB_PATH"
       - name: Create conda channel
@@ -642,9 +642,9 @@ jobs:
         with:
           path: ~/.conda/pkgs
           key:
-            ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}-python-${{ matrix.python }}-spec-${{ matrix.python == '3.14' && matrix.python_spec == '' && 't' || '' }}-${{hashFiles('lockfile') }}
+            ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}-python-${{ matrix.python }}-spec-${{ matrix.python == '3.14' && contains(matrix.python_spec, 'cp314t') && 't' || '' }}-${{hashFiles('lockfile') }}
           restore-keys: |
-            ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}-python-${{ matrix.python }}-spec-${{ matrix.python == '3.14' && matrix.python_spec == '' && 't' || '' }}-
+            ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}-python-${{ matrix.python }}-spec-${{ matrix.python == '3.14' && contains(matrix.python_spec, 'cp314t') && 't' || '' }}-
             ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}-
       - name: Install example requirements
         shell: bash -ex -l {0}

--- a/.github/workflows/run-tests-from-dppy-bits.yaml
+++ b/.github/workflows/run-tests-from-dppy-bits.yaml
@@ -31,7 +31,7 @@ jobs:
         python_spec: ['']
         include:
           - python: '3.14'
-            python_spec: '3.14.* *_cp314'
+            python_spec: '3.14.* *_cp314t'
         experimental: [false]
         runner: [ubuntu-22.04, ubuntu-24.04]
     continue-on-error: ${{ matrix.experimental }}
@@ -90,7 +90,7 @@ jobs:
         python_spec: ['']
         include:
           - python: '3.14'
-            python_spec: '3.14.* *_cp314'
+            python_spec: '3.14.* *_cp314t'
         experimental: [false]
         runner: [windows-latest]
 


### PR DESCRIPTION
The Python 3.14 conda/wheel build matrix intended to produce two variants — GIL-enabled (`cp314`) and free-threaded (`cp314t`) — but both entries actually built the **same** GIL interpreter. This caused the free-threading upload job to fail with a conflict, and meant **no free-threaded package was ever produced**.

The matrix used an **empty `python_spec`** for the entry it labeled `3.14t` (free-threading), relying on a bare `conda build -- python 3.14` to select the free-threaded interpreter:
```yaml
python: ['3.10', '3.11', '3.12', '3.13', '3.14']
python_spec: ['']
include:
  - python: '3.14'
    python_spec: '3.14.* *_cp314'   # GIL
```
But in conda-forge, free-threading is opt-in only — it is not the default build for a bare `python=3.14`:
* Per [PEP 779](https://peps.python.org/pep-0779/), 3.14 free-threading is "officially supported but still optional" (Phase II); making it the default is deferred to a future PEP (Phase III).
* The conda-forge global pinning matrix lists only the GIL ABI (`*_cp314`) as the default `python` variant; the free-threaded ABI (`*_cp314t`) must be requested explicitly.

So `--python 3.14` resolved to the standard cp314 interpreter — identical to the explicit `*_cp314` entry. Both jobs emitted a cp314-cp314 wheel with the same filename, colliding on upload.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [ ] Have you added your changes to the changelog?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
