### PR TITLE
[MAINT] Use `ubuntu-latest` in conda-package workflow

### DIFF
--- a/.github/workflows/conda-package.yml
+++ b/.github/workflows/conda-package.yml
@@ -186,11 +186,11 @@ jobs:
           - python: '3.14'
             python_spec: '3.14.* *_cp314'
             experimental: false
-            runner: ubuntu-22.04
+            runner: ubuntu-latest
           - python: '3.14'
             python_spec: '3.14.* *_cp314t'
             experimental: false
-            runner: ubuntu-22.04
+            runner: ubuntu-latest
         experimental: [false]
         runner: [ubuntu-latest]
     continue-on-error: ${{ matrix.experimental }}

--- a/.github/workflows/os-llvm-sycl-build.yml
+++ b/.github/workflows/os-llvm-sycl-build.yml
@@ -9,7 +9,7 @@ permissions: read-all
 jobs:
   install-compiler:
     name: Build with nightly build of DPC++ toolchain
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     timeout-minutes: 90
 
     env:

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -11,7 +11,7 @@ jobs:
   pre-commit:
     name: pre-commit
 
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     timeout-minutes: 30
 
     steps:


### PR DESCRIPTION
This PR proposes moving conda-package workflow to use Ubuntu 24.04 via `ubuntu-latest`

- [X] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [ ] Have you added your changes to the changelog?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
