### PR TITLE
Fix check for level zero headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Registered `DPCTL_PARTITION_AFFINITY_DOMAIN_UNKNOWN` enumerator when `DPCTLDevice_GetPartitionAffinityDomains` receives an unrecognized value from the SYCL runtime [gh-2324](https://github.com/IntelPython/dpctl/pull/2324)
 
 ### Fixed
+* Fixed incorrect paths in `GetLevelZeroHeaders.cmake` [gh-2366](https://github.com/IntelPython/dpctl/pull/2366)
 
 ### Maintenance
 * Updated pybind11 version used by `dpctl` and examples [gh-2357](https://github.com/IntelPython/dpctl/pull/2357)

--- a/libsyclinterface/cmake/modules/GetLevelZeroHeaders.cmake
+++ b/libsyclinterface/cmake/modules/GetLevelZeroHeaders.cmake
@@ -13,7 +13,7 @@
 # limitations under the License.
 #
 # The module uses git to clone the Level Zero source repository into the
-# CMAKE_CURRENT_BINARY_DIR. The path to the Level Zero headers is then returned
+# CMAKE_BINARY_DIR. The path to the Level Zero headers is then returned
 # to the caller in the LEVEL_ZERO_INCLUDE_DIR variable.
 #
 # Example usage:
@@ -26,13 +26,13 @@
 
 function(get_level_zero_headers)
 
-    if(EXISTS level-zero)
+    if(EXISTS "${CMAKE_BINARY_DIR}/level-zero/.git")
       # Update the checkout
         execute_process(
             COMMAND ${GIT_EXECUTABLE} fetch
             RESULT_VARIABLE result
             ERROR_VARIABLE error
-            WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/level-zero
+            WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/level-zero"
             OUTPUT_STRIP_TRAILING_WHITESPACE
             ERROR_STRIP_TRAILING_WHITESPACE
         )
@@ -43,11 +43,15 @@ function(get_level_zero_headers)
             )
         endif()
     else()
+        # remove level-zero directory if it exists
+        file(REMOVE_RECURSE "${CMAKE_BINARY_DIR}/level-zero")
+
         # Clone the Level Zero git repo
         execute_process(
             COMMAND ${GIT_EXECUTABLE} clone https://github.com/oneapi-src/level-zero.git
             RESULT_VARIABLE result
             ERROR_VARIABLE error
+            WORKING_DIRECTORY "${CMAKE_BINARY_DIR}"
             OUTPUT_STRIP_TRAILING_WHITESPACE
             ERROR_STRIP_TRAILING_WHITESPACE
         )
@@ -65,7 +69,7 @@ function(get_level_zero_headers)
         RESULT_VARIABLE result
         OUTPUT_VARIABLE latest_tag
         ERROR_VARIABLE error
-        WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/level-zero
+        WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/level-zero"
         OUTPUT_STRIP_TRAILING_WHITESPACE
         ERROR_STRIP_TRAILING_WHITESPACE
     )
@@ -81,7 +85,7 @@ function(get_level_zero_headers)
         COMMAND ${GIT_EXECUTABLE} checkout ${latest_tag}
         RESULT_VARIABLE result
         ERROR_VARIABLE error
-        WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/level-zero
+        WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/level-zero"
         OUTPUT_STRIP_TRAILING_WHITESPACE
         ERROR_STRIP_TRAILING_WHITESPACE
     )
@@ -95,7 +99,7 @@ function(get_level_zero_headers)
     # Populate the path to the headers
     find_path(LEVEL_ZERO_INCLUDE_DIR
         NAMES zet_api.h
-        PATHS ${CMAKE_BINARY_DIR}/level-zero/include
+        PATHS "${CMAKE_BINARY_DIR}/level-zero/include"
         NO_DEFAULT_PATH
         NO_CMAKE_ENVIRONMENT_PATH
         NO_CMAKE_PATH


### PR DESCRIPTION
This PR updates the `GetLevelZeroHeaders.cmake`

The paths defined previously in parts of the CMake file did not work and were inconsistent, using `CMAKE_BINARY_DIR`  in some places (which worked) and relative paths in others

- [X] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [ ] Have you added your changes to the changelog?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
