### PR TITLE
Remove `sub_group_independent_forward_progress` device info query

### DIFF
--- a/dpctl/_backend.pxd
+++ b/dpctl/_backend.pxd
@@ -234,9 +234,6 @@ cdef extern from "syclinterface/dpctl_sycl_device_interface.h":
     cdef bool DPCTLDevice_IsAccelerator(const DPCTLSyclDeviceRef DRef)
     cdef bool DPCTLDevice_IsCPU(const DPCTLSyclDeviceRef DRef)
     cdef bool DPCTLDevice_IsGPU(const DPCTLSyclDeviceRef DRef)
-    cdef bool DPCTLDevice_GetSubGroupIndependentForwardProgress(
-        const DPCTLSyclDeviceRef DRef
-    )
     cdef uint32_t DPCTLDevice_GetPreferredVectorWidthChar(
         const DPCTLSyclDeviceRef DRef
     )

--- a/dpctl/_sycl_device.pyx
+++ b/dpctl/_sycl_device.pyx
@@ -99,7 +99,6 @@ from ._backend cimport (  # noqa: E211
     DPCTLDevice_GetPreferredVectorWidthShort,
     DPCTLDevice_GetProfilingTimerResolution,
     DPCTLDevice_GetSingleFPConfig,
-    DPCTLDevice_GetSubGroupIndependentForwardProgress,
     DPCTLDevice_GetSubGroupSizes,
     DPCTLDevice_GetVendor,
     DPCTLDevice_GetVendorId,
@@ -1245,20 +1244,6 @@ cdef class SyclDevice(_SyclDevice):
             DPCTLDevice_GetMaxNumSubGroups(self._device_ref)
         )
         return max_num_sub_groups
-
-    @property
-    def sub_group_independent_forward_progress(self):
-        """ Returns ``True`` if the device supports independent forward progress
-        of sub-groups with respect to other sub-groups in the same work-group.
-
-        Returns:
-            bool:
-                Indicates if the device supports independent forward progress
-                of sub-groups.
-        """
-        return DPCTLDevice_GetSubGroupIndependentForwardProgress(
-            self._device_ref
-        )
 
     @property
     def sub_group_sizes(self):

--- a/dpctl/tests/_device_attributes_checks.py
+++ b/dpctl/tests/_device_attributes_checks.py
@@ -322,13 +322,6 @@ def check_image_3d_max_depth(device):
         pytest.fail("image_3d_max_depth call failed")
 
 
-def check_sub_group_independent_forward_progress(device):
-    try:
-        device.sub_group_independent_forward_progress
-    except Exception:
-        pytest.fail("sub_group_independent_forward_progress call failed")
-
-
 def check_preferred_vector_width_char(device):
     try:
         device.preferred_vector_width_char
@@ -812,7 +805,6 @@ list_of_checks = [
     check_is_accelerator,
     check_is_cpu,
     check_is_gpu,
-    check_sub_group_independent_forward_progress,
     check_preferred_vector_width_char,
     check_preferred_vector_width_short,
     check_preferred_vector_width_int,

--- a/libsyclinterface/include/syclinterface/dpctl_sycl_device_interface.h
+++ b/libsyclinterface/include/syclinterface/dpctl_sycl_device_interface.h
@@ -458,18 +458,6 @@ DPCTL_API
 __dpctl_give DPCTLDeviceVectorRef DPCTLDevice_CreateSubDevicesByAffinity(
     __dpctl_keep const DPCTLSyclDeviceRef DRef,
     DPCTLPartitionAffinityDomainType PartAffDomTy);
-/*!
- * @brief Wrapper over
- * device.get_info<info::device::sub_group_independent_forward_progress>.
- *
- * @param    DRef           Opaque pointer to a ``sycl::device``
- * @return   Returns true if the device supports independent forward progress of
- * sub-groups with respect to other sub-groups in the same work-group.
- * @ingroup DeviceInterface
- */
-DPCTL_API
-bool DPCTLDevice_GetSubGroupIndependentForwardProgress(
-    __dpctl_keep const DPCTLSyclDeviceRef DRef);
 
 /*!
  * @brief Wrapper over

--- a/libsyclinterface/source/dpctl_sycl_device_interface.cpp
+++ b/libsyclinterface/source/dpctl_sycl_device_interface.cpp
@@ -408,22 +408,6 @@ declmethod(GetImage3dMaxHeight, image3d_max_height, size_t);
 declmethod(GetImage3dMaxDepth, image3d_max_depth, size_t);
 #undef declmethod
 
-bool DPCTLDevice_GetSubGroupIndependentForwardProgress(
-    __dpctl_keep const DPCTLSyclDeviceRef DRef)
-{
-    bool SubGroupProgress = false;
-    auto D = unwrap<device>(DRef);
-    if (D) {
-        try {
-            SubGroupProgress = D->get_info<
-                info::device::sub_group_independent_forward_progress>();
-        } catch (std::exception const &e) {
-            error_handler(e, __FILE__, __func__, __LINE__);
-        }
-    }
-    return SubGroupProgress;
-}
-
 namespace
 {
 

--- a/libsyclinterface/tests/test_sycl_device_interface.cpp
+++ b/libsyclinterface/tests/test_sycl_device_interface.cpp
@@ -233,18 +233,6 @@ TEST_P(TestDPCTLSyclDeviceInterface, ChkIsGPU)
     EXPECT_NO_FATAL_FAILURE(DPCTLDevice_IsGPU(DRef));
 }
 
-TEST_P(TestDPCTLSyclDeviceInterface, ChkGetSubGroupIndependentForwardProgress)
-{
-    bool sub_group_progress = 0;
-    EXPECT_NO_FATAL_FAILURE(
-        sub_group_progress =
-            DPCTLDevice_GetSubGroupIndependentForwardProgress(DRef));
-    auto D = reinterpret_cast<device *>(DRef);
-    auto get_sub_group_progress =
-        D->get_info<info::device::sub_group_independent_forward_progress>();
-    EXPECT_TRUE(get_sub_group_progress == sub_group_progress);
-}
-
 TEST_P(TestDPCTLSyclDeviceInterface, ChkGetPreferredVectorWidthChar)
 {
     uint32_t vector_width_char = 0;
@@ -1001,15 +989,6 @@ TEST_F(TestDPCTLSyclDeviceNullArgs, ChkGetMaxImageDims)
     res = 0;
     EXPECT_NO_FATAL_FAILURE(res = DPCTLDevice_GetImage3dMaxDepth(Null_DRef));
     ASSERT_TRUE(res == 0);
-}
-
-TEST_F(TestDPCTLSyclDeviceNullArgs, ChkGetSubGroupIndependentForwardProgress)
-{
-    bool indep_pr = true;
-    EXPECT_NO_FATAL_FAILURE(
-        indep_pr =
-            DPCTLDevice_GetSubGroupIndependentForwardProgress(Null_DRef));
-    ASSERT_FALSE(indep_pr);
 }
 
 TEST_F(TestDPCTLSyclDeviceNullArgs, ChkGetPreferredVectorWidth)


### PR DESCRIPTION
This PR proposes the removal of the `sycl::info::device::sub_group_independent_forward_progress` query, which is now deprecated in SYCL 2020 and will be deprecated in 2026.2.0 compiler

- [X] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [ ] Have you added your changes to the changelog?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
