### PR TITLE
[MAINT] Unpin coverage workflow

### DIFF
--- a/.github/workflows/generate-coverage.yaml
+++ b/.github/workflows/generate-coverage.yaml
@@ -34,8 +34,7 @@ jobs:
 
       - name: Install latest Intel OneAPI
         run: |
-          # TODO: drop 2025.3 requirement when coverage build segfault is resolved
-          sudo apt install intel-oneapi-compiler-dpcpp-cpp-2025.3
+          sudo apt install intel-oneapi-compiler-dpcpp-cpp
           sudo apt install intel-oneapi-tbb
           sudo apt install intel-oneapi-umf
           sudo apt install hwloc


### PR DESCRIPTION
The coverage workflow was pinned due to a break in the 2026.0 compiler, which should be fixed in 2026.1

- [X] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [ ] Have you added your changes to the changelog?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
