### PR TITLE
Fix memset call in basic_concepts user guide

### DIFF
--- a/docs/doc_sources/user_guides/basic_concepts.rst
+++ b/docs/doc_sources/user_guides/basic_concepts.rst
@@ -192,7 +192,7 @@ expose Python buffer interface.
    >>> mem_d.copy_from_host(b"abcdefghijklmnopqrstuvwxyz")
 
    >>> mem_s = dpm.MemoryUSMShared(30)
-   >>> mem_s.memset(value=ord(b"-""))
+   >>> mem_s.memset(val=ord(b"-"))
    >>> mem_s.copy_from_device(mem_d)
 
    >>> # since USM-shared is host-accessible,


### PR DESCRIPTION
## Summary

Fixes a broken example in the "Basic Concepts" user guide.

The snippet on `basic_concepts.rst:195` called:

```python
>>> mem_s.memset(value=ord(b"-""))
```

Two problems:
- `_Memory.memset`'s parameter is named `val`, not `value`, so the keyword argument raises `TypeError`.
- `ord(b"-"")` has a stray extra double-quote, which is a `SyntaxError`.

Corrected to:

```python
>>> mem_s.memset(val=ord(b"-"))
```

Documentation-only change; no code or behavior is affected.
