### PR TITLE
Update OpenCL loader search in CMake

### DIFF
--- a/docs/doc_sources/contributor_guides/building.rst
+++ b/docs/doc_sources/contributor_guides/building.rst
@@ -186,6 +186,30 @@ You can retrieve available options and their descriptions using the option
 :code:`--help`.
 
 
+Runtime loaders when using a nightly DPC++ build
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+:py:mod:`dpctl` creates kernel bundles from OpenCL* source and from SPIR-V by
+calling into the OpenCL ICD loader and the Level Zero loader directly.
+
+The oneAPI DPC++ Compiler installation and the conda packages provide these
+loaders as dependencies. Nightly builds of the open source DPC++ toolchain,
+however, bundle neither, so they must be installed separately:
+
+- ``libOpenCL.so.1``, from the OpenCL ICD loader (for example, ``ocl-icd``
+  conda package or ``ocl-icd-libopencl1`` system package)
+- ``libze_loader.so.1``, from the Level Zero loader (for example, the
+  ``level-zero`` conda package or the ``libze1`` system package)
+
+Both can be installed from the toolchain's own dependencies. The DPC++ toolchain
+pins them in `devops/dependencies.json <https://github.com/intel/llvm/blob/sycl/devops/dependencies.json>`_,
+as the ``level_zero`` and ``oclcpu`` entries.
+
+Should a loader be installed under a different file name, override the name that
+:py:mod:`dpctl` uses with the ``LIBCL_SET_LOADER_FILENAME`` and
+``LIBZE_SET_LOADER_FILENAME`` CMake variables.
+
+
 Building the libsyclinterface Library
 =======================================
 

--- a/libsyclinterface/CMakeLists.txt
+++ b/libsyclinterface/CMakeLists.txt
@@ -48,6 +48,10 @@ set(LIBZE_SET_LOADER_FILENAME "" CACHE STRING "User-provided Level Zero Loader f
 
 set(LIBZE_DEFAULT_LOADER_FILENAME "libze_loader.so.1" CACHE STRING "Default Level Zero Loader filename")
 
+set(LIBCL_SET_LOADER_FILENAME "" CACHE STRING "User-provided OpenCL ICD Loader filename")
+
+set(LIBCL_DEFAULT_LOADER_FILENAME "libOpenCL.so.1" CACHE STRING "Default OpenCL ICD Loader filename")
+
 # Minimum version requirement only when oneAPI dpcpp is used.
 if(DPCTL_DPCPP_FROM_ONEAPI)
     find_package(IntelSyclCompiler 2021.3.0 REQUIRED)
@@ -65,21 +69,24 @@ if(DPCTL_ENABLE_L0_PROGRAM_CREATION)
     endif()
     if (UNIX)
         if ("x${LIBZE_SET_LOADER_FILENAME}" STREQUAL "x")
-            find_library(PI_LEVEL_ZERO_LIB
-                NAMES pi_level_zero ur_adapter_level_zero
+            find_library(LEVEL_ZERO_LIB
+                NAMES ur_adapter_level_zero
                 HINTS ${IntelSyclCompiler_LIBRARY_DIR}
             )
-            find_program(READELF_PROG readelf)
-            find_program(GREP_PROG grep)
-            execute_process(
-                COMMAND ${READELF_PROG} -d ${PI_LEVEL_ZERO_LIB}
-                COMMAND ${GREP_PROG} libze_loader
-                COMMAND ${GREP_PROG} -Po "libze_loader[^\]]*"
-                OUTPUT_VARIABLE LIBZE_LOADER_FILENAME
-                OUTPUT_STRIP_TRAILING_WHITESPACE
-                ERROR_STRIP_TRAILING_WHITESPACE
-            )
-            # if libze_loader is statically linked, LIBZE_LOADER_FILENAME will be an empty string
+            if (LEVEL_ZERO_LIB)
+                find_program(READELF_PROG readelf)
+                find_program(GREP_PROG grep)
+                execute_process(
+                    COMMAND ${READELF_PROG} -d ${LEVEL_ZERO_LIB}
+                    COMMAND ${GREP_PROG} libze_loader
+                    COMMAND ${GREP_PROG} -Po "libze_loader[^\]]*"
+                    OUTPUT_VARIABLE LIBZE_LOADER_FILENAME
+                    OUTPUT_STRIP_TRAILING_WHITESPACE
+                    ERROR_STRIP_TRAILING_WHITESPACE
+                )
+            endif()
+            # empty if the adapter was not found or if it links the Level Zero
+            # loader statically
             if ("x${LIBZE_LOADER_FILENAME}" STREQUAL "x")
                 set(LIBZE_LOADER_FILENAME ${LIBZE_DEFAULT_LOADER_FILENAME})
             endif()
@@ -91,20 +98,31 @@ if(DPCTL_ENABLE_L0_PROGRAM_CREATION)
 endif()
 
 if (UNIX)
-  find_library(OPENCL_LIB
-      NAMES ur_adapter_opencl OpenCL
-      HINTS ${IntelSyclCompiler_LIBRARY_DIR}
-  )
-  find_program(READELF_PROG readelf)
-  find_program(GREP_PROG grep)
-  execute_process(
-    COMMAND ${READELF_PROG} -d ${OPENCL_LIB}
-    COMMAND ${GREP_PROG} OpenCL
-    COMMAND ${GREP_PROG} -Po "libOpenCL[^\]]*"
-    OUTPUT_VARIABLE LIBCL_LOADER_FILENAME
-    OUTPUT_STRIP_TRAILING_WHITESPACE
-    ERROR_STRIP_TRAILING_WHITESPACE
-  )
+  if ("x${LIBCL_SET_LOADER_FILENAME}" STREQUAL "x")
+    find_library(OPENCL_LIB
+        NAMES ur_adapter_opencl OpenCL
+        HINTS ${IntelSyclCompiler_LIBRARY_DIR}
+    )
+    if (OPENCL_LIB)
+      find_program(READELF_PROG readelf)
+      find_program(GREP_PROG grep)
+      execute_process(
+        COMMAND ${READELF_PROG} -d ${OPENCL_LIB}
+        COMMAND ${GREP_PROG} OpenCL
+        COMMAND ${GREP_PROG} -Po "libOpenCL[^\]]*"
+        OUTPUT_VARIABLE LIBCL_LOADER_FILENAME
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+        ERROR_STRIP_TRAILING_WHITESPACE
+      )
+    endif()
+    # Empty if the adapter was not found or if it links the ICD loader
+    # statically
+    if ("x${LIBCL_LOADER_FILENAME}" STREQUAL "x")
+      set(LIBCL_LOADER_FILENAME ${LIBCL_DEFAULT_LOADER_FILENAME})
+    endif()
+  else ()
+    set(LIBCL_LOADER_FILENAME ${LIBCL_SET_LOADER_FILENAME})
+  endif()
   set(LIBCL_LOADER_FILENAME ${LIBCL_LOADER_FILENAME} PARENT_SCOPE)
 endif()
 

--- a/libsyclinterface/CMakeLists.txt
+++ b/libsyclinterface/CMakeLists.txt
@@ -91,14 +91,14 @@ if(DPCTL_ENABLE_L0_PROGRAM_CREATION)
 endif()
 
 if (UNIX)
-  find_library(PI_OPENCL_LIB
-      NAMES pi_opencl ur_adapter_opencl
+  find_library(OPENCL_LIB
+      NAMES ur_adapter_opencl OpenCL
       HINTS ${IntelSyclCompiler_LIBRARY_DIR}
   )
   find_program(READELF_PROG readelf)
   find_program(GREP_PROG grep)
   execute_process(
-    COMMAND ${READELF_PROG} -d ${PI_OPENCL_LIB}
+    COMMAND ${READELF_PROG} -d ${OPENCL_LIB}
     COMMAND ${GREP_PROG} OpenCL
     COMMAND ${GREP_PROG} -Po "libOpenCL[^\]]*"
     OUTPUT_VARIABLE LIBCL_LOADER_FILENAME


### PR DESCRIPTION
This PR updates the OpenCL loader search used when building dpctl, as `pi_opencl` is no longer used, and the open-source compiler is currently not packaging `libur_adapter_opencl.so`.

By adding `OpenCL` to the search, a `libOpenCL.so` installed by `ocl-icd` can be linked to in place of the UR adapter if it is not found.

- [X] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [ ] Have you added your changes to the changelog?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
