### PR TITLE
remove work-around from Windows build script

### DIFF
--- a/conda-recipe/bld.bat
+++ b/conda-recipe/bld.bat
@@ -1,7 +1,3 @@
-REM A workaround for activate-dpcpp.bat issue to be addressed in 2021.4
-set "LIB=%BUILD_PREFIX%\Library\lib;%BUILD_PREFIX%\compiler\lib;%LIB%"
-set "INCLUDE=%BUILD_PREFIX%\include;%INCLUDE%"
-
 "%PYTHON%" setup.py clean --all
 
 REM Overriding IPO is useful for building in resources constrained VMs (public CI)
@@ -9,7 +5,7 @@ if DEFINED OVERRIDE_INTEL_IPO (
   set "CMAKE_ARGS=%CMAKE_ARGS% -DCMAKE_INTERPROCEDURAL_OPTIMIZATION:BOOL=FALSE"
 )
 
-FOR %%V IN (17.0.0 17 18.0.0 18 19.0.0 19 20.0.0 20 21.0.0 21) DO @(
+FOR %%V IN (18.0.0 18 19.0.0 19 20.0.0 20 21.0.0 21 22.0.0 22) DO @(
   REM set DIR_HINT if directory exists
   IF EXIST "%BUILD_PREFIX%\Library\lib\clang\%%V\" (
      SET "SYCL_INCLUDE_DIR_HINT=%BUILD_PREFIX%\Library\lib\clang\%%V"


### PR DESCRIPTION
This PR proposes alignment with https://github.com/IntelPython/dpnp/pull/3013 in removing an obsolete work-around from the Windows build script

Also bumps the clang version hint (`lib/clang/22/` is present in 2026.1.1)

- [X] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [ ] Have you added your changes to the changelog?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
