### PR TITLE
Add `dpctl.SyclQueue.fill()` method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Added a number of `sycl::device` info queries to `dpctl.SyclDevice` [gh-2324](https://github.com/IntelPython/dpctl/pull/2324)
 * Added `sycl::info::context` queries `sycl_platform`, `atomic_memory_order_capabilities`, `atomic_fence_order_capabilities`, `atomic_memory_scope_capabilities`, and `atomic_fence_scope_capabilities` to `dpctl.SyclContext` [gh-2354](https://github.com/IntelPython/dpctl/pull/2354)
 * Added `create_kernel_bundle_from_sycl_source`, `is_sycl_source_compilation_available`, and `dpctl.SyclDevice.can_compile` for supporting the creation of `dpctl.SyclKernelBundle`s from SYCL source strings via DPC++ extension, as well as corresponding C-API functions to support it [gh-2206](https://github.com/IntelPython/dpctl/pull/2206)
+* Added `dpctl.SyclQueue.fill` and `dpctl.SyclQueue.fill_async` methods [gh-2365](https://github.com/IntelPython/dpctl/pull/2365)
+* Added `DPCTLQueue_Fill8/16/32/64/128WithEvents` C-API functions to support `dpctl.SyclQueue.fill_async` [gh-2365](https://github.com/IntelPython/dpctl/pull/2365)
 
 ### Changed
 * Bump minimum NumPy version to 1.26 [gh-2192](https://github.com/IntelPython/dpctl/pull/2192)

--- a/dpctl/_backend.pxd
+++ b/dpctl/_backend.pxd
@@ -684,26 +684,61 @@ cdef extern from "syclinterface/dpctl_sycl_queue_interface.h":
         void *Dest,
         uint8_t Val,
         size_t Count)
+    cdef DPCTLSyclEventRef DPCTLQueue_Fill8WithEvents(
+        const DPCTLSyclQueueRef Q,
+        void *Dest,
+        uint8_t Val,
+        size_t Count,
+        const DPCTLSyclEventRef *depEvents,
+        size_t depEventsCount)
     cdef DPCTLSyclEventRef DPCTLQueue_Fill16(
         const DPCTLSyclQueueRef Q,
         void *Dest,
         uint16_t Val,
         size_t Count)
+    cdef DPCTLSyclEventRef DPCTLQueue_Fill16WithEvents(
+        const DPCTLSyclQueueRef Q,
+        void *Dest,
+        uint16_t Val,
+        size_t Count,
+        const DPCTLSyclEventRef *depEvents,
+        size_t depEventsCount)
     cdef DPCTLSyclEventRef DPCTLQueue_Fill32(
         const DPCTLSyclQueueRef Q,
         void *Dest,
         uint32_t Val,
         size_t Count)
+    cdef DPCTLSyclEventRef DPCTLQueue_Fill32WithEvents(
+        const DPCTLSyclQueueRef Q,
+        void *Dest,
+        uint32_t Val,
+        size_t Count,
+        const DPCTLSyclEventRef *depEvents,
+        size_t depEventsCount)
     cdef DPCTLSyclEventRef DPCTLQueue_Fill64(
         const DPCTLSyclQueueRef Q,
         void *Dest,
         uint64_t Val,
         size_t Count)
+    cdef DPCTLSyclEventRef DPCTLQueue_Fill64WithEvents(
+        const DPCTLSyclQueueRef Q,
+        void *Dest,
+        uint64_t Val,
+        size_t Count,
+        const DPCTLSyclEventRef *depEvents,
+        size_t depEventsCount)
     cdef DPCTLSyclEventRef DPCTLQueue_Fill128(
         const DPCTLSyclQueueRef Q,
         void *Dest,
         uint64_t *Val,
         size_t Count)
+    cdef DPCTLSyclEventRef DPCTLQueue_Fill128WithEvents(
+        const DPCTLSyclQueueRef Q,
+        void *Dest,
+        uint64_t *Val,
+        size_t Count,
+        const DPCTLSyclEventRef *depEvents,
+        size_t depEventsCount)
     cdef DPCTLSyclEventRef DPCTLQueue_Prefetch(
         const DPCTLSyclQueueRef Q,
         const void *Src,

--- a/dpctl/_backend.pxd
+++ b/dpctl/_backend.pxd
@@ -21,7 +21,7 @@
 types defined by dpctl's C API.
 """
 
-from libc.stdint cimport int64_t, uint32_t, uint64_t
+from libc.stdint cimport int64_t, uint8_t, uint16_t, uint32_t, uint64_t
 from libcpp cimport bool
 
 
@@ -678,6 +678,31 @@ cdef extern from "syclinterface/dpctl_sycl_queue_interface.h":
         const DPCTLSyclQueueRef Q,
         void *Dest,
         int Val,
+        size_t Count)
+    cdef DPCTLSyclEventRef DPCTLQueue_Fill8(
+        const DPCTLSyclQueueRef Q,
+        void *Dest,
+        uint8_t Val,
+        size_t Count)
+    cdef DPCTLSyclEventRef DPCTLQueue_Fill16(
+        const DPCTLSyclQueueRef Q,
+        void *Dest,
+        uint16_t Val,
+        size_t Count)
+    cdef DPCTLSyclEventRef DPCTLQueue_Fill32(
+        const DPCTLSyclQueueRef Q,
+        void *Dest,
+        uint32_t Val,
+        size_t Count)
+    cdef DPCTLSyclEventRef DPCTLQueue_Fill64(
+        const DPCTLSyclQueueRef Q,
+        void *Dest,
+        uint64_t Val,
+        size_t Count)
+    cdef DPCTLSyclEventRef DPCTLQueue_Fill128(
+        const DPCTLSyclQueueRef Q,
+        void *Dest,
+        uint64_t *Val,
         size_t Count)
     cdef DPCTLSyclEventRef DPCTLQueue_Prefetch(
         const DPCTLSyclQueueRef Q,

--- a/dpctl/_sycl_queue.pxd
+++ b/dpctl/_sycl_queue.pxd
@@ -108,6 +108,9 @@ cdef public api class SyclQueue (_SyclQueue) [
         self, dest, src, size_t count, list dEvents=*, str dtype=*
     )
     cpdef fill(self, dest, value, size_t count, str dtype=*)
+    cpdef SyclEvent fill_async(
+        self, dest, value, size_t count, list dEvents=*, str dtype=*
+    )
     cpdef prefetch(self, ptr, size_t count=*)
     cpdef mem_advise(self, ptr, size_t count, int mem)
     cpdef SyclEvent submit_barrier(self, dependent_events=*)

--- a/dpctl/_sycl_queue.pxd
+++ b/dpctl/_sycl_queue.pxd
@@ -107,6 +107,7 @@ cdef public api class SyclQueue (_SyclQueue) [
     cpdef SyclEvent copy_async(
         self, dest, src, size_t count, list dEvents=*, str dtype=*
     )
+    cpdef fill(self, dest, value, size_t count, str dtype=*)
     cpdef prefetch(self, ptr, size_t count=*)
     cpdef mem_advise(self, ptr, size_t count, int mem)
     cpdef SyclEvent submit_barrier(self, dependent_events=*)

--- a/dpctl/_sycl_queue.pyx
+++ b/dpctl/_sycl_queue.pyx
@@ -40,6 +40,11 @@ from ._backend cimport (  # noqa: E211
     DPCTLQueue_CopyDataWithEvents,
     DPCTLQueue_Create,
     DPCTLQueue_Delete,
+    DPCTLQueue_Fill8,
+    DPCTLQueue_Fill16,
+    DPCTLQueue_Fill32,
+    DPCTLQueue_Fill64,
+    DPCTLQueue_Fill128,
     DPCTLQueue_GetBackend,
     DPCTLQueue_GetContext,
     DPCTLQueue_GetDevice,
@@ -86,10 +91,13 @@ from cpython.buffer cimport (
     PyObject_GetBuffer,
 )
 from cpython.ref cimport Py_INCREF, PyObject
+from libc.stdint cimport uint8_t, uint16_t, uint32_t, uint64_t
 from libc.stdlib cimport free, malloc
 
 import collections.abc
 import logging
+import struct
+import sys
 
 
 cdef extern from "_host_task_util.hpp":
@@ -600,6 +608,101 @@ cdef DPCTLSyclEventRef _copy_impl(
         q, dst, src, byte_count, dep_events, dep_events_count,
         DPCTLQueue_CopyData, DPCTLQueue_CopyDataWithEvents
     )
+
+
+# struct format per dtype used to pack the fill value into its byte pattern.
+# The pattern's length is the element size.
+# Complex types are packed as (real, imag).
+_fill_dtype_formats = {
+    "i1": "b",
+    "u1": "B",
+    "i2": "h",
+    "u2": "H",
+    "i4": "i",
+    "u4": "I",
+    "f4": "f",
+    "i8": "q",
+    "u8": "Q",
+    "f8": "d",
+    "c8": "ff",
+    "c16": "dd",
+}
+
+
+cdef bytes _pack_fill_pattern(object value, str dtype):
+    """
+    Return the native-byte-order byte pattern of ``value`` interpreted as a
+    single element of ``dtype``. ``sycl::queue::fill`` replicates this pattern
+    across the destination allocation.
+    """
+    cdef str fmt
+    if dtype not in _fill_dtype_formats:
+        raise ValueError(
+            f"Unrecognized dtype '{dtype}'. Expected one of: "
+            "i1, u1, i2, u2, i4, u4, i8, u8, f4, f8, c8, c16"
+        )
+    fmt = _fill_dtype_formats[dtype]
+    try:
+        if dtype == "c8" or dtype == "c16":
+            # complex: pack real then imag
+            cval = complex(value)
+            return struct.pack("=" + fmt, cval.real, cval.imag)
+        return struct.pack("=" + fmt, value)
+    except (struct.error, TypeError, ValueError) as e:
+        raise ValueError(
+            f"Value {value!r} cannot be represented as dtype '{dtype}': {e}"
+        )
+
+
+cdef DPCTLSyclEventRef _fill_impl(
+     SyclQueue q,
+     object dst,
+     object value,
+     size_t count,
+     str dtype
+) except *:
+    cdef void *c_dst_ptr = NULL
+    cdef DPCTLSyclEventRef ERef = NULL
+    cdef uint64_t val128[2]
+    cdef bytes pattern = _pack_fill_pattern(value, dtype)
+    cdef size_t element_size = len(pattern)
+
+    if isinstance(dst, _Memory):
+        c_dst_ptr = <void*>(<_Memory>dst).get_data_ptr()
+    else:
+        raise TypeError(
+            "Parameter `dest` should have type `dpctl.memory._Memory`"
+        )
+
+    if element_size == 1:
+        ERef = DPCTLQueue_Fill8(
+            q._queue_ref, c_dst_ptr,
+            <uint8_t> int.from_bytes(pattern, sys.byteorder), count
+        )
+    elif element_size == 2:
+        ERef = DPCTLQueue_Fill16(
+            q._queue_ref, c_dst_ptr,
+            <uint16_t> int.from_bytes(pattern, sys.byteorder), count
+        )
+    elif element_size == 4:
+        ERef = DPCTLQueue_Fill32(
+            q._queue_ref, c_dst_ptr,
+            <uint32_t> int.from_bytes(pattern, sys.byteorder), count
+        )
+    elif element_size == 8:
+        ERef = DPCTLQueue_Fill64(
+            q._queue_ref, c_dst_ptr,
+            <uint64_t> int.from_bytes(pattern, sys.byteorder), count
+        )
+    else:
+        # 128-bit pattern is passed as two uint64
+        val128[0] = <uint64_t> int.from_bytes(pattern[:8], sys.byteorder)
+        val128[1] = <uint64_t> int.from_bytes(pattern[8:], sys.byteorder)
+        ERef = DPCTLQueue_Fill128(
+            q._queue_ref, c_dst_ptr, val128, count
+        )
+
+    return ERef
 
 
 cdef class _SyclQueue:
@@ -1593,6 +1696,50 @@ cdef class SyclQueue(_SyclQueue):
             )
 
         return SyclEvent._create(ERef)
+
+    cpdef fill(self, dest, value, size_t count, str dtype="u1"):
+        """Fill ``dest`` with ``count`` copies of ``value`` and wait.
+
+        Internally, this dispatches ``sycl::queue::fill``, which sets each of
+        the ``count`` elements of ``dest`` to ``value``. The number of bytes
+        written is ``count`` multiplied by the size of ``dtype``. The default
+        ``dtype`` of ``"u1"`` (a single byte) makes the default a byte-wise
+        fill, analogous to ``memset``.
+
+        Args:
+            dest (dpctl.memory._Memory):
+                Destination USM allocation to fill.
+            value (int, float, complex):
+                Value used to fill ``dest``. It is reinterpreted according to
+                ``dtype``: integral ``dtype`` values expect a Python integer,
+                ``"f4"`` and ``"f8"`` expect a Python float, and ``"c8"`` and
+                ``"c16"`` expect a Python complex.
+            count (int):
+                Number of elements to fill.
+            dtype (str, optional):
+                Data type string of the fill elements. Determines the element
+                size and how ``value`` is interpreted.
+                Defaults to ``"u1"`` (one byte per element).
+                Supported types: i1, u1, i2, u2, i4, u4, i8, u8, f4, f8, c8,
+                c16.
+
+        Raises:
+            TypeError:
+                If ``dest`` is not a ``dpctl.memory._Memory`` USM allocation.
+            ValueError:
+                If ``dtype`` is unrecognized, or ``value`` cannot be
+                represented as ``dtype``.
+        """
+        cdef DPCTLSyclEventRef ERef = NULL
+
+        ERef = _fill_impl(<SyclQueue>self, dest, value, count, dtype)
+        if (ERef is NULL):
+            raise RuntimeError(
+                "SyclQueue.fill operation encountered an error"
+            )
+        with nogil:
+            DPCTLEvent_Wait(ERef)
+        DPCTLEvent_Delete(ERef)
 
     cpdef prefetch(self, mem, size_t count=0):
         cdef void *ptr

--- a/dpctl/_sycl_queue.pyx
+++ b/dpctl/_sycl_queue.pyx
@@ -1764,6 +1764,8 @@ cdef class SyclQueue(_SyclQueue):
             ValueError:
                 If ``dtype`` is unrecognized, or ``value`` cannot be
                 represented as ``dtype``.
+            OverflowError:
+                If ``count`` is negative.
             RuntimeError:
                 If the fill operation encountered an error.
         """
@@ -1788,6 +1790,11 @@ cdef class SyclQueue(_SyclQueue):
         written is ``count`` multiplied by the size of ``dtype``. The default
         ``dtype`` of ``"u1"`` (a single byte) makes the default a byte-wise
         fill, analogous to ``memset``.
+
+        Note:
+            The returned event does not keep ``dest`` alive. Keep ``dest``
+            alive until the event completes, otherwise its USM allocation
+            may be freed mid-operation, causing a use-after-free.
 
         Args:
             dest (dpctl.memory._Memory):
@@ -1819,6 +1826,8 @@ cdef class SyclQueue(_SyclQueue):
             ValueError:
                 If ``dtype`` is unrecognized, or ``value`` cannot be
                 represented as ``dtype``.
+            OverflowError:
+                If ``count`` is negative.
             RuntimeError:
                 If the fill operation encountered an error.
         """

--- a/dpctl/_sycl_queue.pyx
+++ b/dpctl/_sycl_queue.pyx
@@ -638,6 +638,7 @@ cdef DPCTLSyclEventRef _fill_impl(
 ) except *:
     cdef void *c_dst_ptr = NULL
     cdef DPCTLSyclEventRef ERef = NULL
+    cdef _Memory m_dst
     cdef uint64_t val128[2]
     cdef bytes pattern = _pack_fill_pattern(value, dtype)
     cdef size_t element_size = len(pattern)
@@ -647,11 +648,18 @@ cdef DPCTLSyclEventRef _fill_impl(
     cdef uint32_t v32
     cdef uint64_t v64
 
-    if isinstance(dst, _Memory):
-        c_dst_ptr = <void*>(<_Memory>dst).get_data_ptr()
-    else:
+    if not isinstance(dst, _Memory):
         raise TypeError(
             "Parameter `dest` should have type `dpctl.memory._Memory`"
+        )
+    m_dst = <_Memory>dst
+    c_dst_ptr = <void*>m_dst.get_data_ptr()
+
+    # check count fits within the allocation
+    if count > (<size_t>m_dst.nbytes) // element_size:
+        raise ValueError(
+            f"Fill of {count} elements of dtype '{dtype}' is too large "
+            f"to be accommodated in {m_dst.nbytes} bytes allocation"
         )
 
     if element_size == 1:

--- a/dpctl/_sycl_queue.pyx
+++ b/dpctl/_sycl_queue.pyx
@@ -41,10 +41,15 @@ from ._backend cimport (  # noqa: E211
     DPCTLQueue_Create,
     DPCTLQueue_Delete,
     DPCTLQueue_Fill8,
+    DPCTLQueue_Fill8WithEvents,
     DPCTLQueue_Fill16,
+    DPCTLQueue_Fill16WithEvents,
     DPCTLQueue_Fill32,
+    DPCTLQueue_Fill32WithEvents,
     DPCTLQueue_Fill64,
+    DPCTLQueue_Fill64WithEvents,
     DPCTLQueue_Fill128,
+    DPCTLQueue_Fill128WithEvents,
     DPCTLQueue_GetBackend,
     DPCTLQueue_GetContext,
     DPCTLQueue_GetDevice,
@@ -659,13 +664,20 @@ cdef DPCTLSyclEventRef _fill_impl(
      object dst,
      object value,
      size_t count,
-     str dtype
+     str dtype,
+     DPCTLSyclEventRef *dep_events,
+     size_t dep_events_count
 ) except *:
     cdef void *c_dst_ptr = NULL
     cdef DPCTLSyclEventRef ERef = NULL
     cdef uint64_t val128[2]
     cdef bytes pattern = _pack_fill_pattern(value, dtype)
     cdef size_t element_size = len(pattern)
+    cdef bint with_events = dep_events is not NULL and dep_events_count > 0
+    cdef uint8_t v8
+    cdef uint16_t v16
+    cdef uint32_t v32
+    cdef uint64_t v64
 
     if isinstance(dst, _Memory):
         c_dst_ptr = <void*>(<_Memory>dst).get_data_ptr()
@@ -675,32 +687,52 @@ cdef DPCTLSyclEventRef _fill_impl(
         )
 
     if element_size == 1:
-        ERef = DPCTLQueue_Fill8(
-            q._queue_ref, c_dst_ptr,
-            <uint8_t> int.from_bytes(pattern, sys.byteorder), count
-        )
+        v8 = <uint8_t> int.from_bytes(pattern, sys.byteorder)
+        if with_events:
+            ERef = DPCTLQueue_Fill8WithEvents(
+                q._queue_ref, c_dst_ptr, v8, count,
+                dep_events, dep_events_count
+            )
+        else:
+            ERef = DPCTLQueue_Fill8(q._queue_ref, c_dst_ptr, v8, count)
     elif element_size == 2:
-        ERef = DPCTLQueue_Fill16(
-            q._queue_ref, c_dst_ptr,
-            <uint16_t> int.from_bytes(pattern, sys.byteorder), count
-        )
+        v16 = <uint16_t> int.from_bytes(pattern, sys.byteorder)
+        if with_events:
+            ERef = DPCTLQueue_Fill16WithEvents(
+                q._queue_ref, c_dst_ptr, v16, count,
+                dep_events, dep_events_count
+            )
+        else:
+            ERef = DPCTLQueue_Fill16(q._queue_ref, c_dst_ptr, v16, count)
     elif element_size == 4:
-        ERef = DPCTLQueue_Fill32(
-            q._queue_ref, c_dst_ptr,
-            <uint32_t> int.from_bytes(pattern, sys.byteorder), count
-        )
+        v32 = <uint32_t> int.from_bytes(pattern, sys.byteorder)
+        if with_events:
+            ERef = DPCTLQueue_Fill32WithEvents(
+                q._queue_ref, c_dst_ptr, v32, count,
+                dep_events, dep_events_count
+            )
+        else:
+            ERef = DPCTLQueue_Fill32(q._queue_ref, c_dst_ptr, v32, count)
     elif element_size == 8:
-        ERef = DPCTLQueue_Fill64(
-            q._queue_ref, c_dst_ptr,
-            <uint64_t> int.from_bytes(pattern, sys.byteorder), count
-        )
+        v64 = <uint64_t> int.from_bytes(pattern, sys.byteorder)
+        if with_events:
+            ERef = DPCTLQueue_Fill64WithEvents(
+                q._queue_ref, c_dst_ptr, v64, count,
+                dep_events, dep_events_count
+            )
+        else:
+            ERef = DPCTLQueue_Fill64(q._queue_ref, c_dst_ptr, v64, count)
     else:
         # 128-bit pattern is passed as two uint64
         val128[0] = <uint64_t> int.from_bytes(pattern[:8], sys.byteorder)
         val128[1] = <uint64_t> int.from_bytes(pattern[8:], sys.byteorder)
-        ERef = DPCTLQueue_Fill128(
-            q._queue_ref, c_dst_ptr, val128, count
-        )
+        if with_events:
+            ERef = DPCTLQueue_Fill128WithEvents(
+                q._queue_ref, c_dst_ptr, val128, count,
+                dep_events, dep_events_count
+            )
+        else:
+            ERef = DPCTLQueue_Fill128(q._queue_ref, c_dst_ptr, val128, count)
 
     return ERef
 
@@ -1706,6 +1738,9 @@ cdef class SyclQueue(_SyclQueue):
         ``dtype`` of ``"u1"`` (a single byte) makes the default a byte-wise
         fill, analogous to ``memset``.
 
+        This is a synchronizing variant corresponding to
+        :meth:`dpctl.SyclQueue.fill_async`.
+
         Args:
             dest (dpctl.memory._Memory):
                 Destination USM allocation to fill.
@@ -1732,7 +1767,7 @@ cdef class SyclQueue(_SyclQueue):
         """
         cdef DPCTLSyclEventRef ERef = NULL
 
-        ERef = _fill_impl(<SyclQueue>self, dest, value, count, dtype)
+        ERef = _fill_impl(<SyclQueue>self, dest, value, count, dtype, NULL, 0)
         if (ERef is NULL):
             raise RuntimeError(
                 "SyclQueue.fill operation encountered an error"
@@ -1740,6 +1775,84 @@ cdef class SyclQueue(_SyclQueue):
         with nogil:
             DPCTLEvent_Wait(ERef)
         DPCTLEvent_Delete(ERef)
+
+    cpdef SyclEvent fill_async(
+        self, dest, value, size_t count, list dEvents=None, str dtype="u1"
+    ):
+        """Fill ``dest`` with ``count`` copies of ``value`` asynchronously.
+
+        Internally, this dispatches ``sycl::queue::fill``, which sets each of
+        the ``count`` elements of ``dest`` to ``value``. The number of bytes
+        written is ``count`` multiplied by the size of ``dtype``. The default
+        ``dtype`` of ``"u1"`` (a single byte) makes the default a byte-wise
+        fill, analogous to ``memset``.
+
+        Args:
+            dest (dpctl.memory._Memory):
+                Destination USM allocation to fill.
+            value (int, float, complex):
+                Value used to fill ``dest``. It is reinterpreted according to
+                ``dtype``: integral ``dtype`` values expect a Python integer,
+                ``"f4"`` and ``"f8"`` expect a Python float, and ``"c8"`` and
+                ``"c16"`` expect a Python complex.
+            count (int):
+                Number of elements to fill.
+            dEvents (List[dpctl.SyclEvent], optional):
+                Events that this fill depends on.
+            dtype (str, optional):
+                Data type string of the fill elements. Determines the element
+                size and how ``value`` is interpreted.
+                Defaults to ``"u1"`` (one byte per element).
+                Supported types: i1, u1, i2, u2, i4, u4, i8, u8, f4, f8, c8,
+                c16.
+
+        Returns:
+            dpctl.SyclEvent:
+                Event associated with the fill operation.
+
+        Raises:
+            TypeError:
+                If ``dest`` is not a ``dpctl.memory._Memory`` USM allocation,
+                or ``dEvents`` is not a sequence of :class:`dpctl.SyclEvent`.
+            ValueError:
+                If ``dtype`` is unrecognized, or ``value`` cannot be
+                represented as ``dtype``.
+        """
+        cdef DPCTLSyclEventRef ERef = NULL
+        cdef DPCTLSyclEventRef *depEvents = NULL
+        cdef size_t nDE = 0
+
+        if dEvents is None:
+            ERef = _fill_impl(
+                <SyclQueue>self, dest, value, count, dtype, NULL, 0
+            )
+        else:
+            nDE = len(dEvents)
+            depEvents = (
+                <DPCTLSyclEventRef*>malloc(nDE*sizeof(DPCTLSyclEventRef))
+            )
+            if depEvents is NULL:
+                raise MemoryError()
+            try:
+                for idx, de in enumerate(dEvents):
+                    if isinstance(de, SyclEvent):
+                        depEvents[idx] = (<SyclEvent>de).get_event_ref()
+                    else:
+                        raise TypeError(
+                            "A sequence of dpctl.SyclEvent is expected"
+                        )
+                ERef = _fill_impl(
+                    <SyclQueue>self, dest, value, count, dtype, depEvents, nDE
+                )
+            finally:
+                free(depEvents)
+
+        if (ERef is NULL):
+            raise RuntimeError(
+                "SyclQueue.fill operation encountered an error"
+            )
+
+        return SyclEvent._create(ERef)
 
     cpdef prefetch(self, mem, size_t count=0):
         cdef void *ptr

--- a/dpctl/_sycl_queue.pyx
+++ b/dpctl/_sycl_queue.pyx
@@ -621,7 +621,7 @@ cdef bytes _pack_fill_pattern(object value, str dtype):
             cval = complex(value)
             return struct.pack("=" + fmt, cval.real, cval.imag)
         return struct.pack("=" + fmt, value)
-    except (struct.error, TypeError, ValueError) as e:
+    except (struct.error, OverflowError, TypeError, ValueError) as e:
         raise ValueError(
             f"Value {value!r} cannot be represented as dtype '{dtype}': {e}"
         )

--- a/dpctl/_sycl_queue.pyx
+++ b/dpctl/_sycl_queue.pyx
@@ -1764,6 +1764,8 @@ cdef class SyclQueue(_SyclQueue):
             ValueError:
                 If ``dtype`` is unrecognized, or ``value`` cannot be
                 represented as ``dtype``.
+            RuntimeError:
+                If the fill operation encountered an error.
         """
         cdef DPCTLSyclEventRef ERef = NULL
 
@@ -1817,6 +1819,8 @@ cdef class SyclQueue(_SyclQueue):
             ValueError:
                 If ``dtype`` is unrecognized, or ``value`` cannot be
                 represented as ``dtype``.
+            RuntimeError:
+                If the fill operation encountered an error.
         """
         cdef DPCTLSyclEventRef ERef = NULL
         cdef DPCTLSyclEventRef *depEvents = NULL
@@ -1849,7 +1853,7 @@ cdef class SyclQueue(_SyclQueue):
 
         if (ERef is NULL):
             raise RuntimeError(
-                "SyclQueue.fill operation encountered an error"
+                "SyclQueue.fill_async operation encountered an error"
             )
 
         return SyclEvent._create(ERef)

--- a/dpctl/tests/test_sycl_queue_fill.py
+++ b/dpctl/tests/test_sycl_queue_fill.py
@@ -1,0 +1,235 @@
+#                      Data Parallel Control (dpctl)
+#
+# Copyright 2026 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Defines unit test cases for the SyclQueue.fill."""
+
+import numpy as np
+import pytest
+
+import dpctl
+import dpctl.memory
+
+# Maps a dtype string to the NumPy dtype used to build the expected result.
+_dtype_to_np = {
+    "i1": np.int8,
+    "u1": np.uint8,
+    "i2": np.int16,
+    "u2": np.uint16,
+    "i4": np.int32,
+    "u4": np.uint32,
+    "f4": np.float32,
+    "i8": np.int64,
+    "u8": np.uint64,
+    "f8": np.float64,
+    "c8": np.complex64,
+    "c16": np.complex128,
+}
+
+# A representative fill value per dtype, chosen to exercise all bytes and,
+# for signed types, the sign bit.
+_fill_values = {
+    "i1": -7,
+    "u1": 0xAB,
+    "i2": -1234,
+    "u2": 0xABCD,
+    "i4": -123456,
+    "u4": 0x0BADC0DE,
+    "f4": 3.5,
+    "i8": -1234567890123,
+    "u8": 0x0123456789ABCDEF,
+    "f8": 2.718281828459045,
+    "c8": complex(1.5, -2.5),
+    "c16": complex(3.14159, -2.71828),
+}
+
+
+def _read_back(mem, nbytes):
+    """Return the first ``nbytes`` bytes of a USM allocation as ``bytes``."""
+    if isinstance(mem, dpctl.memory.MemoryUSMDevice):
+        result = bytearray(nbytes)
+        mem.copy_to_host(result)
+        return bytes(result)
+    return memoryview(mem)[:nbytes].tobytes()
+
+
+@pytest.mark.parametrize("dtype", list(_dtype_to_np))
+@pytest.mark.parametrize(
+    "usm_type",
+    [
+        lambda n, q: dpctl.memory.MemoryUSMShared(n, queue=q),
+        lambda n, q: dpctl.memory.MemoryUSMHost(n, queue=q),
+        lambda n, q: dpctl.memory.MemoryUSMDevice(n, queue=q),
+    ],
+    ids=["shared", "host", "device"],
+)
+def test_fill_with_dtype_valid(dtype, usm_type):
+    try:
+        q = dpctl.SyclQueue()
+    except dpctl.SyclQueueCreationError:
+        pytest.skip("Default constructor for SyclQueue failed")
+
+    np_dt = _dtype_to_np[dtype]
+    value = _fill_values[dtype]
+    num_elements = 16
+    element_size = np.dtype(np_dt).itemsize
+    nbytes = num_elements * element_size
+
+    mem = usm_type(nbytes, q)
+    q.fill(mem, value, num_elements, dtype=dtype)
+
+    expected = np.full(num_elements, value, dtype=np_dt).tobytes()
+    assert _read_back(mem, nbytes) == expected
+
+
+def test_fill_default_dtype_is_bytewise():
+    try:
+        q = dpctl.SyclQueue()
+    except dpctl.SyclQueueCreationError:
+        pytest.skip("Default constructor for SyclQueue failed")
+
+    nbytes = 64
+    mem = dpctl.memory.MemoryUSMShared(nbytes, queue=q)
+
+    q.fill(mem, 0, nbytes)
+    assert memoryview(mem).tobytes() == b"\x00" * nbytes
+
+    q.fill(mem, 0xFF, nbytes)
+    assert memoryview(mem).tobytes() == b"\xff" * nbytes
+
+
+def test_fill_signed_negative_value():
+    try:
+        q = dpctl.SyclQueue()
+    except dpctl.SyclQueueCreationError:
+        pytest.skip("Default constructor for SyclQueue failed")
+
+    num_elements = 8
+    mem = dpctl.memory.MemoryUSMShared(num_elements, queue=q)
+
+    q.fill(mem, -1, num_elements, dtype="i1")
+    assert memoryview(mem).tobytes() == b"\xff" * num_elements
+
+
+@pytest.mark.parametrize("dtype", ["c8", "c16"])
+def test_fill_complex_from_real_scalar(dtype):
+    try:
+        q = dpctl.SyclQueue()
+    except dpctl.SyclQueueCreationError:
+        pytest.skip("Default constructor for SyclQueue failed")
+
+    np_dt = _dtype_to_np[dtype]
+    num_elements = 8
+    nbytes = num_elements * np.dtype(np_dt).itemsize
+
+    mem = dpctl.memory.MemoryUSMShared(nbytes, queue=q)
+    q.fill(mem, 2.0, num_elements, dtype=dtype)
+
+    expected = np.full(num_elements, complex(2.0, 0.0), dtype=np_dt).tobytes()
+    assert memoryview(mem)[:nbytes].tobytes() == expected
+
+
+@pytest.mark.parametrize(
+    "dtype,element_size",
+    [
+        ("i2", 2),
+        ("i4", 4),
+        ("f8", 8),
+        ("u8", 8),
+    ],
+)
+def test_fill_count_is_in_elements(dtype, element_size):
+    try:
+        q = dpctl.SyclQueue()
+    except dpctl.SyclQueueCreationError:
+        pytest.skip("Default constructor for SyclQueue failed")
+
+    num_elements = 8
+    nbytes = num_elements * element_size
+
+    mem = dpctl.memory.MemoryUSMShared(nbytes, queue=q)
+
+    # Seed the whole allocation with a known sentinel to verify the untouched
+    # tail is left intact.
+    mv = memoryview(mem)
+    for i in range(nbytes):
+        mv[i] = 0xAA
+
+    # Filling half the elements writes exactly half the bytes.
+    q.fill(mem, 1, num_elements // 2, dtype=dtype)
+
+    half_bytes = (num_elements // 2) * element_size
+    expected_head = np.full(
+        num_elements // 2, 1, dtype=_dtype_to_np[dtype]
+    ).tobytes()
+    assert mv[:half_bytes].tobytes() == expected_head
+    assert mv[half_bytes:nbytes].tobytes() == b"\xaa" * (nbytes - half_bytes)
+
+
+def test_fill_with_invalid_dtype():
+    try:
+        q = dpctl.SyclQueue()
+    except dpctl.SyclQueueCreationError:
+        pytest.skip("Default constructor for SyclQueue failed")
+
+    mem = dpctl.memory.MemoryUSMShared(64, queue=q)
+
+    for bad_dtype in ["i3", "f16", "u16", "x4", "42", "float", ""]:
+        with pytest.raises(ValueError) as cm:
+            q.fill(mem, 0, 8, dtype=bad_dtype)
+        assert (
+            "dtype" in str(cm.value).lower()
+            or "unrecognized" in str(cm.value).lower()
+        )
+
+
+@pytest.mark.parametrize(
+    "dtype,value",
+    [
+        ("u1", 256),
+        ("u1", -1),
+        ("i1", 128),
+        ("u2", 1 << 16),
+        ("i4", 1.5),
+        ("u8", 1 << 64),
+    ],
+)
+def test_fill_value_out_of_range(dtype, value):
+    """fill raises ValueError when value cannot be represented as dtype."""
+    try:
+        q = dpctl.SyclQueue()
+    except dpctl.SyclQueueCreationError:
+        pytest.skip("Default constructor for SyclQueue failed")
+
+    mem = dpctl.memory.MemoryUSMShared(64, queue=q)
+
+    with pytest.raises(ValueError):
+        q.fill(mem, value, 8, dtype=dtype)
+
+
+def test_fill_type_error():
+    """fill raises TypeError when ``dest`` is not a USM allocation."""
+    try:
+        q = dpctl.SyclQueue()
+    except dpctl.SyclQueueCreationError:
+        pytest.skip("Default constructor for SyclQueue failed")
+
+    with pytest.raises(TypeError) as cm:
+        q.fill(None, 0, 4)
+    assert "_Memory" in str(cm.value)
+
+    with pytest.raises(TypeError) as cm:
+        q.fill(bytearray(16), 0, 4)
+    assert "_Memory" in str(cm.value)

--- a/dpctl/tests/test_sycl_queue_fill.py
+++ b/dpctl/tests/test_sycl_queue_fill.py
@@ -123,6 +123,70 @@ def test_fill_signed_negative_value():
     assert memoryview(mem).tobytes() == b"\xff" * num_elements
 
 
+def test_fill_async():
+    try:
+        q = dpctl.SyclQueue()
+    except dpctl.SyclQueueCreationError:
+        pytest.skip("Default constructor for SyclQueue failed")
+
+    num_elements = 32
+    mem = dpctl.memory.MemoryUSMShared(num_elements, queue=q)
+
+    e = q.fill_async(mem, 0xAB, num_elements)
+    assert isinstance(e, dpctl.SyclEvent)
+    e.wait()
+
+    assert memoryview(mem).tobytes() == b"\xab" * num_elements
+
+
+def test_fill_async_with_dtype():
+    try:
+        q = dpctl.SyclQueue()
+    except dpctl.SyclQueueCreationError:
+        pytest.skip("Default constructor for SyclQueue failed")
+
+    value = 1.5
+    num_elements = 10
+    nbytes = num_elements * 8
+
+    mem = dpctl.memory.MemoryUSMShared(nbytes, queue=q)
+    e = q.fill_async(mem, value, num_elements, dtype="f8")
+    e.wait()
+
+    expected = np.full(num_elements, value, dtype=np.float64).tobytes()
+    assert memoryview(mem)[:nbytes].tobytes() == expected
+
+
+def test_fill_async_with_dep_events():
+    try:
+        q = dpctl.SyclQueue()
+    except dpctl.SyclQueueCreationError:
+        pytest.skip("Default constructor for SyclQueue failed")
+
+    num_elements = 64
+    mem = dpctl.memory.MemoryUSMShared(num_elements, queue=q)
+
+    # The second fill depends on the first, so its value wins deterministically
+    # even on an out-of-order queue.
+    e1 = q.fill_async(mem, 0x11, num_elements)
+    e2 = q.fill_async(mem, 0x22, num_elements, dEvents=[e1])
+    e2.wait()
+
+    assert memoryview(mem).tobytes() == b"\x22" * num_elements
+
+
+def test_fill_async_bad_dep_events():
+    try:
+        q = dpctl.SyclQueue()
+    except dpctl.SyclQueueCreationError:
+        pytest.skip("Default constructor for SyclQueue failed")
+
+    mem = dpctl.memory.MemoryUSMShared(16, queue=q)
+
+    with pytest.raises(TypeError):
+        q.fill_async(mem, 0, 16, dEvents=[None])
+
+
 @pytest.mark.parametrize("dtype", ["c8", "c16"])
 def test_fill_complex_from_real_scalar(dtype):
     try:

--- a/dpctl/tests/test_sycl_queue_fill.py
+++ b/dpctl/tests/test_sycl_queue_fill.py
@@ -281,6 +281,7 @@ def test_fill_with_invalid_dtype():
         ("u2", 1 << 16),
         ("i4", 1.5),
         ("u8", 1 << 64),
+        ("f4", 1e40),
     ],
 )
 def test_fill_value_out_of_range(dtype, value):

--- a/dpctl/tests/test_sycl_queue_fill.py
+++ b/dpctl/tests/test_sycl_queue_fill.py
@@ -56,6 +56,24 @@ _fill_values = {
 }
 
 
+_MEMORY_CLASSES = [
+    dpctl.memory.MemoryUSMShared,
+    dpctl.memory.MemoryUSMHost,
+    dpctl.memory.MemoryUSMDevice,
+]
+
+
+def _skip_if_usm_unsupported(q, mem_cls):
+    dev = q.sycl_device
+    supported = {
+        dpctl.memory.MemoryUSMShared: dev.has_aspect_usm_shared_allocations,
+        dpctl.memory.MemoryUSMHost: dev.has_aspect_usm_host_allocations,
+        dpctl.memory.MemoryUSMDevice: dev.has_aspect_usm_device_allocations,
+    }
+    if not supported[mem_cls]:
+        pytest.skip(f"{mem_cls.__name__} is not supported on this device")
+
+
 def _read_back(mem, nbytes):
     """Return the first ``nbytes`` bytes of a USM allocation as ``bytes``."""
     if isinstance(mem, dpctl.memory.MemoryUSMDevice):
@@ -67,19 +85,14 @@ def _read_back(mem, nbytes):
 
 @pytest.mark.parametrize("dtype", list(_dtype_to_np))
 @pytest.mark.parametrize(
-    "usm_type",
-    [
-        lambda n, q: dpctl.memory.MemoryUSMShared(n, queue=q),
-        lambda n, q: dpctl.memory.MemoryUSMHost(n, queue=q),
-        lambda n, q: dpctl.memory.MemoryUSMDevice(n, queue=q),
-    ],
-    ids=["shared", "host", "device"],
+    "mem_cls", _MEMORY_CLASSES, ids=["shared", "host", "device"]
 )
-def test_fill_with_dtype_valid(dtype, usm_type):
+def test_fill_with_dtype_valid(dtype, mem_cls):
     try:
         q = dpctl.SyclQueue()
     except dpctl.SyclQueueCreationError:
         pytest.skip("Default constructor for SyclQueue failed")
+    _skip_if_usm_unsupported(q, mem_cls)
 
     np_dt = _dtype_to_np[dtype]
     value = _fill_values[dtype]
@@ -87,7 +100,7 @@ def test_fill_with_dtype_valid(dtype, usm_type):
     element_size = np.dtype(np_dt).itemsize
     nbytes = num_elements * element_size
 
-    mem = usm_type(nbytes, q)
+    mem = mem_cls(nbytes, queue=q)
     q.fill(mem, value, num_elements, dtype=dtype)
 
     expected = np.full(num_elements, value, dtype=np_dt).tobytes()
@@ -164,15 +177,15 @@ def test_fill_async_with_dep_events():
         pytest.skip("Default constructor for SyclQueue failed")
 
     num_elements = 64
+    half = num_elements // 2
     mem = dpctl.memory.MemoryUSMShared(num_elements, queue=q)
 
-    # The second fill depends on the first, so its value wins deterministically
-    # even on an out-of-order queue.
     e1 = q.fill_async(mem, 0x11, num_elements)
-    e2 = q.fill_async(mem, 0x22, num_elements, dEvents=[e1])
+    e2 = q.fill_async(mem, 0x22, half, dEvents=[e1])
     e2.wait()
 
-    assert memoryview(mem).tobytes() == b"\x22" * num_elements
+    expected = b"\x22" * half + b"\x11" * (num_elements - half)
+    assert memoryview(mem).tobytes() == expected
 
 
 def test_fill_async_bad_dep_events():

--- a/dpctl/tests/test_sycl_queue_fill.py
+++ b/dpctl/tests/test_sycl_queue_fill.py
@@ -310,3 +310,22 @@ def test_fill_type_error():
     with pytest.raises(TypeError) as cm:
         q.fill(bytearray(16), 0, 4)
     assert "_Memory" in str(cm.value)
+
+
+def test_fill_count_out_of_bounds():
+    """fill raises ValueError when count exceeds the destination size."""
+    try:
+        q = dpctl.SyclQueue()
+    except dpctl.SyclQueueCreationError:
+        pytest.skip("Default constructor for SyclQueue failed")
+
+    nbytes = 64
+    mem = dpctl.memory.MemoryUSMShared(nbytes, queue=q)
+
+    q.fill(mem, 0, nbytes, dtype="u1")
+    with pytest.raises(ValueError):
+        q.fill(mem, 0, nbytes + 1, dtype="u1")
+    with pytest.raises(ValueError):
+        q.fill(mem, 0, 9, dtype="i8")
+    with pytest.raises(ValueError):
+        q.fill_async(mem, 0, nbytes + 1)

--- a/libsyclinterface/include/syclinterface/dpctl_sycl_queue_interface.h
+++ b/libsyclinterface/include/syclinterface/dpctl_sycl_queue_interface.h
@@ -504,6 +504,29 @@ DPCTLQueue_Fill8(__dpctl_keep const DPCTLSyclQueueRef QRef,
  *
  * @param    QRef           An opaque pointer to the ``sycl::queue``.
  * @param    USMRef         An USM pointer to the memory to fill.
+ * @param    Value          A uint8_t value to fill.
+ * @param    Count          A number of uint8_t elements to fill.
+ * @param    DepEvents      A pointer to array of DPCTLSyclEventRef opaque
+ *                          pointers to dependent events.
+ * @param    DepEventsCount A number of dependent events.
+ * @return   An opaque pointer to the ``sycl::event`` returned by the
+ *           ``sycl::queue::fill`` function.
+ * @ingroup QueueInterface
+ */
+DPCTL_API
+__dpctl_give DPCTLSyclEventRef
+DPCTLQueue_Fill8WithEvents(__dpctl_keep const DPCTLSyclQueueRef QRef,
+                           void *USMRef,
+                           uint8_t Value,
+                           size_t Count,
+                           __dpctl_keep const DPCTLSyclEventRef *DepEvents,
+                           size_t DepEventsCount);
+
+/*!
+ * @brief C-API wrapper for ``sycl::queue::fill``.
+ *
+ * @param    QRef           An opaque pointer to the ``sycl::queue``.
+ * @param    USMRef         An USM pointer to the memory to fill.
  * @param    Value          A uint16_t value to fill.
  * @param    Count          A number of uint16_t elements to fill.
  * @return   An opaque pointer to the ``sycl::event`` returned by the
@@ -516,6 +539,29 @@ DPCTLQueue_Fill16(__dpctl_keep const DPCTLSyclQueueRef QRef,
                   void *USMRef,
                   uint16_t Value,
                   size_t Count);
+
+/*!
+ * @brief C-API wrapper for ``sycl::queue::fill``.
+ *
+ * @param    QRef           An opaque pointer to the ``sycl::queue``.
+ * @param    USMRef         An USM pointer to the memory to fill.
+ * @param    Value          A uint16_t value to fill.
+ * @param    Count          A number of uint16_t elements to fill.
+ * @param    DepEvents      A pointer to array of DPCTLSyclEventRef opaque
+ *                          pointers to dependent events.
+ * @param    DepEventsCount A number of dependent events.
+ * @return   An opaque pointer to the ``sycl::event`` returned by the
+ *           ``sycl::queue::fill`` function.
+ * @ingroup QueueInterface
+ */
+DPCTL_API
+__dpctl_give DPCTLSyclEventRef
+DPCTLQueue_Fill16WithEvents(__dpctl_keep const DPCTLSyclQueueRef QRef,
+                            void *USMRef,
+                            uint16_t Value,
+                            size_t Count,
+                            __dpctl_keep const DPCTLSyclEventRef *DepEvents,
+                            size_t DepEventsCount);
 
 /*!
  * @brief C-API wrapper for ``sycl::queue::fill``.
@@ -540,6 +586,29 @@ DPCTLQueue_Fill32(__dpctl_keep const DPCTLSyclQueueRef QRef,
  *
  * @param    QRef           An opaque pointer to the ``sycl::queue``.
  * @param    USMRef         An USM pointer to the memory to fill.
+ * @param    Value          A uint32_t value to fill.
+ * @param    Count          A number of uint32_t elements to fill.
+ * @param    DepEvents      A pointer to array of DPCTLSyclEventRef opaque
+ *                          pointers to dependent events.
+ * @param    DepEventsCount A number of dependent events.
+ * @return   An opaque pointer to the ``sycl::event`` returned by the
+ *           ``sycl::queue::fill`` function.
+ * @ingroup QueueInterface
+ */
+DPCTL_API
+__dpctl_give DPCTLSyclEventRef
+DPCTLQueue_Fill32WithEvents(__dpctl_keep const DPCTLSyclQueueRef QRef,
+                            void *USMRef,
+                            uint32_t Value,
+                            size_t Count,
+                            __dpctl_keep const DPCTLSyclEventRef *DepEvents,
+                            size_t DepEventsCount);
+
+/*!
+ * @brief C-API wrapper for ``sycl::queue::fill``.
+ *
+ * @param    QRef           An opaque pointer to the ``sycl::queue``.
+ * @param    USMRef         An USM pointer to the memory to fill.
  * @param    Value          A uint64_t value to fill.
  * @param    Count          A number of uint64_t elements to fill.
  * @return   An opaque pointer to the ``sycl::event`` returned by the
@@ -552,6 +621,29 @@ DPCTLQueue_Fill64(__dpctl_keep const DPCTLSyclQueueRef QRef,
                   void *USMRef,
                   uint64_t Value,
                   size_t Count);
+
+/*!
+ * @brief C-API wrapper for ``sycl::queue::fill``.
+ *
+ * @param    QRef           An opaque pointer to the ``sycl::queue``.
+ * @param    USMRef         An USM pointer to the memory to fill.
+ * @param    Value          A uint64_t value to fill.
+ * @param    Count          A number of uint64_t elements to fill.
+ * @param    DepEvents      A pointer to array of DPCTLSyclEventRef opaque
+ *                          pointers to dependent events.
+ * @param    DepEventsCount A number of dependent events.
+ * @return   An opaque pointer to the ``sycl::event`` returned by the
+ *           ``sycl::queue::fill`` function.
+ * @ingroup QueueInterface
+ */
+DPCTL_API
+__dpctl_give DPCTLSyclEventRef
+DPCTLQueue_Fill64WithEvents(__dpctl_keep const DPCTLSyclQueueRef QRef,
+                            void *USMRef,
+                            uint64_t Value,
+                            size_t Count,
+                            __dpctl_keep const DPCTLSyclEventRef *DepEvents,
+                            size_t DepEventsCount);
 
 /*!
  * @brief C-API wrapper for ``sycl::queue::fill``.
@@ -571,5 +663,29 @@ DPCTLQueue_Fill128(__dpctl_keep const DPCTLSyclQueueRef QRef,
                    void *USMRef,
                    uint64_t *Value,
                    size_t Count);
+
+/*!
+ * @brief C-API wrapper for ``sycl::queue::fill``.
+ *
+ * @param    QRef           An opaque pointer to the ``sycl::queue``.
+ * @param    USMRef         An USM pointer to the memory to fill.
+ * @param    Value          A pointer to uint64_t array of 2 elements with value
+ * to fill.
+ * @param    Count          A number of 128-bit elements to fill.
+ * @param    DepEvents      A pointer to array of DPCTLSyclEventRef opaque
+ *                          pointers to dependent events.
+ * @param    DepEventsCount A number of dependent events.
+ * @return   An opaque pointer to the ``sycl::event`` returned by the
+ *           ``sycl::queue::fill`` function.
+ * @ingroup QueueInterface
+ */
+DPCTL_API
+__dpctl_give DPCTLSyclEventRef
+DPCTLQueue_Fill128WithEvents(__dpctl_keep const DPCTLSyclQueueRef QRef,
+                             void *USMRef,
+                             uint64_t *Value,
+                             size_t Count,
+                             __dpctl_keep const DPCTLSyclEventRef *DepEvents,
+                             size_t DepEventsCount);
 
 DPCTL_C_EXTERN_C_END

--- a/libsyclinterface/source/dpctl_sycl_queue_interface.cpp
+++ b/libsyclinterface/source/dpctl_sycl_queue_interface.cpp
@@ -958,8 +958,8 @@ DPCTLQueue_Fill8WithEvents(__dpctl_keep const DPCTLSyclQueueRef QRef,
         return wrap<event>(new event(std::move(ev)));
     }
     else {
-        error_handler("QRef or USMRef passed to fill8 were NULL.", __FILE__,
-                      __func__, __LINE__);
+        error_handler("QRef or USMRef passed to fill8_async were NULL.",
+                      __FILE__, __func__, __LINE__);
         return nullptr;
     }
 }
@@ -1017,8 +1017,8 @@ DPCTLQueue_Fill16WithEvents(__dpctl_keep const DPCTLSyclQueueRef QRef,
         return wrap<event>(new event(std::move(ev)));
     }
     else {
-        error_handler("QRef or USMRef passed to fill16 were NULL.", __FILE__,
-                      __func__, __LINE__);
+        error_handler("QRef or USMRef passed to fill16_async were NULL.",
+                      __FILE__, __func__, __LINE__);
         return nullptr;
     }
 }
@@ -1076,8 +1076,8 @@ DPCTLQueue_Fill32WithEvents(__dpctl_keep const DPCTLSyclQueueRef QRef,
         return wrap<event>(new event(std::move(ev)));
     }
     else {
-        error_handler("QRef or USMRef passed to fill32 were NULL.", __FILE__,
-                      __func__, __LINE__);
+        error_handler("QRef or USMRef passed to fill32_async were NULL.",
+                      __FILE__, __func__, __LINE__);
         return nullptr;
     }
 }
@@ -1135,8 +1135,8 @@ DPCTLQueue_Fill64WithEvents(__dpctl_keep const DPCTLSyclQueueRef QRef,
         return wrap<event>(new event(std::move(ev)));
     }
     else {
-        error_handler("QRef or USMRef passed to fill64 were NULL.", __FILE__,
-                      __func__, __LINE__);
+        error_handler("QRef or USMRef passed to fill64_async were NULL.",
+                      __FILE__, __func__, __LINE__);
         return nullptr;
     }
 }
@@ -1200,8 +1200,8 @@ DPCTLQueue_Fill128WithEvents(__dpctl_keep const DPCTLSyclQueueRef QRef,
         return wrap<event>(new event(std::move(ev)));
     }
     else {
-        error_handler("QRef or USMRef passed to fill128 were NULL.", __FILE__,
-                      __func__, __LINE__);
+        error_handler("QRef or USMRef passed to fill128_async were NULL.",
+                      __FILE__, __func__, __LINE__);
         return nullptr;
     }
 }

--- a/libsyclinterface/source/dpctl_sycl_queue_interface.cpp
+++ b/libsyclinterface/source/dpctl_sycl_queue_interface.cpp
@@ -1184,7 +1184,7 @@ DPCTLQueue_Fill128(__dpctl_keep const DPCTLSyclQueueRef QRef,
                    size_t Count)
 {
     auto Q = unwrap<queue>(QRef);
-    if (Q && USMRef) {
+    if (Q && USMRef && Value) {
         sycl::event ev;
         try {
             complexNumber Val;
@@ -1198,8 +1198,8 @@ DPCTLQueue_Fill128(__dpctl_keep const DPCTLSyclQueueRef QRef,
         return wrap<event>(new event(std::move(ev)));
     }
     else {
-        error_handler("QRef or USMRef passed to fill128 were NULL.", __FILE__,
-                      __func__, __LINE__);
+        error_handler("QRef, USMRef, or Value passed to fill128 were NULL.",
+                      __FILE__, __func__, __LINE__);
         return nullptr;
     }
 }
@@ -1213,7 +1213,7 @@ DPCTLQueue_Fill128WithEvents(__dpctl_keep const DPCTLSyclQueueRef QRef,
                              size_t DepEventsCount)
 {
     auto Q = unwrap<queue>(QRef);
-    if (Q && USMRef) {
+    if (Q && USMRef && Value) {
         sycl::event ev;
         try {
             std::vector<event> dep_events;
@@ -1236,8 +1236,9 @@ DPCTLQueue_Fill128WithEvents(__dpctl_keep const DPCTLSyclQueueRef QRef,
         return wrap<event>(new event(std::move(ev)));
     }
     else {
-        error_handler("QRef or USMRef passed to fill128_async were NULL.",
-                      __FILE__, __func__, __LINE__);
+        error_handler(
+            "QRef, USMRef, or Value passed to fill128_async were NULL.",
+            __FILE__, __func__, __LINE__);
         return nullptr;
     }
 }

--- a/libsyclinterface/source/dpctl_sycl_queue_interface.cpp
+++ b/libsyclinterface/source/dpctl_sycl_queue_interface.cpp
@@ -930,6 +930,41 @@ DPCTLQueue_Fill8(__dpctl_keep const DPCTLSyclQueueRef QRef,
 }
 
 __dpctl_give DPCTLSyclEventRef
+DPCTLQueue_Fill8WithEvents(__dpctl_keep const DPCTLSyclQueueRef QRef,
+                           void *USMRef,
+                           uint8_t Value,
+                           size_t Count,
+                           const DPCTLSyclEventRef *DepEvents,
+                           size_t DepEventsCount)
+{
+    auto Q = unwrap<queue>(QRef);
+    if (Q && USMRef) {
+        sycl::event ev;
+        try {
+            std::vector<event> dep_events;
+            if (DepEvents) {
+                dep_events.reserve(DepEventsCount);
+                for (size_t i = 0; i < DepEventsCount; ++i) {
+                    event *ei = unwrap<event>(DepEvents[i]);
+                    if (ei)
+                        dep_events.push_back(*ei);
+                }
+            }
+            ev = Q->fill<uint8_t>(USMRef, Value, Count, dep_events);
+        } catch (std::exception const &e) {
+            error_handler(e, __FILE__, __func__, __LINE__);
+            return nullptr;
+        }
+        return wrap<event>(new event(std::move(ev)));
+    }
+    else {
+        error_handler("QRef or USMRef passed to fill8 were NULL.", __FILE__,
+                      __func__, __LINE__);
+        return nullptr;
+    }
+}
+
+__dpctl_give DPCTLSyclEventRef
 DPCTLQueue_Fill16(__dpctl_keep const DPCTLSyclQueueRef QRef,
                   void *USMRef,
                   uint16_t Value,
@@ -940,6 +975,41 @@ DPCTLQueue_Fill16(__dpctl_keep const DPCTLSyclQueueRef QRef,
         sycl::event ev;
         try {
             ev = Q->fill<uint16_t>(USMRef, Value, Count);
+        } catch (std::exception const &e) {
+            error_handler(e, __FILE__, __func__, __LINE__);
+            return nullptr;
+        }
+        return wrap<event>(new event(std::move(ev)));
+    }
+    else {
+        error_handler("QRef or USMRef passed to fill16 were NULL.", __FILE__,
+                      __func__, __LINE__);
+        return nullptr;
+    }
+}
+
+__dpctl_give DPCTLSyclEventRef
+DPCTLQueue_Fill16WithEvents(__dpctl_keep const DPCTLSyclQueueRef QRef,
+                            void *USMRef,
+                            uint16_t Value,
+                            size_t Count,
+                            const DPCTLSyclEventRef *DepEvents,
+                            size_t DepEventsCount)
+{
+    auto Q = unwrap<queue>(QRef);
+    if (Q && USMRef) {
+        sycl::event ev;
+        try {
+            std::vector<event> dep_events;
+            if (DepEvents) {
+                dep_events.reserve(DepEventsCount);
+                for (size_t i = 0; i < DepEventsCount; ++i) {
+                    event *ei = unwrap<event>(DepEvents[i]);
+                    if (ei)
+                        dep_events.push_back(*ei);
+                }
+            }
+            ev = Q->fill<uint16_t>(USMRef, Value, Count, dep_events);
         } catch (std::exception const &e) {
             error_handler(e, __FILE__, __func__, __LINE__);
             return nullptr;
@@ -978,6 +1048,41 @@ DPCTLQueue_Fill32(__dpctl_keep const DPCTLSyclQueueRef QRef,
 }
 
 __dpctl_give DPCTLSyclEventRef
+DPCTLQueue_Fill32WithEvents(__dpctl_keep const DPCTLSyclQueueRef QRef,
+                            void *USMRef,
+                            uint32_t Value,
+                            size_t Count,
+                            const DPCTLSyclEventRef *DepEvents,
+                            size_t DepEventsCount)
+{
+    auto Q = unwrap<queue>(QRef);
+    if (Q && USMRef) {
+        sycl::event ev;
+        try {
+            std::vector<event> dep_events;
+            if (DepEvents) {
+                dep_events.reserve(DepEventsCount);
+                for (size_t i = 0; i < DepEventsCount; ++i) {
+                    event *ei = unwrap<event>(DepEvents[i]);
+                    if (ei)
+                        dep_events.push_back(*ei);
+                }
+            }
+            ev = Q->fill<uint32_t>(USMRef, Value, Count, dep_events);
+        } catch (std::exception const &e) {
+            error_handler(e, __FILE__, __func__, __LINE__);
+            return nullptr;
+        }
+        return wrap<event>(new event(std::move(ev)));
+    }
+    else {
+        error_handler("QRef or USMRef passed to fill32 were NULL.", __FILE__,
+                      __func__, __LINE__);
+        return nullptr;
+    }
+}
+
+__dpctl_give DPCTLSyclEventRef
 DPCTLQueue_Fill64(__dpctl_keep const DPCTLSyclQueueRef QRef,
                   void *USMRef,
                   uint64_t Value,
@@ -988,6 +1093,41 @@ DPCTLQueue_Fill64(__dpctl_keep const DPCTLSyclQueueRef QRef,
         sycl::event ev;
         try {
             ev = Q->fill<uint64_t>(USMRef, Value, Count);
+        } catch (std::exception const &e) {
+            error_handler(e, __FILE__, __func__, __LINE__);
+            return nullptr;
+        }
+        return wrap<event>(new event(std::move(ev)));
+    }
+    else {
+        error_handler("QRef or USMRef passed to fill64 were NULL.", __FILE__,
+                      __func__, __LINE__);
+        return nullptr;
+    }
+}
+
+__dpctl_give DPCTLSyclEventRef
+DPCTLQueue_Fill64WithEvents(__dpctl_keep const DPCTLSyclQueueRef QRef,
+                            void *USMRef,
+                            uint64_t Value,
+                            size_t Count,
+                            const DPCTLSyclEventRef *DepEvents,
+                            size_t DepEventsCount)
+{
+    auto Q = unwrap<queue>(QRef);
+    if (Q && USMRef) {
+        sycl::event ev;
+        try {
+            std::vector<event> dep_events;
+            if (DepEvents) {
+                dep_events.reserve(DepEventsCount);
+                for (size_t i = 0; i < DepEventsCount; ++i) {
+                    event *ei = unwrap<event>(DepEvents[i]);
+                    if (ei)
+                        dep_events.push_back(*ei);
+                }
+            }
+            ev = Q->fill<uint64_t>(USMRef, Value, Count, dep_events);
         } catch (std::exception const &e) {
             error_handler(e, __FILE__, __func__, __LINE__);
             return nullptr;
@@ -1015,6 +1155,44 @@ DPCTLQueue_Fill128(__dpctl_keep const DPCTLSyclQueueRef QRef,
             Val.real = Value[0];
             Val.imag = Value[1];
             ev = Q->fill(USMRef, Val, Count);
+        } catch (std::exception const &e) {
+            error_handler(e, __FILE__, __func__, __LINE__);
+            return nullptr;
+        }
+        return wrap<event>(new event(std::move(ev)));
+    }
+    else {
+        error_handler("QRef or USMRef passed to fill128 were NULL.", __FILE__,
+                      __func__, __LINE__);
+        return nullptr;
+    }
+}
+
+__dpctl_give DPCTLSyclEventRef
+DPCTLQueue_Fill128WithEvents(__dpctl_keep const DPCTLSyclQueueRef QRef,
+                             void *USMRef,
+                             uint64_t *Value,
+                             size_t Count,
+                             const DPCTLSyclEventRef *DepEvents,
+                             size_t DepEventsCount)
+{
+    auto Q = unwrap<queue>(QRef);
+    if (Q && USMRef) {
+        sycl::event ev;
+        try {
+            std::vector<event> dep_events;
+            if (DepEvents) {
+                dep_events.reserve(DepEventsCount);
+                for (size_t i = 0; i < DepEventsCount; ++i) {
+                    event *ei = unwrap<event>(DepEvents[i]);
+                    if (ei)
+                        dep_events.push_back(*ei);
+                }
+            }
+            complexNumber Val;
+            Val.real = Value[0];
+            Val.imag = Value[1];
+            ev = Q->fill(USMRef, Val, Count, dep_events);
         } catch (std::exception const &e) {
             error_handler(e, __FILE__, __func__, __LINE__);
             return nullptr;

--- a/libsyclinterface/tests/test_sycl_queue_interface.cpp
+++ b/libsyclinterface/tests/test_sycl_queue_interface.cpp
@@ -559,6 +559,26 @@ TEST(TestDPCTLSyclQueueInterface, CheckFillNullQRef)
 
     ASSERT_NO_FATAL_FAILURE(ERef = DPCTLQueue_Fill128(QRef, p, val128, 1));
     ASSERT_FALSE(bool(ERef));
+
+    ASSERT_NO_FATAL_FAILURE(
+        ERef = DPCTLQueue_Fill8WithEvents(QRef, p, val8, 1, nullptr, 0));
+    ASSERT_FALSE(bool(ERef));
+
+    ASSERT_NO_FATAL_FAILURE(
+        ERef = DPCTLQueue_Fill16WithEvents(QRef, p, val16, 1, nullptr, 0));
+    ASSERT_FALSE(bool(ERef));
+
+    ASSERT_NO_FATAL_FAILURE(
+        ERef = DPCTLQueue_Fill32WithEvents(QRef, p, val32, 1, nullptr, 0));
+    ASSERT_FALSE(bool(ERef));
+
+    ASSERT_NO_FATAL_FAILURE(
+        ERef = DPCTLQueue_Fill64WithEvents(QRef, p, val64, 1, nullptr, 0));
+    ASSERT_FALSE(bool(ERef));
+
+    ASSERT_NO_FATAL_FAILURE(
+        ERef = DPCTLQueue_Fill128WithEvents(QRef, p, val128, 1, nullptr, 0));
+    ASSERT_FALSE(bool(ERef));
 }
 
 TEST_P(TestDPCTLQueueMemberFunctions, CheckFill8)
@@ -740,6 +760,210 @@ TEST_P(TestDPCTLQueueMemberFunctions, CheckFill128)
     ASSERT_NO_FATAL_FAILURE(DPCTLEvent_Wait(Memcpy_ERef));
 
     ASSERT_NO_FATAL_FAILURE(DPCTLEvent_Delete(Fill128_ERef));
+    ASSERT_NO_FATAL_FAILURE(DPCTLEvent_Delete(Memcpy_ERef));
+
+    ASSERT_NO_FATAL_FAILURE(DPCTLfree_with_queue(p, QRef));
+
+    for (size_t i = 0; i < nelems; ++i) {
+        ASSERT_TRUE(host_arr[i].first == val.first);
+        ASSERT_TRUE(host_arr[i].second == val.second);
+    }
+    delete[] host_arr;
+}
+
+TEST_P(TestDPCTLQueueMemberFunctions, CheckFill8WithEvents)
+{
+    using T = uint8_t;
+    DPCTLSyclUSMRef p = nullptr;
+    DPCTLSyclEventRef FillDep_ERef = nullptr;
+    DPCTLSyclEventRef Fill_ERef = nullptr;
+    DPCTLSyclEventRef Memcpy_ERef = nullptr;
+    T val = static_cast<T>(0xB);
+    size_t nelems = 256;
+    T *host_arr = new T[nelems];
+    size_t nbytes = nelems * sizeof(T);
+
+    ASSERT_FALSE(host_arr == nullptr);
+
+    ASSERT_NO_FATAL_FAILURE(p = DPCTLmalloc_device(nbytes, QRef));
+    ASSERT_FALSE(p == nullptr);
+
+    ASSERT_NO_FATAL_FAILURE(FillDep_ERef =
+                                DPCTLQueue_Fill8(QRef, (void *)p, 0, nelems));
+
+    ASSERT_NO_FATAL_FAILURE(
+        Fill_ERef = DPCTLQueue_Fill8WithEvents(QRef, (void *)p, val, nelems,
+                                               &FillDep_ERef, 1));
+
+    ASSERT_NO_FATAL_FAILURE(Memcpy_ERef = DPCTLQueue_MemcpyWithEvents(
+                                QRef, host_arr, p, nbytes, &Fill_ERef, 1));
+    ASSERT_NO_FATAL_FAILURE(DPCTLEvent_Wait(Memcpy_ERef));
+
+    ASSERT_NO_FATAL_FAILURE(DPCTLEvent_Delete(FillDep_ERef));
+    ASSERT_NO_FATAL_FAILURE(DPCTLEvent_Delete(Fill_ERef));
+    ASSERT_NO_FATAL_FAILURE(DPCTLEvent_Delete(Memcpy_ERef));
+
+    ASSERT_NO_FATAL_FAILURE(DPCTLfree_with_queue(p, QRef));
+
+    for (size_t i = 0; i < nelems; ++i) {
+        ASSERT_TRUE(host_arr[i] == val);
+    }
+    delete[] host_arr;
+}
+
+TEST_P(TestDPCTLQueueMemberFunctions, CheckFill16WithEvents)
+{
+    using T = uint16_t;
+    DPCTLSyclUSMRef p = nullptr;
+    DPCTLSyclEventRef FillDep_ERef = nullptr;
+    DPCTLSyclEventRef Fill_ERef = nullptr;
+    DPCTLSyclEventRef Memcpy_ERef = nullptr;
+    T val = static_cast<T>(0xAB);
+    size_t nelems = 256;
+    T *host_arr = new T[nelems];
+    size_t nbytes = nelems * sizeof(T);
+
+    ASSERT_FALSE(host_arr == nullptr);
+
+    ASSERT_NO_FATAL_FAILURE(p = DPCTLmalloc_device(nbytes, QRef));
+    ASSERT_FALSE(p == nullptr);
+
+    ASSERT_NO_FATAL_FAILURE(FillDep_ERef =
+                                DPCTLQueue_Fill16(QRef, (void *)p, 0, nelems));
+
+    ASSERT_NO_FATAL_FAILURE(
+        Fill_ERef = DPCTLQueue_Fill16WithEvents(QRef, (void *)p, val, nelems,
+                                                &FillDep_ERef, 1));
+
+    ASSERT_NO_FATAL_FAILURE(Memcpy_ERef = DPCTLQueue_MemcpyWithEvents(
+                                QRef, host_arr, p, nbytes, &Fill_ERef, 1));
+    ASSERT_NO_FATAL_FAILURE(DPCTLEvent_Wait(Memcpy_ERef));
+
+    ASSERT_NO_FATAL_FAILURE(DPCTLEvent_Delete(FillDep_ERef));
+    ASSERT_NO_FATAL_FAILURE(DPCTLEvent_Delete(Fill_ERef));
+    ASSERT_NO_FATAL_FAILURE(DPCTLEvent_Delete(Memcpy_ERef));
+
+    ASSERT_NO_FATAL_FAILURE(DPCTLfree_with_queue(p, QRef));
+
+    for (size_t i = 0; i < nelems; ++i) {
+        ASSERT_TRUE(host_arr[i] == val);
+    }
+    delete[] host_arr;
+}
+
+TEST_P(TestDPCTLQueueMemberFunctions, CheckFill32WithEvents)
+{
+    using T = uint32_t;
+    DPCTLSyclUSMRef p = nullptr;
+    DPCTLSyclEventRef FillDep_ERef = nullptr;
+    DPCTLSyclEventRef Fill_ERef = nullptr;
+    DPCTLSyclEventRef Memcpy_ERef = nullptr;
+    T val = static_cast<T>(0xABCD);
+    size_t nelems = 256;
+    T *host_arr = new T[nelems];
+    size_t nbytes = nelems * sizeof(T);
+
+    ASSERT_FALSE(host_arr == nullptr);
+
+    ASSERT_NO_FATAL_FAILURE(p = DPCTLmalloc_device(nbytes, QRef));
+    ASSERT_FALSE(p == nullptr);
+
+    ASSERT_NO_FATAL_FAILURE(FillDep_ERef =
+                                DPCTLQueue_Fill32(QRef, (void *)p, 0, nelems));
+
+    ASSERT_NO_FATAL_FAILURE(
+        Fill_ERef = DPCTLQueue_Fill32WithEvents(QRef, (void *)p, val, nelems,
+                                                &FillDep_ERef, 1));
+
+    ASSERT_NO_FATAL_FAILURE(Memcpy_ERef = DPCTLQueue_MemcpyWithEvents(
+                                QRef, host_arr, p, nbytes, &Fill_ERef, 1));
+    ASSERT_NO_FATAL_FAILURE(DPCTLEvent_Wait(Memcpy_ERef));
+
+    ASSERT_NO_FATAL_FAILURE(DPCTLEvent_Delete(FillDep_ERef));
+    ASSERT_NO_FATAL_FAILURE(DPCTLEvent_Delete(Fill_ERef));
+    ASSERT_NO_FATAL_FAILURE(DPCTLEvent_Delete(Memcpy_ERef));
+
+    ASSERT_NO_FATAL_FAILURE(DPCTLfree_with_queue(p, QRef));
+
+    for (size_t i = 0; i < nelems; ++i) {
+        ASSERT_TRUE(host_arr[i] == val);
+    }
+    delete[] host_arr;
+}
+
+TEST_P(TestDPCTLQueueMemberFunctions, CheckFill64WithEvents)
+{
+    using T = uint64_t;
+    DPCTLSyclUSMRef p = nullptr;
+    DPCTLSyclEventRef FillDep_ERef = nullptr;
+    DPCTLSyclEventRef Fill_ERef = nullptr;
+    DPCTLSyclEventRef Memcpy_ERef = nullptr;
+    T val = static_cast<T>(0xABCDEF73);
+    size_t nelems = 256;
+    T *host_arr = new T[nelems];
+    size_t nbytes = nelems * sizeof(T);
+
+    ASSERT_FALSE(host_arr == nullptr);
+
+    ASSERT_NO_FATAL_FAILURE(p = DPCTLmalloc_device(nbytes, QRef));
+    ASSERT_FALSE(p == nullptr);
+
+    ASSERT_NO_FATAL_FAILURE(FillDep_ERef =
+                                DPCTLQueue_Fill64(QRef, (void *)p, 0, nelems));
+
+    ASSERT_NO_FATAL_FAILURE(
+        Fill_ERef = DPCTLQueue_Fill64WithEvents(QRef, (void *)p, val, nelems,
+                                                &FillDep_ERef, 1));
+
+    ASSERT_NO_FATAL_FAILURE(Memcpy_ERef = DPCTLQueue_MemcpyWithEvents(
+                                QRef, host_arr, p, nbytes, &Fill_ERef, 1));
+    ASSERT_NO_FATAL_FAILURE(DPCTLEvent_Wait(Memcpy_ERef));
+
+    ASSERT_NO_FATAL_FAILURE(DPCTLEvent_Delete(FillDep_ERef));
+    ASSERT_NO_FATAL_FAILURE(DPCTLEvent_Delete(Fill_ERef));
+    ASSERT_NO_FATAL_FAILURE(DPCTLEvent_Delete(Memcpy_ERef));
+
+    ASSERT_NO_FATAL_FAILURE(DPCTLfree_with_queue(p, QRef));
+
+    for (size_t i = 0; i < nelems; ++i) {
+        ASSERT_TRUE(host_arr[i] == val);
+    }
+    delete[] host_arr;
+}
+
+TEST_P(TestDPCTLQueueMemberFunctions, CheckFill128WithEvents)
+{
+    using T = value128_t;
+    DPCTLSyclUSMRef p = nullptr;
+    DPCTLSyclEventRef FillDep_ERef = nullptr;
+    DPCTLSyclEventRef Fill_ERef = nullptr;
+    DPCTLSyclEventRef Memcpy_ERef = nullptr;
+    T val{static_cast<uint64_t>(0xABCDEF73), static_cast<uint64_t>(0x3746AF05)};
+    T zero{};
+    size_t nelems = 256;
+    T *host_arr = new T[nelems];
+    size_t nbytes = nelems * sizeof(T);
+
+    ASSERT_FALSE(host_arr == nullptr);
+
+    ASSERT_NO_FATAL_FAILURE(p = DPCTLmalloc_device(nbytes, QRef));
+    ASSERT_FALSE(p == nullptr);
+
+    ASSERT_NO_FATAL_FAILURE(
+        FillDep_ERef = DPCTLQueue_Fill128(
+            QRef, (void *)p, reinterpret_cast<uint64_t *>(&zero), nelems));
+
+    ASSERT_NO_FATAL_FAILURE(Fill_ERef = DPCTLQueue_Fill128WithEvents(
+                                QRef, (void *)p,
+                                reinterpret_cast<uint64_t *>(&val), nelems,
+                                &FillDep_ERef, 1));
+
+    ASSERT_NO_FATAL_FAILURE(Memcpy_ERef = DPCTLQueue_MemcpyWithEvents(
+                                QRef, host_arr, p, nbytes, &Fill_ERef, 1));
+    ASSERT_NO_FATAL_FAILURE(DPCTLEvent_Wait(Memcpy_ERef));
+
+    ASSERT_NO_FATAL_FAILURE(DPCTLEvent_Delete(FillDep_ERef));
+    ASSERT_NO_FATAL_FAILURE(DPCTLEvent_Delete(Fill_ERef));
     ASSERT_NO_FATAL_FAILURE(DPCTLEvent_Delete(Memcpy_ERef));
 
     ASSERT_NO_FATAL_FAILURE(DPCTLfree_with_queue(p, QRef));

--- a/libsyclinterface/tests/test_sycl_queue_interface.cpp
+++ b/libsyclinterface/tests/test_sycl_queue_interface.cpp
@@ -796,6 +796,10 @@ TEST_P(TestDPCTLQueueMemberFunctions, CheckFill128)
     ASSERT_FALSE(p == nullptr);
 
     ASSERT_NO_FATAL_FAILURE(
+        Fill128_ERef = DPCTLQueue_Fill128(QRef, (void *)p, nullptr, nelems));
+    ASSERT_FALSE(bool(Fill128_ERef));
+
+    ASSERT_NO_FATAL_FAILURE(
         Fill128_ERef = DPCTLQueue_Fill128(
             QRef, (void *)p, reinterpret_cast<uint64_t *>(&val), nelems));
 
@@ -992,6 +996,10 @@ TEST_P(TestDPCTLQueueMemberFunctions, CheckFill128WithEvents)
 
     ASSERT_NO_FATAL_FAILURE(p = DPCTLmalloc_device(nbytes, QRef));
     ASSERT_FALSE(p == nullptr);
+
+    ASSERT_NO_FATAL_FAILURE(Fill_ERef = DPCTLQueue_Fill128WithEvents(
+                                QRef, (void *)p, nullptr, nelems, nullptr, 0));
+    ASSERT_FALSE(bool(Fill_ERef));
 
     ASSERT_NO_FATAL_FAILURE(
         FillDep_ERef = DPCTLQueue_Fill128(


### PR DESCRIPTION
This PR proposes adding `dpctl.SyclQueue.fill` and `dpctl.SyclQueue.fill_async` methods as a Python wrapper over `sycl::queue::fill` backed by the existing `DPCTLQueue_Fill8/16/32/64/128` and new `DPCTLQueue_Fill8/16/32/64/128WithEvents` C-API functions and adding a new `test_sycl_queue_fill.py`

- [ ] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [ ] Have you added your changes to the changelog?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
