### PR TITLE
ci: harden GitHub Actions workflows and add zizmor scan

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,8 @@ updates:
     schedule:
       interval: "weekly"
       day: "saturday"
+    cooldown:
+      default-days: 7
     labels: ["autoupdate"]
     groups:
       github-actions:
@@ -15,6 +17,8 @@ updates:
     schedule:
       interval: "weekly"
       day: "saturday"
+    cooldown:
+      default-days: 7
     labels: ["autoupdate"]
     groups:
       pre-commit:

--- a/.github/workflows/backfill-docs.yml
+++ b/.github/workflows/backfill-docs.yml
@@ -7,7 +7,8 @@ on:
         required: true
         type: string
 
-permissions: read-all
+permissions:
+  contents: read
 
 env:
   CHECK_CONFIG_SCRIPT: "import sys; from packaging.version import parse; print('true' if parse('0.17.0') <= parse(sys.argv[1]) < parse('0.22.0') else 'false')"
@@ -67,8 +68,10 @@ jobs:
           persist-credentials: false
       - name: Inject new docs configuration
         shell: bash -l {0}
+        env:
+          TAG: ${{ github.event.inputs.tag }}
         run: |
-          NEEDS_CONFIG=$(python -c "${{ env.CHECK_CONFIG_SCRIPT }}" "${{ github.event.inputs.tag }}")
+          NEEDS_CONFIG=$(python -c "$CHECK_CONFIG_SCRIPT" "$TAG")
 
           if [[ "${NEEDS_CONFIG}" == "true" ]]; then
             git fetch origin master

--- a/.github/workflows/conda-package-cf.yml
+++ b/.github/workflows/conda-package-cf.yml
@@ -6,7 +6,8 @@ on:
       - master
   pull_request:
 
-permissions: read-all
+permissions:
+  contents: read
 
 env:
   PACKAGE_NAME: dpctl
@@ -41,6 +42,7 @@ jobs:
 
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          persist-credentials: false
           fetch-depth: 0
 
       - name: Set pkgs_dirs
@@ -109,6 +111,7 @@ jobs:
       # the recipe takes the version from git describe
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          persist-credentials: false
           fetch-depth: 0
 
       - uses: conda-incubator/setup-miniconda@8ee1f361103df19b6f8c8655fd3967a8ecb162d5 # v4.0.1

--- a/.github/workflows/conda-package.yml
+++ b/.github/workflows/conda-package.yml
@@ -6,7 +6,8 @@ on:
       - master
   pull_request:
 
-permissions: read-all
+permissions:
+  contents: read
 
 env:
   PACKAGE_NAME: dpctl
@@ -41,6 +42,7 @@ jobs:
 
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          persist-credentials: false
           fetch-depth: 0
 
       - name: Set pkgs_dirs
@@ -118,6 +120,7 @@ jobs:
 
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          persist-credentials: false
           fetch-depth: 0
 
       - uses: conda-incubator/setup-miniconda@8ee1f361103df19b6f8c8655fd3967a8ecb162d5 # v4.0.1
@@ -618,6 +621,7 @@ jobs:
       - name: Checkout dpctl repo
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          persist-credentials: false
           fetch-depth: 0
       - name: Download artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -788,6 +792,7 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          persist-credentials: false
           repository: IntelPython/devops-tools
           fetch-depth: 0
 

--- a/.github/workflows/generate-coverage.yaml
+++ b/.github/workflows/generate-coverage.yaml
@@ -4,7 +4,8 @@ on:
   push:
     branches: [master]
 
-permissions: read-all
+permissions:
+  contents: read
 
 jobs:
   generate-coverage:
@@ -82,6 +83,7 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          persist-credentials: false
           fetch-depth: 0
 
       - name: Install Lcov

--- a/.github/workflows/generate-docs.yml
+++ b/.github/workflows/generate-docs.yml
@@ -6,7 +6,8 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, closed]
 
-permissions: read-all
+permissions:
+  contents: read
 
 jobs:
   build-and-deploy:
@@ -143,7 +144,7 @@ jobs:
         if: ${{ github.event.pull_request && !github.event.pull_request.head.repo.fork && github.event.action != 'closed' }}
         env:
           PR_NUM: ${{ github.event.number }}
-        uses: mshick/add-pr-comment@ec328af66588ab8f77cdeb2c264f14aba45bbf59 # v3.12.0.8.3.12.0
+        uses: mshick/add-pr-comment@ec328af66588ab8f77cdeb2c264f14aba45bbf59 # v3.12.0
         with:
           message: |
             View rendered docs @ https://intelpython.github.io/dpctl/pulls/${{ env.PR_NUM }}/index.html
@@ -152,7 +153,7 @@ jobs:
         if: ${{ github.event.pull_request && !github.event.pull_request.head.repo.fork && github.event.action == 'closed' }}
         env:
           PR_NUM: ${{ github.event.number }}
-        uses: mshick/add-pr-comment@ec328af66588ab8f77cdeb2c264f14aba45bbf59 # v3.12.0.8.3.12.0
+        uses: mshick/add-pr-comment@ec328af66588ab8f77cdeb2c264f14aba45bbf59 # v3.12.0
         with:
           message: |
             Deleted rendered PR docs from intelpython.github.com/dpctl, latest should be updated shortly. :crossed_fingers:

--- a/.github/workflows/openssf-scorecard.yml
+++ b/.github/workflows/openssf-scorecard.yml
@@ -16,7 +16,8 @@ on:
     branches: [ "master" ]
 
 # Declare default permissions as read only.
-permissions: read-all
+permissions:
+  contents: read
 
 jobs:
   analysis:

--- a/.github/workflows/os-llvm-sycl-build.yml
+++ b/.github/workflows/os-llvm-sycl-build.yml
@@ -4,7 +4,8 @@ on:
   push:
     branches: [master]
 
-permissions: read-all
+permissions:
+  contents: read
 
 jobs:
   install-compiler:
@@ -128,6 +129,7 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          persist-credentials: false
           fetch-depth: 0
 
       - name: Create set_allvars.sh

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -5,7 +5,8 @@ on:
   push:
     branches: [master]
 
-permissions: read-all
+permissions:
+  contents: read
 
 jobs:
   pre-commit:
@@ -18,6 +19,7 @@ jobs:
     - name: Checkout dpctl
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
+        persist-credentials: false
         ref: ${{ github.sha }}  # use hash to pass no-commit-to-branch check
     - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
       with:

--- a/.github/workflows/run-tests-from-dppy-bits.yaml
+++ b/.github/workflows/run-tests-from-dppy-bits.yaml
@@ -9,7 +9,8 @@ on:
     - cron: '28 2 * * *'
   workflow_dispatch:
 
-permissions: read-all
+permissions:
+  contents: read
 
 env:
   MODULE_NAME: dpctl

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,39 @@
+name: Security scan of GitHub Actions workflows (zizmor)
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  zizmor:
+    name: Scan GitHub Actions workflows
+
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    permissions:
+      contents: read # needed to clone the repo
+
+    steps:
+      - name: Checkout dpctl repo
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@70fb788f84895a7701f5643d103d587e460b5c99 # v0.6.3
+        with:
+          # Low/informational template-injection notes come from internally-defined
+          # values (no external input), so they are reported as annotations but do not gate CI
+          min-severity: medium
+          advanced-security: false
+          annotations: true
+          inputs: .github/


### PR DESCRIPTION
Adds a CI job that runs the [zizmor](https://docs.zizmor.sh) static analyzer over the workflow files under `.github/`.

`zizmor` audits GitHub Actions workflows for supply-chain and privilege-escalation weaknesses — unpinned action references, credential persistence through the checkout token, template injection via `${{ ... }}` expansion in `run:` blocks, and overly broad `GITHUB_TOKEN` permissions.

Alongside the new scan, this applies the corresponding hardening to the existing workflows so they pass the audit:

- add `persist-credentials: false` to every `actions/checkout` step that lacked it
- narrow top-level `permissions: read-all` to `permissions: contents: read`
- move `github.event.inputs.tag` into an `env:` var in `backfill-docs.yml` to avoid template injection in a `run:` block
- fix a malformed version-pin comment for `mshick/add-pr-comment` (`# v3.12.0.8.3.12.0` -> `# v3.12.0`)
- add a 7-day `cooldown` to the dependabot update entries

This is a CI/configuration-only change; no library code, tests, or documentation are affected.