### PR TITLE
Fix warnings in coverage builds

### DIFF
--- a/libsyclinterface/tests/test_sycl_device_interface.cpp
+++ b/libsyclinterface/tests/test_sycl_device_interface.cpp
@@ -610,7 +610,7 @@ TEST_P(TestDPCTLSyclDeviceInterface, ChkGetBackendVersion)
 
 TEST_P(TestDPCTLSyclDeviceInterface, ChkGetLocalMemType)
 {
-    DPCTLLocalMemType lmt;
+    DPCTLLocalMemType lmt = DPCTL_LOCAL_MEM_TYPE_UNKNOWN;
     EXPECT_NO_FATAL_FAILURE(lmt = DPCTLDevice_GetLocalMemType(DRef));
     EXPECT_TRUE(lmt == DPCTL_LOCAL_MEM_TYPE_NONE ||
                 lmt == DPCTL_LOCAL_MEM_TYPE_LOCAL ||
@@ -619,7 +619,7 @@ TEST_P(TestDPCTLSyclDeviceInterface, ChkGetLocalMemType)
 
 TEST_P(TestDPCTLSyclDeviceInterface, ChkGetPartitionTypeProperty)
 {
-    DPCTLPartitionPropertyType ptp;
+    DPCTLPartitionPropertyType ptp = DPCTL_PARTITION_UNKNOWN;
     EXPECT_NO_FATAL_FAILURE(ptp = DPCTLDevice_GetPartitionTypeProperty(DRef));
     EXPECT_TRUE(
         ptp == DPCTL_PARTITION_UNKNOWN || ptp == DPCTL_PARTITION_NO_PARTITION ||
@@ -768,7 +768,8 @@ TEST_P(TestDPCTLSyclDeviceInterface, ChkGetPartitionAffinityDomains)
 
 TEST_P(TestDPCTLSyclDeviceInterface, ChkGetPartitionTypeAffinityDomain)
 {
-    DPCTLPartitionAffinityDomainType ptad;
+    DPCTLPartitionAffinityDomainType ptad =
+        DPCTL_PARTITION_AFFINITY_DOMAIN_UNKNOWN;
     EXPECT_NO_FATAL_FAILURE(
         ptad = DPCTLDevice_GetPartitionTypeAffinityDomain(DRef));
     EXPECT_TRUE(ptad == DPCTLPartitionAffinityDomainType::not_applicable ||


### PR DESCRIPTION
This PR proposes fixing warnings which have appeared for uninitialized variables in Coverage builds

- [ ] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] Have you checked performance impact of proposed changes?
- [ ] Have you added documentation for your changes, if necessary?
- [ ] Have you added your changes to the changelog?
- [ ] If this PR is a work in progress, are you opening the PR as a draft?
