### PR TITLE
add opencl-headers to meta.yaml

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -49,6 +49,7 @@ requirements:
         {% endfor %}
         # versioneer dependency
         - tomli # [py<311]
+        - opencl-headers >=2025.06.13 # [win]
     run:
         - python
         - {{ pin_compatible('intel-sycl-rt', min_pin='x.x', max_pin='x') }}


### PR DESCRIPTION
This PR applies a work-around for a missing dependency on `opencl-headers` in the `intel-sycl-rt` package, which removed the headers in fixing clobbering when installed from Intel channel alongside `ocl-icd` and `ocl-icd-system`

- [X] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [ ] Have you added your changes to the changelog?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
