### PR TITLE
Pin compiler to minimum `2026.0.0`

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set required_compiler_version = "2024.2.0" %}
+{% set required_compiler_version = "2026.0.0" %}
 
 {% set pyproject = load_file_data('pyproject.toml') %}
 {% set py_build_deps = pyproject.get('build-system', {}).get('requires', []) %}

--- a/docs/doc_sources/contributor_guides/building.rst
+++ b/docs/doc_sources/contributor_guides/building.rst
@@ -211,7 +211,7 @@ library.
     INSTALL_PREFIX=$(pwd)/../install
     rm -rf "${INSTALL_PREFIX}"
     export ONEAPI_ROOT=/opt/intel/oneapi
-    # Values are set as appropriate for oneAPI DPC++ 2024.0
+    # Values are set as appropriate for oneAPI DPC++ 2026.0
     # or later.
     DPCPP_ROOT=${ONEAPI_ROOT}/compiler/latest/
 

--- a/libsyclinterface/CMakeLists.txt
+++ b/libsyclinterface/CMakeLists.txt
@@ -50,7 +50,7 @@ set(LIBZE_DEFAULT_LOADER_FILENAME "libze_loader.so.1" CACHE STRING "Default Leve
 
 # Minimum version requirement only when oneAPI dpcpp is used.
 if(DPCTL_DPCPP_FROM_ONEAPI)
-    find_package(IntelSyclCompiler 2021.3.0 REQUIRED)
+    find_package(IntelSyclCompiler 2026.0.0 REQUIRED)
 else()
     find_package(IntelSyclCompiler REQUIRED)
 endif()

--- a/libsyclinterface/include/syclinterface/Config/dpctl_config.h.in
+++ b/libsyclinterface/include/syclinterface/Config/dpctl_config.h.in
@@ -28,7 +28,7 @@
 /* Defined when dpctl was built with level zero program creation enabled. */
 #cmakedefine DPCTL_ENABLE_L0_PROGRAM_CREATION 1
 
-#define __SYCL_COMPILER_VERSION_REQUIRED 20221201L
+#define __SYCL_COMPILER_VERSION_REQUIRED 20260331
 
 /* The DPCPP version used to build dpctl */
 #define DPCTL_DPCPP_VERSION "@IntelSyclCompiler_VERSION@"


### PR DESCRIPTION
A number of new features in dpctl require newer compiler versions

This PR updates the minimum required DPC++ compiler version to 2026.0.0, as later versions should be compatible, but this sets a floor for where some features may be lost, and will allow the removal of some macros hiding features from later versions from earlier compilers

- [X] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [ ] Have you added your changes to the changelog?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
